### PR TITLE
perf(encoding): SIMD-dispatch common_prefix_len

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7,6 +7,18 @@
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
+#[cfg(target_arch = "aarch64")]
+use core::arch::aarch64::{uint8x16_t, vceqq_u8, vld1q_u8, vst1q_u8};
+#[cfg(target_arch = "x86")]
+use core::arch::x86::{
+    __m128i, __m256i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm256_cmpeq_epi8,
+    _mm256_loadu_si256, _mm256_movemask_epi8,
+};
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::{
+    __m128i, __m256i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm256_cmpeq_epi8,
+    _mm256_loadu_si256, _mm256_movemask_epi8,
+};
 use core::convert::TryInto;
 use core::num::NonZeroUsize;
 
@@ -14,6 +26,12 @@ use super::CompressionLevel;
 use super::Matcher;
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
+#[cfg(all(feature = "std", target_arch = "aarch64"))]
+use std::arch::is_aarch64_feature_detected;
+#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+use std::arch::is_x86_feature_detected;
+#[cfg(feature = "std")]
+use std::sync::OnceLock;
 
 const MIN_MATCH_LEN: usize = 5;
 const FAST_HASH_FILL_STEP: usize = 3;
@@ -45,6 +63,17 @@ const HC_EMPTY: u32 = 0;
 // Maximum search depth across all HC-based levels. Used to size the
 // fixed-length candidate array returned by chain_candidates().
 const MAX_HC_SEARCH_DEPTH: usize = 32;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum PrefixKernel {
+    Scalar,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    X86Sse42,
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    X86Avx2,
+    #[cfg(target_arch = "aarch64")]
+    Aarch64Neon,
+}
 
 /// Bundled tuning knobs for the hash-chain matcher. Using a typed config
 /// instead of positional `usize` args eliminates parameter-order hazards.
@@ -852,6 +881,65 @@ pub(crate) struct MatchGenerator {
 }
 
 impl MatchGenerator {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[inline(always)]
+    const fn select_x86_prefix_kernel(has_avx2: bool, has_sse42: bool) -> PrefixKernel {
+        if has_avx2 {
+            return PrefixKernel::X86Avx2;
+        }
+        if has_sse42 {
+            return PrefixKernel::X86Sse42;
+        }
+        PrefixKernel::Scalar
+    }
+
+    #[cfg(feature = "std")]
+    #[inline(always)]
+    fn detect_prefix_kernel() -> PrefixKernel {
+        static KERNEL: OnceLock<PrefixKernel> = OnceLock::new();
+        *KERNEL.get_or_init(|| {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            {
+                let kernel = Self::select_x86_prefix_kernel(
+                    is_x86_feature_detected!("avx2"),
+                    is_x86_feature_detected!("sse4.2"),
+                );
+                if kernel != PrefixKernel::Scalar {
+                    return kernel;
+                }
+            }
+            #[cfg(target_arch = "aarch64")]
+            {
+                if is_aarch64_feature_detected!("neon") {
+                    return PrefixKernel::Aarch64Neon;
+                }
+            }
+            PrefixKernel::Scalar
+        })
+    }
+
+    #[cfg(not(feature = "std"))]
+    #[inline(always)]
+    fn detect_prefix_kernel() -> PrefixKernel {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            let kernel = Self::select_x86_prefix_kernel(
+                cfg!(target_feature = "avx2"),
+                cfg!(target_feature = "sse4.2"),
+            );
+            if kernel != PrefixKernel::Scalar {
+                return kernel;
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if cfg!(target_feature = "neon") {
+                return PrefixKernel::Aarch64Neon;
+            }
+        }
+        PrefixKernel::Scalar
+    }
+
     #[inline(always)]
     #[cfg(target_endian = "little")]
     fn mismatch_byte_index(diff: usize) -> usize {
@@ -1003,11 +1091,34 @@ impl MatchGenerator {
     #[inline(always)]
     fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
         let max = a.len().min(b.len());
-        let chunk = core::mem::size_of::<usize>();
         let mut off = 0usize;
         let lhs = a.as_ptr();
         let rhs = b.as_ptr();
 
+        match Self::detect_prefix_kernel() {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            PrefixKernel::X86Avx2 => {
+                off = unsafe { Self::prefix_len_simd_avx2(lhs, rhs, max) };
+            }
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            PrefixKernel::X86Sse42 => {
+                off = unsafe { Self::prefix_len_simd_sse42(lhs, rhs, max) };
+            }
+            #[cfg(target_arch = "aarch64")]
+            PrefixKernel::Aarch64Neon => {
+                off = unsafe { Self::prefix_len_simd_neon(lhs, rhs, max) };
+            }
+            PrefixKernel::Scalar => {}
+        }
+
+        Self::common_prefix_len_scalar(a, b, off, max)
+    }
+
+    #[inline(always)]
+    fn common_prefix_len_scalar(a: &[u8], b: &[u8], mut off: usize, max: usize) -> usize {
+        let chunk = core::mem::size_of::<usize>();
+        let lhs = a.as_ptr();
+        let rhs = b.as_ptr();
         while off + chunk <= max {
             let lhs_word = unsafe { core::ptr::read_unaligned(lhs.add(off) as *const usize) };
             let rhs_word = unsafe { core::ptr::read_unaligned(rhs.add(off) as *const usize) };
@@ -1017,10 +1128,61 @@ impl MatchGenerator {
             }
             off += chunk;
         }
-
         off + core::iter::zip(&a[off..max], &b[off..max])
             .take_while(|(x, y)| x == y)
             .count()
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn prefix_len_simd_sse42(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+        let mut off = 0usize;
+        while off + 16 <= max {
+            let a: __m128i = unsafe { _mm_loadu_si128(lhs.add(off).cast::<__m128i>()) };
+            let b: __m128i = unsafe { _mm_loadu_si128(rhs.add(off).cast::<__m128i>()) };
+            let eq = _mm_cmpeq_epi8(a, b);
+            let mask = _mm_movemask_epi8(eq) as u32;
+            if mask != 0xFFFF {
+                return off + (!mask).trailing_zeros() as usize;
+            }
+            off += 16;
+        }
+        off
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2")]
+    unsafe fn prefix_len_simd_avx2(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+        let mut off = 0usize;
+        while off + 32 <= max {
+            let a: __m256i = unsafe { _mm256_loadu_si256(lhs.add(off).cast::<__m256i>()) };
+            let b: __m256i = unsafe { _mm256_loadu_si256(rhs.add(off).cast::<__m256i>()) };
+            let eq = _mm256_cmpeq_epi8(a, b);
+            let mask = _mm256_movemask_epi8(eq) as u32;
+            if mask != u32::MAX {
+                return off + (!mask).trailing_zeros() as usize;
+            }
+            off += 32;
+        }
+        off
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    #[target_feature(enable = "neon")]
+    unsafe fn prefix_len_simd_neon(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+        let mut off = 0usize;
+        while off + 16 <= max {
+            let a: uint8x16_t = unsafe { vld1q_u8(lhs.add(off)) };
+            let b: uint8x16_t = unsafe { vld1q_u8(rhs.add(off)) };
+            let eq = vceqq_u8(a, b);
+            let mut bytes = [0u8; 16];
+            unsafe { vst1q_u8(bytes.as_mut_ptr(), eq) };
+            if let Some(idx) = bytes.iter().position(|&v| v != u8::MAX) {
+                return off + idx;
+            }
+            off += 16;
+        }
+        off
     }
 
     /// Process bytes and add the suffixes to the suffix store up to a specific index
@@ -3448,6 +3610,45 @@ fn adjust_params_for_zero_source_size_uses_min_hinted_window_floor() {
     params.window_log = 22;
     let adjusted = adjust_params_for_source_size(params, 0);
     assert_eq!(adjusted.window_log, MIN_HINTED_WINDOW_LOG);
+}
+
+#[test]
+fn common_prefix_len_matches_scalar_reference_across_offsets() {
+    fn scalar_reference(a: &[u8], b: &[u8]) -> usize {
+        a.iter()
+            .zip(b.iter())
+            .take_while(|(lhs, rhs)| lhs == rhs)
+            .count()
+    }
+
+    for len in [0usize, 1, 5, 15, 16, 17, 31, 32, 33, 64, 65, 127, 191] {
+        let a: Vec<u8> = (0..len).map(|i| ((i * 13 + 7) & 0xFF) as u8).collect();
+        let b = a.clone();
+        assert_eq!(
+            MatchGenerator::common_prefix_len(&a, &b),
+            scalar_reference(&a, &b)
+        );
+
+        for mismatch in [0usize, 1, 7, 15, 16, 31, 32, 47, 63, 95, 127] {
+            if mismatch >= len {
+                continue;
+            }
+            let mut altered = b.clone();
+            altered[mismatch] ^= 0x5A;
+            assert_eq!(
+                MatchGenerator::common_prefix_len(&a, &altered),
+                scalar_reference(&a, &altered),
+                "len={len} mismatch={mismatch}"
+            );
+        }
+    }
+
+    let long = alloc::vec![0xAB; 320];
+    let shorter = alloc::vec![0xAB; 137];
+    assert_eq!(
+        MatchGenerator::common_prefix_len(&long, &shorter),
+        scalar_reference(&long, &shorter)
+    );
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7,7 +7,7 @@
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 use core::arch::aarch64::{uint8x16_t, vceqq_u8, vgetq_lane_u64, vld1q_u8, vreinterpretq_u64_u8};
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
@@ -26,7 +26,7 @@ use super::CompressionLevel;
 use super::Matcher;
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
-#[cfg(all(feature = "std", target_arch = "aarch64"))]
+#[cfg(all(feature = "std", target_arch = "aarch64", target_endian = "little"))]
 use std::arch::is_aarch64_feature_detected;
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 use std::arch::is_x86_feature_detected;
@@ -71,7 +71,7 @@ enum PrefixKernel {
     X86Sse2,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     X86Avx2,
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     Aarch64Neon,
 }
 
@@ -908,7 +908,7 @@ impl MatchGenerator {
                     return kernel;
                 }
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
             {
                 if is_aarch64_feature_detected!("neon") {
                     return PrefixKernel::Aarch64Neon;
@@ -931,7 +931,7 @@ impl MatchGenerator {
                 return kernel;
             }
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         {
             if cfg!(target_feature = "neon") {
                 return PrefixKernel::Aarch64Neon;
@@ -1104,7 +1104,7 @@ impl MatchGenerator {
             PrefixKernel::X86Sse2 => {
                 off = unsafe { Self::prefix_len_simd_sse2(lhs, rhs, max) };
             }
-            #[cfg(target_arch = "aarch64")]
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
             PrefixKernel::Aarch64Neon => {
                 off = unsafe { Self::prefix_len_simd_neon(lhs, rhs, max) };
             }
@@ -1167,7 +1167,7 @@ impl MatchGenerator {
         off
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
     unsafe fn prefix_len_simd_neon(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
         let mut off = 0usize;
@@ -1179,12 +1179,12 @@ impl MatchGenerator {
             let low = vgetq_lane_u64(lanes, 0);
             if low != u64::MAX {
                 let diff = low ^ u64::MAX;
-                return off + (diff.trailing_zeros() as usize / 8);
+                return off + Self::mismatch_byte_index(diff as usize);
             }
             let high = vgetq_lane_u64(lanes, 1);
             if high != u64::MAX {
                 let diff = high ^ u64::MAX;
-                return off + 8 + (diff.trailing_zeros() as usize / 8);
+                return off + 8 + Self::mismatch_byte_index(diff as usize);
             }
             off += 16;
         }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8,7 +8,7 @@
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 #[cfg(target_arch = "aarch64")]
-use core::arch::aarch64::{uint8x16_t, vceqq_u8, vld1q_u8, vst1q_u8};
+use core::arch::aarch64::{uint8x16_t, vceqq_u8, vgetq_lane_u64, vld1q_u8, vreinterpretq_u64_u8};
 #[cfg(target_arch = "x86")]
 use core::arch::x86::{
     __m128i, __m256i, _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm256_cmpeq_epi8,
@@ -68,7 +68,7 @@ const MAX_HC_SEARCH_DEPTH: usize = 32;
 enum PrefixKernel {
     Scalar,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    X86Sse42,
+    X86Sse2,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     X86Avx2,
     #[cfg(target_arch = "aarch64")]
@@ -883,12 +883,12 @@ pub(crate) struct MatchGenerator {
 impl MatchGenerator {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[inline(always)]
-    const fn select_x86_prefix_kernel(has_avx2: bool, has_sse42: bool) -> PrefixKernel {
+    const fn select_x86_prefix_kernel(has_avx2: bool, has_sse2: bool) -> PrefixKernel {
         if has_avx2 {
             return PrefixKernel::X86Avx2;
         }
-        if has_sse42 {
-            return PrefixKernel::X86Sse42;
+        if has_sse2 {
+            return PrefixKernel::X86Sse2;
         }
         PrefixKernel::Scalar
     }
@@ -902,7 +902,7 @@ impl MatchGenerator {
             {
                 let kernel = Self::select_x86_prefix_kernel(
                     is_x86_feature_detected!("avx2"),
-                    is_x86_feature_detected!("sse4.2"),
+                    is_x86_feature_detected!("sse2"),
                 );
                 if kernel != PrefixKernel::Scalar {
                     return kernel;
@@ -925,7 +925,7 @@ impl MatchGenerator {
         {
             let kernel = Self::select_x86_prefix_kernel(
                 cfg!(target_feature = "avx2"),
-                cfg!(target_feature = "sse4.2"),
+                cfg!(target_feature = "sse2"),
             );
             if kernel != PrefixKernel::Scalar {
                 return kernel;
@@ -1101,8 +1101,8 @@ impl MatchGenerator {
                 off = unsafe { Self::prefix_len_simd_avx2(lhs, rhs, max) };
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            PrefixKernel::X86Sse42 => {
-                off = unsafe { Self::prefix_len_simd_sse42(lhs, rhs, max) };
+            PrefixKernel::X86Sse2 => {
+                off = unsafe { Self::prefix_len_simd_sse2(lhs, rhs, max) };
             }
             #[cfg(target_arch = "aarch64")]
             PrefixKernel::Aarch64Neon => {
@@ -1134,8 +1134,8 @@ impl MatchGenerator {
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "sse4.2")]
-    unsafe fn prefix_len_simd_sse42(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+    #[target_feature(enable = "sse2")]
+    unsafe fn prefix_len_simd_sse2(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
         let mut off = 0usize;
         while off + 16 <= max {
             let a: __m128i = unsafe { _mm_loadu_si128(lhs.add(off).cast::<__m128i>()) };
@@ -1175,10 +1175,16 @@ impl MatchGenerator {
             let a: uint8x16_t = unsafe { vld1q_u8(lhs.add(off)) };
             let b: uint8x16_t = unsafe { vld1q_u8(rhs.add(off)) };
             let eq = vceqq_u8(a, b);
-            let mut bytes = [0u8; 16];
-            unsafe { vst1q_u8(bytes.as_mut_ptr(), eq) };
-            if let Some(idx) = bytes.iter().position(|&v| v != u8::MAX) {
-                return off + idx;
+            let lanes = vreinterpretq_u64_u8(eq);
+            let low = vgetq_lane_u64(lanes, 0);
+            if low != u64::MAX {
+                let diff = low ^ u64::MAX;
+                return off + (diff.trailing_zeros() as usize / 8);
+            }
+            let high = vgetq_lane_u64(lanes, 1);
+            if high != u64::MAX {
+                let diff = high ^ u64::MAX;
+                return off + 8 + (diff.trailing_zeros() as usize / 8);
             }
             off += 16;
         }
@@ -3621,25 +3627,49 @@ fn common_prefix_len_matches_scalar_reference_across_offsets() {
             .count()
     }
 
-    for len in [0usize, 1, 5, 15, 16, 17, 31, 32, 33, 64, 65, 127, 191] {
-        let a: Vec<u8> = (0..len).map(|i| ((i * 13 + 7) & 0xFF) as u8).collect();
-        let b = a.clone();
-        assert_eq!(
-            MatchGenerator::common_prefix_len(&a, &b),
-            scalar_reference(&a, &b)
-        );
+    for total_len in [
+        0usize, 1, 5, 15, 16, 17, 31, 32, 33, 64, 65, 127, 191, 257, 320,
+    ] {
+        let base: Vec<u8> = (0..total_len)
+            .map(|i| ((i * 13 + 7) & 0xFF) as u8)
+            .collect();
 
-        for mismatch in [0usize, 1, 7, 15, 16, 31, 32, 47, 63, 95, 127] {
-            if mismatch >= len {
+        for start in [0usize, 1, 3] {
+            if start > total_len {
                 continue;
             }
-            let mut altered = b.clone();
-            altered[mismatch] ^= 0x5A;
+            let a = &base[start..];
+            let b = a.to_vec();
             assert_eq!(
-                MatchGenerator::common_prefix_len(&a, &altered),
-                scalar_reference(&a, &altered),
-                "len={len} mismatch={mismatch}"
+                MatchGenerator::common_prefix_len(a, &b),
+                scalar_reference(a, &b),
+                "equal slices total_len={total_len} start={start}"
             );
+
+            let len = a.len();
+            for mismatch in [0usize, 1, 7, 15, 16, 31, 32, 47, 63, 95, 127, 128, 129, 191] {
+                if mismatch >= len {
+                    continue;
+                }
+                let mut altered = b.clone();
+                altered[mismatch] ^= 0x5A;
+                assert_eq!(
+                    MatchGenerator::common_prefix_len(a, &altered),
+                    scalar_reference(a, &altered),
+                    "total_len={total_len} start={start} mismatch={mismatch}"
+                );
+            }
+
+            if len > 0 {
+                let mismatch = len - 1;
+                let mut altered = b.clone();
+                altered[mismatch] ^= 0xA5;
+                assert_eq!(
+                    MatchGenerator::common_prefix_len(a, &altered),
+                    scalar_reference(a, &altered),
+                    "tail mismatch total_len={total_len} start={start} mismatch={mismatch}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add runtime SIMD dispatch for common_prefix_len with AVX2, SSE2, and AArch64 NEON kernels (little-endian AArch64 only)
- keep scalar fallback for unsupported targets and tail handling to preserve bounds safety
- add scalar-parity regression test covering varying lengths and mismatch offsets

## Validation
- cargo build -p structured-zstd --features hash,std,dict_builder
- cargo fmt --all -- --check
- cargo clippy -p structured-zstd --all-targets --features hash,std,dict_builder -- -D warnings
- cargo nextest run -p structured-zstd --features hash,std,dict_builder

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized prefix-length computation with architecture-specific SIMD implementations for x86 (SSE2, AVX2) and ARM64 (NEON), improving encoding performance across supported architectures.

* **Tests**
  * Added comprehensive unit tests for prefix-length computation validation across multiple slice lengths, offsets, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->