### PR TITLE
perf(decoding): port upstream extend_and_fill / extend_from_reader for RLE+Raw blocks

### DIFF
--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -75,9 +75,14 @@ impl BlockDecoder {
                 Ok(1)
             }
             BlockType::Raw => {
+                // Pass `source` by value, not `&mut source`: `extend_from_reader<R: Read>`
+                // takes `R` by value, and `crate::io::Read` (the `no_std` shim) does not
+                // provide a blanket `impl<R: Read + ?Sized> Read for &mut R` like
+                // `std::io::Read` does, so `&mut source` would fail to compile without
+                // the `std` feature. `source` is not used after this match arm.
                 workspace
                     .buffer
-                    .extend_from_reader(&mut source, header.decompressed_size as usize)
+                    .extend_from_reader(source, header.decompressed_size as usize)
                     .map_err(|err| DecodeBlockContentError::ReadError {
                         step: block_type,
                         source: err,

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -59,30 +59,18 @@ impl BlockDecoder {
         let block_type = header.block_type;
         match block_type {
             BlockType::RLE => {
-                const BATCH_SIZE: usize = 512;
-                let mut buf = [0u8; BATCH_SIZE];
-                let full_reads = header.decompressed_size / BATCH_SIZE as u32;
-                let single_read_size = header.decompressed_size % BATCH_SIZE as u32;
-
-                workspace.buffer.reserve(header.decompressed_size as usize);
-
-                source.read_exact(&mut buf[0..1]).map_err(|err| {
+                let mut buf = [0u8; 1];
+                source.read_exact(&mut buf[..]).map_err(|err| {
                     DecodeBlockContentError::ReadError {
                         step: block_type,
                         source: err,
                     }
                 })?;
+                workspace
+                    .buffer
+                    .extend_and_fill(buf[0], header.decompressed_size as usize);
+
                 self.internal_state = DecoderState::ReadyToDecodeNextHeader;
-
-                for i in 1..BATCH_SIZE {
-                    buf[i] = buf[0];
-                }
-
-                for _ in 0..full_reads {
-                    workspace.buffer.push(&buf[..]);
-                }
-                let smaller = &mut buf[..single_read_size as usize];
-                workspace.buffer.push(smaller);
 
                 Ok(1)
             }

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -75,31 +75,13 @@ impl BlockDecoder {
                 Ok(1)
             }
             BlockType::Raw => {
-                const BATCH_SIZE: usize = 128 * 1024;
-                let mut buf = [0u8; BATCH_SIZE];
-                let full_reads = header.decompressed_size / BATCH_SIZE as u32;
-                let single_read_size = header.decompressed_size % BATCH_SIZE as u32;
-
-                workspace.buffer.reserve(header.decompressed_size as usize);
-
-                for _ in 0..full_reads {
-                    source.read_exact(&mut buf[..]).map_err(|err| {
-                        DecodeBlockContentError::ReadError {
-                            step: block_type,
-                            source: err,
-                        }
-                    })?;
-                    workspace.buffer.push(&buf[..]);
-                }
-
-                let smaller = &mut buf[..single_read_size as usize];
-                source
-                    .read_exact(smaller)
+                workspace
+                    .buffer
+                    .extend_from_reader(&mut source, header.decompressed_size as usize)
                     .map_err(|err| DecodeBlockContentError::ReadError {
                         step: block_type,
                         source: err,
                     })?;
-                workspace.buffer.push(smaller);
 
                 self.internal_state = DecoderState::ReadyToDecodeNextHeader;
                 Ok(u64::from(header.decompressed_size))

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -69,6 +69,15 @@ impl DecodeBuffer {
         self.buffer.reserve(amount);
     }
 
+    /// Fill `fill_length` bytes of the output with the literal `fill_with`,
+    /// advancing the ringbuffer cursor in place. Used by the RLE block path
+    /// (and, after upstream commit `29a56160`, the Raw block path) so the
+    /// decoder doesn't need a stack scratch buffer to materialise repeated
+    /// bytes before pushing them.
+    pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
+        self.buffer.extend_and_fill(fill_with, fill_length);
+    }
+
     pub fn push(&mut self, data: &[u8]) {
         self.buffer.extend(data);
         self.total_output_counter += data.len() as u64;

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -78,6 +78,14 @@ impl DecodeBuffer {
         self.buffer.extend_and_fill(fill_with, fill_length);
     }
 
+    pub fn extend_from_reader<R: Read>(
+        &mut self,
+        read: R,
+        fill_length: usize,
+    ) -> Result<(), crate::io::Error> {
+        self.buffer.extend_from_reader(read, fill_length)
+    }
+
     pub fn push(&mut self, data: &[u8]) {
         self.buffer.extend(data);
         self.total_output_counter += data.len() as u64;

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -73,17 +73,26 @@ impl DecodeBuffer {
     /// advancing the ringbuffer cursor in place. Used by the RLE block path
     /// (and, after upstream commit `29a56160`, the Raw block path) so the
     /// decoder doesn't need a stack scratch buffer to materialise repeated
-    /// bytes before pushing them.
+    /// bytes before pushing them. Mirrors `push`'s `total_output_counter`
+    /// bookkeeping so dictionary-repeat validation in `repeat_from_dict`
+    /// stays accurate after RLE/Raw blocks.
     pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
         self.buffer.extend_and_fill(fill_with, fill_length);
+        self.total_output_counter += fill_length as u64;
     }
 
+    /// Read `fill_length` bytes from `read` directly into the ringbuffer's
+    /// free slots. Mirrors `push`'s `total_output_counter` bookkeeping —
+    /// only after the read succeeds, so an EOF/IO error leaves the counter
+    /// (and `tail`) unchanged.
     pub fn extend_from_reader<R: Read>(
         &mut self,
         read: R,
         fill_length: usize,
     ) -> Result<(), crate::io::Error> {
-        self.buffer.extend_from_reader(read, fill_length)
+        self.buffer.extend_from_reader(read, fill_length)?;
+        self.total_output_counter += fill_length as u64;
+        Ok(())
     }
 
     pub fn push(&mut self, data: &[u8]) {

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -71,20 +71,22 @@ impl DecodeBuffer {
 
     /// Fill `fill_length` bytes of the output with the literal `fill_with`,
     /// advancing the ringbuffer cursor in place. Used by the RLE block path
-    /// (and, after upstream commit `29a56160`, the Raw block path) so the
-    /// decoder doesn't need a stack scratch buffer to materialise repeated
-    /// bytes before pushing them. Mirrors `push`'s `total_output_counter`
-    /// bookkeeping so dictionary-repeat validation in `repeat_from_dict`
-    /// stays accurate after RLE/Raw blocks.
+    /// (upstream commit `fbc1f2ca`) so the decoder doesn't need a stack
+    /// scratch buffer to materialise repeated bytes before pushing them.
+    /// Mirrors `push`'s `total_output_counter` bookkeeping so
+    /// dictionary-repeat validation in `repeat_from_dict` stays accurate
+    /// after RLE blocks.
     pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
         self.buffer.extend_and_fill(fill_with, fill_length);
         self.total_output_counter += fill_length as u64;
     }
 
     /// Read `fill_length` bytes from `read` directly into the ringbuffer's
-    /// free slots. Mirrors `push`'s `total_output_counter` bookkeeping —
-    /// only after the read succeeds, so an EOF/IO error leaves the counter
-    /// (and `tail`) unchanged.
+    /// free slots. Used by the Raw block path (upstream commit `29a56160`)
+    /// so the decoder doesn't need a 128 KB stack scratch buffer to stage
+    /// each chunk before pushing it. Mirrors `push`'s
+    /// `total_output_counter` bookkeeping — only after the read succeeds,
+    /// so an EOF/IO error leaves the counter (and `tail`) unchanged.
     pub fn extend_from_reader<R: Read>(
         &mut self,
         read: R,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -395,10 +395,7 @@ impl FrameDecoder {
 
     /// Returns the checksum that was read from the data. Only available after all bytes have been read. It is the last 4 bytes of a zstd-frame
     pub fn get_checksum_from_data(&self) -> Option<u32> {
-        let state = match &self.state {
-            None => return None,
-            Some(s) => s,
-        };
+        let state = self.state.as_ref()?;
 
         state.check_sum
     }
@@ -409,10 +406,7 @@ impl FrameDecoder {
     pub fn get_calculated_checksum(&self) -> Option<u32> {
         use core::hash::Hasher;
 
-        let state = match &self.state {
-            None => return None,
-            Some(s) => s,
-        };
+        let state = self.state.as_ref()?;
         let cksum_64bit = state.decoder_scratch.buffer.hash.finish();
         //truncate to lower 32bit because reasons...
         Some(cksum_64bit as u32)

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -1,3 +1,4 @@
+use crate::io::Read;
 use alloc::alloc::{alloc, dealloc};
 use core::{alloc::Layout, ptr::NonNull, slice};
 
@@ -475,6 +476,9 @@ impl RingBuffer {
     }
 
     pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
+        if fill_length == 0 {
+            return;
+        }
         self.reserve(fill_length);
         let ((ptr1, len1), (ptr2, len2)) = self.free_slice_parts();
         debug_assert!(len1 + len2 >= fill_length);
@@ -489,7 +493,37 @@ impl RingBuffer {
                 ptr2.write_bytes(fill_with, fill2);
             }
         }
-        self.tail = (self.tail + fill_length) % self.cap
+        self.tail = (self.tail + fill_length) % self.cap;
+    }
+
+    pub fn extend_from_reader<R: Read>(
+        &mut self,
+        mut read: R,
+        fill_length: usize,
+    ) -> Result<(), crate::io::Error> {
+        if fill_length == 0 {
+            return Ok(());
+        }
+        self.reserve(fill_length);
+        let ((ptr1, len1), (ptr2, len2)) = self.free_slice_parts();
+        debug_assert!(len1 + len2 >= fill_length);
+        let fill1 = usize::min(len1, fill_length);
+        let s1 = unsafe {
+            ptr1.write_bytes(0, fill1);
+            slice::from_raw_parts_mut(ptr1, fill1)
+        };
+        read.read_exact(s1)?;
+        if fill1 < fill_length {
+            let fill2 = fill_length - fill1;
+            debug_assert_eq!(fill_length, fill1 + fill2);
+            let s2 = unsafe {
+                ptr2.write_bytes(0, fill2);
+                slice::from_raw_parts_mut(ptr2, fill2)
+            };
+            read.read_exact(s2)?;
+        }
+        self.tail = (self.tail + fill_length) % self.cap;
+        Ok(())
     }
 
     #[allow(dead_code)]

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -474,6 +474,24 @@ impl RingBuffer {
         self.tail = (self.tail + len) % self.cap;
     }
 
+    pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
+        self.reserve(fill_length);
+        let ((ptr1, len1), (ptr2, len2)) = self.free_slice_parts();
+        debug_assert!(len1 + len2 >= fill_length);
+        let fill1 = usize::min(len1, fill_length);
+        unsafe {
+            ptr1.write_bytes(fill_with, fill1);
+        }
+        if fill1 < fill_length {
+            let fill2 = fill_length - fill1;
+            debug_assert_eq!(fill_length, fill1 + fill2);
+            unsafe {
+                ptr2.write_bytes(fill_with, fill2);
+            }
+        }
+        self.tail = (self.tail + fill_length) % self.cap
+    }
+
     #[allow(dead_code)]
     /// This function is functionally the same as [RingBuffer::extend_from_within_unchecked],
     /// but it does not contain any branching operations.

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -1165,4 +1165,104 @@ mod tests {
             &src_overshoot[1..1 + fallback_len]
         );
     }
+
+    /// Helper: drive the ringbuffer into a wrapped layout where the two
+    /// free-slice halves straddle the physical end of the backing buffer.
+    /// Returns a buffer whose `len() == fill_len` of `pre_byte` data and
+    /// whose free region wraps.
+    fn build_wrapped_buffer(cap: usize, fill_len: usize, pre_byte: u8) -> RingBuffer {
+        let mut rb = RingBuffer::new();
+        rb.reserve(cap);
+        let actual_cap = rb.cap;
+        // Push to near-end of the physical buffer.
+        let pre_len = actual_cap - 2;
+        let prefix = alloc::vec![pre_byte; pre_len];
+        rb.extend(&prefix);
+        // Drop those bytes so head advances past them; tail now sits near
+        // the end of `cap`, head is in the middle. Subsequent inserts will
+        // wrap across the physical end.
+        rb.drop_first_n(pre_len - fill_len);
+        assert_eq!(rb.len(), fill_len);
+        assert!(rb.tail > rb.head, "tail should still trail tape end");
+        rb
+    }
+
+    #[test]
+    fn extend_and_fill_contiguous_layout() {
+        let mut rb = RingBuffer::new();
+        rb.extend_and_fill(0xAB, 7);
+        assert_eq!(rb.len(), 7);
+        let (s1, s2) = rb.as_slices();
+        let mut combined = alloc::vec::Vec::with_capacity(7);
+        combined.extend_from_slice(s1);
+        combined.extend_from_slice(s2);
+        assert_eq!(combined, alloc::vec![0xAB; 7]);
+    }
+
+    #[test]
+    fn extend_and_fill_wrapped_layout() {
+        // Pre-fill so the free region straddles the wrap boundary, then
+        // verify both halves are written with the fill byte.
+        let mut rb = build_wrapped_buffer(16, 2, 0x11);
+        let extra = rb.cap - 2; // fills exactly to capacity, forcing a wrap
+        rb.extend_and_fill(0x22, extra);
+        assert_eq!(rb.len(), 2 + extra);
+        let (s1, s2) = rb.as_slices();
+        let mut combined = alloc::vec::Vec::with_capacity(rb.len());
+        combined.extend_from_slice(s1);
+        combined.extend_from_slice(s2);
+        let mut expected = alloc::vec![0x11; 2];
+        expected.extend(alloc::vec![0x22; extra]);
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn extend_from_reader_contiguous_layout() {
+        let mut rb = RingBuffer::new();
+        let src: [u8; 6] = [1, 2, 3, 4, 5, 6];
+        rb.extend_from_reader(&src[..], 6).unwrap();
+        assert_eq!(rb.len(), 6);
+        let (s1, s2) = rb.as_slices();
+        let mut combined = alloc::vec::Vec::with_capacity(6);
+        combined.extend_from_slice(s1);
+        combined.extend_from_slice(s2);
+        assert_eq!(combined, src);
+    }
+
+    #[test]
+    fn extend_from_reader_wrapped_layout() {
+        let mut rb = build_wrapped_buffer(16, 3, 0xAA);
+        let extra = rb.cap - 3;
+        let src: alloc::vec::Vec<u8> = (0..extra as u8).collect();
+        rb.extend_from_reader(src.as_slice(), extra).unwrap();
+        assert_eq!(rb.len(), 3 + extra);
+        let (s1, s2) = rb.as_slices();
+        let mut combined = alloc::vec::Vec::with_capacity(rb.len());
+        combined.extend_from_slice(s1);
+        combined.extend_from_slice(s2);
+        let mut expected = alloc::vec![0xAA; 3];
+        expected.extend_from_slice(&src);
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn extend_from_reader_eof_leaves_state_unchanged() {
+        let mut rb = RingBuffer::new();
+        rb.extend(b"prefix");
+        let snapshot_len = rb.len();
+        let snapshot_slices: (alloc::vec::Vec<u8>, alloc::vec::Vec<u8>) = {
+            let (a, b) = rb.as_slices();
+            (a.to_vec(), b.to_vec())
+        };
+
+        // Reader yields only 2 bytes but we ask for 10 → `read_exact` fails
+        // on the second chunk, and `tail` must not advance.
+        let short: [u8; 2] = [0xCC, 0xDD];
+        let err = rb.extend_from_reader(&short[..], 10);
+        assert!(err.is_err(), "short reader must propagate IO error");
+        assert_eq!(rb.len(), snapshot_len, "len() must be unchanged on error");
+        let (a, b) = rb.as_slices();
+        assert_eq!(a, snapshot_slices.0.as_slice());
+        assert_eq!(b, snapshot_slices.1.as_slice());
+    }
 }


### PR DESCRIPTION
## Summary

Port three upstream commits from `KillingSpark/zstd-rs` that remove stack-buffer scratch space from the RLE and Raw block decode paths, plus a follow-up lint fix. The decoder now writes directly into the ringbuffer free slices (`memset`-style for RLE, `read_exact`-style for Raw) instead of staging through a fixed-size stack buffer and pushing chunks.

This addresses the two pending decoder fixes captured in `memory/decoder_pending_fixes.md`. Upstream already implemented the Raw block half — we did not have to write it ourselves.

## Upstream commits ported

| Upstream SHA | Subject |
|---|---|
| `fbc1f2ca` | RLE block decoding does not need a buffer on the stack |
| `29a56160` | Raw block decoding does not need a buffer on the stack |
| `c800b575` | make clippy happy |

Skipped: release/changelog/docs commits (`3ecdba56`, `1c7aafb8`, `da53f315`) — fork-specific content diverges. `b269cc40` (Debug derive on `CompressionLevel`) skipped because our fork already has it.

## What changed

- `zstd/src/decoding/ringbuffer.rs`: new `extend_and_fill(byte, len)` and `extend_from_reader(reader, len)` methods. Both use `free_slice_parts()` plus `ptr::write_bytes` / `Read::read_exact` to fill the two contiguous free regions directly, then advance `tail`. Single pass, no scratch allocation.
- `zstd/src/decoding/decode_buffer.rs`: forward both methods through the `DecodeBuffer` wrapper. Our fork-specific `reserve(amount)` helper is preserved alongside the new methods.
- `zstd/src/decoding/block_decoder.rs`:
  - RLE branch: 16 lines (512-byte stack buffer + fill loop + multiple `push()`) → 6 lines (1-byte `read_exact` + `extend_and_fill`).
  - Raw branch: ~20 lines (128 KB stack buffer + chunked `read_exact`/`push` loop) → 5 lines (`extend_from_reader`). The 128 KB stack buffer was an embedded/async-runtime stack-overflow risk.

## Conflict resolution notes

Upstream paths are `ruzstd/src/...`; git resolved them to our `zstd/src/...` automatically via path-following. The remaining conflicts were fork-specific edits we made earlier:

- Removed redundant `workspace.buffer.reserve(...)` calls before the new write paths — the new ringbuffer methods do their own `reserve()` internally.
- Kept our `DecodeBuffer::reserve(amount)` helper (independent API, used elsewhere).

## Testing

- Clippy `-D warnings` clean on x86_64 + aarch64.
- Nextest release suite: 84/84 PASS — roundtrip + decoder + ringbuffer + ratio gate.

## Related

- Tracks: pending fixes in `memory/decoder_pending_fixes.md`.
- Baseline tag: `perf/post-pr-110-baseline`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public API methods for buffer extension operations with direct IO support.

* **Improvements**
  * Simplified RLE block decoding for better performance.
  * Refactored checksum calculation logic.
  * Expanded test coverage for buffer operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->