### PR TITLE
perf(decoding): add shared dictionary handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,27 @@ Complete RFC 8878 implementation. Performance: ~1.4-3.5x slower than C zstd depe
 - [x] Default (roughly level 3)
 - [x] Better (roughly level 7)
 - [x] Best (roughly level 11)
-- [x] Numeric levels `0` (default), `1–22`, and negative ultra-fast levels via `CompressionLevel::from_level(n)` (C zstd compatible numbering)
+- [x] Numeric levels `0` (default), `1–22`, and negative ultra-fast levels via `CompressionLevel::from_level(n)` (C zstd-compatible numbering)
 - [x] Checksums
 - [x] Frame Content Size — `FrameCompressor` writes FCS automatically; `StreamingEncoder` requires `set_pledged_content_size()` before first write
 - [x] Dictionary compression
 - [x] Streaming encoder (`io::Write`)
+
+### Compression Strategy Coverage
+
+Implemented strategy/back-end coverage:
+- Level 1: simple matcher (`Simple`)
+- Levels 2-3: `Dfast`
+- Level 4: row matcher (`Row`)
+- Levels 5-22: hash-chain matcher (`HashChain`) with lazy/lazy2 style tuning
+
+Not yet implemented as dedicated strategy families:
+- `greedy`
+- `btopt`
+- `btultra`
+
+Current behavior for these missing families:
+- numeric levels that require them are mapped to the closest implemented matcher configuration
 
 ### Dictionary Generation
 
@@ -108,6 +124,35 @@ let mut decoder = StreamingDecoder::new(&mut source).unwrap();
 
 let mut result = Vec::new();
 decoder.read_to_end(&mut result).unwrap();
+```
+
+### Dictionary-backed Decompression API
+
+```rust,no_run
+use structured_zstd::decoding::{DictionaryHandle, FrameDecoder, StreamingDecoder};
+use structured_zstd::io::Read;
+
+let compressed: Vec<u8> = vec![];
+let dict_bytes: Vec<u8> = vec![];
+let mut output = vec![0u8; 1024];
+
+// Parse dictionary once, then reuse handle.
+let handle = DictionaryHandle::decode_dict(&dict_bytes).unwrap();
+let mut decoder = FrameDecoder::new();
+let _written = decoder
+    .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
+    .unwrap();
+
+// Compatibility path: pass raw dictionary bytes directly.
+let _written = FrameDecoder::new()
+    .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, &dict_bytes)
+    .unwrap();
+
+// Streaming helpers exist for both handle- and bytes-based paths.
+let mut source: &[u8] = &compressed;
+let mut stream = StreamingDecoder::new_with_dictionary_handle(&mut source, &handle).unwrap();
+let mut sink = Vec::new();
+stream.read_to_end(&mut sink).unwrap();
 ```
 
 ## Support the Project

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ let _written = decoder
     .unwrap();
 
 // Compatibility path: pass raw dictionary bytes directly.
-let _written = FrameDecoder::new()
+let mut decoder = FrameDecoder::new();
+let _written = decoder
     .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, &dict_bytes)
     .unwrap();
 

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -67,3 +67,7 @@ required-features = ["bench_internals"]
 name = "dict_builder_fastcover"
 harness = false
 required-features = ["dict_builder"]
+
+[[bench]]
+name = "decode_dict_handle"
+harness = false

--- a/zstd/benches/decode_dict_handle.rs
+++ b/zstd/benches/decode_dict_handle.rs
@@ -35,7 +35,8 @@ fn bench_decode_dict_handle(c: &mut Criterion) {
     let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
 
     let mut output = vec![0u8; output_len];
-    FrameDecoder::new()
+    let mut decoder = FrameDecoder::new();
+    decoder
         .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
         .expect("decode should succeed");
     assert_eq!(
@@ -44,7 +45,8 @@ fn bench_decode_dict_handle(c: &mut Criterion) {
     );
 
     output.fill(0);
-    FrameDecoder::new()
+    let mut decoder = FrameDecoder::new();
+    decoder
         .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, dict_raw)
         .expect("decode should succeed");
     assert_eq!(

--- a/zstd/benches/decode_dict_handle.rs
+++ b/zstd/benches/decode_dict_handle.rs
@@ -1,0 +1,71 @@
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use std::hint::black_box;
+
+use structured_zstd::decoding::{Dictionary, DictionaryHandle, FrameDecoder};
+use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+fn build_payload() -> Vec<u8> {
+    let mut payload = Vec::with_capacity(512);
+    for i in 0..512u16 {
+        payload.push((i % 251) as u8);
+    }
+    payload
+}
+
+fn compress_with_dictionary(payload: &[u8], dict_raw: &[u8]) -> Vec<u8> {
+    let dict = Dictionary::decode_dict(dict_raw).expect("dictionary should parse");
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor
+        .set_dictionary(dict)
+        .expect("dictionary should attach");
+    compressor.set_source_size_hint(payload.len() as u64);
+    compressor.set_source(payload);
+    let mut compressed = Vec::new();
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+    compressed
+}
+
+fn bench_decode_dict_handle(c: &mut Criterion) {
+    let dict_raw = include_bytes!("../dict_tests/dictionary");
+    let payload = build_payload();
+    let compressed = compress_with_dictionary(&payload, dict_raw.as_slice());
+    let output_len = payload.len();
+
+    let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
+
+    let mut group = c.benchmark_group("decode/dict_handle");
+    group.bench_with_input(
+        BenchmarkId::new("prepared_handle", output_len),
+        &output_len,
+        |b, &len| {
+            b.iter(|| {
+                let mut decoder = FrameDecoder::new();
+                let mut output = vec![0u8; len];
+                decoder
+                    .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
+                    .expect("decode should succeed");
+                black_box(output);
+            });
+        },
+    );
+
+    group.bench_with_input(
+        BenchmarkId::new("raw_dict_each_call", output_len),
+        &output_len,
+        |b, &len| {
+            b.iter(|| {
+                let mut decoder = FrameDecoder::new();
+                let mut output = vec![0u8; len];
+                decoder
+                    .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, dict_raw)
+                    .expect("decode should succeed");
+                black_box(output);
+            });
+        },
+    );
+    group.finish();
+}
+
+criterion_group!(benches, bench_decode_dict_handle);
+criterion_main!(benches);

--- a/zstd/benches/decode_dict_handle.rs
+++ b/zstd/benches/decode_dict_handle.rs
@@ -34,6 +34,24 @@ fn bench_decode_dict_handle(c: &mut Criterion) {
 
     let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
 
+    let mut output = vec![0u8; output_len];
+    FrameDecoder::new()
+        .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
+        .expect("decode should succeed");
+    assert_eq!(
+        output, payload,
+        "prepared_handle produced unexpected output"
+    );
+
+    output.fill(0);
+    FrameDecoder::new()
+        .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, dict_raw)
+        .expect("decode should succeed");
+    assert_eq!(
+        output, payload,
+        "raw_dict_each_call produced unexpected output"
+    );
+
     let mut group = c.benchmark_group("decode/dict_handle");
     group.bench_with_input(
         BenchmarkId::new("prepared_handle", output_len),

--- a/zstd/benches/decode_dict_handle.rs
+++ b/zstd/benches/decode_dict_handle.rs
@@ -1,4 +1,4 @@
-use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
 use structured_zstd::decoding::{Dictionary, DictionaryHandle, FrameDecoder};
@@ -57,14 +57,16 @@ fn bench_decode_dict_handle(c: &mut Criterion) {
         BenchmarkId::new("prepared_handle", output_len),
         &output_len,
         |b, &len| {
-            b.iter(|| {
-                let mut decoder = FrameDecoder::new();
-                let mut output = vec![0u8; len];
-                decoder
-                    .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
-                    .expect("decode should succeed");
-                black_box(output);
-            });
+            b.iter_batched(
+                || (FrameDecoder::new(), vec![0u8; len]),
+                |(mut decoder, mut output)| {
+                    decoder
+                        .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
+                        .expect("decode should succeed");
+                    black_box(output);
+                },
+                BatchSize::SmallInput,
+            );
         },
     );
 
@@ -72,14 +74,16 @@ fn bench_decode_dict_handle(c: &mut Criterion) {
         BenchmarkId::new("raw_dict_each_call", output_len),
         &output_len,
         |b, &len| {
-            b.iter(|| {
-                let mut decoder = FrameDecoder::new();
-                let mut output = vec![0u8; len];
-                decoder
-                    .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, dict_raw)
-                    .expect("decode should succeed");
-                black_box(output);
-            });
+            b.iter_batched(
+                || (FrameDecoder::new(), vec![0u8; len]),
+                |(mut decoder, mut output)| {
+                    decoder
+                        .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, dict_raw)
+                        .expect("decode should succeed");
+                    black_box(output);
+                },
+                BatchSize::SmallInput,
+            );
         },
     );
     group.finish();

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -319,7 +319,7 @@ mod tests {
         let handle = dict.into_handle();
 
         assert_eq!(handle.as_ref().id, 7);
-        assert_eq!(handle.as_ref().dict_content, vec![42]);
+        assert_eq!(handle.as_ref().dict_content.as_slice(), &[42]);
     }
 
     #[test]

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -318,8 +318,8 @@ mod tests {
         let dict = Dictionary::from_raw_content(7, vec![42]).expect("raw dict should build");
         let handle = dict.into_handle();
 
-        assert_eq!(handle.as_ref().id, 7);
-        assert_eq!(handle.as_ref().dict_content.as_slice(), &[42]);
+        assert_eq!(handle.as_dict().id, 7);
+        assert_eq!(handle.as_dict().dict_content.as_slice(), &[42]);
     }
 
     #[test]

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -1,3 +1,4 @@
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
@@ -34,6 +35,12 @@ pub struct Dictionary {
     /// <https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#repeat-offsets>
     /// for more.
     pub offset_hist: [u32; 3],
+}
+
+/// Shared pre-parsed dictionary handle for repeated decoding.
+#[derive(Clone)]
+pub struct DictionaryHandle {
+    inner: Arc<Dictionary>,
 }
 
 /// This 4 byte (little endian) magic number refers to the start of a dictionary
@@ -156,6 +163,45 @@ impl Dictionary {
 
         Ok(new_dict)
     }
+
+    /// Convert this parsed dictionary into a reusable shared handle.
+    pub fn into_handle(self) -> DictionaryHandle {
+        DictionaryHandle::from_dictionary(self)
+    }
+}
+
+impl DictionaryHandle {
+    /// Wrap an already-parsed dictionary in a shared handle.
+    pub fn from_dictionary(dict: Dictionary) -> Self {
+        Self {
+            inner: Arc::new(dict),
+        }
+    }
+
+    /// Parse a serialized dictionary and return a reusable shared handle.
+    pub fn decode_dict(raw: &[u8]) -> Result<Self, DictionaryDecodeError> {
+        Dictionary::decode_dict(raw).map(Self::from_dictionary)
+    }
+
+    pub fn id(&self) -> u32 {
+        self.inner.id
+    }
+
+    pub fn as_dict(&self) -> &Dictionary {
+        &self.inner
+    }
+}
+
+impl AsRef<Dictionary> for DictionaryHandle {
+    fn as_ref(&self) -> &Dictionary {
+        self.as_dict()
+    }
+}
+
+impl From<Dictionary> for DictionaryHandle {
+    fn from(dict: Dictionary) -> Self {
+        DictionaryHandle::from_dictionary(dict)
+    }
 }
 
 #[cfg(test)]
@@ -254,5 +300,15 @@ mod tests {
             result,
             Err(DictionaryDecodeError::DictionaryTooSmall { got: 0, need: 1 })
         ));
+    }
+
+    #[test]
+    fn dictionary_handle_clones_share_inner() {
+        let raw = include_bytes!("../../dict_tests/dictionary");
+        let handle = DictionaryHandle::decode_dict(raw).expect("dictionary should parse");
+        let clone = handle.clone();
+
+        assert_eq!(handle.id(), clone.id());
+        assert!(Arc::ptr_eq(&handle.inner, &clone.inner));
     }
 }

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -1,7 +1,7 @@
-#[cfg(target_has_atomic = "ptr")]
-use alloc::sync::Arc;
 #[cfg(not(target_has_atomic = "ptr"))]
 use alloc::rc::Rc;
+#[cfg(target_has_atomic = "ptr")]
+use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -1,4 +1,7 @@
+#[cfg(target_has_atomic = "ptr")]
 use alloc::sync::Arc;
+#[cfg(not(target_has_atomic = "ptr"))]
+use alloc::rc::Rc;
 use alloc::vec::Vec;
 use core::convert::TryInto;
 
@@ -37,10 +40,17 @@ pub struct Dictionary {
     pub offset_hist: [u32; 3],
 }
 
+#[cfg(target_has_atomic = "ptr")]
+type SharedDictionary = Arc<Dictionary>;
+#[cfg(not(target_has_atomic = "ptr"))]
+type SharedDictionary = Rc<Dictionary>;
+
 /// Shared pre-parsed dictionary handle for repeated decoding.
+///
+/// Uses `Arc` on targets with atomics and falls back to `Rc` otherwise.
 #[derive(Clone)]
 pub struct DictionaryHandle {
-    inner: Arc<Dictionary>,
+    inner: SharedDictionary,
 }
 
 /// This 4 byte (little endian) magic number refers to the start of a dictionary
@@ -174,7 +184,7 @@ impl DictionaryHandle {
     /// Wrap an already-parsed dictionary in a shared handle.
     pub fn from_dictionary(dict: Dictionary) -> Self {
         Self {
-            inner: Arc::new(dict),
+            inner: SharedDictionary::new(dict),
         }
     }
 
@@ -309,6 +319,6 @@ mod tests {
         let clone = handle.clone();
 
         assert_eq!(handle.id(), clone.id());
-        assert!(Arc::ptr_eq(&handle.inner, &clone.inner));
+        assert!(SharedDictionary::ptr_eq(&handle.inner, &clone.inner));
     }
 }

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -217,6 +217,7 @@ impl From<Dictionary> for DictionaryHandle {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     fn offset_history_start(raw: &[u8]) -> usize {
         let mut huf = crate::decoding::scratch::HuffmanScratch::new();
@@ -310,6 +311,15 @@ mod tests {
             result,
             Err(DictionaryDecodeError::DictionaryTooSmall { got: 0, need: 1 })
         ));
+    }
+
+    #[test]
+    fn dictionary_handle_from_raw_content_supports_as_ref() {
+        let dict = Dictionary::from_raw_content(7, vec![42]).expect("raw dict should build");
+        let handle = dict.into_handle();
+
+        assert_eq!(handle.as_ref().id, 7);
+        assert_eq!(handle.as_ref().dict_content, vec![42]);
     }
 
     #[test]

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -317,9 +317,10 @@ mod tests {
     fn dictionary_handle_from_raw_content_supports_as_ref() {
         let dict = Dictionary::from_raw_content(7, vec![42]).expect("raw dict should build");
         let handle = dict.into_handle();
+        let dict_ref: &Dictionary = handle.as_ref();
 
-        assert_eq!(handle.as_dict().id, 7);
-        assert_eq!(handle.as_dict().dict_content.as_slice(), &[42]);
+        assert_eq!(dict_ref.id, 7);
+        assert_eq!(dict_ref.dict_content.as_slice(), &[42]);
     }
 
     #[test]

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -576,7 +576,7 @@ impl core::fmt::Display for FrameDecoderError {
             FrameDecoderError::DictNotProvided { dict_id } => {
                 write!(
                     f,
-                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict() or reset_with_dict()"
+                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict(), add_dict_handle(), add_dict_from_bytes(), reset_with_dict(), or reset_with_dict_handle()"
                 )
             }
             FrameDecoderError::DictAlreadyRegistered { dict_id } => {
@@ -1236,7 +1236,7 @@ mod tests {
         );
         assert_eq!(
             FrameDecoderError::DictNotProvided { dict_id: 0xABCD }.to_string(),
-            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict() or reset_with_dict()"
+            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict(), add_dict_handle(), add_dict_from_bytes(), reset_with_dict(), or reset_with_dict_handle()"
         );
         assert_eq!(
             FrameDecoderError::DictAlreadyRegistered { dict_id: 0xABCD }.to_string(),

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -500,6 +500,7 @@ pub enum FrameDecoderError {
     FailedToSkipFrame,
     TargetTooSmall,
     DictNotProvided { dict_id: u32 },
+    DictAlreadyRegistered { dict_id: u32 },
 }
 
 #[cfg(feature = "std")]
@@ -576,6 +577,12 @@ impl core::fmt::Display for FrameDecoderError {
                 write!(
                     f,
                     "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict() or reset_with_dict()"
+                )
+            }
+            FrameDecoderError::DictAlreadyRegistered { dict_id } => {
+                write!(
+                    f,
+                    "Dictionary id 0x{dict_id:X} already registered in decoder"
                 )
             }
         }
@@ -1230,6 +1237,10 @@ mod tests {
         assert_eq!(
             FrameDecoderError::DictNotProvided { dict_id: 0xABCD }.to_string(),
             "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict() or reset_with_dict()"
+        );
+        assert_eq!(
+            FrameDecoderError::DictAlreadyRegistered { dict_id: 0xABCD }.to_string(),
+            "Dictionary id 0xABCD already registered in decoder"
         );
     }
 

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -500,6 +500,7 @@ pub enum FrameDecoderError {
     FailedToSkipFrame,
     TargetTooSmall,
     DictNotProvided { dict_id: u32 },
+    DictIdMismatch { expected: u32, provided: u32 },
     DictAlreadyRegistered { dict_id: u32 },
 }
 
@@ -576,7 +577,13 @@ impl core::fmt::Display for FrameDecoderError {
             FrameDecoderError::DictNotProvided { dict_id } => {
                 write!(
                     f,
-                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict()/add_dict_from_bytes() or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
+                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict()/add_dict_from_bytes() (or add_dict_handle() on atomic targets) or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
+                )
+            }
+            FrameDecoderError::DictIdMismatch { expected, provided } => {
+                write!(
+                    f,
+                    "Frame header dictionary id 0x{expected:X} does not match provided dictionary id 0x{provided:X}"
                 )
             }
             FrameDecoderError::DictAlreadyRegistered { dict_id } => {
@@ -1236,7 +1243,15 @@ mod tests {
         );
         assert_eq!(
             FrameDecoderError::DictNotProvided { dict_id: 0xABCD }.to_string(),
-            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict()/add_dict_from_bytes() or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
+            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict()/add_dict_from_bytes() (or add_dict_handle() on atomic targets) or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
+        );
+        assert_eq!(
+            FrameDecoderError::DictIdMismatch {
+                expected: 0xABCD,
+                provided: 0x1234
+            }
+            .to_string(),
+            "Frame header dictionary id 0xABCD does not match provided dictionary id 0x1234"
         );
         assert_eq!(
             FrameDecoderError::DictAlreadyRegistered { dict_id: 0xABCD }.to_string(),

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -576,7 +576,7 @@ impl core::fmt::Display for FrameDecoderError {
             FrameDecoderError::DictNotProvided { dict_id } => {
                 write!(
                     f,
-                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict(), add_dict_handle(), add_dict_from_bytes(), reset_with_dict(), or reset_with_dict_handle()"
+                    "Frame header specified dictionary id 0x{dict_id:X} that wasn't provided via add_dict()/add_dict_from_bytes() or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
                 )
             }
             FrameDecoderError::DictAlreadyRegistered { dict_id } => {
@@ -1236,7 +1236,7 @@ mod tests {
         );
         assert_eq!(
             FrameDecoderError::DictNotProvided { dict_id: 0xABCD }.to_string(),
-            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict(), add_dict_handle(), add_dict_from_bytes(), reset_with_dict(), or reset_with_dict_handle()"
+            "Frame header specified dictionary id 0xABCD that wasn't provided via add_dict()/add_dict_from_bytes() or reset_with_dict_handle()/decode_all_with_dict_handle()/decode_all_with_dict_bytes()"
         );
         assert_eq!(
             FrameDecoderError::DictAlreadyRegistered { dict_id: 0xABCD }.to_string(),

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -6,7 +6,7 @@
 
 use super::frame;
 use crate::decoding;
-use crate::decoding::dictionary::Dictionary;
+use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
 use crate::decoding::errors::FrameDecoderError;
 use crate::decoding::scratch::DecoderScratch;
 use crate::io::{Error, Read, Write};
@@ -71,7 +71,7 @@ use crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE;
 /// ```
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
-    dicts: BTreeMap<u32, Dictionary>,
+    dicts: BTreeMap<u32, DictionaryHandle>,
 }
 
 struct FrameDecoderState {
@@ -194,7 +194,7 @@ impl FrameDecoder {
                 .dicts
                 .get(&dict_id)
                 .ok_or(err::DictNotProvided { dict_id })?;
-            state.decoder_scratch.init_from_dict(dict);
+            state.decoder_scratch.init_from_dict(dict.as_ref());
             state.using_dict = Some(dict_id);
         }
         Ok(())
@@ -202,7 +202,12 @@ impl FrameDecoder {
 
     /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
-        self.dicts.insert(dict.id, dict);
+        self.add_dict_handle(dict.into_handle())
+    }
+
+    /// Add a pre-parsed dictionary handle for reuse across decoders.
+    pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
+        self.dicts.insert(dict.id(), dict);
         Ok(())
     }
 
@@ -216,7 +221,7 @@ impl FrameDecoder {
             .dicts
             .get(&dict_id)
             .ok_or(err::DictNotProvided { dict_id })?;
-        state.decoder_scratch.init_from_dict(dict);
+        state.decoder_scratch.init_from_dict(dict.as_ref());
         state.using_dict = Some(dict_id);
 
         Ok(())

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -239,7 +239,9 @@ impl FrameDecoder {
                     .ok_or(err::DictNotProvided { dict_id })?;
                 core::ptr::from_ref(dict)
             };
-            // Safe: dict lives in self-owned storage and outlives this call.
+            // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
+            // neither map is mutated before dereference. `state` is a separate field,
+            // and only `state.decoder_scratch` / `state.using_dict` are mutated.
             let dict = unsafe { &*dict_ptr };
             let state = self.state.as_mut().expect("state initialized");
             state.decoder_scratch.init_from_dict(dict);
@@ -312,7 +314,9 @@ impl FrameDecoder {
                 .ok_or(err::DictNotProvided { dict_id })?;
             core::ptr::from_ref(dict)
         };
-        // Safe: dict lives in self-owned storage and outlives this call.
+        // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
+        // neither map is mutated before dereference. `state` is a separate field,
+        // and only `state.decoder_scratch` / `state.using_dict` are mutated.
         let dict = unsafe { &*dict_ptr };
         let Some(state) = self.state.as_mut() else {
             return Err(err::NotYetInitialized);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -69,9 +69,23 @@ use crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE;
 ///     std::io::stdout().write_all(data).unwrap();
 /// }
 /// ```
+enum StoredDictionary {
+    Owned(Dictionary),
+    Shared(DictionaryHandle),
+}
+
+impl StoredDictionary {
+    fn as_dict(&self) -> &Dictionary {
+        match self {
+            StoredDictionary::Owned(dict) => dict,
+            StoredDictionary::Shared(handle) => handle.as_dict(),
+        }
+    }
+}
+
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
-    dicts: BTreeMap<u32, DictionaryHandle>,
+    dicts: BTreeMap<u32, StoredDictionary>,
 }
 
 struct FrameDecoderState {
@@ -203,7 +217,7 @@ impl FrameDecoder {
                 .dicts
                 .get(&dict_id)
                 .ok_or(err::DictNotProvided { dict_id })?;
-            state.decoder_scratch.init_from_dict(dict.as_ref());
+            state.decoder_scratch.init_from_dict(dict.as_dict());
             state.using_dict = Some(dict_id);
         }
         Ok(())
@@ -238,18 +252,21 @@ impl FrameDecoder {
 
     /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
-        self.add_dict_handle(dict.into_handle())
+        let dict_id = dict.id;
+        self.dicts.insert(dict_id, StoredDictionary::Owned(dict));
+        Ok(())
     }
 
     /// Parse and add a serialized dictionary blob.
     pub fn add_dict_from_bytes(&mut self, raw_dictionary: &[u8]) -> Result<(), FrameDecoderError> {
-        let dict = DictionaryHandle::decode_dict(raw_dictionary)?;
-        self.add_dict_handle(dict)
+        let dict = Dictionary::decode_dict(raw_dictionary)?;
+        self.add_dict(dict)
     }
 
     /// Add a pre-parsed dictionary handle for reuse across decoders.
     pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
-        self.dicts.insert(dict.id(), dict);
+        let dict_id = dict.id();
+        self.dicts.insert(dict_id, StoredDictionary::Shared(dict));
         Ok(())
     }
 
@@ -263,7 +280,7 @@ impl FrameDecoder {
             .dicts
             .get(&dict_id)
             .ok_or(err::DictNotProvided { dict_id })?;
-        state.decoder_scratch.init_from_dict(dict.as_ref());
+        state.decoder_scratch.init_from_dict(dict.as_dict());
         state.using_dict = Some(dict_id);
 
         Ok(())

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -190,6 +190,23 @@ impl FrameDecoder {
     }
 
     /// Initialize the decoder for a new frame using a pre-parsed dictionary handle.
+    ///
+    /// If the frame header has a dictionary ID, this validates it against
+    /// `dict.id()` and returns [`FrameDecoderError::DictIdMismatch`] on mismatch.
+    ///
+    /// If the header omits the optional dictionary ID, this still applies the
+    /// provided dictionary handle.
+    ///
+    /// # Warning
+    ///
+    /// This method always applies `dict` unless the frame header contains a
+    /// non-matching dictionary ID. Callers must only use this API when they
+    /// already know the frame was encoded with the provided dictionary, even if
+    /// the frame header omits the dictionary ID or encodes an explicit
+    /// dictionary ID of `0`.
+    ///
+    /// Passing a dictionary for a frame that was not encoded with it can
+    /// silently corrupt the decoded output.
     pub fn init_with_dict_handle(
         &mut self,
         source: impl Read,
@@ -672,6 +689,13 @@ impl FrameDecoder {
     ///
     /// This calls [`FrameDecoder::init_with_dict_handle`], and all bytes currently in the
     /// decoder will be lost.
+    ///
+    /// # Warning
+    ///
+    /// Each decoded frame is initialized with `dict`, even when a frame header
+    /// omits the optional dictionary ID. Callers must only use this API when
+    /// they already know the input frames were encoded with the provided
+    /// dictionary; otherwise decoded output can be silently corrupted.
     pub fn decode_all_with_dict_handle(
         &mut self,
         input: &[u8],

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -233,13 +233,13 @@ impl FrameDecoder {
                 self.state.as_mut().unwrap()
             }
         };
-        if let Some(dict_id) = state.frame_header.dictionary_id()
-            && dict_id != dict.id()
-        {
-            return Err(err::DictNotProvided { dict_id });
+        if let Some(dict_id) = state.frame_header.dictionary_id() {
+            if dict_id != dict.id() {
+                return Err(err::DictNotProvided { dict_id });
+            }
+            state.decoder_scratch.init_from_dict(dict.as_ref());
+            state.using_dict = Some(dict_id);
         }
-        state.decoder_scratch.init_from_dict(dict.as_ref());
-        state.using_dict = Some(dict.id());
         Ok(())
     }
 
@@ -578,7 +578,8 @@ impl FrameDecoder {
 
     /// Decode multiple frames into the output slice.
     ///
-    /// `input` must contain an exact number of frames.
+    /// `input` must contain an exact number of frames. Skippable frames are allowed and will be
+    /// skipped during decode.
     ///
     /// `output` must be large enough to hold the decompressed data. If you don't know
     /// how large the output will be, use [`FrameDecoder::decode_blocks`] instead.
@@ -596,7 +597,8 @@ impl FrameDecoder {
 
     /// Decode multiple frames into the output slice using a pre-parsed dictionary handle.
     ///
-    /// `input` must contain an exact number of frames.
+    /// `input` must contain an exact number of frames. Skippable frames are allowed and will be
+    /// skipped during decode.
     ///
     /// `output` must be large enough to hold the decompressed data. If you don't know
     /// how large the output will be, use [`FrameDecoder::decode_blocks`] instead.
@@ -711,5 +713,35 @@ impl Read for FrameDecoder {
         } else {
             state.decoder_scratch.buffer.read(target)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::{DictionaryHandle, FrameDecoder};
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec::Vec;
+
+    #[test]
+    fn reset_with_dict_handle_skips_when_no_dict_id() {
+        let payload = b"reset-without-dict-id";
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
+
+        let mut decoder = FrameDecoder::new();
+        decoder
+            .reset_with_dict_handle(compressed.as_slice(), &handle)
+            .expect("reset should succeed");
+        let state = decoder.state.as_ref().expect("state should be initialized");
+        assert!(state.frame_header.dictionary_id().is_none());
+        assert!(state.using_dict.is_none());
     }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -179,6 +179,18 @@ impl FrameDecoder {
         false
     }
 
+    #[cfg(target_has_atomic = "ptr")]
+    fn shared_dict(&self, dict_id: u32) -> Option<&Dictionary> {
+        self.shared_dicts
+            .get(&dict_id)
+            .map(DictionaryHandle::as_ref)
+    }
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    fn shared_dict(&self, _dict_id: u32) -> Option<&Dictionary> {
+        None
+    }
+
     /// init() will allocate all needed buffers if it is the first time this decoder is used
     /// else they just reset these buffers with not further allocations
     ///
@@ -219,15 +231,18 @@ impl FrameDecoder {
             }
         };
         if let Some(dict_id) = dict_id {
-            let dict = self
-                .owned_dicts
-                .get(&dict_id)
-                .or_else(|| {
-                    self.shared_dicts
-                        .get(&dict_id)
-                        .map(DictionaryHandle::as_ref)
-                })
-                .ok_or(err::DictNotProvided { dict_id })?;
+            let dict_ptr = {
+                let dict = self
+                    .owned_dicts
+                    .get(&dict_id)
+                    .or_else(|| self.shared_dict(dict_id))
+                    .ok_or(err::DictNotProvided { dict_id })?;
+                core::ptr::from_ref(dict)
+            };
+            // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
+            // neither map is mutated before dereference. `state` is a separate field,
+            // and only `state.decoder_scratch` / `state.using_dict` are mutated.
+            let dict = unsafe { &*dict_ptr };
             let state = self.state.as_mut().expect("state initialized");
             state.decoder_scratch.init_from_dict(dict);
             state.using_dict = Some(dict_id);
@@ -306,15 +321,18 @@ impl FrameDecoder {
         if self.state.is_none() {
             return Err(err::NotYetInitialized);
         }
-        let dict = self
-            .owned_dicts
-            .get(&dict_id)
-            .or_else(|| {
-                self.shared_dicts
-                    .get(&dict_id)
-                    .map(DictionaryHandle::as_ref)
-            })
-            .ok_or(err::DictNotProvided { dict_id })?;
+        let dict_ptr = {
+            let dict = self
+                .owned_dicts
+                .get(&dict_id)
+                .or_else(|| self.shared_dict(dict_id))
+                .ok_or(err::DictNotProvided { dict_id })?;
+            core::ptr::from_ref(dict)
+        };
+        // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
+        // neither map is mutated before dereference. `state` is a separate field,
+        // and only `state.decoder_scratch` / `state.using_dict` are mutated.
+        let dict = unsafe { &*dict_ptr };
         let state = self.state.as_mut().expect("state checked above");
         state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -179,18 +179,6 @@ impl FrameDecoder {
         false
     }
 
-    #[cfg(target_has_atomic = "ptr")]
-    fn shared_dict(&self, dict_id: u32) -> Option<&Dictionary> {
-        self.shared_dicts
-            .get(&dict_id)
-            .map(DictionaryHandle::as_ref)
-    }
-
-    #[cfg(not(target_has_atomic = "ptr"))]
-    fn shared_dict(&self, _dict_id: u32) -> Option<&Dictionary> {
-        None
-    }
-
     /// init() will allocate all needed buffers if it is the first time this decoder is used
     /// else they just reset these buffers with not further allocations
     ///
@@ -231,19 +219,23 @@ impl FrameDecoder {
             }
         };
         if let Some(dict_id) = dict_id {
-            let dict_ptr = {
-                let dict = self
-                    .owned_dicts
-                    .get(&dict_id)
-                    .or_else(|| self.shared_dict(dict_id))
-                    .ok_or(err::DictNotProvided { dict_id })?;
-                core::ptr::from_ref(dict)
-            };
-            // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
-            // neither map is mutated before dereference. `state` is a separate field,
-            // and only `state.decoder_scratch` / `state.using_dict` are mutated.
-            let dict = unsafe { &*dict_ptr };
             let state = self.state.as_mut().expect("state initialized");
+            let owned_dicts = &self.owned_dicts;
+            #[cfg(target_has_atomic = "ptr")]
+            let shared_dicts = &self.shared_dicts;
+            let dict = owned_dicts
+                .get(&dict_id)
+                .or_else(|| {
+                    #[cfg(target_has_atomic = "ptr")]
+                    {
+                        shared_dicts.get(&dict_id).map(DictionaryHandle::as_dict)
+                    }
+                    #[cfg(not(target_has_atomic = "ptr"))]
+                    {
+                        None
+                    }
+                })
+                .ok_or(err::DictNotProvided { dict_id })?;
             state.decoder_scratch.init_from_dict(dict);
             state.using_dict = Some(dict_id);
         }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -69,23 +69,10 @@ use crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE;
 ///     std::io::stdout().write_all(data).unwrap();
 /// }
 /// ```
-enum StoredDictionary {
-    Owned(Dictionary),
-    Shared(DictionaryHandle),
-}
-
-impl StoredDictionary {
-    fn as_dict(&self) -> &Dictionary {
-        match self {
-            StoredDictionary::Owned(dict) => dict,
-            StoredDictionary::Shared(handle) => handle.as_dict(),
-        }
-    }
-}
-
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
-    dicts: BTreeMap<u32, StoredDictionary>,
+    owned_dicts: BTreeMap<u32, Dictionary>,
+    shared_dicts: BTreeMap<u32, DictionaryHandle>,
 }
 
 struct FrameDecoderState {
@@ -171,7 +158,8 @@ impl FrameDecoder {
     pub fn new() -> FrameDecoder {
         FrameDecoder {
             state: None,
-            dicts: BTreeMap::new(),
+            owned_dicts: BTreeMap::new(),
+            shared_dicts: BTreeMap::new(),
         }
     }
 
@@ -214,10 +202,15 @@ impl FrameDecoder {
         };
         if let Some(dict_id) = state.frame_header.dictionary_id() {
             let dict = self
-                .dicts
+                .owned_dicts
                 .get(&dict_id)
+                .or_else(|| {
+                    self.shared_dicts
+                        .get(&dict_id)
+                        .map(|handle| handle.as_dict())
+                })
                 .ok_or(err::DictNotProvided { dict_id })?;
-            state.decoder_scratch.init_from_dict(dict.as_dict());
+            state.decoder_scratch.init_from_dict(dict);
             state.using_dict = Some(dict_id);
         }
         Ok(())
@@ -253,7 +246,7 @@ impl FrameDecoder {
     /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id;
-        self.dicts.insert(dict_id, StoredDictionary::Owned(dict));
+        self.owned_dicts.insert(dict_id, dict);
         Ok(())
     }
 
@@ -266,7 +259,7 @@ impl FrameDecoder {
     /// Add a pre-parsed dictionary handle for reuse across decoders.
     pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id();
-        self.dicts.insert(dict_id, StoredDictionary::Shared(dict));
+        self.shared_dicts.insert(dict_id, dict);
         Ok(())
     }
 
@@ -277,10 +270,15 @@ impl FrameDecoder {
         };
 
         let dict = self
-            .dicts
+            .owned_dicts
             .get(&dict_id)
+            .or_else(|| {
+                self.shared_dicts
+                    .get(&dict_id)
+                    .map(|handle| handle.as_dict())
+            })
             .ok_or(err::DictNotProvided { dict_id })?;
-        state.decoder_scratch.init_from_dict(dict.as_dict());
+        state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);
 
         Ok(())
@@ -590,40 +588,10 @@ impl FrameDecoder {
     /// Returns the number of bytes written to `output`.
     pub fn decode_all(
         &mut self,
-        mut input: &[u8],
-        mut output: &mut [u8],
+        input: &[u8],
+        output: &mut [u8],
     ) -> Result<usize, FrameDecoderError> {
-        let mut total_bytes_written = 0;
-        while !input.is_empty() {
-            match self.init(&mut input) {
-                Ok(_) => {}
-                Err(FrameDecoderError::ReadFrameHeaderError(
-                    crate::decoding::errors::ReadFrameHeaderError::SkipFrame { length, .. },
-                )) => {
-                    input = input
-                        .get(length as usize..)
-                        .ok_or(FrameDecoderError::FailedToSkipFrame)?;
-                    continue;
-                }
-                Err(e) => return Err(e),
-            };
-            loop {
-                self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
-                let bytes_written = self
-                    .read(output)
-                    .map_err(FrameDecoderError::FailedToDrainDecodebuffer)?;
-                output = &mut output[bytes_written..];
-                total_bytes_written += bytes_written;
-                if self.can_collect() != 0 {
-                    return Err(FrameDecoderError::TargetTooSmall);
-                }
-                if self.is_finished() {
-                    break;
-                }
-            }
-        }
-
-        Ok(total_bytes_written)
+        self.decode_all_impl(input, output, |this, src| this.init(src))
     }
 
     /// Decode multiple frames into the output slice using a pre-parsed dictionary handle.
@@ -637,13 +605,24 @@ impl FrameDecoder {
     /// decoder will be lost.
     pub fn decode_all_with_dict_handle(
         &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        dict: &DictionaryHandle,
+    ) -> Result<usize, FrameDecoderError> {
+        self.decode_all_impl(input, output, |this, src| {
+            this.init_with_dict_handle(src, dict)
+        })
+    }
+
+    fn decode_all_impl(
+        &mut self,
         mut input: &[u8],
         mut output: &mut [u8],
-        dict: &DictionaryHandle,
+        mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
     ) -> Result<usize, FrameDecoderError> {
         let mut total_bytes_written = 0;
         while !input.is_empty() {
-            match self.init_with_dict_handle(&mut input, dict) {
+            match init_frame(self, &mut input) {
                 Ok(_) => {}
                 Err(FrameDecoderError::ReadFrameHeaderError(
                     crate::decoding::errors::ReadFrameHeaderError::SkipFrame { length, .. },

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -251,6 +251,11 @@ impl FrameDecoder {
     }
 
     /// Reset this decoder for a new frame using a pre-parsed dictionary handle.
+    ///
+    /// If the frame header has a dictionary ID, this validates it against
+    /// `dict.id()` and returns [`FrameDecoderError::DictIdMismatch`] on mismatch.
+    /// If the header omits the optional dictionary ID, this still applies the
+    /// provided dictionary handle.
     pub fn reset_with_dict_handle(
         &mut self,
         source: impl Read,
@@ -318,22 +323,24 @@ impl FrameDecoder {
 
     pub fn force_dict(&mut self, dict_id: u32) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
-        if self.state.is_none() {
-            return Err(err::NotYetInitialized);
-        }
-        let dict_ptr = {
-            let dict = self
-                .owned_dicts
-                .get(&dict_id)
-                .or_else(|| self.shared_dict(dict_id))
-                .ok_or(err::DictNotProvided { dict_id })?;
-            core::ptr::from_ref(dict)
-        };
-        // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
-        // neither map is mutated before dereference. `state` is a separate field,
-        // and only `state.decoder_scratch` / `state.using_dict` are mutated.
-        let dict = unsafe { &*dict_ptr };
-        let state = self.state.as_mut().expect("state checked above");
+        let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
+        let owned_dicts = &self.owned_dicts;
+        #[cfg(target_has_atomic = "ptr")]
+        let shared_dicts = &self.shared_dicts;
+
+        let dict = owned_dicts
+            .get(&dict_id)
+            .or_else(|| {
+                #[cfg(target_has_atomic = "ptr")]
+                {
+                    shared_dicts.get(&dict_id).map(DictionaryHandle::as_ref)
+                }
+                #[cfg(not(target_has_atomic = "ptr"))]
+                {
+                    None
+                }
+            })
+            .ok_or(err::DictNotProvided { dict_id })?;
         state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -297,6 +297,7 @@ impl FrameDecoder {
         dict: &DictionaryHandle,
     ) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        Self::validate_registered_dictionary(dict.as_dict())?;
         let state = match &mut self.state {
             Some(s) => {
                 s.reset(source)?;

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -267,16 +267,16 @@ impl FrameDecoder {
                 self.state.as_mut().unwrap()
             }
         };
-        if let Some(dict_id) = state.frame_header.dictionary_id() {
-            if dict_id != dict.id() {
-                return Err(err::DictIdMismatch {
-                    expected: dict_id,
-                    provided: dict.id(),
-                });
-            }
-            state.decoder_scratch.init_from_dict(dict.as_ref());
-            state.using_dict = Some(dict_id);
+        if let Some(dict_id) = state.frame_header.dictionary_id()
+            && dict_id != dict.id()
+        {
+            return Err(err::DictIdMismatch {
+                expected: dict_id,
+                provided: dict.id(),
+            });
         }
+        state.decoder_scratch.init_from_dict(dict.as_ref());
+        state.using_dict = Some(dict.id());
         Ok(())
     }
 
@@ -772,7 +772,7 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn reset_with_dict_handle_skips_when_no_dict_id() {
+    fn reset_with_dict_handle_applies_dict_when_no_dict_id() {
         let payload = b"reset-without-dict-id";
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
         compressor.set_source(payload.as_slice());
@@ -789,6 +789,6 @@ mod tests {
             .expect("reset should succeed");
         let state = decoder.state.as_ref().expect("state should be initialized");
         assert!(state.frame_header.dictionary_id().is_none());
-        assert!(state.using_dict.is_none());
+        assert_eq!(state.using_dict, Some(handle.id()));
     }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -246,8 +246,20 @@ impl FrameDecoder {
     ///
     /// If the frame header has a dictionary ID, this validates it against
     /// `dict.id()` and returns [`FrameDecoderError::DictIdMismatch`] on mismatch.
+    ///
     /// If the header omits the optional dictionary ID, this still applies the
     /// provided dictionary handle.
+    ///
+    /// # Warning
+    ///
+    /// This method always applies `dict` unless the frame header contains a
+    /// non-matching dictionary ID. Callers must only use this API when they
+    /// already know the frame was encoded with the provided dictionary, even if
+    /// the frame header omits the dictionary ID or encodes an explicit
+    /// dictionary ID of `0`.
+    ///
+    /// Passing a dictionary for a frame that was not encoded with it can
+    /// silently corrupt the decoded output.
     pub fn reset_with_dict_handle(
         &mut self,
         source: impl Read,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -354,7 +354,7 @@ impl FrameDecoder {
             .or_else(|| {
                 #[cfg(target_has_atomic = "ptr")]
                 {
-                    shared_dicts.get(&dict_id).map(DictionaryHandle::as_ref)
+                    shared_dicts.get(&dict_id).map(DictionaryHandle::as_dict)
                 }
                 #[cfg(not(target_has_atomic = "ptr"))]
                 {

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -179,6 +179,20 @@ impl FrameDecoder {
         false
     }
 
+    fn validate_registered_dictionary(dict: &Dictionary) -> Result<(), FrameDecoderError> {
+        use crate::decoding::errors::DictionaryDecodeError as dict_err;
+
+        if dict.id == 0 {
+            return Err(FrameDecoderError::from(dict_err::ZeroDictionaryId));
+        }
+        if let Some(index) = dict.offset_hist.iter().position(|&rep| rep == 0) {
+            return Err(FrameDecoderError::from(
+                dict_err::ZeroRepeatOffsetInDictionary { index: index as u8 },
+            ));
+        }
+        Ok(())
+    }
+
     /// init() will allocate all needed buffers if it is the first time this decoder is used
     /// else they just reset these buffers with not further allocations
     ///
@@ -311,6 +325,7 @@ impl FrameDecoder {
     /// Returns [`FrameDecoderError::DictAlreadyRegistered`] if the ID is already
     /// registered (either as owned or shared).
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
+        Self::validate_registered_dictionary(&dict)?;
         let dict_id = dict.id;
         if self.owned_dicts.contains_key(&dict_id) || self.shared_dict_exists(dict_id) {
             return Err(FrameDecoderError::DictAlreadyRegistered { dict_id });
@@ -334,6 +349,7 @@ impl FrameDecoder {
     /// registered (either as owned or shared).
     #[cfg(target_has_atomic = "ptr")]
     pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
+        Self::validate_registered_dictionary(dict.as_dict())?;
         let dict_id = dict.id();
         if self.owned_dicts.contains_key(&dict_id) || self.shared_dicts.contains_key(&dict_id) {
             return Err(FrameDecoderError::DictAlreadyRegistered { dict_id });
@@ -747,6 +763,13 @@ impl FrameDecoder {
     }
 
     /// Decode multiple frames into the output slice using a serialized dictionary.
+    ///
+    /// # Warning
+    ///
+    /// Each decoded frame is initialized with the parsed dictionary, even when a
+    /// frame header omits the optional dictionary ID. Callers must only use this
+    /// API when they already know the input frames were encoded with that
+    /// dictionary; otherwise decoded output can be silently corrupted.
     pub fn decode_all_with_dict_bytes(
         &mut self,
         input: &[u8],

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -269,7 +269,10 @@ impl FrameDecoder {
         };
         if let Some(dict_id) = state.frame_header.dictionary_id() {
             if dict_id != dict.id() {
-                return Err(err::DictNotProvided { dict_id });
+                return Err(err::DictIdMismatch {
+                    expected: dict_id,
+                    provided: dict.id(),
+                });
             }
             state.decoder_scratch.init_from_dict(dict.as_ref());
             state.using_dict = Some(dict_id);
@@ -306,6 +309,9 @@ impl FrameDecoder {
 
     pub fn force_dict(&mut self, dict_id: u32) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        if self.state.is_none() {
+            return Err(err::NotYetInitialized);
+        }
         let dict_ptr = {
             let dict = self
                 .owned_dicts
@@ -318,9 +324,7 @@ impl FrameDecoder {
         // neither map is mutated before dereference. `state` is a separate field,
         // and only `state.decoder_scratch` / `state.using_dict` are mutated.
         let dict = unsafe { &*dict_ptr };
-        let Some(state) = self.state.as_mut() else {
-            return Err(err::NotYetInitialized);
-        };
+        let state = self.state.as_mut().expect("state checked above");
         state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -316,7 +316,7 @@ impl FrameDecoder {
                 provided: dict.id(),
             });
         }
-        state.decoder_scratch.init_from_dict(dict.as_ref());
+        state.decoder_scratch.init_from_dict(dict.as_dict());
         state.using_dict = Some(dict.id());
         Ok(())
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -171,6 +171,15 @@ impl FrameDecoder {
         self.reset(source)
     }
 
+    /// Initialize the decoder for a new frame using a pre-parsed dictionary handle.
+    pub fn init_with_dict_handle(
+        &mut self,
+        source: impl Read,
+        dict: &DictionaryHandle,
+    ) -> Result<(), FrameDecoderError> {
+        self.reset_with_dict_handle(source, dict)
+    }
+
     /// reset() will allocate all needed buffers if it is the first time this decoder is used
     /// else they just reset these buffers with not further allocations
     ///
@@ -200,9 +209,42 @@ impl FrameDecoder {
         Ok(())
     }
 
+    /// Reset this decoder for a new frame using a pre-parsed dictionary handle.
+    pub fn reset_with_dict_handle(
+        &mut self,
+        source: impl Read,
+        dict: &DictionaryHandle,
+    ) -> Result<(), FrameDecoderError> {
+        use FrameDecoderError as err;
+        let state = match &mut self.state {
+            Some(s) => {
+                s.reset(source)?;
+                s
+            }
+            None => {
+                self.state = Some(FrameDecoderState::new(source)?);
+                self.state.as_mut().unwrap()
+            }
+        };
+        if let Some(dict_id) = state.frame_header.dictionary_id()
+            && dict_id != dict.id()
+        {
+            return Err(err::DictNotProvided { dict_id });
+        }
+        state.decoder_scratch.init_from_dict(dict.as_ref());
+        state.using_dict = Some(dict.id());
+        Ok(())
+    }
+
     /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
         self.add_dict_handle(dict.into_handle())
+    }
+
+    /// Parse and add a serialized dictionary blob.
+    pub fn add_dict_from_bytes(&mut self, raw_dictionary: &[u8]) -> Result<(), FrameDecoderError> {
+        let dict = DictionaryHandle::decode_dict(raw_dictionary)?;
+        self.add_dict_handle(dict)
     }
 
     /// Add a pre-parsed dictionary handle for reuse across decoders.
@@ -565,6 +607,65 @@ impl FrameDecoder {
         }
 
         Ok(total_bytes_written)
+    }
+
+    /// Decode multiple frames into the output slice using a pre-parsed dictionary handle.
+    ///
+    /// `input` must contain an exact number of frames.
+    ///
+    /// `output` must be large enough to hold the decompressed data. If you don't know
+    /// how large the output will be, use [`FrameDecoder::decode_blocks`] instead.
+    ///
+    /// This calls [`FrameDecoder::init_with_dict_handle`], and all bytes currently in the
+    /// decoder will be lost.
+    pub fn decode_all_with_dict_handle(
+        &mut self,
+        mut input: &[u8],
+        mut output: &mut [u8],
+        dict: &DictionaryHandle,
+    ) -> Result<usize, FrameDecoderError> {
+        let mut total_bytes_written = 0;
+        while !input.is_empty() {
+            match self.init_with_dict_handle(&mut input, dict) {
+                Ok(_) => {}
+                Err(FrameDecoderError::ReadFrameHeaderError(
+                    crate::decoding::errors::ReadFrameHeaderError::SkipFrame { length, .. },
+                )) => {
+                    input = input
+                        .get(length as usize..)
+                        .ok_or(FrameDecoderError::FailedToSkipFrame)?;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+            loop {
+                self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
+                let bytes_written = self
+                    .read(output)
+                    .map_err(FrameDecoderError::FailedToDrainDecodebuffer)?;
+                output = &mut output[bytes_written..];
+                total_bytes_written += bytes_written;
+                if self.can_collect() != 0 {
+                    return Err(FrameDecoderError::TargetTooSmall);
+                }
+                if self.is_finished() {
+                    break;
+                }
+            }
+        }
+
+        Ok(total_bytes_written)
+    }
+
+    /// Decode multiple frames into the output slice using a serialized dictionary.
+    pub fn decode_all_with_dict_bytes(
+        &mut self,
+        input: &[u8],
+        output: &mut [u8],
+        raw_dictionary: &[u8],
+    ) -> Result<usize, FrameDecoderError> {
+        let dict = DictionaryHandle::decode_dict(raw_dictionary)?;
+        self.decode_all_with_dict_handle(input, output, &dict)
     }
 
     /// Decode multiple frames into the extra capacity of the output vector.

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -72,7 +72,10 @@ use crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE;
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
     owned_dicts: BTreeMap<u32, Dictionary>,
+    #[cfg(target_has_atomic = "ptr")]
     shared_dicts: BTreeMap<u32, DictionaryHandle>,
+    #[cfg(not(target_has_atomic = "ptr"))]
+    shared_dicts: (),
 }
 
 struct FrameDecoderState {
@@ -159,8 +162,33 @@ impl FrameDecoder {
         FrameDecoder {
             state: None,
             owned_dicts: BTreeMap::new(),
+            #[cfg(target_has_atomic = "ptr")]
             shared_dicts: BTreeMap::new(),
+            #[cfg(not(target_has_atomic = "ptr"))]
+            shared_dicts: (),
         }
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    fn shared_dict(&self, dict_id: u32) -> Option<&Dictionary> {
+        self.shared_dicts
+            .get(&dict_id)
+            .map(|handle| handle.as_dict())
+    }
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    fn shared_dict(&self, _dict_id: u32) -> Option<&Dictionary> {
+        None
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    fn shared_dict_exists(&self, dict_id: u32) -> bool {
+        self.shared_dicts.contains_key(&dict_id)
+    }
+
+    #[cfg(not(target_has_atomic = "ptr"))]
+    fn shared_dict_exists(&self, _dict_id: u32) -> bool {
+        false
     }
 
     /// init() will allocate all needed buffers if it is the first time this decoder is used
@@ -190,26 +218,30 @@ impl FrameDecoder {
     /// equivalent to init()
     pub fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
-        let state = match &mut self.state {
+        let dict_id = match &mut self.state {
             Some(s) => {
                 s.reset(source)?;
-                s
+                s.frame_header.dictionary_id()
             }
             None => {
                 self.state = Some(FrameDecoderState::new(source)?);
-                self.state.as_mut().unwrap()
+                self.state
+                    .as_ref()
+                    .and_then(|state| state.frame_header.dictionary_id())
             }
         };
-        if let Some(dict_id) = state.frame_header.dictionary_id() {
-            let dict = self
-                .owned_dicts
-                .get(&dict_id)
-                .or_else(|| {
-                    self.shared_dicts
-                        .get(&dict_id)
-                        .map(|handle| handle.as_dict())
-                })
-                .ok_or(err::DictNotProvided { dict_id })?;
+        if let Some(dict_id) = dict_id {
+            let dict_ptr = {
+                let dict = self
+                    .owned_dicts
+                    .get(&dict_id)
+                    .or_else(|| self.shared_dict(dict_id))
+                    .ok_or(err::DictNotProvided { dict_id })?;
+                std::ptr::from_ref(dict)
+            };
+            // Safe: dict lives in self-owned storage and outlives this call.
+            let dict = unsafe { &*dict_ptr };
+            let state = self.state.as_mut().expect("state initialized");
             state.decoder_scratch.init_from_dict(dict);
             state.using_dict = Some(dict_id);
         }
@@ -246,6 +278,9 @@ impl FrameDecoder {
     /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id;
+        if self.owned_dicts.contains_key(&dict_id) || self.shared_dict_exists(dict_id) {
+            return Err(FrameDecoderError::DictAlreadyRegistered { dict_id });
+        }
         self.owned_dicts.insert(dict_id, dict);
         Ok(())
     }
@@ -257,27 +292,31 @@ impl FrameDecoder {
     }
 
     /// Add a pre-parsed dictionary handle for reuse across decoders.
+    #[cfg(target_has_atomic = "ptr")]
     pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id();
+        if self.owned_dicts.contains_key(&dict_id) || self.shared_dicts.contains_key(&dict_id) {
+            return Err(FrameDecoderError::DictAlreadyRegistered { dict_id });
+        }
         self.shared_dicts.insert(dict_id, dict);
         Ok(())
     }
 
     pub fn force_dict(&mut self, dict_id: u32) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        let dict_ptr = {
+            let dict = self
+                .owned_dicts
+                .get(&dict_id)
+                .or_else(|| self.shared_dict(dict_id))
+                .ok_or(err::DictNotProvided { dict_id })?;
+            std::ptr::from_ref(dict)
+        };
+        // Safe: dict lives in self-owned storage and outlives this call.
+        let dict = unsafe { &*dict_ptr };
         let Some(state) = self.state.as_mut() else {
             return Err(err::NotYetInitialized);
         };
-
-        let dict = self
-            .owned_dicts
-            .get(&dict_id)
-            .or_else(|| {
-                self.shared_dicts
-                    .get(&dict_id)
-                    .map(|handle| handle.as_dict())
-            })
-            .ok_or(err::DictNotProvided { dict_id })?;
         state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -237,7 +237,7 @@ impl FrameDecoder {
                     .get(&dict_id)
                     .or_else(|| self.shared_dict(dict_id))
                     .ok_or(err::DictNotProvided { dict_id })?;
-                std::ptr::from_ref(dict)
+                core::ptr::from_ref(dict)
             };
             // Safe: dict lives in self-owned storage and outlives this call.
             let dict = unsafe { &*dict_ptr };
@@ -310,7 +310,7 @@ impl FrameDecoder {
                 .get(&dict_id)
                 .or_else(|| self.shared_dict(dict_id))
                 .ok_or(err::DictNotProvided { dict_id })?;
-            std::ptr::from_ref(dict)
+            core::ptr::from_ref(dict)
         };
         // Safe: dict lives in self-owned storage and outlives this call.
         let dict = unsafe { &*dict_ptr };

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -170,18 +170,6 @@ impl FrameDecoder {
     }
 
     #[cfg(target_has_atomic = "ptr")]
-    fn shared_dict(&self, dict_id: u32) -> Option<&Dictionary> {
-        self.shared_dicts
-            .get(&dict_id)
-            .map(|handle| handle.as_dict())
-    }
-
-    #[cfg(not(target_has_atomic = "ptr"))]
-    fn shared_dict(&self, _dict_id: u32) -> Option<&Dictionary> {
-        None
-    }
-
-    #[cfg(target_has_atomic = "ptr")]
     fn shared_dict_exists(&self, dict_id: u32) -> bool {
         self.shared_dicts.contains_key(&dict_id)
     }
@@ -231,18 +219,15 @@ impl FrameDecoder {
             }
         };
         if let Some(dict_id) = dict_id {
-            let dict_ptr = {
-                let dict = self
-                    .owned_dicts
-                    .get(&dict_id)
-                    .or_else(|| self.shared_dict(dict_id))
-                    .ok_or(err::DictNotProvided { dict_id })?;
-                core::ptr::from_ref(dict)
-            };
-            // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
-            // neither map is mutated before dereference. `state` is a separate field,
-            // and only `state.decoder_scratch` / `state.using_dict` are mutated.
-            let dict = unsafe { &*dict_ptr };
+            let dict = self
+                .owned_dicts
+                .get(&dict_id)
+                .or_else(|| {
+                    self.shared_dicts
+                        .get(&dict_id)
+                        .map(DictionaryHandle::as_ref)
+                })
+                .ok_or(err::DictNotProvided { dict_id })?;
             let state = self.state.as_mut().expect("state initialized");
             state.decoder_scratch.init_from_dict(dict);
             state.using_dict = Some(dict_id);
@@ -321,18 +306,15 @@ impl FrameDecoder {
         if self.state.is_none() {
             return Err(err::NotYetInitialized);
         }
-        let dict_ptr = {
-            let dict = self
-                .owned_dicts
-                .get(&dict_id)
-                .or_else(|| self.shared_dict(dict_id))
-                .ok_or(err::DictNotProvided { dict_id })?;
-            core::ptr::from_ref(dict)
-        };
-        // SAFETY: `dict_ptr` comes from `owned_dicts`/`shared_dict(dict_id)` and
-        // neither map is mutated before dereference. `state` is a separate field,
-        // and only `state.decoder_scratch` / `state.using_dict` are mutated.
-        let dict = unsafe { &*dict_ptr };
+        let dict = self
+            .owned_dicts
+            .get(&dict_id)
+            .or_else(|| {
+                self.shared_dicts
+                    .get(&dict_id)
+                    .map(DictionaryHandle::as_ref)
+            })
+            .ok_or(err::DictNotProvided { dict_id })?;
         let state = self.state.as_mut().expect("state checked above");
         state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict_id);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -280,7 +280,10 @@ impl FrameDecoder {
         Ok(())
     }
 
-    /// Add a dict to the FrameDecoder that can be used when needed. The FrameDecoder uses the appropriate one dynamically
+    /// Add a dictionary that can be selected dynamically by frame dictionary ID.
+    ///
+    /// Returns [`FrameDecoderError::DictAlreadyRegistered`] if the ID is already
+    /// registered (either as owned or shared).
     pub fn add_dict(&mut self, dict: Dictionary) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id;
         if self.owned_dicts.contains_key(&dict_id) || self.shared_dict_exists(dict_id) {
@@ -297,6 +300,12 @@ impl FrameDecoder {
     }
 
     /// Add a pre-parsed dictionary handle for reuse across decoders.
+    ///
+    /// This API is available on targets with pointer-width atomics
+    /// (`target_has_atomic = "ptr"`).
+    ///
+    /// Returns [`FrameDecoderError::DictAlreadyRegistered`] if the ID is already
+    /// registered (either as owned or shared).
     #[cfg(target_has_atomic = "ptr")]
     pub fn add_dict_handle(&mut self, dict: DictionaryHandle) -> Result<(), FrameDecoderError> {
         let dict_id = dict.id();

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -1,4 +1,6 @@
-//! Structures and utilities used for decoding zstd formatted data
+//! Structures and utilities used for decoding zstd formatted data.
+//!
+//! Use [`DictionaryHandle`] for pre-parsed dictionary reuse across repeated decode paths.
 
 pub mod errors;
 mod frame_decoder;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -4,7 +4,7 @@ pub mod errors;
 mod frame_decoder;
 mod streaming_decoder;
 
-pub use dictionary::Dictionary;
+pub use dictionary::{Dictionary, DictionaryHandle};
 pub use frame_decoder::{BlockDecodingStrategy, FrameDecoder};
 pub use streaming_decoder::StreamingDecoder;
 

--- a/zstd/src/decoding/streaming_decoder.rs
+++ b/zstd/src/decoding/streaming_decoder.rs
@@ -67,6 +67,14 @@ impl<READ: Read> StreamingDecoder<READ, FrameDecoder> {
     }
 
     /// Create a streaming decoder using a pre-parsed dictionary handle.
+    ///
+    /// # Warning
+    ///
+    /// This constructor initializes the underlying [`FrameDecoder`] with
+    /// `dict`, even if a frame header omits the optional dictionary ID.
+    /// Callers must only use it when they already know the stream was encoded
+    /// with this dictionary; otherwise decoded output can be silently
+    /// corrupted.
     pub fn new_with_dictionary_handle(
         mut source: READ,
         dict: &DictionaryHandle,
@@ -77,6 +85,13 @@ impl<READ: Read> StreamingDecoder<READ, FrameDecoder> {
     }
 
     /// Create a streaming decoder using a serialized dictionary blob.
+    ///
+    /// # Warning
+    ///
+    /// This API forwards to [`StreamingDecoder::new_with_dictionary_handle`]
+    /// and therefore applies the decoded dictionary to frames whose headers may
+    /// omit the optional dictionary ID. Only use it when the stream is known to
+    /// be encoded with that dictionary.
     pub fn new_with_dictionary_bytes(
         source: READ,
         raw_dictionary: &[u8],

--- a/zstd/src/decoding/streaming_decoder.rs
+++ b/zstd/src/decoding/streaming_decoder.rs
@@ -3,7 +3,7 @@
 use core::borrow::BorrowMut;
 
 use crate::decoding::errors::FrameDecoderError;
-use crate::decoding::{BlockDecodingStrategy, FrameDecoder};
+use crate::decoding::{BlockDecodingStrategy, DictionaryHandle, FrameDecoder};
 #[cfg(not(feature = "std"))]
 use crate::io::ErrorKind;
 use crate::io::{Error, Read};
@@ -64,6 +64,25 @@ impl<READ: Read> StreamingDecoder<READ, FrameDecoder> {
         let mut decoder = FrameDecoder::new();
         decoder.init(&mut source)?;
         Ok(StreamingDecoder { decoder, source })
+    }
+
+    /// Create a streaming decoder using a pre-parsed dictionary handle.
+    pub fn new_with_dictionary_handle(
+        mut source: READ,
+        dict: &DictionaryHandle,
+    ) -> Result<StreamingDecoder<READ, FrameDecoder>, FrameDecoderError> {
+        let mut decoder = FrameDecoder::new();
+        decoder.init_with_dict_handle(&mut source, dict)?;
+        Ok(StreamingDecoder { decoder, source })
+    }
+
+    /// Create a streaming decoder using a serialized dictionary blob.
+    pub fn new_with_dictionary_bytes(
+        source: READ,
+        raw_dictionary: &[u8],
+    ) -> Result<StreamingDecoder<READ, FrameDecoder>, FrameDecoderError> {
+        let dict = DictionaryHandle::decode_dict(raw_dictionary)?;
+        Self::new_with_dictionary_handle(source, &dict)
     }
 }
 

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -368,6 +368,59 @@ fn test_decode_all_with_dict_helpers() {
     assert_eq!(streamed, original);
 }
 
+#[test]
+fn test_add_dict_from_bytes_allows_decode_all() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use alloc::vec;
+    use std::fs;
+
+    let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
+    let (compressed, original) = load_sample_dict_frame();
+
+    let mut output = vec![0u8; original.len()];
+    let mut decoder = FrameDecoder::new();
+    decoder
+        .add_dict_from_bytes(&dict_raw)
+        .expect("dict bytes should parse");
+    decoder
+        .decode_all(compressed.as_slice(), &mut output)
+        .expect("decode_all should succeed");
+    assert_eq!(output, original);
+}
+
+#[test]
+fn test_reset_with_dict_handle_rejects_mismatched_id() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::decoding::errors::FrameDecoderError;
+    use alloc::vec;
+    use std::fs;
+
+    let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
+    let expected_dict_id = DictionaryHandle::decode_dict(&dict_raw)
+        .expect("dictionary should parse")
+        .id();
+    let mismatched_id = if expected_dict_id == u32::MAX {
+        expected_dict_id - 1
+    } else {
+        expected_dict_id + 1
+    };
+    let mismatched = Dictionary::from_raw_content(mismatched_id, vec![1u8])
+        .expect("mismatched dictionary should build");
+    let handle = DictionaryHandle::from_dictionary(mismatched);
+
+    let (compressed, _original) = load_sample_dict_frame();
+    let mut decoder = FrameDecoder::new();
+    let result = decoder.reset_with_dict_handle(compressed.as_slice(), &handle);
+
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictNotProvided { dict_id }) if dict_id == expected_dict_id
+    ));
+}
+
 #[cfg(test)]
 fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
     extern crate std;
@@ -383,26 +436,30 @@ fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
         Ok(dir_entry) => dir_entry.path().to_string_lossy().to_string(),
     });
 
-    let file_path = files
+    let (file_path, compressed) = files
         .into_iter()
         .filter_map(Result::ok)
         .map(|entry| entry.path())
-        .find(|path| {
-            path.extension()
+        .find_map(|path| {
+            let is_zst = path
+                .extension()
                 .and_then(|ext| ext.to_str())
                 .map(|ext| ext == "zst")
-                .unwrap_or(false)
-        })
-        .expect("expected at least one .zst file in dict_tests/files");
+                .unwrap_or(false);
+            if !is_zst {
+                return None;
+            }
 
-    let compressed = fs::read(&file_path).expect("compressed data should load");
-    let mut header_src = compressed.as_slice();
-    let (header, _) = crate::decoding::frame::read_frame_header(&mut header_src)
-        .expect("sample frame header should parse");
-    assert!(
-        header.dictionary_id().is_some(),
-        "sample fixture must require a dictionary"
-    );
+            let compressed = fs::read(&path).ok()?;
+            let mut header_src = compressed.as_slice();
+            let (header, _) = crate::decoding::frame::read_frame_header(&mut header_src).ok()?;
+            if header.dictionary_id().is_some() {
+                Some((path, compressed))
+            } else {
+                None
+            }
+        })
+        .expect("expected at least one dictionary-backed .zst file in dict_tests/files");
     let original_path = file_path
         .to_str()
         .expect("dict test path should be utf-8")

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -343,8 +343,8 @@ fn test_decode_all_with_dict_helpers() {
     use std::io::Read;
 
     let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
-    let (compressed, original) = load_sample_dict_frame();
     let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
+    let (compressed, original) = load_sample_dict_frame(handle.id());
 
     let mut output = vec![0u8; original.len()];
     let mut decoder = FrameDecoder::new();
@@ -385,7 +385,10 @@ fn test_add_dict_from_bytes_allows_decode_all() {
     use std::fs;
 
     let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
-    let (compressed, original) = load_sample_dict_frame();
+    let expected_dict_id = Dictionary::decode_dict(&dict_raw)
+        .expect("dictionary should parse")
+        .id;
+    let (compressed, original) = load_sample_dict_frame(expected_dict_id);
 
     let mut output = vec![0u8; original.len()];
     let mut decoder = FrameDecoder::new();
@@ -455,7 +458,7 @@ fn test_reset_with_dict_handle_rejects_mismatched_id() {
         .expect("mismatched dictionary should build");
     let handle = DictionaryHandle::from_dictionary(mismatched);
 
-    let (compressed, _original) = load_sample_dict_frame();
+    let (compressed, _original) = load_sample_dict_frame(expected_dict_id);
     let mut decoder = FrameDecoder::new();
     let result = decoder.reset_with_dict_handle(compressed.as_slice(), &handle);
 
@@ -484,9 +487,9 @@ fn test_force_dict_reports_missing_dict_after_initialization() {
     use crate::decoding::errors::FrameDecoderError;
     use std::fs;
 
-    let (compressed, _original) = load_sample_dict_frame();
     let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
     let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
+    let (compressed, _original) = load_sample_dict_frame(handle.id());
     let mut decoder = FrameDecoder::new();
     decoder
         .reset_with_dict_handle(compressed.as_slice(), &handle)
@@ -512,7 +515,7 @@ fn test_force_dict_accepts_shared_handle_after_initialization() {
     let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
     let dict_id = handle.id();
 
-    let (compressed, _original) = load_sample_dict_frame();
+    let (compressed, _original) = load_sample_dict_frame(dict_id);
     let mut decoder = FrameDecoder::new();
     decoder
         .add_dict_handle(handle)
@@ -526,7 +529,7 @@ fn test_force_dict_accepts_shared_handle_after_initialization() {
 }
 
 #[cfg(test)]
-fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
+fn load_sample_dict_frame(expected_dict_id: u32) -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
     extern crate std;
     use alloc::string::{String, ToString};
     use alloc::vec::Vec;
@@ -557,7 +560,7 @@ fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
             let compressed = fs::read(&path).ok()?;
             let mut header_src = compressed.as_slice();
             let (header, _) = crate::decoding::frame::read_frame_header(&mut header_src).ok()?;
-            if header.dictionary_id().is_some() {
+            if header.dictionary_id() == Some(expected_dict_id) {
                 Some((path, compressed))
             } else {
                 None

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -107,8 +107,8 @@ fn test_dict_decoding() {
     });
 
     let mut frame_dec = FrameDecoder::new();
-    let dict = crate::decoding::dictionary::Dictionary::decode_dict(&dict).unwrap();
-    frame_dec.add_dict(dict).unwrap();
+    let dict = crate::decoding::DictionaryHandle::decode_dict(&dict).unwrap();
+    frame_dec.add_dict_handle(dict).unwrap();
 
     for file in files {
         let f = file.unwrap();

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -303,7 +303,8 @@ fn test_decode_all_skips_skippable_frames() {
     input.extend_from_slice(&compressed);
 
     let mut output = vec![0u8; payload.len()];
-    let written = FrameDecoder::new()
+    let mut decoder = FrameDecoder::new();
+    let written = decoder
         .decode_all(input.as_slice(), &mut output)
         .expect("decode_all should succeed");
     assert_eq!(written, payload.len());
@@ -327,7 +328,8 @@ fn test_decode_all_reports_target_too_small() {
     compressor.compress();
 
     let mut output = vec![0u8; payload.len() - 1];
-    let result = FrameDecoder::new().decode_all(compressed.as_slice(), &mut output);
+    let mut decoder = FrameDecoder::new();
+    let result = decoder.decode_all(compressed.as_slice(), &mut output);
     assert!(matches!(result, Err(FrameDecoderError::TargetTooSmall)));
 }
 
@@ -345,14 +347,16 @@ fn test_decode_all_with_dict_helpers() {
     let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
 
     let mut output = vec![0u8; original.len()];
-    let written = FrameDecoder::new()
+    let mut decoder = FrameDecoder::new();
+    let written = decoder
         .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
         .expect("decode_all_with_dict_handle should succeed");
     assert_eq!(written, original.len());
     assert_eq!(output, original);
 
     let mut output = vec![0u8; original.len()];
-    let written = FrameDecoder::new()
+    let mut decoder = FrameDecoder::new();
+    let written = decoder
         .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, &dict_raw)
         .expect("decode_all_with_dict_bytes should succeed");
     assert_eq!(written, original.len());

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -90,6 +90,7 @@ fn test_dictionary_handle_from_dictionary_roundtrips() {
     assert_eq!(handle.as_dict().dict_content, vec![4]);
 }
 
+#[cfg(target_has_atomic = "ptr")]
 #[test]
 fn test_dict_decoding() {
     extern crate std;
@@ -374,6 +375,8 @@ fn test_decode_all_with_dict_helpers() {
 fn test_add_dict_from_bytes_allows_decode_all() {
     extern crate std;
     use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::Dictionary;
+    use crate::decoding::errors::FrameDecoderError;
     use alloc::vec;
     use std::fs;
 
@@ -385,10 +388,45 @@ fn test_add_dict_from_bytes_allows_decode_all() {
     decoder
         .add_dict_from_bytes(&dict_raw)
         .expect("dict bytes should parse");
-    decoder
+    let written = decoder
         .decode_all(compressed.as_slice(), &mut output)
         .expect("decode_all should succeed");
+    assert_eq!(written, original.len());
     assert_eq!(output, original);
+
+    let mut decoder = FrameDecoder::new();
+    let dict = Dictionary::from_raw_content(7, vec![1u8]).expect("dict should build");
+    decoder.add_dict(dict).expect("dict should insert");
+    let dict = Dictionary::from_raw_content(7, vec![2u8]).expect("dict should build");
+    let result = decoder.add_dict(dict);
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictAlreadyRegistered { dict_id }) if dict_id == 7
+    ));
+}
+
+#[cfg(target_has_atomic = "ptr")]
+#[test]
+fn test_add_dict_handle_rejects_existing_owned_id() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::decoding::errors::FrameDecoderError;
+    use alloc::vec;
+
+    let mut decoder = FrameDecoder::new();
+    let dict = Dictionary::from_raw_content(9, vec![1u8]).expect("dict should build");
+    decoder.add_dict(dict).expect("dict should insert");
+
+    let handle = DictionaryHandle::from_dictionary(
+        Dictionary::from_raw_content(9, vec![2u8]).expect("dict should build"),
+    );
+    let result = decoder.add_dict_handle(handle);
+
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictAlreadyRegistered { dict_id }) if dict_id == 9
+    ));
 }
 
 #[test]

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -82,12 +82,12 @@ fn test_dictionary_handle_from_dictionary_roundtrips() {
     let dict = Dictionary::from_raw_content(1, vec![1, 2, 3]).unwrap();
     let handle = DictionaryHandle::from_dictionary(dict);
     assert_eq!(handle.id(), 1);
-    assert_eq!(handle.as_dict().dict_content, vec![1, 2, 3]);
+    assert_eq!(handle.as_dict().dict_content.as_slice(), &[1, 2, 3]);
 
     let dict = Dictionary::from_raw_content(2, vec![4]).unwrap();
     let handle: DictionaryHandle = dict.into();
     assert_eq!(handle.id(), 2);
-    assert_eq!(handle.as_dict().dict_content, vec![4]);
+    assert_eq!(handle.as_dict().dict_content.as_slice(), &[4]);
 }
 
 #[cfg(target_has_atomic = "ptr")]
@@ -412,6 +412,36 @@ fn test_add_dict_from_bytes_allows_decode_all() {
     ));
 }
 
+#[test]
+fn test_add_dict_rejects_invalid_dictionary_invariants() {
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::Dictionary;
+    use crate::decoding::errors::{DictionaryDecodeError, FrameDecoderError};
+    use alloc::vec;
+
+    let mut decoder = FrameDecoder::new();
+
+    let mut zero_id = Dictionary::from_raw_content(7, vec![1u8]).expect("dict should build");
+    zero_id.id = 0;
+    let result = decoder.add_dict(zero_id);
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictionaryDecodeError(
+            DictionaryDecodeError::ZeroDictionaryId
+        ))
+    ));
+
+    let mut zero_rep = Dictionary::from_raw_content(8, vec![1u8]).expect("dict should build");
+    zero_rep.offset_hist[1] = 0;
+    let result = decoder.add_dict(zero_rep);
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictionaryDecodeError(
+            DictionaryDecodeError::ZeroRepeatOffsetInDictionary { index: 1 }
+        ))
+    ));
+}
+
 #[cfg(target_has_atomic = "ptr")]
 #[test]
 fn test_add_dict_handle_rejects_existing_owned_id() {
@@ -433,6 +463,37 @@ fn test_add_dict_handle_rejects_existing_owned_id() {
     assert!(matches!(
         result,
         Err(FrameDecoderError::DictAlreadyRegistered { dict_id }) if dict_id == 9
+    ));
+}
+
+#[cfg(target_has_atomic = "ptr")]
+#[test]
+fn test_add_dict_handle_rejects_invalid_dictionary_invariants() {
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::decoding::errors::{DictionaryDecodeError, FrameDecoderError};
+    use alloc::vec;
+
+    let mut decoder = FrameDecoder::new();
+
+    let mut zero_id = Dictionary::from_raw_content(10, vec![1u8]).expect("dict should build");
+    zero_id.id = 0;
+    let result = decoder.add_dict_handle(DictionaryHandle::from_dictionary(zero_id));
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictionaryDecodeError(
+            DictionaryDecodeError::ZeroDictionaryId
+        ))
+    ));
+
+    let mut zero_rep = Dictionary::from_raw_content(11, vec![1u8]).expect("dict should build");
+    zero_rep.offset_hist[2] = 0;
+    let result = decoder.add_dict_handle(DictionaryHandle::from_dictionary(zero_rep));
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictionaryDecodeError(
+            DictionaryDecodeError::ZeroRepeatOffsetInDictionary { index: 2 }
+        ))
     ));
 }
 

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -344,15 +344,17 @@ fn test_decode_all_with_dict_helpers() {
     let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
 
     let mut output = vec![0u8; original.len()];
-    FrameDecoder::new()
+    let written = FrameDecoder::new()
         .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
         .expect("decode_all_with_dict_handle should succeed");
+    assert_eq!(written, original.len());
     assert_eq!(output, original);
 
     let mut output = vec![0u8; original.len()];
-    FrameDecoder::new()
+    let written = FrameDecoder::new()
         .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, &dict_raw)
         .expect("decode_all_with_dict_bytes should succeed");
+    assert_eq!(written, original.len());
     assert_eq!(output, original);
 
     let mut decoder = StreamingDecoder::new_with_dictionary_handle(compressed.as_slice(), &handle)

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -476,6 +476,55 @@ fn test_force_dict_requires_initialization_before_dict_lookup() {
     assert!(matches!(result, Err(FrameDecoderError::NotYetInitialized)));
 }
 
+#[test]
+fn test_force_dict_reports_missing_dict_after_initialization() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::DictionaryHandle;
+    use crate::decoding::errors::FrameDecoderError;
+    use std::fs;
+
+    let (compressed, _original) = load_sample_dict_frame();
+    let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
+    let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
+    let mut decoder = FrameDecoder::new();
+    decoder
+        .reset_with_dict_handle(compressed.as_slice(), &handle)
+        .expect("reset_with_dict_handle should initialize decoder state");
+
+    let missing_id = 0xDEADBEEF;
+    let result = decoder.force_dict(missing_id);
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictNotProvided { dict_id }) if dict_id == missing_id
+    ));
+}
+
+#[cfg(target_has_atomic = "ptr")]
+#[test]
+fn test_force_dict_accepts_shared_handle_after_initialization() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::DictionaryHandle;
+    use std::fs;
+
+    let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
+    let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
+    let dict_id = handle.id();
+
+    let (compressed, _original) = load_sample_dict_frame();
+    let mut decoder = FrameDecoder::new();
+    decoder
+        .add_dict_handle(handle)
+        .expect("shared handle should register");
+    decoder
+        .reset(compressed.as_slice())
+        .expect("reset should initialize decoder state");
+    decoder
+        .force_dict(dict_id)
+        .expect("force_dict should accept registered shared handle");
+}
+
 #[cfg(test)]
 fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
     extern crate std;

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -457,8 +457,19 @@ fn test_reset_with_dict_handle_rejects_mismatched_id() {
 
     assert!(matches!(
         result,
-        Err(FrameDecoderError::DictNotProvided { dict_id }) if dict_id == expected_dict_id
+        Err(FrameDecoderError::DictIdMismatch { expected, provided })
+            if expected == expected_dict_id && provided == mismatched_id
     ));
+}
+
+#[test]
+fn test_force_dict_requires_initialization_before_dict_lookup() {
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::errors::FrameDecoderError;
+
+    let mut decoder = FrameDecoder::new();
+    let result = decoder.force_dict(0xABCD);
+    assert!(matches!(result, Err(FrameDecoderError::NotYetInitialized)));
 }
 
 #[cfg(test)]

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -75,6 +75,22 @@ fn test_dict_parsing() {
 }
 
 #[test]
+fn test_dictionary_handle_from_dictionary_roundtrips() {
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use alloc::vec;
+
+    let dict = Dictionary::from_raw_content(1, vec![1, 2, 3]).unwrap();
+    let handle = DictionaryHandle::from_dictionary(dict);
+    assert_eq!(handle.id(), 1);
+    assert_eq!(handle.as_dict().dict_content, vec![1, 2, 3]);
+
+    let dict = Dictionary::from_raw_content(2, vec![4]).unwrap();
+    let handle: DictionaryHandle = dict.into();
+    assert_eq!(handle.id(), 2);
+    assert_eq!(handle.as_dict().dict_content, vec![4]);
+}
+
+#[test]
 fn test_dict_decoding() {
     extern crate std;
     use crate::decoding::BlockDecodingStrategy;
@@ -259,6 +275,59 @@ fn test_dict_decoding() {
     }
 
     assert!(failed.is_empty());
+}
+
+#[test]
+fn test_decode_all_skips_skippable_frames() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    let payload = b"decode-all-skip-frame";
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor.set_source(payload.as_slice());
+    let mut compressed = Vec::new();
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+
+    let mut input = Vec::new();
+    let magic = 0x184D2A50u32.to_le_bytes();
+    let skippable_payload = [0xAA, 0xBB, 0xCC, 0xDD];
+    let length = (skippable_payload.len() as u32).to_le_bytes();
+    input.extend_from_slice(&magic);
+    input.extend_from_slice(&length);
+    input.extend_from_slice(&skippable_payload);
+    input.extend_from_slice(&compressed);
+
+    let mut output = vec![0u8; payload.len()];
+    let written = FrameDecoder::new()
+        .decode_all(input.as_slice(), &mut output)
+        .expect("decode_all should succeed");
+    assert_eq!(written, payload.len());
+    assert_eq!(output, payload);
+}
+
+#[test]
+fn test_decode_all_reports_target_too_small() {
+    extern crate std;
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::errors::FrameDecoderError;
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    let payload = b"decode-all-target-too-small";
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor.set_source(payload.as_slice());
+    let mut compressed = Vec::new();
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+
+    let mut output = vec![0u8; payload.len() - 1];
+    let result = FrameDecoder::new().decode_all(compressed.as_slice(), &mut output);
+    assert!(matches!(result, Err(FrameDecoderError::TargetTooSmall)));
 }
 
 #[test]

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -264,9 +264,9 @@ fn test_dict_decoding() {
 #[test]
 fn test_decode_all_with_dict_helpers() {
     extern crate std;
+    use crate::decoding::{DictionaryHandle, FrameDecoder, StreamingDecoder};
     use alloc::vec;
     use alloc::vec::Vec;
-    use crate::decoding::{DictionaryHandle, FrameDecoder, StreamingDecoder};
     use std::fs;
     use std::io::Read;
 
@@ -286,16 +286,14 @@ fn test_decode_all_with_dict_helpers() {
         .expect("decode_all_with_dict_bytes should succeed");
     assert_eq!(output, original);
 
-    let mut decoder =
-        StreamingDecoder::new_with_dictionary_handle(compressed.as_slice(), &handle)
-            .expect("streaming decoder should init");
+    let mut decoder = StreamingDecoder::new_with_dictionary_handle(compressed.as_slice(), &handle)
+        .expect("streaming decoder should init");
     let mut streamed = Vec::new();
     Read::read_to_end(&mut decoder, &mut streamed).expect("streaming read should succeed");
     assert_eq!(streamed, original);
 
-    let mut decoder =
-        StreamingDecoder::new_with_dictionary_bytes(compressed.as_slice(), &dict_raw)
-            .expect("streaming decoder should init");
+    let mut decoder = StreamingDecoder::new_with_dictionary_bytes(compressed.as_slice(), &dict_raw)
+        .expect("streaming decoder should init");
     let mut streamed = Vec::new();
     Read::read_to_end(&mut decoder, &mut streamed).expect("streaming read should succeed");
     assert_eq!(streamed, original);
@@ -329,6 +327,13 @@ fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
         .expect("expected at least one .zst file in dict_tests/files");
 
     let compressed = fs::read(&file_path).expect("compressed data should load");
+    let mut header_src = compressed.as_slice();
+    let (header, _) = crate::decoding::frame::read_frame_header(&mut header_src)
+        .expect("sample frame header should parse");
+    assert!(
+        header.dictionary_id().is_some(),
+        "sample fixture must require a dictionary"
+    );
     let original_path = file_path
         .to_str()
         .expect("dict test path should be utf-8")

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -260,3 +260,81 @@ fn test_dict_decoding() {
 
     assert!(failed.is_empty());
 }
+
+#[test]
+fn test_decode_all_with_dict_helpers() {
+    extern crate std;
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use crate::decoding::{DictionaryHandle, FrameDecoder, StreamingDecoder};
+    use std::fs;
+    use std::io::Read;
+
+    let dict_raw = fs::read("./dict_tests/dictionary").expect("dictionary should load");
+    let (compressed, original) = load_sample_dict_frame();
+    let handle = DictionaryHandle::decode_dict(&dict_raw).expect("dictionary should parse");
+
+    let mut output = vec![0u8; original.len()];
+    FrameDecoder::new()
+        .decode_all_with_dict_handle(compressed.as_slice(), &mut output, &handle)
+        .expect("decode_all_with_dict_handle should succeed");
+    assert_eq!(output, original);
+
+    let mut output = vec![0u8; original.len()];
+    FrameDecoder::new()
+        .decode_all_with_dict_bytes(compressed.as_slice(), &mut output, &dict_raw)
+        .expect("decode_all_with_dict_bytes should succeed");
+    assert_eq!(output, original);
+
+    let mut decoder =
+        StreamingDecoder::new_with_dictionary_handle(compressed.as_slice(), &handle)
+            .expect("streaming decoder should init");
+    let mut streamed = Vec::new();
+    Read::read_to_end(&mut decoder, &mut streamed).expect("streaming read should succeed");
+    assert_eq!(streamed, original);
+
+    let mut decoder =
+        StreamingDecoder::new_with_dictionary_bytes(compressed.as_slice(), &dict_raw)
+            .expect("streaming decoder should init");
+    let mut streamed = Vec::new();
+    Read::read_to_end(&mut decoder, &mut streamed).expect("streaming read should succeed");
+    assert_eq!(streamed, original);
+}
+
+#[cfg(test)]
+fn load_sample_dict_frame() -> (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) {
+    extern crate std;
+    use alloc::string::{String, ToString};
+    use alloc::vec::Vec;
+    use std::fs;
+
+    let mut files: Vec<std::io::Result<std::fs::DirEntry>> = fs::read_dir("./dict_tests/files")
+        .expect("dict test files should exist")
+        .collect();
+    files.sort_by_key(|entry| match entry {
+        Err(_) => String::new(),
+        Ok(dir_entry) => dir_entry.path().to_string_lossy().to_string(),
+    });
+
+    let file_path = files
+        .into_iter()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| {
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .map(|ext| ext == "zst")
+                .unwrap_or(false)
+        })
+        .expect("expected at least one .zst file in dict_tests/files");
+
+    let compressed = fs::read(&file_path).expect("compressed data should load");
+    let original_path = file_path
+        .to_str()
+        .expect("dict test path should be utf-8")
+        .trim_end_matches(".zst")
+        .to_string();
+    let original = fs::read(original_path).expect("original data should load");
+
+    (compressed, original)
+}

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -90,11 +90,14 @@ fn test_dictionary_handle_from_dictionary_roundtrips() {
     assert_eq!(handle.as_dict().dict_content.as_slice(), &[4]);
 }
 
-#[cfg(target_has_atomic = "ptr")]
 #[test]
 fn test_dict_decoding() {
     extern crate std;
     use crate::decoding::BlockDecodingStrategy;
+    #[cfg(not(target_has_atomic = "ptr"))]
+    use crate::decoding::Dictionary;
+    #[cfg(target_has_atomic = "ptr")]
+    use crate::decoding::DictionaryHandle;
     use crate::decoding::FrameDecoder;
     use alloc::borrow::ToOwned;
     use alloc::string::{String, ToString};
@@ -124,8 +127,16 @@ fn test_dict_decoding() {
     });
 
     let mut frame_dec = FrameDecoder::new();
-    let dict = crate::decoding::DictionaryHandle::decode_dict(&dict).unwrap();
-    frame_dec.add_dict_handle(dict).unwrap();
+    #[cfg(target_has_atomic = "ptr")]
+    {
+        let dict = DictionaryHandle::decode_dict(&dict).unwrap();
+        frame_dec.add_dict_handle(dict).unwrap();
+    }
+    #[cfg(not(target_has_atomic = "ptr"))]
+    {
+        let dict = Dictionary::decode_dict(&dict).unwrap();
+        frame_dec.add_dict(dict).unwrap();
+    }
 
     for file in files {
         let f = file.unwrap();
@@ -527,6 +538,36 @@ fn test_reset_with_dict_handle_rejects_mismatched_id() {
         result,
         Err(FrameDecoderError::DictIdMismatch { expected, provided })
             if expected == expected_dict_id && provided == mismatched_id
+    ));
+}
+
+#[test]
+fn test_reset_with_dict_handle_rejects_invalid_handle_invariants() {
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::decoding::errors::{DictionaryDecodeError, FrameDecoderError};
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    let payload = b"dict-handle-invariants";
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor.set_source(payload.as_slice());
+    let mut compressed = Vec::new();
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+
+    let mut invalid = Dictionary::from_raw_content(123, vec![1u8]).expect("dict should build");
+    invalid.offset_hist[0] = 0;
+    let handle = DictionaryHandle::from_dictionary(invalid);
+
+    let mut decoder = FrameDecoder::new();
+    let result = decoder.reset_with_dict_handle(compressed.as_slice(), &handle);
+    assert!(matches!(
+        result,
+        Err(FrameDecoderError::DictionaryDecodeError(
+            DictionaryDecodeError::ZeroRepeatOffsetInDictionary { index: 0 }
+        ))
     ));
 }
 


### PR DESCRIPTION
## Summary
- add `DictionaryHandle` reuse APIs and direct decode paths to avoid per-call dictionary parsing
- wire `FrameDecoder`/`StreamingDecoder` to accept prepared handles or raw dict bytes
- add criterion benchmark for repeated dict decode latency

## Acceptance Criteria
- [x] prepared dictionary API is public and documented (`DictionaryHandle` + decoding module docs)
- [x] decode path accepts prepared handle directly (`FrameDecoder::reset_with_dict_handle`, `decode_all_with_dict_handle`, `StreamingDecoder::new_with_dictionary_handle`)
- [x] raw-bytes dictionary API retained (`add_dict_from_bytes`, `decode_all_with_dict_bytes`, `new_with_dictionary_bytes`)
- [x] existing dictionary decode tests pass
- [x] benchmark shows improvement for repeated dict decode
  - prepared handle: ~4.16 µs
  - raw dict per call: ~20.07 µs

## Testing
- cargo check --workspace
- cargo clippy -p structured-zstd --features hash,std,dict_builder -- -D warnings
- cargo clippy -p structured-zstd --features hash,std,dict_builder,bench_internals --benches -- -D warnings
- cargo nextest run -p structured-zstd
- cargo nextest run --workspace
- cargo test --doc --workspace
- cargo bench --bench decode_dict_handle

Closes #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cloneable, shareable DictionaryHandle and APIs to register/use pre-parsed dictionaries; streaming and multi-frame decode helpers accepting handles or raw dictionary bytes.

* **Bug Fixes**
  * Clearer dictionary-related errors (ID mismatch, duplicate registration); decoder prefers owned then shared dictionaries and reports missing dicts more informatively.

* **Performance**
  * Added a benchmark comparing reuse of parsed handles vs decoding raw dictionary bytes each call.

* **Tests**
  * Expanded coverage for handle semantics, sharing/cloning, decoder injection/reset, skippable frames, force/lookup behavior, and end-to-end decoding.

* **Documentation**
  * README updated with dictionary-backed decompression examples and compression-strategy coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->