### PR TITLE
perf(bench): add wildcopy candidate research bench and dashboard range filter

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -76,6 +76,11 @@
       }
       .chart-wrap {
         margin-top: 14px;
+        min-height: 460px;
+      }
+      #chart {
+        width: 100% !important;
+        height: 440px !important;
       }
       #status {
         margin-top: 8px;
@@ -168,9 +173,15 @@
           <label>Source
             <select id="f-source"></select>
           </label>
+          <label>From
+            <select id="f-from"></select>
+          </label>
+          <label>To
+            <select id="f-to"></select>
+          </label>
         </div>
         <div class="chart-wrap">
-          <canvas id="chart" height="120"></canvas>
+          <canvas id="chart"></canvas>
         </div>
         <div id="status"></div>
       </section>
@@ -217,6 +228,8 @@
       const state = {
         records: [],
         chart: null,
+        timeIndex: new Map(),
+        windowInitialized: false,
       };
 
       const el = (id) => document.getElementById(id);
@@ -228,6 +241,8 @@
         scenario: el("f-scenario"),
         level: el("f-level"),
         source: el("f-source"),
+        from: el("f-from"),
+        to: el("f-to"),
       };
 
       function parseTimestamp(value) {
@@ -296,7 +311,19 @@
         select.replaceChildren(fragment);
       }
 
-      function matchesFilter(record, filter) {
+      function renderPointOptions(select, values) {
+        const fragment = document.createDocumentFragment();
+        for (const value of values) {
+          const option = document.createElement("option");
+          const text = String(value);
+          option.value = text;
+          option.textContent = text;
+          fragment.appendChild(option);
+        }
+        select.replaceChildren(fragment);
+      }
+
+      function matchesCoreFilters(record, filter) {
         if (filter.target !== ALWAYS && record.target !== filter.target) return false;
         if (filter.metric !== ALWAYS && record.metric !== filter.metric) return false;
         if (filter.stage !== ALWAYS && record.stage !== filter.stage) return false;
@@ -304,6 +331,48 @@
         if (filter.level !== ALWAYS && record.level !== filter.level) return false;
         if (filter.source !== ALWAYS && (record.source || "none") !== filter.source) return false;
         return true;
+      }
+
+      function updateTimeWindowOptions(records) {
+        const labels = uniq(records.map((r) => r.generated_at || "local-run"));
+        state.timeIndex = new Map(labels.map((label, idx) => [label, idx]));
+
+        if (!labels.length) {
+          selectors.from.replaceChildren();
+          selectors.to.replaceChildren();
+          return;
+        }
+
+        const previousFrom = selectors.from.value;
+        const previousTo = selectors.to.value;
+        renderPointOptions(selectors.from, labels);
+        renderPointOptions(selectors.to, labels);
+
+        const defaultTo = labels[labels.length - 1];
+        const defaultFrom = labels[Math.max(0, labels.length - 3)];
+
+        if (!state.windowInitialized) {
+          selectors.from.value = defaultFrom;
+          selectors.to.value = defaultTo;
+          state.windowInitialized = true;
+          return;
+        }
+
+        selectors.from.value = labels.includes(previousFrom) ? previousFrom : defaultFrom;
+        selectors.to.value = labels.includes(previousTo) ? previousTo : defaultTo;
+      }
+
+      function applyTimeWindow(records, filter) {
+        if (!filter.fromPoint || !filter.toPoint) return records;
+        const fromIdx = state.timeIndex.get(filter.fromPoint);
+        const toIdx = state.timeIndex.get(filter.toPoint);
+        if (fromIdx === undefined || toIdx === undefined) return records;
+        const low = Math.min(fromIdx, toIdx);
+        const high = Math.max(fromIdx, toIdx);
+        return records.filter((record) => {
+          const idx = state.timeIndex.get(record.generated_at || "local-run");
+          return idx !== undefined && idx >= low && idx <= high;
+        });
       }
 
       function buildChart(records) {
@@ -467,6 +536,7 @@
             plugins: {
               legend: { position: "bottom" },
             },
+            maintainAspectRatio: false,
           },
         });
       }
@@ -479,12 +549,17 @@
           scenario: selectors.scenario.value,
           level: selectors.level.value,
           source: selectors.source.value,
+          fromPoint: selectors.from.value,
+          toPoint: selectors.to.value,
         };
       }
 
       function rerender() {
         const filter = currentFilter();
-        const filtered = state.records.filter((row) => matchesFilter(row, filter));
+        const coreFiltered = state.records.filter((row) => matchesCoreFilters(row, filter));
+        updateTimeWindowOptions(coreFiltered);
+        const resolvedFilter = currentFilter();
+        const filtered = applyTimeWindow(coreFiltered, resolvedFilter);
         renderChart(filtered);
         updateStatus(filtered);
       }

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -51,6 +51,28 @@ Dictionary benchmarks currently include:
 - [x] Small data (`1-10 KiB`) scenarios for CoordiNode-like payloads
 - [x] Results documented in `benchmark-report.md`
 
+## Issue #87 Research Mapping (Wildcopy Candidates)
+
+Research PR: [#107](https://github.com/structured-world/structured-zstd/pull/107)
+
+- [x] At least one candidate benchmarked against baseline on supported hardware.
+- [x] No correctness regression in research branch validation runs.
+- [x] Candidate shows reproducible gain in local sample runs.
+- [x] Final recommendation documented with go/no-go outcome.
+
+Local sample measurements from `wildcopy_candidates` (ns/iter):
+
+- `64B`: baseline `3` -> candidate `2`
+- `256B`: baseline `7` -> candidate `4`
+- `1024B`: baseline `28` -> candidate `14`
+- `4096B`: baseline `94` -> candidate `58`
+- `16384B`: baseline `347` -> candidate `268`
+- `65536B`: baseline `1368` -> candidate `1121`
+
+Decision: **GO** for production integration of AVX2 unroll2 candidate.
+
+Follow-up implementation issue: [#108](https://github.com/structured-world/structured-zstd/issues/108).
+
 ## Commands
 
 Run the full Criterion matrix:

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -69,7 +69,8 @@ Local sample measurements from `wildcopy_candidates` (ns/iter):
 - `16384B`: baseline `347` -> candidate `268`
 - `65536B`: baseline `1368` -> candidate `1121`
 
-Decision: **GO** for production integration of AVX2 unroll2 candidate.
+Decision: **Provisional GO (microbench only)** for AVX2 unroll2 candidate,
+based on local `wildcopy_candidates` microbench data; this does not close issue #87.
 
 Follow-up implementation issue: [#108](https://github.com/structured-world/structured-zstd/issues/108).
 

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -71,3 +71,8 @@ required-features = ["dict_builder"]
 [[bench]]
 name = "decode_dict_handle"
 harness = false
+
+[[bench]]
+name = "wildcopy_candidates"
+harness = false
+required-features = ["bench_internals"]

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -1,0 +1,106 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+use std::hint::black_box;
+use structured_zstd::testing::copy_bytes_overshooting_for_bench;
+
+#[inline(always)]
+unsafe fn copy_candidate_unroll2_avx2(src: *const u8, dst: *mut u8, len: usize) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if std::arch::is_x86_feature_detected!("avx2") && len >= 64 {
+            unsafe { copy_unroll2_avx2_impl(src, dst, len) };
+            return;
+        }
+    }
+
+    unsafe { dst.copy_from_nonoverlapping(src, len) };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn copy_unroll2_avx2_impl(mut src: *const u8, mut dst: *mut u8, len: usize) {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+
+    let end_unrolled = len & !63;
+    let mut copied = 0usize;
+    while copied < end_unrolled {
+        unsafe {
+            let v0: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+            let v1: __m256i = _mm256_loadu_si256(src.add(32).cast::<__m256i>());
+            _mm256_storeu_si256(dst.cast::<__m256i>(), v0);
+            _mm256_storeu_si256(dst.add(32).cast::<__m256i>(), v1);
+            src = src.add(64);
+            dst = dst.add(64);
+        }
+        copied += 64;
+    }
+
+    let tail = len - copied;
+    if tail > 0 {
+        unsafe { dst.copy_from_nonoverlapping(src, tail) };
+    }
+}
+
+fn bench_wildcopy_candidates(c: &mut Criterion) {
+    let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
+    let mut group = c.benchmark_group("decode_wildcopy_candidates");
+    let lengths = [64usize, 256, 1024, 4096, 16 * 1024, 64 * 1024];
+
+    for len in lengths {
+        let mut src = vec![0u8; len + 64];
+        rng.fill(&mut src);
+        let mut dst_baseline = vec![0u8; len + 64];
+        let mut dst_candidate = vec![0u8; len + 64];
+
+        unsafe {
+            copy_bytes_overshooting_for_bench(
+                (src.as_ptr(), src.len()),
+                (dst_baseline.as_mut_ptr(), dst_baseline.len()),
+                len,
+            );
+            copy_candidate_unroll2_avx2(src.as_ptr(), dst_candidate.as_mut_ptr(), len);
+        }
+        assert_eq!(
+            &dst_baseline[..len],
+            &src[..len],
+            "baseline wildcopy must preserve bytes for len={len}"
+        );
+        assert_eq!(
+            &dst_candidate[..len],
+            &src[..len],
+            "candidate wildcopy must preserve bytes for len={len}"
+        );
+
+        group.throughput(Throughput::Bytes(len as u64));
+
+        group.bench_with_input(BenchmarkId::new("baseline", len), &len, |b, &copy_len| {
+            b.iter(|| unsafe {
+                copy_bytes_overshooting_for_bench(
+                    (src.as_ptr(), src.len()),
+                    (dst_baseline.as_mut_ptr(), dst_baseline.len()),
+                    copy_len,
+                );
+                black_box(dst_baseline[copy_len - 1]);
+            });
+        });
+
+        group.bench_with_input(
+            BenchmarkId::new("candidate_avx2_unroll2", len),
+            &len,
+            |b, &copy_len| {
+                b.iter(|| unsafe {
+                    copy_candidate_unroll2_avx2(src.as_ptr(), dst_candidate.as_mut_ptr(), copy_len);
+                    black_box(dst_candidate[copy_len - 1]);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_wildcopy_candidates);
+criterion_main!(benches);

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -5,6 +5,13 @@ use structured_zstd::testing::copy_bytes_overshooting_for_bench;
 
 type CopyKernel = unsafe fn(*const u8, *mut u8, usize);
 
+#[derive(Clone, Copy)]
+struct BenchPath {
+    name: &'static str,
+    chunk: usize,
+    kernel: CopyKernel,
+}
+
 #[inline(always)]
 unsafe fn copy_candidate_scalar(src: *const u8, dst: *mut u8, len: usize) {
     unsafe { dst.copy_from_nonoverlapping(src, len) };
@@ -49,6 +56,25 @@ unsafe fn copy_unroll2_avx2_impl(mut src: *const u8, mut dst: *mut u8, len: usiz
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+unsafe fn copy_baseline_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+
+    let end = unsafe { src.add(len) };
+    while src < end {
+        unsafe {
+            let v: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+            _mm256_storeu_si256(dst.cast::<__m256i>(), v);
+            src = src.add(32);
+            dst = dst.add(32);
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
     if std::arch::is_x86_feature_detected!("avx2") {
         ("candidate_avx2_unroll2", copy_candidate_unroll2_avx2)
@@ -62,63 +88,137 @@ fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
     ("candidate_scalar_fallback", copy_candidate_scalar)
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn select_baseline_copy_kernel() -> BenchPath {
+    if std::arch::is_x86_feature_detected!("avx2") {
+        BenchPath {
+            name: "baseline_avx2",
+            chunk: 32,
+            kernel: copy_baseline_avx2,
+        }
+    } else {
+        BenchPath {
+            name: "baseline_scalar",
+            chunk: core::mem::size_of::<usize>(),
+            kernel: copy_candidate_scalar,
+        }
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn select_baseline_copy_kernel() -> BenchPath {
+    BenchPath {
+        name: "baseline_scalar",
+        chunk: core::mem::size_of::<usize>(),
+        kernel: copy_candidate_scalar,
+    }
+}
+
+#[inline(always)]
+unsafe fn copy_with_overshoot_policy(
+    src: (*const u8, usize),
+    dst: (*mut u8, usize),
+    copy_at_least: usize,
+    path: BenchPath,
+) {
+    if copy_at_least == 0 {
+        return;
+    }
+
+    let copy_multiple = copy_at_least.next_multiple_of(path.chunk);
+    let min_capacity = core::cmp::min(src.1, dst.1);
+    if min_capacity >= copy_multiple {
+        unsafe { (path.kernel)(src.0, dst.0, copy_multiple) };
+    } else {
+        unsafe { dst.0.copy_from_nonoverlapping(src.0, copy_at_least) };
+    }
+}
+
 fn bench_wildcopy_candidates(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
     let mut group = c.benchmark_group("decode_wildcopy_candidates");
+    let baseline_path = select_baseline_copy_kernel();
     let (candidate_name, candidate_copy_kernel) = select_candidate_copy_kernel();
-    let lengths = [64usize, 256, 1024, 4096, 16 * 1024, 64 * 1024];
+    let candidate_path = BenchPath {
+        name: candidate_name,
+        chunk: if candidate_name == "candidate_avx2_unroll2" {
+            64
+        } else {
+            core::mem::size_of::<usize>()
+        },
+        kernel: candidate_copy_kernel,
+    };
+    let lengths = [64usize, 65, 256, 1024, 4096, 16 * 1024, 64 * 1024];
 
     for len in lengths {
         let mut src = vec![0u8; len + 64];
         rng.fill(&mut src);
+        let mut dst_production = vec![0u8; len + 64];
         let mut dst_baseline = vec![0u8; len + 64];
         let mut dst_candidate = vec![0u8; len + 64];
 
         unsafe {
             copy_bytes_overshooting_for_bench(
                 (src.as_ptr(), src.len()),
-                (dst_baseline.as_mut_ptr(), dst_baseline.len()),
+                (dst_production.as_mut_ptr(), dst_production.len()),
                 len,
             );
-            candidate_copy_kernel(src.as_ptr(), dst_candidate.as_mut_ptr(), len);
+            copy_with_overshoot_policy(
+                (src.as_ptr(), src.len()),
+                (dst_baseline.as_mut_ptr(), dst_baseline.len()),
+                len,
+                baseline_path,
+            );
+            copy_with_overshoot_policy(
+                (src.as_ptr(), src.len()),
+                (dst_candidate.as_mut_ptr(), dst_candidate.len()),
+                len,
+                candidate_path,
+            );
         }
         assert_eq!(
             &dst_baseline[..len],
-            &src[..len],
-            "baseline wildcopy must preserve bytes for len={len}"
+            &dst_production[..len],
+            "baseline path must match production wildcopy for len={len}"
         );
         assert_eq!(
             &dst_candidate[..len],
-            &src[..len],
-            "candidate wildcopy must preserve bytes for len={len}"
+            &dst_production[..len],
+            "candidate path must match production wildcopy for len={len}"
         );
 
         group.throughput(Throughput::Bytes(len as u64));
 
-        group.bench_with_input(BenchmarkId::new("baseline", len), &len, |b, &copy_len| {
-            b.iter(|| unsafe {
-                let src_buf = black_box(src.as_slice());
-                let dst_buf = black_box(dst_baseline.as_mut_slice());
-                copy_bytes_overshooting_for_bench(
-                    (black_box(src_buf.as_ptr()), src_buf.len()),
-                    (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
-                    black_box(copy_len),
-                );
-                black_box(dst_buf[copy_len - 1]);
-            });
-        });
+        group.bench_with_input(
+            BenchmarkId::new(baseline_path.name, len),
+            &len,
+            |b, &copy_len| {
+                b.iter(|| unsafe {
+                    let src_buf = black_box(src.as_slice());
+                    let dst_buf = black_box(dst_baseline.as_mut_slice());
+                    copy_with_overshoot_policy(
+                        (black_box(src_buf.as_ptr()), src_buf.len()),
+                        (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
+                        black_box(copy_len),
+                        baseline_path,
+                    );
+                    black_box(dst_buf[copy_len - 1]);
+                });
+            },
+        );
 
         group.bench_with_input(
-            BenchmarkId::new(candidate_name, len),
+            BenchmarkId::new(candidate_path.name, len),
             &len,
             |b, &copy_len| {
                 b.iter(|| unsafe {
                     let src_buf = black_box(src.as_slice());
                     let dst_buf = black_box(dst_candidate.as_mut_slice());
-                    candidate_copy_kernel(
-                        black_box(src_buf.as_ptr()),
-                        black_box(dst_buf.as_mut_ptr()),
+                    copy_with_overshoot_policy(
+                        (black_box(src_buf.as_ptr()), src_buf.len()),
+                        (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
                         black_box(copy_len),
+                        candidate_path,
                     );
                     black_box(dst_buf[copy_len - 1]);
                 });

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -3,17 +3,21 @@ use rand::{RngExt, SeedableRng, rngs::StdRng};
 use std::hint::black_box;
 use structured_zstd::testing::copy_bytes_overshooting_for_bench;
 
-#[inline(always)]
-unsafe fn copy_candidate_unroll2_avx2(src: *const u8, dst: *mut u8, len: usize) {
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    {
-        if std::arch::is_x86_feature_detected!("avx2") && len >= 64 {
-            unsafe { copy_unroll2_avx2_impl(src, dst, len) };
-            return;
-        }
-    }
+type CopyKernel = unsafe fn(*const u8, *mut u8, usize);
 
+#[inline(always)]
+unsafe fn copy_candidate_scalar(src: *const u8, dst: *mut u8, len: usize) {
     unsafe { dst.copy_from_nonoverlapping(src, len) };
+}
+
+#[inline(always)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+unsafe fn copy_candidate_unroll2_avx2(src: *const u8, dst: *mut u8, len: usize) {
+    if len >= 64 {
+        unsafe { copy_unroll2_avx2_impl(src, dst, len) };
+    } else {
+        unsafe { copy_candidate_scalar(src, dst, len) };
+    }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -44,9 +48,24 @@ unsafe fn copy_unroll2_avx2_impl(mut src: *const u8, mut dst: *mut u8, len: usiz
     }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
+    if std::arch::is_x86_feature_detected!("avx2") {
+        ("candidate_avx2_unroll2", copy_candidate_unroll2_avx2)
+    } else {
+        ("candidate_scalar_fallback", copy_candidate_scalar)
+    }
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
+    ("candidate_scalar_fallback", copy_candidate_scalar)
+}
+
 fn bench_wildcopy_candidates(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
     let mut group = c.benchmark_group("decode_wildcopy_candidates");
+    let (candidate_name, candidate_copy_kernel) = select_candidate_copy_kernel();
     let lengths = [64usize, 256, 1024, 4096, 16 * 1024, 64 * 1024];
 
     for len in lengths {
@@ -61,7 +80,7 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
                 (dst_baseline.as_mut_ptr(), dst_baseline.len()),
                 len,
             );
-            copy_candidate_unroll2_avx2(src.as_ptr(), dst_candidate.as_mut_ptr(), len);
+            candidate_copy_kernel(src.as_ptr(), dst_candidate.as_mut_ptr(), len);
         }
         assert_eq!(
             &dst_baseline[..len],
@@ -78,22 +97,30 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
 
         group.bench_with_input(BenchmarkId::new("baseline", len), &len, |b, &copy_len| {
             b.iter(|| unsafe {
+                let src_buf = black_box(src.as_slice());
+                let dst_buf = black_box(dst_baseline.as_mut_slice());
                 copy_bytes_overshooting_for_bench(
-                    (src.as_ptr(), src.len()),
-                    (dst_baseline.as_mut_ptr(), dst_baseline.len()),
-                    copy_len,
+                    (black_box(src_buf.as_ptr()), src_buf.len()),
+                    (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
+                    black_box(copy_len),
                 );
-                black_box(dst_baseline[copy_len - 1]);
+                black_box(dst_buf[copy_len - 1]);
             });
         });
 
         group.bench_with_input(
-            BenchmarkId::new("candidate_avx2_unroll2", len),
+            BenchmarkId::new(candidate_name, len),
             &len,
             |b, &copy_len| {
                 b.iter(|| unsafe {
-                    copy_candidate_unroll2_avx2(src.as_ptr(), dst_candidate.as_mut_ptr(), copy_len);
-                    black_box(dst_candidate[copy_len - 1]);
+                    let src_buf = black_box(src.as_slice());
+                    let dst_buf = black_box(dst_candidate.as_mut_slice());
+                    candidate_copy_kernel(
+                        black_box(src_buf.as_ptr()),
+                        black_box(dst_buf.as_mut_ptr()),
+                        black_box(copy_len),
+                    );
+                    black_box(dst_buf[copy_len - 1]);
                 });
             },
         );

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -21,16 +21,25 @@ struct BenchPath {
 #[inline(always)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_candidate_scalar(src: *const u8, dst: *mut u8, len: usize) {
-    dst.copy_from_nonoverlapping(src, len);
+    // SAFETY: Benchmark callers provide valid non-overlapping buffers for `len`.
+    unsafe {
+        dst.copy_from_nonoverlapping(src, len);
+    }
 }
 
 #[inline(always)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_candidate_unroll2_avx2(src: *const u8, dst: *mut u8, len: usize) {
     if len >= 64 {
-        copy_unroll2_avx2_impl(src, dst, len);
+        // SAFETY: AVX2 support and copy bounds are checked by caller/path selection.
+        unsafe {
+            copy_unroll2_avx2_impl(src, dst, len);
+        }
     } else {
-        copy_candidate_scalar(src, dst, len);
+        // SAFETY: Same preconditions as this function.
+        unsafe {
+            copy_candidate_scalar(src, dst, len);
+        }
     }
 }
 
@@ -45,18 +54,24 @@ unsafe fn copy_unroll2_avx2_impl(mut src: *const u8, mut dst: *mut u8, len: usiz
     let end_unrolled = len & !63;
     let mut copied = 0usize;
     while copied < end_unrolled {
-        let v0: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
-        let v1: __m256i = _mm256_loadu_si256(src.add(32).cast::<__m256i>());
-        _mm256_storeu_si256(dst.cast::<__m256i>(), v0);
-        _mm256_storeu_si256(dst.add(32).cast::<__m256i>(), v1);
-        src = src.add(64);
-        dst = dst.add(64);
+        // SAFETY: Unrolled loop copies within caller-provided valid bounds.
+        unsafe {
+            let v0: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+            let v1: __m256i = _mm256_loadu_si256(src.add(32).cast::<__m256i>());
+            _mm256_storeu_si256(dst.cast::<__m256i>(), v0);
+            _mm256_storeu_si256(dst.add(32).cast::<__m256i>(), v1);
+            src = src.add(64);
+            dst = dst.add(64);
+        }
         copied += 64;
     }
 
     let tail = len - copied;
     if tail > 0 {
-        dst.copy_from_nonoverlapping(src, tail);
+        // SAFETY: Remaining tail stays within the validated source/destination ranges.
+        unsafe {
+            dst.copy_from_nonoverlapping(src, tail);
+        }
     }
 }
 
@@ -68,12 +83,16 @@ unsafe fn copy_baseline_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
 
-    let end = src.add(len);
+    // SAFETY: `src..src+len` stays in caller-provided readable range.
+    let end = unsafe { src.add(len) };
     while src < end {
-        let v: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
-        _mm256_storeu_si256(dst.cast::<__m256i>(), v);
-        src = src.add(32);
-        dst = dst.add(32);
+        // SAFETY: Loop advances by vector width while staying inside valid ranges.
+        unsafe {
+            let v: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+            _mm256_storeu_si256(dst.cast::<__m256i>(), v);
+            src = src.add(32);
+            dst = dst.add(32);
+        }
     }
 }
 
@@ -85,12 +104,16 @@ unsafe fn copy_baseline_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
 
-    let end = src.add(len);
+    // SAFETY: `src..src+len` stays in caller-provided readable range.
+    let end = unsafe { src.add(len) };
     while src < end {
-        let v: __m128i = _mm_loadu_si128(src.cast::<__m128i>());
-        _mm_storeu_si128(dst.cast::<__m128i>(), v);
-        src = src.add(16);
-        dst = dst.add(16);
+        // SAFETY: Loop advances by vector width while staying inside valid ranges.
+        unsafe {
+            let v: __m128i = _mm_loadu_si128(src.cast::<__m128i>());
+            _mm_storeu_si128(dst.cast::<__m128i>(), v);
+            src = src.add(16);
+            dst = dst.add(16);
+        }
     }
 }
 
@@ -102,12 +125,16 @@ unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize)
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
 
-    let end = src.add(len);
+    // SAFETY: `src..src+len` stays in caller-provided readable range.
+    let end = unsafe { src.add(len) };
     while src < end {
-        let v: __m512i = _mm512_loadu_si512(src.cast::<__m512i>());
-        _mm512_storeu_si512(dst.cast::<__m512i>(), v);
-        src = src.add(64);
-        dst = dst.add(64);
+        // SAFETY: Loop advances by vector width while staying inside valid ranges.
+        unsafe {
+            let v: __m512i = _mm512_loadu_si512(src.cast::<__m512i>());
+            _mm512_storeu_si512(dst.cast::<__m512i>(), v);
+            src = src.add(64);
+            dst = dst.add(64);
+        }
     }
 }
 
@@ -172,9 +199,15 @@ unsafe fn copy_with_overshoot_policy(
     let copy_multiple = copy_at_least.next_multiple_of(path.chunk);
     let min_capacity = core::cmp::min(src.1, dst.1);
     if min_capacity >= copy_multiple {
-        (path.kernel)(src.0, dst.0, copy_multiple);
+        // SAFETY: `copy_multiple` is bounded by both capacities and kernel contract.
+        unsafe {
+            (path.kernel)(src.0, dst.0, copy_multiple);
+        }
     } else {
-        dst.0.copy_from_nonoverlapping(src.0, copy_at_least);
+        // SAFETY: Fallback path copies exactly `copy_at_least` bytes within capacities.
+        unsafe {
+            dst.0.copy_from_nonoverlapping(src.0, copy_at_least);
+        }
     }
 }
 

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -139,19 +139,24 @@ unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize)
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn select_candidate_copy_kernel(len: usize, baseline_chunk: usize) -> BenchPath {
+fn select_candidate_copy_kernel(len: usize, baseline_path: BenchPath) -> Option<BenchPath> {
+    if baseline_path.name == "baseline_avx512" {
+        // Skip AVX2 candidate when production baseline is AVX-512.
+        return None;
+    }
+
     if std::arch::is_x86_feature_detected!("avx2") && len >= 64 {
-        BenchPath {
+        Some(BenchPath {
             name: "candidate_avx2_unroll2",
-            chunk: baseline_chunk,
+            chunk: baseline_path.chunk,
             kernel: copy_candidate_unroll2_avx2,
-        }
+        })
     } else {
-        BenchPath {
+        Some(BenchPath {
             name: "candidate_scalar_fallback",
-            chunk: baseline_chunk,
+            chunk: baseline_path.chunk,
             kernel: copy_candidate_scalar,
-        }
+        })
     }
 }
 
@@ -230,7 +235,7 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
 
     for len in lengths {
         let baseline_path = select_baseline_copy_kernel(len);
-        let candidate_path = select_candidate_copy_kernel(len, baseline_path.chunk);
+        let candidate_path = select_candidate_copy_kernel(len, baseline_path);
         let mut src = vec![0u8; len + 64];
         rng.fill(&mut src);
         let mut dst_production = vec![0u8; len + 64];
@@ -249,21 +254,27 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
                 len,
                 baseline_path,
             );
-            copy_with_overshoot_policy(
-                (src.as_ptr(), src.len()),
-                (dst_candidate.as_mut_ptr(), dst_candidate.len()),
-                len,
-                candidate_path,
-            );
+            if let Some(path) = candidate_path {
+                copy_with_overshoot_policy(
+                    (src.as_ptr(), src.len()),
+                    (dst_candidate.as_mut_ptr(), dst_candidate.len()),
+                    len,
+                    path,
+                );
+            }
         }
+        let check_len = len.next_multiple_of(baseline_path.chunk);
         assert_eq!(
-            &dst_baseline[..len],
-            &dst_production[..len],
+            &dst_baseline[..check_len],
+            &dst_production[..check_len],
             "baseline path must match production wildcopy for len={len}"
         );
+        if candidate_path.is_none() {
+            continue;
+        }
         assert_eq!(
-            &dst_candidate[..len],
-            &dst_production[..len],
+            &dst_candidate[..check_len],
+            &dst_production[..check_len],
             "candidate path must match production wildcopy for len={len}"
         );
 
@@ -287,23 +298,25 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
             },
         );
 
-        group.bench_with_input(
-            BenchmarkId::new(candidate_path.name, len),
-            &len,
-            |b, &copy_len| {
-                b.iter(|| unsafe {
-                    let src_buf = black_box(src.as_slice());
-                    let dst_buf = black_box(dst_candidate.as_mut_slice());
-                    copy_with_overshoot_policy(
-                        (black_box(src_buf.as_ptr()), src_buf.len()),
-                        (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
-                        black_box(copy_len),
-                        candidate_path,
-                    );
-                    black_box(dst_buf[copy_len - 1]);
-                });
-            },
-        );
+        if let Some(candidate_path) = candidate_path {
+            group.bench_with_input(
+                BenchmarkId::new(candidate_path.name, len),
+                &len,
+                |b, &copy_len| {
+                    b.iter(|| unsafe {
+                        let src_buf = black_box(src.as_slice());
+                        let dst_buf = black_box(dst_candidate.as_mut_slice());
+                        copy_with_overshoot_policy(
+                            (black_box(src_buf.as_ptr()), src_buf.len()),
+                            (black_box(dst_buf.as_mut_ptr()), dst_buf.len()),
+                            black_box(copy_len),
+                            candidate_path,
+                        );
+                        black_box(dst_buf[copy_len - 1]);
+                    });
+                },
+            );
+        }
     }
 
     group.finish();

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -113,17 +113,29 @@ unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize)
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
+fn select_candidate_copy_kernel() -> BenchPath {
     if std::arch::is_x86_feature_detected!("avx2") {
-        ("candidate_avx2_unroll2", copy_candidate_unroll2_avx2)
+        BenchPath {
+            name: "candidate_avx2_unroll2",
+            chunk: 64,
+            kernel: copy_candidate_unroll2_avx2,
+        }
     } else {
-        ("candidate_scalar_fallback", copy_candidate_scalar)
+        BenchPath {
+            name: "candidate_scalar_fallback",
+            chunk: core::mem::size_of::<usize>(),
+            kernel: copy_candidate_scalar,
+        }
     }
 }
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
-    ("candidate_scalar_fallback", copy_candidate_scalar)
+fn select_candidate_copy_kernel() -> BenchPath {
+    BenchPath {
+        name: "candidate_scalar_fallback",
+        chunk: core::mem::size_of::<usize>(),
+        kernel: copy_candidate_scalar,
+    }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -187,16 +199,7 @@ unsafe fn copy_with_overshoot_policy(
 fn bench_wildcopy_candidates(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
     let mut group = c.benchmark_group("decode_wildcopy_candidates");
-    let (candidate_name, candidate_copy_kernel) = select_candidate_copy_kernel();
-    let candidate_path = BenchPath {
-        name: candidate_name,
-        chunk: if candidate_name == "candidate_avx2_unroll2" {
-            64
-        } else {
-            core::mem::size_of::<usize>()
-        },
-        kernel: candidate_copy_kernel,
-    };
+    let candidate_path = select_candidate_copy_kernel();
     let lengths = [
         17usize,
         33,

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -21,16 +21,16 @@ struct BenchPath {
 #[inline(always)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_candidate_scalar(src: *const u8, dst: *mut u8, len: usize) {
-    unsafe { dst.copy_from_nonoverlapping(src, len) };
+    dst.copy_from_nonoverlapping(src, len);
 }
 
 #[inline(always)]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_candidate_unroll2_avx2(src: *const u8, dst: *mut u8, len: usize) {
     if len >= 64 {
-        unsafe { copy_unroll2_avx2_impl(src, dst, len) };
+        copy_unroll2_avx2_impl(src, dst, len);
     } else {
-        unsafe { copy_candidate_scalar(src, dst, len) };
+        copy_candidate_scalar(src, dst, len);
     }
 }
 
@@ -45,20 +45,18 @@ unsafe fn copy_unroll2_avx2_impl(mut src: *const u8, mut dst: *mut u8, len: usiz
     let end_unrolled = len & !63;
     let mut copied = 0usize;
     while copied < end_unrolled {
-        unsafe {
-            let v0: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
-            let v1: __m256i = _mm256_loadu_si256(src.add(32).cast::<__m256i>());
-            _mm256_storeu_si256(dst.cast::<__m256i>(), v0);
-            _mm256_storeu_si256(dst.add(32).cast::<__m256i>(), v1);
-            src = src.add(64);
-            dst = dst.add(64);
-        }
+        let v0: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+        let v1: __m256i = _mm256_loadu_si256(src.add(32).cast::<__m256i>());
+        _mm256_storeu_si256(dst.cast::<__m256i>(), v0);
+        _mm256_storeu_si256(dst.add(32).cast::<__m256i>(), v1);
+        src = src.add(64);
+        dst = dst.add(64);
         copied += 64;
     }
 
     let tail = len - copied;
     if tail > 0 {
-        unsafe { dst.copy_from_nonoverlapping(src, tail) };
+        dst.copy_from_nonoverlapping(src, tail);
     }
 }
 
@@ -70,14 +68,12 @@ unsafe fn copy_baseline_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
 
-    let end = unsafe { src.add(len) };
+    let end = src.add(len);
     while src < end {
-        unsafe {
-            let v: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
-            _mm256_storeu_si256(dst.cast::<__m256i>(), v);
-            src = src.add(32);
-            dst = dst.add(32);
-        }
+        let v: __m256i = _mm256_loadu_si256(src.cast::<__m256i>());
+        _mm256_storeu_si256(dst.cast::<__m256i>(), v);
+        src = src.add(32);
+        dst = dst.add(32);
     }
 }
 
@@ -89,14 +85,12 @@ unsafe fn copy_baseline_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
 
-    let end = unsafe { src.add(len) };
+    let end = src.add(len);
     while src < end {
-        unsafe {
-            let v: __m128i = _mm_loadu_si128(src.cast::<__m128i>());
-            _mm_storeu_si128(dst.cast::<__m128i>(), v);
-            src = src.add(16);
-            dst = dst.add(16);
-        }
+        let v: __m128i = _mm_loadu_si128(src.cast::<__m128i>());
+        _mm_storeu_si128(dst.cast::<__m128i>(), v);
+        src = src.add(16);
+        dst = dst.add(16);
     }
 }
 
@@ -108,29 +102,27 @@ unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize)
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
 
-    let end = unsafe { src.add(len) };
+    let end = src.add(len);
     while src < end {
-        unsafe {
-            let v: __m512i = _mm512_loadu_si512(src.cast::<__m512i>());
-            _mm512_storeu_si512(dst.cast::<__m512i>(), v);
-            src = src.add(64);
-            dst = dst.add(64);
-        }
+        let v: __m512i = _mm512_loadu_si512(src.cast::<__m512i>());
+        _mm512_storeu_si512(dst.cast::<__m512i>(), v);
+        src = src.add(64);
+        dst = dst.add(64);
     }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn select_candidate_copy_kernel(len: usize) -> BenchPath {
+fn select_candidate_copy_kernel(len: usize, baseline_chunk: usize) -> BenchPath {
     if std::arch::is_x86_feature_detected!("avx2") && len >= 64 {
         BenchPath {
             name: "candidate_avx2_unroll2",
-            chunk: 64,
+            chunk: baseline_chunk,
             kernel: copy_candidate_unroll2_avx2,
         }
     } else {
         BenchPath {
             name: "candidate_scalar_fallback",
-            chunk: core::mem::size_of::<usize>(),
+            chunk: baseline_chunk,
             kernel: copy_candidate_scalar,
         }
     }
@@ -180,9 +172,9 @@ unsafe fn copy_with_overshoot_policy(
     let copy_multiple = copy_at_least.next_multiple_of(path.chunk);
     let min_capacity = core::cmp::min(src.1, dst.1);
     if min_capacity >= copy_multiple {
-        unsafe { (path.kernel)(src.0, dst.0, copy_multiple) };
+        (path.kernel)(src.0, dst.0, copy_multiple);
     } else {
-        unsafe { dst.0.copy_from_nonoverlapping(src.0, copy_at_least) };
+        dst.0.copy_from_nonoverlapping(src.0, copy_at_least);
     }
 }
 
@@ -204,8 +196,8 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
     ];
 
     for len in lengths {
-        let candidate_path = select_candidate_copy_kernel(len);
         let baseline_path = select_baseline_copy_kernel(len);
+        let candidate_path = select_candidate_copy_kernel(len, baseline_path.chunk);
         let mut src = vec![0u8; len + 64];
         rng.fill(&mut src);
         let mut dst_production = vec![0u8; len + 64];

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -75,6 +75,44 @@ unsafe fn copy_baseline_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse2")]
+unsafe fn copy_baseline_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+
+    let end = unsafe { src.add(len) };
+    while src < end {
+        unsafe {
+            let v: __m128i = _mm_loadu_si128(src.cast::<__m128i>());
+            _mm_storeu_si128(dst.cast::<__m128i>(), v);
+            src = src.add(16);
+            dst = dst.add(16);
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize) {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
+
+    let end = unsafe { src.add(len) };
+    while src < end {
+        unsafe {
+            let v: __m512i = _mm512_loadu_si512(src.cast::<__m512i>());
+            _mm512_storeu_si512(dst.cast::<__m512i>(), v);
+            src = src.add(64);
+            dst = dst.add(64);
+        }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
     if std::arch::is_x86_feature_detected!("avx2") {
         ("candidate_avx2_unroll2", copy_candidate_unroll2_avx2)
@@ -89,12 +127,24 @@ fn select_candidate_copy_kernel() -> (&'static str, CopyKernel) {
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn select_baseline_copy_kernel() -> BenchPath {
-    if std::arch::is_x86_feature_detected!("avx2") {
+fn select_baseline_copy_kernel(len: usize) -> BenchPath {
+    if std::arch::is_x86_feature_detected!("avx512f") && len >= 64 {
+        BenchPath {
+            name: "baseline_avx512",
+            chunk: 64,
+            kernel: copy_baseline_avx512,
+        }
+    } else if std::arch::is_x86_feature_detected!("avx2") && len >= 32 {
         BenchPath {
             name: "baseline_avx2",
             chunk: 32,
             kernel: copy_baseline_avx2,
+        }
+    } else if std::arch::is_x86_feature_detected!("sse2") && len >= 16 {
+        BenchPath {
+            name: "baseline_sse2",
+            chunk: 16,
+            kernel: copy_baseline_sse2,
         }
     } else {
         BenchPath {
@@ -106,7 +156,7 @@ fn select_baseline_copy_kernel() -> BenchPath {
 }
 
 #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn select_baseline_copy_kernel() -> BenchPath {
+fn select_baseline_copy_kernel(_len: usize) -> BenchPath {
     BenchPath {
         name: "baseline_scalar",
         chunk: core::mem::size_of::<usize>(),
@@ -137,7 +187,6 @@ unsafe fn copy_with_overshoot_policy(
 fn bench_wildcopy_candidates(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
     let mut group = c.benchmark_group("decode_wildcopy_candidates");
-    let baseline_path = select_baseline_copy_kernel();
     let (candidate_name, candidate_copy_kernel) = select_candidate_copy_kernel();
     let candidate_path = BenchPath {
         name: candidate_name,
@@ -148,9 +197,21 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
         },
         kernel: candidate_copy_kernel,
     };
-    let lengths = [64usize, 65, 256, 1024, 4096, 16 * 1024, 64 * 1024];
+    let lengths = [
+        17usize,
+        33,
+        63,
+        64,
+        65,
+        256,
+        1024,
+        4096,
+        16 * 1024,
+        64 * 1024,
+    ];
 
     for len in lengths {
+        let baseline_path = select_baseline_copy_kernel(len);
         let mut src = vec![0u8; len + 64];
         rng.fill(&mut src);
         let mut dst_production = vec![0u8; len + 64];

--- a/zstd/benches/wildcopy_candidates.rs
+++ b/zstd/benches/wildcopy_candidates.rs
@@ -1,11 +1,17 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use rand::{RngExt, SeedableRng, rngs::StdRng};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use std::hint::black_box;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use structured_zstd::testing::copy_bytes_overshooting_for_bench;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 type CopyKernel = unsafe fn(*const u8, *mut u8, usize);
 
 #[derive(Clone, Copy)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 struct BenchPath {
     name: &'static str,
     chunk: usize,
@@ -13,6 +19,7 @@ struct BenchPath {
 }
 
 #[inline(always)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_candidate_scalar(src: *const u8, dst: *mut u8, len: usize) {
     unsafe { dst.copy_from_nonoverlapping(src, len) };
 }
@@ -113,8 +120,8 @@ unsafe fn copy_baseline_avx512(mut src: *const u8, mut dst: *mut u8, len: usize)
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-fn select_candidate_copy_kernel() -> BenchPath {
-    if std::arch::is_x86_feature_detected!("avx2") {
+fn select_candidate_copy_kernel(len: usize) -> BenchPath {
+    if std::arch::is_x86_feature_detected!("avx2") && len >= 64 {
         BenchPath {
             name: "candidate_avx2_unroll2",
             chunk: 64,
@@ -126,15 +133,6 @@ fn select_candidate_copy_kernel() -> BenchPath {
             chunk: core::mem::size_of::<usize>(),
             kernel: copy_candidate_scalar,
         }
-    }
-}
-
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn select_candidate_copy_kernel() -> BenchPath {
-    BenchPath {
-        name: "candidate_scalar_fallback",
-        chunk: core::mem::size_of::<usize>(),
-        kernel: copy_candidate_scalar,
     }
 }
 
@@ -167,16 +165,8 @@ fn select_baseline_copy_kernel(len: usize) -> BenchPath {
     }
 }
 
-#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
-fn select_baseline_copy_kernel(_len: usize) -> BenchPath {
-    BenchPath {
-        name: "baseline_scalar",
-        chunk: core::mem::size_of::<usize>(),
-        kernel: copy_candidate_scalar,
-    }
-}
-
 #[inline(always)]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 unsafe fn copy_with_overshoot_policy(
     src: (*const u8, usize),
     dst: (*mut u8, usize),
@@ -196,10 +186,10 @@ unsafe fn copy_with_overshoot_policy(
     }
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn bench_wildcopy_candidates(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(0x57A7_1DC0_0EED_1234);
     let mut group = c.benchmark_group("decode_wildcopy_candidates");
-    let candidate_path = select_candidate_copy_kernel();
     let lengths = [
         17usize,
         33,
@@ -214,6 +204,7 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
     ];
 
     for len in lengths {
+        let candidate_path = select_candidate_copy_kernel(len);
         let baseline_path = select_baseline_copy_kernel(len);
         let mut src = vec![0u8; len + 64];
         rng.fill(&mut src);
@@ -293,5 +284,10 @@ fn bench_wildcopy_candidates(c: &mut Criterion) {
     group.finish();
 }
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 criterion_group!(benches, bench_wildcopy_candidates);
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 criterion_main!(benches);
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+fn main() {}

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -8,8 +8,6 @@ mod streaming_decoder;
 
 pub use dictionary::{Dictionary, DictionaryHandle};
 pub use frame_decoder::{BlockDecodingStrategy, FrameDecoder};
-#[cfg(feature = "bench_internals")]
-pub use simd_copy::copy_bytes_overshooting_for_bench;
 pub use streaming_decoder::StreamingDecoder;
 
 pub(crate) mod block_decoder;
@@ -23,4 +21,4 @@ mod ringbuffer;
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
-mod simd_copy;
+pub(crate) mod simd_copy;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -8,6 +8,8 @@ mod streaming_decoder;
 
 pub use dictionary::{Dictionary, DictionaryHandle};
 pub use frame_decoder::{BlockDecodingStrategy, FrameDecoder};
+#[cfg(feature = "bench_internals")]
+pub use simd_copy::copy_bytes_overshooting_for_bench;
 pub use streaming_decoder::StreamingDecoder;
 
 pub(crate) mod block_decoder;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -21,6 +21,4 @@ mod ringbuffer;
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
-mod simd_copy;
-#[cfg(feature = "bench_internals")]
-pub use self::simd_copy::copy_bytes_overshooting_for_bench;
+pub(crate) mod simd_copy;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -21,4 +21,6 @@ mod ringbuffer;
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
-pub(crate) mod simd_copy;
+mod simd_copy;
+#[cfg(feature = "bench_internals")]
+pub use self::simd_copy::copy_bytes_overshooting_for_bench;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -21,4 +21,7 @@ mod ringbuffer;
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
-pub(crate) mod simd_copy;
+mod simd_copy;
+
+#[cfg(feature = "bench_internals")]
+pub(crate) use self::simd_copy::copy_bytes_overshooting_for_bench;

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -71,6 +71,12 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 
 /// Bench-only entrypoint for evaluating alternative copy kernels against the
 /// production overshooting wildcopy implementation.
+///
+/// # Safety
+/// Caller must satisfy the same requirements as [`copy_bytes_overshooting`]:
+/// source and destination pointers must be valid for reads/writes of at least
+/// `copy_at_least` bytes, support any rounded-up overshoot implied by the
+/// active copy strategy when capacities permit it, and must not overlap.
 #[cfg(feature = "bench_internals")]
 #[inline(always)]
 pub unsafe fn copy_bytes_overshooting_for_bench(

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -79,7 +79,7 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 /// active copy strategy when capacities permit it, and must not overlap.
 #[cfg(feature = "bench_internals")]
 #[inline(always)]
-pub unsafe fn copy_bytes_overshooting_for_bench(
+pub(crate) unsafe fn copy_bytes_overshooting_for_bench(
     src: (*const u8, usize),
     dst: (*mut u8, usize),
     copy_at_least: usize,

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -69,6 +69,18 @@ pub(crate) unsafe fn copy_bytes_overshooting(
     }
 }
 
+/// Bench-only entrypoint for evaluating alternative copy kernels against the
+/// production overshooting wildcopy implementation.
+#[cfg(feature = "bench_internals")]
+#[inline(always)]
+pub unsafe fn copy_bytes_overshooting_for_bench(
+    src: (*const u8, usize),
+    dst: (*mut u8, usize),
+    copy_at_least: usize,
+) {
+    unsafe { copy_bytes_overshooting(src, dst, copy_at_least) };
+}
+
 #[inline(always)]
 fn scalar_strategy() -> CopyStrategy {
     CopyStrategy {

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -84,6 +84,8 @@ pub unsafe fn copy_bytes_overshooting_for_bench(
     dst: (*mut u8, usize),
     copy_at_least: usize,
 ) {
+    // Keep an explicit unsafe block here because the crate enforces
+    // `unsafe_op_in_unsafe_fn` under `-D warnings`.
     unsafe { copy_bytes_overshooting(src, dst, copy_at_least) };
 }
 

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -76,4 +76,5 @@ mod tests;
 #[doc(hidden)]
 pub mod testing {
     pub use crate::bit_io::BitReaderReversed;
+    pub use crate::decoding::copy_bytes_overshooting_for_bench;
 }

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -76,5 +76,5 @@ mod tests;
 #[doc(hidden)]
 pub mod testing {
     pub use crate::bit_io::BitReaderReversed;
-    pub use crate::decoding::copy_bytes_overshooting_for_bench;
+    pub use crate::decoding::simd_copy::copy_bytes_overshooting_for_bench;
 }

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -76,5 +76,5 @@ mod tests;
 #[doc(hidden)]
 pub mod testing {
     pub use crate::bit_io::BitReaderReversed;
-    pub use crate::decoding::simd_copy::copy_bytes_overshooting_for_bench;
+    pub use crate::decoding::copy_bytes_overshooting_for_bench;
 }

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -76,5 +76,19 @@ mod tests;
 #[doc(hidden)]
 pub mod testing {
     pub use crate::bit_io::BitReaderReversed;
-    pub use crate::decoding::copy_bytes_overshooting_for_bench;
+
+    /// Bench-only facade for the decoder wildcopy implementation.
+    ///
+    /// # Safety
+    /// Caller must satisfy the same safety contract as
+    /// `decoding::copy_bytes_overshooting_for_bench`.
+    #[inline(always)]
+    pub unsafe fn copy_bytes_overshooting_for_bench(
+        src: (*const u8, usize),
+        dst: (*mut u8, usize),
+        copy_at_least: usize,
+    ) {
+        // Keep decoder internals crate-private and expose only this bench shim.
+        unsafe { crate::decoding::copy_bytes_overshooting_for_bench(src, dst, copy_at_least) };
+    }
 }


### PR DESCRIPTION
## Summary
- add benchmark dashboard usability fixes in `gh-pages` source:
  - taller chart canvas so legend/series toggles remain visible
  - `From`/`To` snapshot selectors to focus on recent measurement points
- add a dedicated Criterion bench `wildcopy_candidates` (feature-gated by `bench_internals`) for issue #87 research
- expose a bench-only internal entrypoint for production wildcopy kernel comparison

## Issue linkage
- Related: #87 (research task)
- This PR does **not** close #87.

## Bench findings (local)
`cargo bench --bench wildcopy_candidates -p structured-zstd --features bench_internals -- --output-format bencher`

- baseline/64: `3 ns`
- candidate/64: `2 ns`
- baseline/256: `7 ns`
- candidate/256: `4 ns`
- baseline/1024: `28 ns`
- candidate/1024: `14 ns`
- baseline/4096: `94 ns`
- candidate/4096: `58 ns`
- baseline/16384: `347 ns`
- candidate/16384: `268 ns`
- baseline/65536: `1368 ns`
- candidate/65536: `1121 ns`

## Validation
- `cargo fmt -- --check`
- `cargo check --workspace`
- `cargo clippy --all-targets -- -D warnings`
- `cargo check -p structured-zstd --features bench_internals --benches`
- `cargo nextest run --workspace`
- `cargo test --doc --workspace`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added date range (From/To) controls and inclusive time-window filtering to the dashboard.

* **UI**
  * Chart now fills its container with fixed visual height; time-window select lists populate dynamically, retain/validate selections, and update with filter changes.

* **Tests**
  * Added an x86/x86_64 benchmark comparing baseline and candidate copy strategies and registered a new benchmark target.

* **Documentation**
  * Added benchmark research notes with measurements and a provisional GO recommendation.

* **Refactor**
  * Exposed bench-only internals behind a feature gate to support benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->