### PR TITLE
perf(encoding): interleave fastest hash fill insertion

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -502,7 +502,7 @@ impl MatchGenerator {
         if last_entry.data.len() < MIN_MATCH_LEN {
             return;
         }
-        let insert_limit = idx.saturating_sub(MIN_MATCH_LEN).saturating_add(1);
+        let insert_limit = idx.saturating_sub(MIN_MATCH_LEN - 1);
         if insert_limit > start {
             let data = last_entry.data.as_slice();
             let suffixes = &mut last_entry.suffixes;
@@ -1459,6 +1459,46 @@ fn simple_matcher_add_suffixes_till_backfills_last_searchable_anchor() {
     let last = matcher.window.last().unwrap();
     let tail = &last.data[5..10];
     assert_eq!(last.suffixes.get(tail), Some(5));
+}
+
+#[test]
+fn simple_matcher_add_suffixes_till_skips_when_idx_below_min_match_len() {
+    let mut matcher = MatchGenerator::new(128);
+    matcher.hash_fill_step = FAST_HASH_FILL_STEP;
+    matcher.add_data(
+        b"abcdefghijklmnopqrstuvwxyz".to_vec(),
+        SuffixStore::with_capacity(1 << 16),
+        |_, _| {},
+    );
+
+    matcher.add_suffixes_till(MIN_MATCH_LEN - 1, FAST_HASH_FILL_STEP);
+
+    let last = matcher.window.last().unwrap();
+    let first_key = &last.data[..MIN_MATCH_LEN];
+    assert_eq!(last.suffixes.get(first_key), None);
+}
+
+#[test]
+fn simple_matcher_add_suffixes_till_fast_step_registers_interleaved_positions() {
+    let mut matcher = MatchGenerator::new(128);
+    matcher.hash_fill_step = FAST_HASH_FILL_STEP;
+    matcher.add_data(
+        b"abcdefghijklmnopqrstuvwxyz".to_vec(),
+        SuffixStore::with_capacity(1 << 16),
+        |_, _| {},
+    );
+
+    matcher.add_suffixes_till(17, FAST_HASH_FILL_STEP);
+
+    let last = matcher.window.last().unwrap();
+    for pos in [0usize, 3, 6, 9, 12] {
+        let key = &last.data[pos..pos + MIN_MATCH_LEN];
+        assert_eq!(
+            last.suffixes.get(key),
+            Some(pos),
+            "expected interleaved suffix registration at pos {pos}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add an interleaved suffix-hash insertion path in `MatchGenerator::add_suffixes_till()` for fastest mode (`FAST_HASH_FILL_STEP = 3`)
- keep tail-anchor/backfill behavior unchanged to preserve boundary matching semantics
- ignore generated benchmark artifacts (`benchmark-report.md`, `benchmark-results.json`)

## Benchmark (vs `origin/main`, `STRUCTURED_ZSTD_BENCH_LARGE_BYTES=16777216`)
Fastest pure-Rust compression improved on key scenarios:
- `decodecorpus-z000033`: 13.613 ms -> 12.090 ms (-11.19%)
- `high-entropy-1m`: 19.056 ms -> 17.542 ms (-7.95%)
- `large-log-stream`: 14.466 ms -> 12.480 ms (-13.73%)
- `low-entropy-1m`: 0.903 ms -> 0.759 ms (-15.95%)

## Validation
- `cargo fmt -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`
- `cargo nextest run --workspace`
- `cargo bench --bench compare_ffi -p structured-zstd --no-run`
- `STRUCTURED_ZSTD_BENCH_LARGE_BYTES=16777216 bash .github/scripts/run-benchmarks.sh` (branch + baseline in temp worktree)

Refs #14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal suffix matching generation for better performance and efficiency (no public API changes).
* **Bug Fixes**
  * Resolved cases where internal entries could be incorrectly recorded, improving correctness of matching behavior.
* **Tests**
  * Added unit tests to validate boundary behavior and optimized fast-path insertion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->