### PR TITLE
chore: bump MSRV to 1.92, ignore dtolnay/rust-toolchain in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"
     commit-message:
       prefix: "ci(deps)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.87"
+          toolchain: "1.92"
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 name = "structured-zstd-cli"
 version = "0.8.2"
-rust-version = "1.87.0"
+rust-version = "1.92"
 authors = ["Moritz Borcherding <moritz.borcherding@web.de>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "structured-zstd"
 version = "0.0.2"
-rust-version = "1.87"
+rust-version = "1.92"
 authors = [
     "Moritz Borcherding <moritz.borcherding@web.de>",
     "Structured World Foundation <foundation@sw.foundation>",


### PR DESCRIPTION
## Summary
- Bump `rust-version` in zstd/ and cli/ Cargo.toml: 1.87 → 1.92
- Update MSRV CI job toolchain: 1.87 → 1.92
- Exclude `dtolnay/rust-toolchain` from dependabot github-actions updates

Closes #31