### PR TITLE
perf(encoding): #111 Phase 2 — saturating_* cleanup on hot path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,19 +50,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - name: Prepend toolchain bin to PATH (macos shim workaround)
+        if: runner.os == 'macOS'
+        # macos-latest preinstalled rustup ships via Homebrew without the
+        # `~/.cargo/bin/{cargo,rustc}` proxy shims. `rustup run stable cargo`
+        # works for the outer call but the cargo it launches then invokes
+        # `rustc -vV` through the same broken proxy. Putting the toolchain's
+        # actual `bin/` ahead on PATH gives every nested invocation the
+        # real binaries.
+        run: |
+          TC="$(rustup show active-toolchain | awk '{print $1}')"
+          echo "$HOME/.rustup/toolchains/$TC/bin" >> $GITHUB_PATH
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: ${{ runner.os }}-cargo
       - name: Test
         working-directory: zstd
-        # `rustup run stable cargo` instead of bare `cargo` so the dispatch
-        # works on macos-latest where the Homebrew rustup install omits the
-        # `~/.cargo/bin/cargo` proxy shim. No-op on Linux / Windows runners
-        # whose `cargo` proxy is intact.
-        run: rustup run stable cargo nextest run --profile ci -p structured-zstd --features hash,std,dict_builder
+        run: cargo nextest run --profile ci -p structured-zstd --features hash,std,dict_builder
       - name: Doc tests
-        run: rustup run stable cargo test --doc -p structured-zstd --features hash,std,dict_builder
+        run: cargo test --doc -p structured-zstd --features hash,std,dict_builder
 
   cross-i686:
     needs: lint

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -319,7 +319,11 @@ impl BtMatcher {
     /// Donor parity: `ZSTD_storeSeq` — encode `actual_offset` into the
     /// donor's compact offset base (1/2/3 for rep slots, otherwise
     /// `actual_offset + 3`) and update the rolling `reps` window in
-    /// lock-step. Returns `(off_base, next_reps)`.
+    /// lock-step. Returns `(off_base, next_reps)`. The non-rep branch
+    /// uses `saturating_add` so a `u32` near `u32::MAX` (only possible
+    /// via malformed external input) clamps to `u32::MAX` rather than
+    /// wrapping into a small rep-code value that would silently corrupt
+    /// the encoded stream.
     pub(crate) fn encode_offset_with_reps(
         actual_offset: u32,
         lit_len: usize,
@@ -334,7 +338,7 @@ impl BtMatcher {
             } else if actual_offset == reps[2] {
                 3
             } else {
-                actual_offset + 3
+                actual_offset.saturating_add(3)
             }
         } else if actual_offset == reps[1] {
             1
@@ -343,7 +347,7 @@ impl BtMatcher {
         } else if reps[0] > 1 && actual_offset == reps[0] - 1 {
             3
         } else {
-            actual_offset + 3
+            actual_offset.saturating_add(3)
         };
 
         if lit_len > 0 {
@@ -393,7 +397,7 @@ impl BtMatcher {
             } else if actual_offset == reps[2] {
                 3
             } else {
-                actual_offset + 3
+                actual_offset.saturating_add(3)
             }
         } else if actual_offset == reps[1] {
             1
@@ -402,7 +406,7 @@ impl BtMatcher {
         } else if reps[0] > 1 && actual_offset == reps[0] - 1 {
             3
         } else {
-            actual_offset + 3
+            actual_offset.saturating_add(3)
         }
     }
 

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -334,7 +334,7 @@ impl BtMatcher {
             } else if actual_offset == reps[2] {
                 3
             } else {
-                actual_offset.saturating_add(3)
+                actual_offset + 3
             }
         } else if actual_offset == reps[1] {
             1
@@ -343,7 +343,7 @@ impl BtMatcher {
         } else if reps[0] > 1 && actual_offset == reps[0] - 1 {
             3
         } else {
-            actual_offset.saturating_add(3)
+            actual_offset + 3
         };
 
         if lit_len > 0 {
@@ -393,7 +393,7 @@ impl BtMatcher {
             } else if actual_offset == reps[2] {
                 3
             } else {
-                actual_offset.saturating_add(3)
+                actual_offset + 3
             }
         } else if actual_offset == reps[1] {
             1
@@ -402,7 +402,7 @@ impl BtMatcher {
         } else if reps[0] > 1 && actual_offset == reps[0] - 1 {
             3
         } else {
-            actual_offset.saturating_add(3)
+            actual_offset + 3
         }
     }
 
@@ -544,8 +544,11 @@ impl BtMatcher {
         stamp: u32,
     ) -> i32 {
         if lit_len == 0 {
-            return profile.lit_length_price(stats, lit_len) as i32
-                - profile.lit_length_price(stats, lit_len.saturating_sub(1)) as i32;
+            // The `lit_len == 0` branch is the rare case where computing
+            // `lit_len - 1` would underflow; we feed `0` to both
+            // `lit_length_price` calls so the delta is 0 by construction.
+            // No need to compute `0_usize - 1`.
+            return 0;
         }
         let price =
             Self::cached_lit_length_price(profile, stats, lit_len, prices, generations, stamp);

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -607,6 +607,18 @@ impl DfastMatchGenerator {
     }
 
     pub(crate) fn insert_positions_with_step(&mut self, start: usize, end: usize, step: usize) {
+        // The raw `pos += step` below is correct only while `step` is
+        // bounded by `DFAST_INCOMPRESSIBLE_SKIP_STEP` (the only value
+        // any in-tree caller passes here). Asserting it locally keeps
+        // a future caller from quietly reintroducing the overflow risk
+        // that the upstream `check_stream_abs_headroom` gate is sized
+        // for.
+        assert!(
+            step <= DFAST_INCOMPRESSIBLE_SKIP_STEP,
+            "insert_positions_with_step: step ({step}) exceeds \
+             DFAST_INCOMPRESSIBLE_SKIP_STEP — raw `pos += step` would \
+             eat into the STREAM_ABS_HEADROOM reserve"
+        );
         let start = start.max(self.history_abs_start);
         let end = end.min(self.history_abs_end());
         if step <= 1 {
@@ -619,7 +631,8 @@ impl DfastMatchGenerator {
             // `pos + step` is safe: `pos < end <= history_abs_end()` and
             // `history_abs_end <= usize::MAX - STREAM_ABS_HEADROOM` by
             // the upstream `check_stream_abs_headroom` gate, while
-            // `step` is bounded by `DFAST_INCOMPRESSIBLE_SKIP_STEP`.
+            // `step` is bounded above by the assertion at function
+            // entry.
             pos += step;
         }
     }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -26,6 +26,7 @@ use super::match_table::helpers::{
     LazyMatchConfig, best_len_offset_candidate, common_prefix_len, extend_backwards_shared,
     pick_lazy_match_shared, repcode_candidate_shared,
 };
+use super::match_table::storage::check_stream_abs_headroom;
 use super::opt::types::MatchCandidate;
 
 pub(crate) struct DfastMatchGenerator {
@@ -108,6 +109,7 @@ impl DfastMatchGenerator {
 
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
+        check_stream_abs_headroom(self.history_abs_start, self.window_size, data.len());
         while self.window_size + data.len() > self.max_window_size {
             let removed = self.window.pop_front().unwrap();
             self.window_size -= removed.len();
@@ -212,9 +214,13 @@ impl DfastMatchGenerator {
         //
         // 1. Block-local arithmetic (`pos`, `skip_step`, `start +
         //    candidate.match_len`, `DFAST_SKIP_STEP_GROWTH_INTERVAL`):
-        //    bounded by `current_len <= HC_BLOCKSIZE_MAX (128 KiB)`.
-        //    The `while pos + DFAST_MIN_MATCH_LEN <= current_len`
-        //    guard keeps every offset well within that bound.
+        //    the dynamic bound is `current_len` itself — the `while
+        //    pos + DFAST_MIN_MATCH_LEN <= current_len` guard keeps
+        //    every offset within that bound regardless of how the
+        //    caller sized `max_window_size`. In production this also
+        //    happens to be `≤ HC_BLOCKSIZE_MAX (128 KiB)` because the
+        //    frame compressor never hands out larger blocks, but the
+        //    safety argument above does not rely on that limit.
         // 2. Absolute-position arithmetic (`current_abs_start + pos`):
         //    `current_abs_start` is the frame-lifetime cursor and
         //    advances with total bytes processed, NOT with the
@@ -222,13 +228,14 @@ impl DfastMatchGenerator {
         //    can therefore push `current_abs_start + pos` past
         //    `usize::MAX` even though memory usage stays bounded by
         //    `window_size`. The runtime enforcement lives in
-        //    `MatchTable::add_data` (see `STREAM_ABS_HEADROOM` =
-        //    `HC_OPT_NUM + 16`): every ingest fails fast with a
+        //    `DfastMatchGenerator::add_data`, which routes through
+        //    `check_stream_abs_headroom` (the same gate used by
+        //    `MatchTable::add_data`): every ingest fails fast with a
         //    clear panic if cumulative input would push the cursor
-        //    within `STREAM_ABS_HEADROOM` of `usize::MAX`. Raw `+`
-        //    here is donor parity and is correct precisely because
-        //    that upstream gate runs before this loop sees any new
-        //    bytes.
+        //    within `STREAM_ABS_HEADROOM` (`= HC_OPT_NUM + 16`) of
+        //    `usize::MAX`. Raw `+` here is donor parity and is
+        //    correct precisely because that upstream gate runs before
+        //    this loop sees any new bytes.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
@@ -287,10 +294,14 @@ impl DfastMatchGenerator {
         //
         // 1. Block-local arithmetic (`ip0..ip3 = pos + N` for small
         //    `N`, `pos + skip_step` with `skip_step <=
-        //    DFAST_MAX_SKIP_STEP`): bounded by `current_len <=
-        //    HC_BLOCKSIZE_MAX (128 KiB)`. The `while pos +
-        //    DFAST_MIN_MATCH_LEN <= current_len` guard keeps every
-        //    offset well within that bound.
+        //    DFAST_MAX_SKIP_STEP`): the dynamic bound is `current_len`
+        //    itself — the `while pos + DFAST_MIN_MATCH_LEN <=
+        //    current_len` guard keeps every offset within that bound
+        //    regardless of how the caller sized `max_window_size`.
+        //    In production this also happens to be `≤
+        //    HC_BLOCKSIZE_MAX (128 KiB)` because the frame compressor
+        //    never hands out larger blocks, but the safety argument
+        //    above does not rely on that limit.
         // 2. Absolute-position arithmetic (`current_abs_start + ip0`,
         //    `current_abs_start + ip2`, etc.): `current_abs_start` is
         //    the frame-lifetime cursor and advances with total bytes
@@ -298,11 +309,12 @@ impl DfastMatchGenerator {
         //    streaming encode on i686 can push `current_abs_start +
         //    ipN` past `usize::MAX` even though memory stays bounded
         //    by `window_size`. The runtime enforcement lives in
-        //    `MatchTable::add_data` (`STREAM_ABS_HEADROOM` cap):
-        //    every ingest fails fast if cumulative input would
-        //    advance the cursor within `STREAM_ABS_HEADROOM` of
-        //    `usize::MAX`, which keeps the raw `current_abs_start +
-        //    ipN` arithmetic below `usize::MAX` for every position
+        //    `DfastMatchGenerator::add_data` via
+        //    `check_stream_abs_headroom`: every ingest fails fast if
+        //    cumulative input would advance the cursor within
+        //    `STREAM_ABS_HEADROOM` of `usize::MAX`, which keeps the
+        //    raw `current_abs_start + ipN` arithmetic below
+        //    `usize::MAX` for every position
         //    this loop ever observes.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
@@ -604,7 +616,11 @@ impl DfastMatchGenerator {
         let mut pos = start;
         while pos < end {
             self.insert_position(pos);
-            pos = pos.saturating_add(step);
+            // `pos + step` is safe: `pos < end <= history_abs_end()` and
+            // `history_abs_end <= usize::MAX - STREAM_ABS_HEADROOM` by
+            // the upstream `check_stream_abs_headroom` gate, while
+            // `step` is bounded by `DFAST_INCOMPRESSIBLE_SKIP_STEP`.
+            pos += step;
         }
     }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -222,11 +222,11 @@ impl DfastMatchGenerator {
                 );
                 pos = start + candidate.match_len;
                 skip_step = 1;
-                next_skip_growth_pos = pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
                 miss_run = 0;
             } else {
                 self.insert_position(abs_pos);
-                miss_run = miss_run.saturating_add(1);
+                miss_run += 1;
                 let use_local_adaptive_skip = miss_run >= DFAST_LOCAL_SKIP_TRIGGER;
                 if use_adaptive_skip || use_local_adaptive_skip {
                     let skip_cap = if use_adaptive_skip {
@@ -236,10 +236,9 @@ impl DfastMatchGenerator {
                     };
                     if pos >= next_skip_growth_pos {
                         skip_step = (skip_step + 1).min(skip_cap);
-                        next_skip_growth_pos =
-                            next_skip_growth_pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                        next_skip_growth_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
                     }
-                    pos = pos.saturating_add(skip_step);
+                    pos += skip_step;
                 } else {
                     pos += 1;
                 }
@@ -265,9 +264,9 @@ impl DfastMatchGenerator {
         let mut miss_run = 0usize;
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
-            let ip1 = ip0.saturating_add(1);
-            let ip2 = ip0.saturating_add(2);
-            let ip3 = ip0.saturating_add(3);
+            let ip1 = ip0 + 1;
+            let ip2 = ip0 + 2;
+            let ip3 = ip0 + 3;
 
             let abs_ip0 = current_abs_start + ip0;
             let lit_len_ip0 = ip0 - literals_start;
@@ -287,7 +286,7 @@ impl DfastMatchGenerator {
                     );
                     pos = start + rep.match_len;
                     skip_step = 1;
-                    next_skip_growth_pos = pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                    next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
                     miss_run = 0;
                     continue;
                 }
@@ -303,7 +302,7 @@ impl DfastMatchGenerator {
                 );
                 pos = start + candidate.match_len;
                 skip_step = 1;
-                next_skip_growth_pos = pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
                 miss_run = 0;
             } else {
                 self.insert_position(abs_ip0);
@@ -316,18 +315,17 @@ impl DfastMatchGenerator {
                 if ip3 + 4 <= current_len {
                     self.insert_position(current_abs_start + ip3);
                 }
-                miss_run = miss_run.saturating_add(1);
+                miss_run += 1;
                 if block_is_strict_incompressible || miss_run >= DFAST_LOCAL_SKIP_TRIGGER {
                     let skip_cap = DFAST_MAX_SKIP_STEP;
                     if pos >= next_skip_growth_pos {
                         skip_step = (skip_step + 1).min(skip_cap);
-                        next_skip_growth_pos =
-                            next_skip_growth_pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                        next_skip_growth_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
                     }
-                    pos = pos.saturating_add(skip_step);
+                    pos += skip_step;
                 } else {
                     skip_step = 1;
-                    next_skip_growth_pos = pos.saturating_add(DFAST_SKIP_STEP_GROWTH_INTERVAL);
+                    next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
                     pos += 1;
                 }
             }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -208,13 +208,21 @@ impl DfastMatchGenerator {
         let mut skip_step = 1usize;
         let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
         let mut miss_run = 0usize;
-        // Loop invariant: `pos + DFAST_MIN_MATCH_LEN <= current_len <=
-        // HC_BLOCKSIZE_MAX (128 KiB)`. Every unchecked `+` inside the
-        // body operates on a sub-position offset (`start +
-        // candidate.match_len`), a constant (`DFAST_SKIP_STEP_GROWTH_INTERVAL`),
-        // or a step capped by `DFAST_MAX_SKIP_STEP` — all bounded by
-        // `current_len`, so none can overflow `usize` on any supported
-        // target (i686 included).
+        // Loop invariants (two distinct bounds):
+        //
+        // 1. Block-local arithmetic (`pos`, `skip_step`, `start +
+        //    candidate.match_len`, `DFAST_SKIP_STEP_GROWTH_INTERVAL`):
+        //    bounded by `current_len <= HC_BLOCKSIZE_MAX (128 KiB)`.
+        //    The `while pos + DFAST_MIN_MATCH_LEN <= current_len`
+        //    guard keeps every offset well within that bound.
+        // 2. Absolute-position arithmetic (`current_abs_start + pos`,
+        //    `current_abs_start + ip2`): `current_abs_start` is the
+        //    frame-lifetime cursor at the start of the current block.
+        //    The frame compressor's total processed bytes cannot
+        //    exceed the host's `usize` (we'd need that much RAM to
+        //    hold history), so `current_abs_start + pos <= usize::MAX`
+        //    is structurally guaranteed across all supported targets,
+        //    i686 included.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
@@ -269,11 +277,22 @@ impl DfastMatchGenerator {
         let mut skip_step = 1usize;
         let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
         let mut miss_run = 0usize;
-        // Loop invariant: `pos + DFAST_MIN_MATCH_LEN <= current_len <=
-        // HC_BLOCKSIZE_MAX (128 KiB)`. Each unchecked `+` below is on a
-        // sub-position offset (`ip0..ip3`) or a step (`skip_step <=
-        // DFAST_MAX_SKIP_STEP`) bounded by `current_len`, so no usize
-        // arithmetic in this hot loop can overflow.
+        // Loop invariants (two distinct bounds):
+        //
+        // 1. Block-local arithmetic (`ip0..ip3 = pos + N` for small
+        //    `N`, `pos + skip_step` with `skip_step <=
+        //    DFAST_MAX_SKIP_STEP`): bounded by `current_len <=
+        //    HC_BLOCKSIZE_MAX (128 KiB)`. The `while pos +
+        //    DFAST_MIN_MATCH_LEN <= current_len` guard keeps every
+        //    offset well within that bound.
+        // 2. Absolute-position arithmetic (`current_abs_start + ip0`,
+        //    `current_abs_start + ip2`, etc.): `current_abs_start` is
+        //    the frame-lifetime cursor at the start of the current
+        //    block. The frame compressor's total processed bytes
+        //    cannot exceed the host's `usize` (we'd need that much
+        //    RAM to hold history), so `current_abs_start + ipN <=
+        //    usize::MAX` is structurally guaranteed across all
+        //    supported targets, i686 included.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
             let ip1 = ip0 + 1;

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -221,13 +221,14 @@ impl DfastMatchGenerator {
         //    retained window size. A long streaming encode on i686
         //    can therefore push `current_abs_start + pos` past
         //    `usize::MAX` even though memory usage stays bounded by
-        //    `window_size`. This loop assumes the caller respects the
-        //    documented `usize::MAX` total-input cap (enforced at
-        //    the frame compressor boundary); raw `+` here is
-        //    deliberate donor parity but DOES depend on that
-        //    upstream guard. New raw arithmetic on absolute cursors
-        //    should preserve that contract or switch to
-        //    `saturating_add` like the BT macros do.
+        //    `window_size`. The runtime enforcement lives in
+        //    `MatchTable::add_data` (see `STREAM_ABS_HEADROOM` =
+        //    `HC_OPT_NUM + 16`): every ingest fails fast with a
+        //    clear panic if cumulative input would push the cursor
+        //    within `STREAM_ABS_HEADROOM` of `usize::MAX`. Raw `+`
+        //    here is donor parity and is correct precisely because
+        //    that upstream gate runs before this loop sees any new
+        //    bytes.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
@@ -296,11 +297,13 @@ impl DfastMatchGenerator {
         //    processed, NOT with the retained window size. A long
         //    streaming encode on i686 can push `current_abs_start +
         //    ipN` past `usize::MAX` even though memory stays bounded
-        //    by `window_size`. This loop assumes the caller respects
-        //    the documented `usize::MAX` total-input cap enforced at
-        //    the frame compressor boundary; new raw arithmetic on
-        //    absolute cursors should either preserve that contract
-        //    or switch to `saturating_add` like the BT macros do.
+        //    by `window_size`. The runtime enforcement lives in
+        //    `MatchTable::add_data` (`STREAM_ABS_HEADROOM` cap):
+        //    every ingest fails fast if cumulative input would
+        //    advance the cursor within `STREAM_ABS_HEADROOM` of
+        //    `usize::MAX`, which keeps the raw `current_abs_start +
+        //    ipN` arithmetic below `usize::MAX` for every position
+        //    this loop ever observes.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
             let ip1 = ip0 + 1;

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -208,21 +208,26 @@ impl DfastMatchGenerator {
         let mut skip_step = 1usize;
         let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
         let mut miss_run = 0usize;
-        // Loop invariants (two distinct bounds):
+        // Loop invariants:
         //
         // 1. Block-local arithmetic (`pos`, `skip_step`, `start +
         //    candidate.match_len`, `DFAST_SKIP_STEP_GROWTH_INTERVAL`):
         //    bounded by `current_len <= HC_BLOCKSIZE_MAX (128 KiB)`.
         //    The `while pos + DFAST_MIN_MATCH_LEN <= current_len`
         //    guard keeps every offset well within that bound.
-        // 2. Absolute-position arithmetic (`current_abs_start + pos`,
-        //    `current_abs_start + ip2`): `current_abs_start` is the
-        //    frame-lifetime cursor at the start of the current block.
-        //    The frame compressor's total processed bytes cannot
-        //    exceed the host's `usize` (we'd need that much RAM to
-        //    hold history), so `current_abs_start + pos <= usize::MAX`
-        //    is structurally guaranteed across all supported targets,
-        //    i686 included.
+        // 2. Absolute-position arithmetic (`current_abs_start + pos`):
+        //    `current_abs_start` is the frame-lifetime cursor and
+        //    advances with total bytes processed, NOT with the
+        //    retained window size. A long streaming encode on i686
+        //    can therefore push `current_abs_start + pos` past
+        //    `usize::MAX` even though memory usage stays bounded by
+        //    `window_size`. This loop assumes the caller respects the
+        //    documented `usize::MAX` total-input cap (enforced at
+        //    the frame compressor boundary); raw `+` here is
+        //    deliberate donor parity but DOES depend on that
+        //    upstream guard. New raw arithmetic on absolute cursors
+        //    should preserve that contract or switch to
+        //    `saturating_add` like the BT macros do.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
@@ -287,12 +292,15 @@ impl DfastMatchGenerator {
         //    offset well within that bound.
         // 2. Absolute-position arithmetic (`current_abs_start + ip0`,
         //    `current_abs_start + ip2`, etc.): `current_abs_start` is
-        //    the frame-lifetime cursor at the start of the current
-        //    block. The frame compressor's total processed bytes
-        //    cannot exceed the host's `usize` (we'd need that much
-        //    RAM to hold history), so `current_abs_start + ipN <=
-        //    usize::MAX` is structurally guaranteed across all
-        //    supported targets, i686 included.
+        //    the frame-lifetime cursor and advances with total bytes
+        //    processed, NOT with the retained window size. A long
+        //    streaming encode on i686 can push `current_abs_start +
+        //    ipN` past `usize::MAX` even though memory stays bounded
+        //    by `window_size`. This loop assumes the caller respects
+        //    the documented `usize::MAX` total-input cap enforced at
+        //    the frame compressor boundary; new raw arithmetic on
+        //    absolute cursors should either preserve that contract
+        //    or switch to `saturating_add` like the BT macros do.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
             let ip1 = ip0 + 1;

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -262,6 +262,11 @@ impl DfastMatchGenerator {
         let mut skip_step = 1usize;
         let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
         let mut miss_run = 0usize;
+        // Loop invariant: `pos + DFAST_MIN_MATCH_LEN <= current_len <=
+        // HC_BLOCKSIZE_MAX (128 KiB)`. Each unchecked `+` below is on a
+        // sub-position offset (`ip0..ip3`) or a step (`skip_step <=
+        // DFAST_MAX_SKIP_STEP`) bounded by `current_len`, so no usize
+        // arithmetic in this hot loop can overflow.
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let ip0 = pos;
             let ip1 = ip0 + 1;

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -208,6 +208,13 @@ impl DfastMatchGenerator {
         let mut skip_step = 1usize;
         let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
         let mut miss_run = 0usize;
+        // Loop invariant: `pos + DFAST_MIN_MATCH_LEN <= current_len <=
+        // HC_BLOCKSIZE_MAX (128 KiB)`. Every unchecked `+` inside the
+        // body operates on a sub-position offset (`start +
+        // candidate.match_len`), a constant (`DFAST_SKIP_STEP_GROWTH_INTERVAL`),
+        // or a step capped by `DFAST_MAX_SKIP_STEP` — all bounded by
+        // `current_len`, so none can overflow `usize` on any supported
+        // target (i686 included).
         while pos + DFAST_MIN_MATCH_LEN <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -48,11 +48,7 @@ use super::strategy::HcParseMode;
     target_endian = "little"
 ))]
 use std::arch::is_aarch64_feature_detected;
-#[cfg(all(
-    test,
-    feature = "std",
-    any(target_arch = "x86", target_arch = "x86_64")
-))]
+#[cfg(all(test, feature = "std", target_arch = "x86_64"))]
 use std::arch::is_x86_feature_detected;
 
 pub(crate) const DFAST_MIN_MATCH_LEN: usize = 6;
@@ -1082,8 +1078,15 @@ macro_rules! bt_insert_step_no_rebase_body {
         // sentinel that ALWAYS triggers.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($target_abs);
-        // `abs_pos + 9` only overflows on usize::MAX-adjacent input which
-        // never occurs in practice — encode blocks cap at HC_BLOCKSIZE_MAX.
+        // The caller has already proven `idx + 8 <= concat.len()` and
+        // `idx = abs_pos - history_abs_start`. So
+        // `abs_pos + 8 <= history_abs_start + concat.len() = history_abs_end`,
+        // which the frame compressor caps at a value the BT walker can
+        // address (`window_size + history_abs_start <= usize::MAX - 16`).
+        // `abs_pos + 9` therefore stays in `usize` even on 32-bit i686
+        // — the bound is the frame-level history budget, not a
+        // "blocks cap" claim.
+        debug_assert!($abs_pos <= usize::MAX - 9);
         let mut match_end_abs = $abs_pos + 9;
         let mut best_len = 8usize;
         let mut compares_left = $search_depth;
@@ -1348,13 +1351,20 @@ macro_rules! build_optimal_plan_impl_body {
                 )
             };
             if !candidates.is_empty() {
-                // `min_match_len >= HC_FORMAT_MINMATCH (4)` by invariant.
+                // `min_match_len >= HC_FORMAT_MINMATCH (3)` by invariant.
                 last_pos = (min_match_len - 1).min(frontier_limit);
                 for p in 1..min_match_len.min(nodes.len()) {
                     BtMatcher::reset_opt_node(&mut nodes[p]);
-                    // `initial_litlen + p <= u32::MAX`: lit_len capped well
-                    // below 2^32 by HC_OPT_NUM.
-                    nodes[p].litlen = (initial_litlen + p) as u32;
+                    // `initial_litlen` is the litlen carried from prior
+                    // optimal-plan segments — its real bound is the
+                    // current block length (the frame compressor caps
+                    // block scan at `HC_BLOCKSIZE_MAX`), not the segment
+                    // `current_len`. `p < min_match_len` (small constant),
+                    // so the seed-position litlen stays well within
+                    // `u32::MAX`; `u32::try_from` panics rather than
+                    // silently truncates if the invariant is ever broken.
+                    nodes[p].litlen = u32::try_from(initial_litlen + p)
+                        .expect("optimal parser seed litlen out of u32 range");
                 }
             }
 
@@ -1657,7 +1667,9 @@ macro_rules! build_optimal_plan_impl_body {
             }
             let mut prev_max_len = min_match_len - 1;
             for candidate in candidates.iter() {
-                // `pos < frontier_limit` is the outer loop's invariant.
+                // Outer loop guards `pos <= frontier_limit` (see the
+                // `while ... pos <= frontier_limit` condition); the
+                // subtraction below is therefore safe.
                 debug_assert!(pos <= frontier_limit);
                 let max_match_len = candidate
                     .match_len
@@ -1884,9 +1896,16 @@ macro_rules! build_optimal_plan_impl_body {
             }
             store_start -= 1;
             store[store_start] = next_stretch;
-            // `litlen + mlen` are both u32 stored in `HcOptimalNode` —
-            // sum fits in usize on any supported target.
-            let step = (next_stretch.litlen as usize) + (next_stretch.mlen as usize);
+            // Parser invariant: every emitted stretch is bounded by the
+            // current block, so `litlen + mlen <= current_len <=
+            // HC_BLOCKSIZE_MAX (128 KiB)`. The `as usize` widening + raw
+            // `+` is safe on 32-bit targets — two u32 values do NOT
+            // automatically fit in `usize` on i686, the block bound is
+            // what makes this addition safe.
+            let litlen = next_stretch.litlen as usize;
+            let mlen = next_stretch.mlen as usize;
+            debug_assert!(litlen + mlen <= $current_len);
+            let step = litlen + mlen;
             if step == 0 || stretch_pos < step {
                 break;
             }
@@ -2023,9 +2042,12 @@ macro_rules! collect_optimal_candidates_initialized_body {
                     if rep.match_len > $profile.sufficient_match_len {
                         skip_further_match_search = true;
                     }
-                    // `abs_pos + rep.match_len` is bounded by
-                    // `current_abs_end + HC_OPT_NUM` (donor caps match_len
-                    // there) — far below usize::MAX.
+                    // `for_each_repcode_candidate_with_reps` caps
+                    // `rep.match_len` at the per-call `tail_limit =
+                    // current_abs_end - abs_pos`, so `abs_pos +
+                    // rep.match_len <= current_abs_end`. The raw sum
+                    // therefore stays in `usize` on every supported
+                    // target.
                     if $abs_pos + rep.match_len >= $current_abs_end {
                         skip_further_match_search = true;
                     }
@@ -2325,7 +2347,7 @@ macro_rules! bt_insert_and_collect_matches_body {
         $table.hash_table[hash] = stored;
         // Donor semantics: `bestLength` starts at `lengthToBeat - 1`; rep/hash3
         // probing may raise it; BT then only reports strictly longer matches.
-        // `min_match_len >= HC_FORMAT_MINMATCH (4)` by configure invariant,
+        // `min_match_len >= HC_FORMAT_MINMATCH (3)` by configure invariant,
         // so `min_match_len - 1 >= 3` cannot underflow.
         debug_assert!($min_match_len >= 1, "min_match_len must be at least 1");
         let mut best_len = (*$best_len_for_skip).max($min_match_len - 1);
@@ -2368,10 +2390,13 @@ macro_rules! bt_insert_and_collect_matches_body {
                 );
                 if accepted {
                     best_len = match_len;
-                    // `match_len <= tail_limit` and `candidate_abs < abs_pos
-                    // <= current_abs_end`, so `candidate_abs + match_len` is
-                    // bounded by `current_abs_end + tail_limit < 2 *
-                    // current_abs_end` — far below usize::MAX.
+                    // BT walker invariants: `candidate_abs < abs_pos`
+                    // and `match_len <= tail_limit = current_abs_end -
+                    // abs_pos`. So `candidate_abs + match_len <
+                    // abs_pos + tail_limit = current_abs_end`, which
+                    // fits in `usize` on every supported target (32-bit
+                    // i686 included) — the addition stays within the
+                    // current block.
                     let candidate_end = candidate_abs + match_len;
                     if candidate_end > match_end_abs {
                         match_end_abs = candidate_end;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1360,11 +1360,15 @@ macro_rules! build_optimal_plan_impl_body {
                     // current block length (the frame compressor caps
                     // block scan at `HC_BLOCKSIZE_MAX`), not the segment
                     // `current_len`. `p < min_match_len` (small constant),
-                    // so the seed-position litlen stays well within
-                    // `u32::MAX`; `u32::try_from` panics rather than
-                    // silently truncates if the invariant is ever broken.
-                    nodes[p].litlen = u32::try_from(initial_litlen + p)
+                    // so the sum stays well within `u32::MAX`. Use
+                    // `checked_add` FIRST so the `usize` addition itself
+                    // cannot overflow on i686 (where `usize` is 32-bit
+                    // and a wrapping `+` would slip past `try_from`).
+                    let seed_litlen = initial_litlen
+                        .checked_add(p)
+                        .and_then(|s| u32::try_from(s).ok())
                         .expect("optimal parser seed litlen out of u32 range");
+                    nodes[p].litlen = seed_litlen;
                 }
             }
 
@@ -2348,7 +2352,7 @@ macro_rules! bt_insert_and_collect_matches_body {
         // Donor semantics: `bestLength` starts at `lengthToBeat - 1`; rep/hash3
         // probing may raise it; BT then only reports strictly longer matches.
         // `min_match_len >= HC_FORMAT_MINMATCH (3)` by configure invariant,
-        // so `min_match_len - 1 >= 3` cannot underflow.
+        // so `min_match_len - 1 >= 2` cannot underflow.
         debug_assert!($min_match_len >= 1, "min_match_len must be at least 1");
         let mut best_len = (*$best_len_for_skip).max($min_match_len - 1);
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1059,7 +1059,11 @@ macro_rules! bt_insert_step_no_rebase_body {
         if idx + 8 > concat.len() {
             return 1;
         }
-        let tail_limit = $current_abs_end.saturating_sub($abs_pos);
+        debug_assert!(
+            $abs_pos <= $current_abs_end,
+            "BT walker called past current block end"
+        );
+        let tail_limit = $current_abs_end - $abs_pos;
         let hash = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
             concat,
             idx,
@@ -1071,9 +1075,16 @@ macro_rules! bt_insert_step_no_rebase_body {
         };
         let stored = relative_pos + 1;
         let bt_mask = $table.bt_mask();
+        // `abs_pos < bt_mask` legitimately happens for the first BT walk of
+        // a fresh frame (bt_low effectively "no floor"). Saturating keeps
+        // the floor at 0 so the `candidate_abs <= bt_low` check never
+        // triggers early; raw subtraction would underflow into a huge
+        // sentinel that ALWAYS triggers.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($target_abs);
-        let mut match_end_abs = $abs_pos.saturating_add(9);
+        // `abs_pos + 9` only overflows on usize::MAX-adjacent input which
+        // never occurs in practice — encode blocks cap at HC_BLOCKSIZE_MAX.
+        let mut match_end_abs = $abs_pos + 9;
         let mut best_len = 8usize;
         let mut compares_left = $search_depth;
         let mut common_length_smaller = 0usize;
@@ -1112,7 +1123,10 @@ macro_rules! bt_insert_step_no_rebase_body {
 
             if match_len > best_len {
                 best_len = match_len;
-                let candidate_end = candidate_abs.saturating_add(match_len);
+                // `candidate_abs + match_len <= current_abs_end` by BT walk
+                // invariant — `match_len <= tail_limit = current_abs_end -
+                // abs_pos` and `candidate_abs < abs_pos`.
+                let candidate_end = candidate_abs + match_len;
                 if candidate_end > match_end_abs {
                     match_end_abs = candidate_end;
                 }
@@ -1157,7 +1171,11 @@ macro_rules! bt_insert_step_no_rebase_body {
         } else {
             0
         };
-        speed_positions.max(match_end_abs.saturating_sub($abs_pos.saturating_add(8)))
+        // `match_end_abs` is initialized to `abs_pos + 9` and only ever
+        // monotonically increased by `candidate_end` (also `> abs_pos`).
+        // So `match_end_abs > abs_pos + 8` is invariant — raw subtraction
+        // is safe.
+        speed_positions.max(match_end_abs - ($abs_pos + 8))
     }};
 }
 pub(crate) use bt_insert_step_no_rebase_body;
@@ -1189,7 +1207,8 @@ macro_rules! build_optimal_plan_impl_body {
     ) => {{
         let current_abs_end = $current_abs_start + $current_len;
         let min_match_len = HC_OPT_MIN_MATCH_LEN;
-        let frontier_limit = $current_len.min(HC_OPT_NUM.saturating_sub(1));
+        // `HC_OPT_NUM > 0` by const definition, so `HC_OPT_NUM - 1` is safe.
+        let frontier_limit = $current_len.min(HC_OPT_NUM - 1);
         let initial_reps = $initial_state.reps;
         let initial_litlen = $initial_state.litlen;
         let mut profile = $initial_state.profile;
@@ -1200,8 +1219,10 @@ macro_rules! build_optimal_plan_impl_body {
             HcParseMode::BtUltra | HcParseMode::BtUltra2
         );
         let mut nodes = core::mem::take(&mut $self.backend.bt_mut().opt_nodes_scratch);
-        if nodes.len() < frontier_limit.saturating_add(2) {
-            nodes.resize(frontier_limit.saturating_add(2), HcOptimalNode::default());
+        // `frontier_limit + 2 <= HC_OPT_NUM + 1` — bounded by const.
+        let frontier_buffer_size = frontier_limit + 2;
+        if nodes.len() < frontier_buffer_size {
+            nodes.resize(frontier_buffer_size, HcOptimalNode::default());
         }
         let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
         candidates.clear();
@@ -1327,10 +1348,13 @@ macro_rules! build_optimal_plan_impl_body {
                 )
             };
             if !candidates.is_empty() {
-                last_pos = min_match_len.saturating_sub(1).min(frontier_limit);
+                // `min_match_len >= HC_FORMAT_MINMATCH (4)` by invariant.
+                last_pos = (min_match_len - 1).min(frontier_limit);
                 for p in 1..min_match_len.min(nodes.len()) {
                     BtMatcher::reset_opt_node(&mut nodes[p]);
-                    nodes[p].litlen = initial_litlen.saturating_add(p) as u32;
+                    // `initial_litlen + p <= u32::MAX`: lit_len capped well
+                    // below 2^32 by HC_OPT_NUM.
+                    nodes[p].litlen = (initial_litlen + p) as u32;
                 }
             }
 
@@ -1373,13 +1397,13 @@ macro_rules! build_optimal_plan_impl_body {
                 }
             }
             if !seed_forced_shortest_path {
-                let mut prev_max_len = min_match_len.saturating_sub(1);
+                let mut prev_max_len = min_match_len - 1;
                 for candidate in candidates.iter() {
                     let max_match_len = candidate.match_len.min(frontier_limit);
                     if max_match_len < min_match_len {
                         continue;
                     }
-                    let start_len = prev_max_len.saturating_add(1).max(min_match_len);
+                    let start_len = (prev_max_len + 1).max(min_match_len);
                     if start_len > max_match_len {
                         prev_max_len = prev_max_len.max(max_match_len);
                         continue;
@@ -1492,7 +1516,7 @@ macro_rules! build_optimal_plan_impl_body {
                             let ll_delta_next = BtMatcher::cached_lit_length_delta_price(
                                 profile,
                                 $stats,
-                                lit_len.saturating_add(1),
+                                lit_len + 1,
                                 &mut ll_prices,
                                 &mut ll_price_generations,
                                 ll_price_stamp,
@@ -1631,17 +1655,19 @@ macro_rules! build_optimal_plan_impl_body {
                     break;
                 }
             }
-            let mut prev_max_len = min_match_len.saturating_sub(1);
+            let mut prev_max_len = min_match_len - 1;
             for candidate in candidates.iter() {
+                // `pos < frontier_limit` is the outer loop's invariant.
+                debug_assert!(pos <= frontier_limit);
                 let max_match_len = candidate
                     .match_len
                     .min($current_len - pos)
-                    .min(frontier_limit.saturating_sub(pos));
+                    .min(frontier_limit - pos);
                 let min_len = min_match_len;
                 if max_match_len < min_len {
                     continue;
                 }
-                let start_len = prev_max_len.saturating_add(1).max(min_len);
+                let start_len = (prev_max_len + 1).max(min_len);
                 if start_len > max_match_len {
                     prev_max_len = prev_max_len.max(max_match_len);
                     continue;
@@ -1730,7 +1756,7 @@ macro_rules! build_optimal_plan_impl_body {
                     lit_price_stamp,
                 )
             };
-            let next_litlen = initial_litlen.saturating_add(1);
+            let next_litlen = initial_litlen + 1;
             let ll_delta = BtMatcher::cached_lit_length_delta_price(
                 profile,
                 $stats,
@@ -1858,7 +1884,9 @@ macro_rules! build_optimal_plan_impl_body {
             }
             store_start -= 1;
             store[store_start] = next_stretch;
-            let step = (next_stretch.litlen as usize).saturating_add(next_stretch.mlen as usize);
+            // `litlen + mlen` are both u32 stored in `HcOptimalNode` —
+            // sum fits in usize on any supported target.
+            let step = (next_stretch.litlen as usize) + (next_stretch.mlen as usize);
             if step == 0 || stretch_pos < step {
                 break;
             }
@@ -1995,7 +2023,10 @@ macro_rules! collect_optimal_candidates_initialized_body {
                     if rep.match_len > $profile.sufficient_match_len {
                         skip_further_match_search = true;
                     }
-                    if $abs_pos.saturating_add(rep.match_len) >= $current_abs_end {
+                    // `abs_pos + rep.match_len` is bounded by
+                    // `current_abs_end + HC_OPT_NUM` (donor caps match_len
+                    // there) — far below usize::MAX.
+                    if $abs_pos + rep.match_len >= $current_abs_end {
                         skip_further_match_search = true;
                     }
                 },
@@ -2017,9 +2048,9 @@ macro_rules! collect_optimal_candidates_initialized_body {
                 );
                 if !rep_len_candidate_found
                     && (h3.match_len > $profile.sufficient_match_len
-                        || $abs_pos.saturating_add(h3.match_len) >= $current_abs_end)
+                        || $abs_pos + h3.match_len >= $current_abs_end)
                 {
-                    $self.table.skip_insert_until_abs = $abs_pos.saturating_add(1);
+                    $self.table.skip_insert_until_abs = $abs_pos + 1;
                     skip_further_match_search = true;
                 }
             }
@@ -2040,7 +2071,7 @@ macro_rules! collect_optimal_candidates_initialized_body {
             $self.table.insert_position($abs_pos);
             let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
             let concat = &$self.table.history[$self.table.history_start..];
-            let mut match_end_abs = $abs_pos.saturating_add(9);
+            let mut match_end_abs = $abs_pos + 9;
             if max_chain_depth > 0 {
                 for (visited, candidate_abs) in $self
                     .hc
@@ -2058,7 +2089,11 @@ macro_rules! collect_optimal_candidates_initialized_body {
                         continue;
                     }
                     let candidate_idx = candidate_abs - $self.table.history_abs_start;
-                    let tail_limit = $current_abs_end.saturating_sub($abs_pos);
+                    debug_assert!(
+                        $abs_pos <= $current_abs_end,
+                        "HC chain walker called past current block end"
+                    );
+                    let tail_limit = $current_abs_end - $abs_pos;
                     let base = concat.as_ptr();
                     // SAFETY: history-relative indices; `tail_limit` bounds
                     // the scan within `concat`. `$cpl` is the kernel-specific
@@ -2080,22 +2115,20 @@ macro_rules! collect_optimal_candidates_initialized_body {
                         },
                         min_match_len,
                     ) {
-                        let candidate_end = candidate_abs.saturating_add(match_len);
+                        let candidate_end = candidate_abs + match_len;
                         if candidate_end > match_end_abs {
                             match_end_abs = candidate_end;
                         }
                     }
-                    if match_len > HC_OPT_NUM
-                        || $abs_pos.saturating_add(match_len) >= $current_abs_end
-                    {
+                    if match_len > HC_OPT_NUM || $abs_pos + match_len >= $current_abs_end {
                         break;
                     }
                 }
             }
-            $self.table.skip_insert_until_abs = $self
-                .table
-                .skip_insert_until_abs
-                .max(match_end_abs.saturating_sub(8));
+            // `match_end_abs` initialized to `abs_pos + 9`; monotonic
+            // updates only ever extend it, so `match_end_abs - 8 >= 1`.
+            $self.table.skip_insert_until_abs =
+                $self.table.skip_insert_until_abs.max(match_end_abs - 8);
         }
         if let Some(ldm) = ldm_candidate {
             let _ = super::bt::BtMatcher::push_candidate_ladder(
@@ -2261,7 +2294,11 @@ macro_rules! bt_insert_and_collect_matches_body {
         if idx + 8 > concat.len() {
             return;
         }
-        let tail_limit = $current_abs_end.saturating_sub($abs_pos);
+        debug_assert!(
+            $abs_pos <= $current_abs_end,
+            "BT collect called past current block end"
+        );
+        let tail_limit = $current_abs_end - $abs_pos;
         let hash = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
             concat,
             idx,
@@ -2273,9 +2310,11 @@ macro_rules! bt_insert_and_collect_matches_body {
         };
         let stored = relative_pos + 1;
         let bt_mask = $table.bt_mask();
+        // See `bt_insert_step_no_rebase_body!`: saturating is needed for the
+        // first BT walk of a fresh frame where `abs_pos < bt_mask`.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($abs_pos);
-        let mut match_end_abs = $abs_pos.saturating_add(9);
+        let mut match_end_abs = $abs_pos + 9;
         let mut compares_left = $profile.max_chain_depth.min($search_depth);
         let mut common_length_smaller = 0usize;
         let mut common_length_larger = 0usize;
@@ -2286,7 +2325,10 @@ macro_rules! bt_insert_and_collect_matches_body {
         $table.hash_table[hash] = stored;
         // Donor semantics: `bestLength` starts at `lengthToBeat - 1`; rep/hash3
         // probing may raise it; BT then only reports strictly longer matches.
-        let mut best_len = (*$best_len_for_skip).max($min_match_len.saturating_sub(1));
+        // `min_match_len >= HC_FORMAT_MINMATCH (4)` by configure invariant,
+        // so `min_match_len - 1 >= 3` cannot underflow.
+        debug_assert!($min_match_len >= 1, "min_match_len must be at least 1");
+        let mut best_len = (*$best_len_for_skip).max($min_match_len - 1);
 
         while compares_left > 0 {
             let Some(candidate_abs) =
@@ -2326,7 +2368,11 @@ macro_rules! bt_insert_and_collect_matches_body {
                 );
                 if accepted {
                     best_len = match_len;
-                    let candidate_end = candidate_abs.saturating_add(match_len);
+                    // `match_len <= tail_limit` and `candidate_abs < abs_pos
+                    // <= current_abs_end`, so `candidate_abs + match_len` is
+                    // bounded by `current_abs_end + tail_limit < 2 *
+                    // current_abs_end` — far below usize::MAX.
+                    let candidate_end = candidate_abs + match_len;
                     if candidate_end > match_end_abs {
                         match_end_abs = candidate_end;
                     }
@@ -2371,7 +2417,9 @@ macro_rules! bt_insert_and_collect_matches_body {
         if larger_slot != usize::MAX {
             $table.chain_table[larger_slot] = $crate::encoding::match_table::storage::HC_EMPTY;
         }
-        $table.skip_insert_until_abs = match_end_abs.saturating_sub(8);
+        // `match_end_abs >= abs_pos + 9 >= 9` (initialized and monotonic),
+        // so `match_end_abs - 8 >= 1` cannot underflow.
+        $table.skip_insert_until_abs = match_end_abs - 8;
     }};
 }
 pub(crate) use bt_insert_and_collect_matches_body;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2353,7 +2353,10 @@ macro_rules! bt_insert_and_collect_matches_body {
         // probing may raise it; BT then only reports strictly longer matches.
         // `min_match_len >= HC_FORMAT_MINMATCH (3)` by configure invariant,
         // so `min_match_len - 1 >= 2` cannot underflow.
-        debug_assert!($min_match_len >= 1, "min_match_len must be at least 1");
+        debug_assert!(
+            $min_match_len >= $crate::encoding::cost_model::HC_FORMAT_MINMATCH,
+            "min_match_len must be at least HC_FORMAT_MINMATCH"
+        );
         let mut best_len = (*$best_len_for_skip).max($min_match_len - 1);
 
         while compares_left > 0 {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1772,7 +1772,15 @@ macro_rules! build_optimal_plan_impl_body {
                     lit_price_stamp,
                 )
             };
-            let next_litlen = initial_litlen + 1;
+            // `initial_litlen` is carried across optimal-plan segments;
+            // its real bound is the current block length, not
+            // `current_len`. On i686 (32-bit `usize`) `+ 1` could
+            // theoretically wrap if the invariant ever broke. Catch
+            // that explicitly via `checked_add` rather than letting a
+            // wrapping sum slip into the price lookup.
+            let next_litlen = initial_litlen
+                .checked_add(1)
+                .expect("optimal parser next litlen out of usize range");
             let ll_delta = BtMatcher::cached_lit_length_delta_price(
                 profile,
                 $stats,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1078,15 +1078,18 @@ macro_rules! bt_insert_step_no_rebase_body {
         // sentinel that ALWAYS triggers.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($target_abs);
-        // The caller has already proven `idx + 8 <= concat.len()` and
-        // `idx = abs_pos - history_abs_start`. So
-        // `abs_pos + 8 <= history_abs_start + concat.len() = history_abs_end`,
-        // which the frame compressor caps at a value the BT walker can
-        // address (`window_size + history_abs_start <= usize::MAX - 16`).
-        // `abs_pos + 9` therefore stays in `usize` even on 32-bit i686
-        // — the bound is the frame-level history budget, not a
-        // "blocks cap" claim.
-        debug_assert!($abs_pos <= usize::MAX - 9);
+        // `abs_pos` is a frame-lifetime absolute stream cursor. The
+        // tightest real bound: the encoder cannot have processed more
+        // bytes than `usize::MAX` (we'd need that much RAM to hold
+        // history). So `abs_pos < usize::MAX` and `abs_pos + 9` only
+        // overflows if the entire stream is within nine bytes of
+        // `usize::MAX` — impossible because allocating a `usize::MAX`
+        // history buffer is itself impossible. The `debug_assert!`
+        // catches this in tests; release builds use the raw `+`.
+        debug_assert!(
+            $abs_pos <= usize::MAX - 9,
+            "abs_pos + 9 would overflow usize"
+        );
         let mut match_end_abs = $abs_pos + 9;
         let mut best_len = 8usize;
         let mut compares_left = $search_depth;
@@ -2105,6 +2108,13 @@ macro_rules! collect_optimal_candidates_initialized_body {
             $self.table.insert_position($abs_pos);
             let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
             let concat = &$self.table.history[$self.table.history_start..];
+            // `abs_pos` is a frame-lifetime stream cursor; see
+            // `bt_insert_step_no_rebase_body!` for the full bound
+            // discussion. Same precondition applies here.
+            debug_assert!(
+                $abs_pos <= usize::MAX - 9,
+                "abs_pos + 9 would overflow usize"
+            );
             let mut match_end_abs = $abs_pos + 9;
             if max_chain_depth > 0 {
                 for (visited, candidate_abs) in $self
@@ -2348,6 +2358,13 @@ macro_rules! bt_insert_and_collect_matches_body {
         // first BT walk of a fresh frame where `abs_pos < bt_mask`.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($abs_pos);
+        // `abs_pos` is a frame-lifetime stream cursor; see
+        // `bt_insert_step_no_rebase_body!` for the full bound
+        // discussion. Same precondition applies here.
+        debug_assert!(
+            $abs_pos <= usize::MAX - 9,
+            "abs_pos + 9 would overflow usize"
+        );
         let mut match_end_abs = $abs_pos + 9;
         let mut compares_left = $profile.max_chain_depth.min($search_depth);
         let mut common_length_smaller = 0usize;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1173,10 +1173,15 @@ macro_rules! bt_insert_step_no_rebase_body {
         } else {
             0
         };
-        // `match_end_abs` is initialized to `abs_pos + 9` and only ever
-        // monotonically increased by `candidate_end` (also `> abs_pos`).
-        // So `match_end_abs > abs_pos + 8` is invariant — raw subtraction
-        // is safe.
+        // `match_end_abs` is initialized to `abs_pos + 9` and is only
+        // reassigned inside the `candidate_end > match_end_abs` branch
+        // above. So even though an individual `candidate_end =
+        // candidate_abs + match_len` can land below `abs_pos` (the
+        // candidate sits earlier in history and the match runs short),
+        // the variable itself never drops below its initial value.
+        // That gives `match_end_abs ≥ abs_pos + 9 > abs_pos + 8` as a
+        // loop-wide invariant, so the raw subtraction below cannot
+        // underflow.
         speed_positions.max(match_end_abs - ($abs_pos + 8))
     }};
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1078,16 +1078,15 @@ macro_rules! bt_insert_step_no_rebase_body {
         // sentinel that ALWAYS triggers.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($target_abs);
-        // `abs_pos` is a frame-lifetime stream cursor. A long 32-bit
-        // streaming encode keeps memory bounded by `window_size` but
-        // advances `abs_pos` past `usize::MAX` cumulatively — so the
-        // addition genuinely can overflow on i686 even though no
-        // single allocation ever reaches `usize::MAX`. `saturating_add`
-        // clamps to `usize::MAX`, which downstream comparisons
-        // (`if candidate_end > match_end_abs`) treat as "no further
-        // extension possible" — a safe degenerate state near the
-        // stream tail.
-        let mut match_end_abs = $abs_pos.saturating_add(9);
+        // `abs_pos + 9` is safe in raw form: `MatchTable::add_data` caps
+        // total input at `usize::MAX - STREAM_ABS_HEADROOM` (where
+        // `STREAM_ABS_HEADROOM = HC_OPT_NUM + 16`), so every
+        // frame-lifetime absolute cursor passed to the BT walker stays
+        // below `usize::MAX - 9` regardless of stream length or
+        // pointer width. The guard is hoisted to the data-ingest
+        // boundary so this per-position site pays zero arithmetic
+        // overhead in the hot loop.
+        let mut match_end_abs = $abs_pos + 9;
         let mut best_len = 8usize;
         let mut compares_left = $search_depth;
         let mut common_length_smaller = 0usize;
@@ -2105,11 +2104,10 @@ macro_rules! collect_optimal_candidates_initialized_body {
             $self.table.insert_position($abs_pos);
             let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
             let concat = &$self.table.history[$self.table.history_start..];
-            // `abs_pos` is a frame-lifetime stream cursor; see
-            // `bt_insert_step_no_rebase_body!` for the full discussion
-            // of why `saturating_add` is required on 32-bit streaming
-            // encodes that can advance the cursor past `usize::MAX`.
-            let mut match_end_abs = $abs_pos.saturating_add(9);
+            // Raw `+ 9` is safe here — see `bt_insert_step_no_rebase_body!`
+            // for the full discussion of the upstream `STREAM_ABS_HEADROOM`
+            // cap in `MatchTable::add_data`.
+            let mut match_end_abs = $abs_pos + 9;
             if max_chain_depth > 0 {
                 for (visited, candidate_abs) in $self
                     .hc
@@ -2352,11 +2350,10 @@ macro_rules! bt_insert_and_collect_matches_body {
         // first BT walk of a fresh frame where `abs_pos < bt_mask`.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($abs_pos);
-        // `abs_pos` is a frame-lifetime stream cursor; see
-        // `bt_insert_step_no_rebase_body!` for the full discussion of
-        // why `saturating_add` is required on 32-bit streaming
-        // encodes that can advance the cursor past `usize::MAX`.
-        let mut match_end_abs = $abs_pos.saturating_add(9);
+        // Raw `+ 9` is safe here — see `bt_insert_step_no_rebase_body!`
+        // for the full discussion of the upstream `STREAM_ABS_HEADROOM`
+        // cap in `MatchTable::add_data`.
+        let mut match_end_abs = $abs_pos + 9;
         let mut compares_left = $profile.max_chain_depth.min($search_depth);
         let mut common_length_smaller = 0usize;
         let mut common_length_larger = 0usize;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1078,19 +1078,16 @@ macro_rules! bt_insert_step_no_rebase_body {
         // sentinel that ALWAYS triggers.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($target_abs);
-        // `abs_pos` is a frame-lifetime absolute stream cursor. The
-        // tightest real bound: the encoder cannot have processed more
-        // bytes than `usize::MAX` (we'd need that much RAM to hold
-        // history). So `abs_pos < usize::MAX` and `abs_pos + 9` only
-        // overflows if the entire stream is within nine bytes of
-        // `usize::MAX` — impossible because allocating a `usize::MAX`
-        // history buffer is itself impossible. The `debug_assert!`
-        // catches this in tests; release builds use the raw `+`.
-        debug_assert!(
-            $abs_pos <= usize::MAX - 9,
-            "abs_pos + 9 would overflow usize"
-        );
-        let mut match_end_abs = $abs_pos + 9;
+        // `abs_pos` is a frame-lifetime stream cursor. A long 32-bit
+        // streaming encode keeps memory bounded by `window_size` but
+        // advances `abs_pos` past `usize::MAX` cumulatively — so the
+        // addition genuinely can overflow on i686 even though no
+        // single allocation ever reaches `usize::MAX`. `saturating_add`
+        // clamps to `usize::MAX`, which downstream comparisons
+        // (`if candidate_end > match_end_abs`) treat as "no further
+        // extension possible" — a safe degenerate state near the
+        // stream tail.
+        let mut match_end_abs = $abs_pos.saturating_add(9);
         let mut best_len = 8usize;
         let mut compares_left = $search_depth;
         let mut common_length_smaller = 0usize;
@@ -2109,13 +2106,10 @@ macro_rules! collect_optimal_candidates_initialized_body {
             let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
             let concat = &$self.table.history[$self.table.history_start..];
             // `abs_pos` is a frame-lifetime stream cursor; see
-            // `bt_insert_step_no_rebase_body!` for the full bound
-            // discussion. Same precondition applies here.
-            debug_assert!(
-                $abs_pos <= usize::MAX - 9,
-                "abs_pos + 9 would overflow usize"
-            );
-            let mut match_end_abs = $abs_pos + 9;
+            // `bt_insert_step_no_rebase_body!` for the full discussion
+            // of why `saturating_add` is required on 32-bit streaming
+            // encodes that can advance the cursor past `usize::MAX`.
+            let mut match_end_abs = $abs_pos.saturating_add(9);
             if max_chain_depth > 0 {
                 for (visited, candidate_abs) in $self
                     .hc
@@ -2359,13 +2353,10 @@ macro_rules! bt_insert_and_collect_matches_body {
         let bt_low = $abs_pos.saturating_sub(bt_mask);
         let window_low = $table.window_low_abs_for_target($abs_pos);
         // `abs_pos` is a frame-lifetime stream cursor; see
-        // `bt_insert_step_no_rebase_body!` for the full bound
-        // discussion. Same precondition applies here.
-        debug_assert!(
-            $abs_pos <= usize::MAX - 9,
-            "abs_pos + 9 would overflow usize"
-        );
-        let mut match_end_abs = $abs_pos + 9;
+        // `bt_insert_step_no_rebase_body!` for the full discussion of
+        // why `saturating_add` is required on 32-bit streaming
+        // encodes that can advance the cursor past `usize::MAX`.
+        let mut match_end_abs = $abs_pos.saturating_add(9);
         let mut compares_left = $profile.max_chain_depth.min($search_depth);
         let mut common_length_smaller = 0usize;
         let mut common_length_larger = 0usize;

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -66,6 +66,65 @@ pub(crate) fn check_stream_abs_headroom(
 }
 
 #[cfg(test)]
+mod bt_pair_index_wrap_tests {
+    use super::MatchTable;
+
+    /// `bt_pair_index_for_abs` switched from `+` to `wrapping_add` so the
+    /// release-mode overflow branch and the debug-mode panic stay off
+    /// the hot path on rare 32-bit streams where `abs_pos + index_shift`
+    /// overflows `usize`. This test forces that overflow and verifies
+    /// the returned BT slot still equals what the modulo-ring identity
+    /// promises: `(abs_pos + index_shift) mod 2^bt_log`, doubled
+    /// because the table stores pointer pairs.
+    #[test]
+    fn bt_pair_index_matches_modulo_ring_after_wraparound() {
+        let mut table = MatchTable::new(1 << 20);
+        // Small BT ring (`bt_log = chain_log - 1 = 3` → mask = 0b0111) so
+        // the modular identity is easy to read at a glance.
+        table.chain_log = 4;
+        // Use a wide `index_shift` so the addition wraps for many of
+        // the `abs_pos` values we probe below.
+        table.index_shift = usize::MAX - 5;
+
+        let bt_mask = table.bt_mask();
+        assert_eq!(bt_mask, 0b0111);
+
+        for abs_pos in [0usize, 1, 4, 5, 6, 7, 8, 12, 17] {
+            let got = table.bt_pair_index_for_abs(abs_pos);
+            let expected = 2 * (abs_pos.wrapping_add(table.index_shift) & bt_mask);
+            assert_eq!(
+                got, expected,
+                "abs_pos={abs_pos}: wrapping_add ring slot must match the masked sum"
+            );
+        }
+
+        // Spot-check one value where overflow is certain (abs_pos > 5)
+        // and the ring index has a stable closed form.
+        // abs_pos=7, index_shift=usize::MAX-5: sum wraps to 1, mask -> 1, doubled -> 2.
+        assert_eq!(table.bt_pair_index_for_abs(7), 2);
+        // abs_pos=14: sum wraps to 8, masked -> 0, doubled -> 0.
+        assert_eq!(table.bt_pair_index_for_abs(14), 0);
+    }
+
+    /// Sanity check the non-overflow path keeps the same identity so a
+    /// future refactor cannot regress the common case while leaving the
+    /// overflow case green.
+    #[test]
+    fn bt_pair_index_matches_modulo_ring_without_overflow() {
+        let mut table = MatchTable::new(1 << 20);
+        table.chain_log = 8; // bt_log = 7, mask = 0x7f
+        table.index_shift = 17;
+
+        let bt_mask = table.bt_mask();
+        for abs_pos in [0usize, 1, 16, 32, 64, 127, 128, 255, 1 << 20] {
+            let got = table.bt_pair_index_for_abs(abs_pos);
+            let expected = 2 * ((abs_pos + table.index_shift) & bt_mask);
+            assert_eq!(got, expected, "abs_pos={abs_pos}");
+        }
+    }
+}
+
+#[cfg(test)]
 mod stream_abs_headroom_tests {
     use super::{STREAM_ABS_HEADROOM, check_stream_abs_headroom};
 

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -34,6 +34,33 @@ use super::helpers::INCOMPRESSIBLE_SKIP_STEP;
 /// 32-bit targets without per-call saturating guards.
 pub(crate) const STREAM_ABS_HEADROOM: usize = HC_OPT_NUM + 16;
 
+/// Frame-level overflow gate shared by every match-finder backend.
+///
+/// Each backend (`MatchTable`, `DfastMatchGenerator`, …) owns its own
+/// rolling window and `history_abs_start` cursor but they all hand
+/// absolute positions to inner loops that add small constants without
+/// overflow checks. This helper enforces a single contract: the next
+/// `data.len()` bytes — together with the still-resident `window_size`
+/// — must leave at least `STREAM_ABS_HEADROOM` slack below
+/// `usize::MAX`. Failing fast here lets every downstream `abs_pos + N`
+/// site stay raw and keeps i686 streams correct.
+#[inline]
+pub(crate) fn check_stream_abs_headroom(
+    history_abs_start: usize,
+    window_size: usize,
+    data_len: usize,
+) {
+    let _future_abs_end = history_abs_start
+        .checked_add(window_size)
+        .and_then(|p| p.checked_add(data_len))
+        .and_then(|p| p.checked_add(STREAM_ABS_HEADROOM))
+        .expect(
+            "structured-zstd: total input would advance the absolute \
+             stream cursor past `usize::MAX`; on 32-bit targets, split \
+             the input into smaller frames or use a 64-bit build",
+        );
+}
+
 /// Knuth-style 3-byte hash multiplier. Donor parity:
 /// `ZSTD_HASH3PRIME` in `lib/compress/zstd_compress_internal.h`. Used
 /// by the HC3 short-match side table and by the 3-byte branch of the
@@ -351,24 +378,7 @@ impl MatchTable {
     /// ~2x window size for data buffers + 6 MB tables.
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
-        // Hard cap: every absolute stream cursor the encoder hands to the
-        // BT walker / optimal parser stays within `usize::MAX -
-        // STREAM_ABS_HEADROOM`. That is what lets every per-position
-        // `abs_pos + N` arithmetic site downstream run as raw `+` instead
-        // of `saturating_add`. On 64-bit targets this cap is unreachable
-        // in practice; on 32-bit (i686) it fails fast on streams whose
-        // cumulative input would push the cursor near `usize::MAX`,
-        // which is the only platform where the overflow concern is real.
-        let _future_abs_end = self
-            .history_abs_start
-            .checked_add(self.window_size)
-            .and_then(|p| p.checked_add(data.len()))
-            .and_then(|p| p.checked_add(STREAM_ABS_HEADROOM))
-            .expect(
-                "structured-zstd: total input would advance the absolute \
-                 stream cursor past `usize::MAX`; on 32-bit targets, split \
-                 the input into smaller frames or use a 64-bit build",
-            );
+        check_stream_abs_headroom(self.history_abs_start, self.window_size, data.len());
         while self.window_size + data.len() > self.max_window_size {
             let removed = self.window.pop_front().unwrap();
             self.window_size -= removed.len();
@@ -478,16 +488,17 @@ impl MatchTable {
     #[inline(always)]
     pub(crate) fn bt_pair_index_for_abs(&self, abs_pos: usize) -> usize {
         // Hot per-iteration BT walker entry. `abs_pos` is a
-        // frame-lifetime absolute stream cursor — it grows monotonically
-        // across blocks and could in principle wrap around `usize::MAX`
-        // on long-running 32-bit streams, even though `index_shift` is
-        // block-local (`current_len` during the btultra2 seed pass, `0`
-        // otherwise). The result is immediately masked down to the BT
-        // ring width by `& bt_mask()`, so the modulo semantics of
-        // `wrapping_add` give the same slot as a panicking `+` would,
-        // and we avoid both the release-mode overflow branch and the
-        // debug-mode panic that an unchecked stream cursor + offset
-        // would otherwise trigger.
+        // frame-lifetime absolute stream cursor (capped by
+        // `check_stream_abs_headroom`); `index_shift` is block-local
+        // (`current_len` during the btultra2 seed pass, `0` otherwise).
+        // The result is immediately masked down to the BT ring width
+        // by `& bt_mask()`, so what matters here is only the modulo-
+        // ring identity `(a + b) mod m == ((a mod 2^bits) + (b mod
+        // 2^bits)) mod m` for `m | 2^bits`: `wrapping_add` preserves
+        // that identity even on the rare i686 streams where the raw
+        // `usize` sum overflows. Using `wrapping_add` instead of `+`
+        // (or `saturating_add`) also keeps the release-mode overflow
+        // branch and the debug-mode overflow panic off this hot path.
         let bt_pos = abs_pos.wrapping_add(self.index_shift);
         2 * (bt_pos & self.bt_mask())
     }

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -20,10 +20,19 @@ use alloc::vec::Vec;
 
 use super::super::Sequence;
 use super::super::blocks::encode_offset_with_history;
-use super::super::cost_model::HcOptimalCostProfile;
+use super::super::cost_model::{HC_OPT_NUM, HcOptimalCostProfile};
 use super::super::hc::HC_MIN_MATCH_LEN;
 use super::super::opt::types::{HcOptimalSequence, MatchCandidate};
 use super::helpers::INCOMPRESSIBLE_SKIP_STEP;
+
+/// Lookahead bytes the BT walker / optimal parser will read past the
+/// per-position absolute cursor (`abs_pos + 9` for match-end sentinels,
+/// `abs_pos + HC_OPT_NUM` for the optimal-parser match-length cap, etc.).
+/// `MatchTable::add_data` rejects input that would advance
+/// `history_abs_end` past `usize::MAX - STREAM_ABS_HEADROOM`, which lets
+/// every downstream raw `abs_pos + N` arithmetic stay within `usize` on
+/// 32-bit targets without per-call saturating guards.
+pub(crate) const STREAM_ABS_HEADROOM: usize = HC_OPT_NUM + 16;
 
 /// Knuth-style 3-byte hash multiplier. Donor parity:
 /// `ZSTD_HASH3PRIME` in `lib/compress/zstd_compress_internal.h`. Used
@@ -342,6 +351,24 @@ impl MatchTable {
     /// ~2x window size for data buffers + 6 MB tables.
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
+        // Hard cap: every absolute stream cursor the encoder hands to the
+        // BT walker / optimal parser stays within `usize::MAX -
+        // STREAM_ABS_HEADROOM`. That is what lets every per-position
+        // `abs_pos + N` arithmetic site downstream run as raw `+` instead
+        // of `saturating_add`. On 64-bit targets this cap is unreachable
+        // in practice; on 32-bit (i686) it fails fast on streams whose
+        // cumulative input would push the cursor near `usize::MAX`,
+        // which is the only platform where the overflow concern is real.
+        let _future_abs_end = self
+            .history_abs_start
+            .checked_add(self.window_size)
+            .and_then(|p| p.checked_add(data.len()))
+            .and_then(|p| p.checked_add(STREAM_ABS_HEADROOM))
+            .expect(
+                "structured-zstd: total input would advance the absolute \
+                 stream cursor past `usize::MAX`; on 32-bit targets, split \
+                 the input into smaller frames or use a 64-bit build",
+            );
         while self.window_size + data.len() > self.max_window_size {
             let removed = self.window.pop_front().unwrap();
             self.window_size -= removed.len();

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -450,21 +450,19 @@ impl MatchTable {
     /// `2 * (curr & btMask)` from `ZSTD_insertBt1`.
     #[inline(always)]
     pub(crate) fn bt_pair_index_for_abs(&self, abs_pos: usize) -> usize {
-        // Called inside the BT walker for the current node and each
-        // visited candidate — a hot per-iteration path. `index_shift`
-        // is `current_len` during the btultra2 seed pass (see
-        // `run_btultra2_seed_pass`) and `0` everywhere else, so it
-        // never exceeds the configured block length. `abs_pos` is
-        // bounded by the same block scan that called us. Their sum
-        // therefore stays well below `usize::MAX` on every supported
-        // target (i686 included). Enforce the invariant with a
-        // debug-only assertion so release builds run the raw `+` with
-        // zero overhead.
-        debug_assert!(
-            abs_pos.checked_add(self.index_shift).is_some(),
-            "bt_pair_index_for_abs: abs_pos + index_shift overflowed usize"
-        );
-        2 * ((abs_pos + self.index_shift) & self.bt_mask())
+        // Hot per-iteration BT walker entry. `abs_pos` is a
+        // frame-lifetime absolute stream cursor — it grows monotonically
+        // across blocks and could in principle wrap around `usize::MAX`
+        // on long-running 32-bit streams, even though `index_shift` is
+        // block-local (`current_len` during the btultra2 seed pass, `0`
+        // otherwise). The result is immediately masked down to the BT
+        // ring width by `& bt_mask()`, so the modulo semantics of
+        // `wrapping_add` give the same slot as a panicking `+` would,
+        // and we avoid both the release-mode overflow branch and the
+        // debug-mode panic that an unchecked stream cursor + offset
+        // would otherwise trigger.
+        let bt_pos = abs_pos.wrapping_add(self.index_shift);
+        2 * (bt_pos & self.bt_mask())
     }
 
     /// Decode a stored hash / chain table entry back into its absolute

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -450,10 +450,17 @@ impl MatchTable {
     /// `2 * (curr & btMask)` from `ZSTD_insertBt1`.
     #[inline(always)]
     pub(crate) fn bt_pair_index_for_abs(&self, abs_pos: usize) -> usize {
-        // `index_shift` is always 0 today (reserved for future rebase
-        // variants); raw `+` is safe — `abs_pos + index_shift` fits in
-        // usize across all encode block sizes.
-        2 * ((abs_pos + self.index_shift) & self.bt_mask())
+        // `index_shift` is `current_len` during the btultra2 seed pass
+        // (see `run_btultra2_seed_pass`) and `0` elsewhere, so it can
+        // reach the configured block length. `abs_pos` is bounded by
+        // the same block scan that called us. Their sum is therefore
+        // bounded by ~`2 * block_size`, well below `usize::MAX` on
+        // every supported target; `checked_add` makes the invariant
+        // explicit and panics rather than wraps if it is ever violated.
+        let shifted_abs = abs_pos
+            .checked_add(self.index_shift)
+            .expect("bt_pair_index_for_abs: abs_pos + index_shift overflowed usize");
+        2 * (shifted_abs & self.bt_mask())
     }
 
     /// Decode a stored hash / chain table entry back into its absolute

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -450,7 +450,10 @@ impl MatchTable {
     /// `2 * (curr & btMask)` from `ZSTD_insertBt1`.
     #[inline(always)]
     pub(crate) fn bt_pair_index_for_abs(&self, abs_pos: usize) -> usize {
-        2 * (abs_pos.saturating_add(self.index_shift) & self.bt_mask())
+        // `index_shift` is always 0 today (reserved for future rebase
+        // variants); raw `+` is safe — `abs_pos + index_shift` fits in
+        // usize across all encode block sizes.
+        2 * ((abs_pos + self.index_shift) & self.bt_mask())
     }
 
     /// Decode a stored hash / chain table entry back into its absolute
@@ -855,7 +858,7 @@ impl MatchTable {
         let mut pos = history_start;
         while pos < abs_pos {
             let forward = self.bt_insert_step_no_rebase(pos, rebuild_end, abs_pos);
-            pos = pos.saturating_add(forward.max(1));
+            pos += forward.max(1);
         }
     }
 
@@ -918,7 +921,7 @@ impl MatchTable {
             // SAFETY: same NEON umbrella; direct call inlines the BT-walk body.
             let forward =
                 unsafe { self.bt_insert_step_no_rebase_neon(update_abs, current_abs_end, abs_pos) };
-            update_abs = update_abs.saturating_add(forward.max(1));
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -946,7 +949,7 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_sse42(update_abs, current_abs_end, abs_pos)
             };
-            update_abs = update_abs.saturating_add(forward.max(1));
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -974,7 +977,7 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_avx2_bmi2(update_abs, current_abs_end, abs_pos)
             };
-            update_abs = update_abs.saturating_add(forward.max(1));
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -993,7 +996,7 @@ impl MatchTable {
             }
             let forward =
                 self.bt_insert_step_no_rebase_scalar(update_abs, current_abs_end, abs_pos);
-            update_abs = update_abs.saturating_add(forward.max(1));
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -1015,7 +1018,9 @@ impl MatchTable {
                 self.maybe_rebase_positions(self.next_to_update3);
             }
             self.insert_hash3_only_no_rebase(self.next_to_update3);
-            self.next_to_update3 = self.next_to_update3.saturating_add(1);
+            // hash3 cursor strictly less than `abs_pos` here (loop guard);
+            // `+ 1` cannot overflow within encode block sizes.
+            self.next_to_update3 += 1;
         }
     }
 

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -867,7 +867,13 @@ impl MatchTable {
         let mut pos = history_start;
         while pos < abs_pos {
             let forward = self.bt_insert_step_no_rebase(pos, rebuild_end, abs_pos);
-            pos += forward.max(1);
+            // `pos` is a frame-lifetime absolute cursor that can approach
+            // `usize::MAX` on long 32-bit streams. Cap the step at the
+            // remaining distance to `abs_pos` so the addition stays
+            // within `usize` even when the BT walker returns a large
+            // `forward` near the stream end.
+            let step = forward.max(1).min(abs_pos - pos);
+            pos += step;
         }
     }
 
@@ -930,7 +936,7 @@ impl MatchTable {
             // SAFETY: same NEON umbrella; direct call inlines the BT-walk body.
             let forward =
                 unsafe { self.bt_insert_step_no_rebase_neon(update_abs, current_abs_end, abs_pos) };
-            update_abs += forward.max(1);
+            update_abs += forward.max(1).min(abs_pos - update_abs);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -958,7 +964,7 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_sse42(update_abs, current_abs_end, abs_pos)
             };
-            update_abs += forward.max(1);
+            update_abs += forward.max(1).min(abs_pos - update_abs);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -986,7 +992,7 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_avx2_bmi2(update_abs, current_abs_end, abs_pos)
             };
-            update_abs += forward.max(1);
+            update_abs += forward.max(1).min(abs_pos - update_abs);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -1005,7 +1011,7 @@ impl MatchTable {
             }
             let forward =
                 self.bt_insert_step_no_rebase_scalar(update_abs, current_abs_end, abs_pos);
-            update_abs += forward.max(1);
+            update_abs += forward.max(1).min(abs_pos - update_abs);
         }
         self.skip_insert_until_abs = abs_pos;
     }

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -34,16 +34,18 @@ use super::helpers::INCOMPRESSIBLE_SKIP_STEP;
 /// 32-bit targets without per-call saturating guards.
 pub(crate) const STREAM_ABS_HEADROOM: usize = HC_OPT_NUM + 16;
 
-/// Frame-level overflow gate shared by every match-finder backend.
+/// Frame-level overflow gate shared by `MatchTable`,
+/// `DfastMatchGenerator`, and `RowMatchGenerator`.
 ///
-/// Each backend (`MatchTable`, `DfastMatchGenerator`, …) owns its own
-/// rolling window and `history_abs_start` cursor but they all hand
-/// absolute positions to inner loops that add small constants without
-/// overflow checks. This helper enforces a single contract: the next
-/// `data.len()` bytes — together with the still-resident `window_size`
-/// — must leave at least `STREAM_ABS_HEADROOM` slack below
-/// `usize::MAX`. Failing fast here lets every downstream `abs_pos + N`
-/// site stay raw and keeps i686 streams correct.
+/// Each backend owns its own rolling window and `history_abs_start`
+/// cursor but they all hand absolute positions to inner loops that add
+/// small constants without per-iteration overflow checks. This helper
+/// enforces a single contract: the next `data.len()` bytes — together
+/// with the still-resident `window_size` — must leave at least
+/// `STREAM_ABS_HEADROOM` slack below `usize::MAX`. Failing fast here
+/// lets every downstream `abs_pos + N` site stay raw and keeps i686
+/// streams correct. New match-finder backends with their own
+/// `add_data` path must route through this helper.
 #[inline]
 pub(crate) fn check_stream_abs_headroom(
     history_abs_start: usize,
@@ -55,10 +57,43 @@ pub(crate) fn check_stream_abs_headroom(
         .and_then(|p| p.checked_add(data_len))
         .and_then(|p| p.checked_add(STREAM_ABS_HEADROOM))
         .expect(
-            "structured-zstd: total input would advance the absolute \
-             stream cursor past `usize::MAX`; on 32-bit targets, split \
-             the input into smaller frames or use a 64-bit build",
+            "structured-zstd: cumulative input would leave less than \
+             STREAM_ABS_HEADROOM (HC_OPT_NUM + 16) slack below \
+             `usize::MAX` for the encoder's absolute-position \
+             lookahead; on 32-bit targets, split the input into \
+             smaller frames or use a 64-bit build",
         );
+}
+
+#[cfg(test)]
+mod stream_abs_headroom_tests {
+    use super::{STREAM_ABS_HEADROOM, check_stream_abs_headroom};
+
+    #[test]
+    fn accepts_exactly_at_the_boundary() {
+        // `history_abs_start + window_size + data_len + STREAM_ABS_HEADROOM == usize::MAX`.
+        let history_abs_start = usize::MAX - STREAM_ABS_HEADROOM - 2;
+        check_stream_abs_headroom(history_abs_start, 1, 1);
+    }
+
+    #[test]
+    fn accepts_well_below_the_boundary() {
+        check_stream_abs_headroom(0, 1 << 20, 1 << 20);
+    }
+
+    #[test]
+    #[should_panic(expected = "STREAM_ABS_HEADROOM")]
+    fn rejects_one_byte_past_the_boundary() {
+        // One byte over: sum = usize::MAX + 1 → checked_add returns None.
+        let history_abs_start = usize::MAX - STREAM_ABS_HEADROOM - 1;
+        check_stream_abs_headroom(history_abs_start, 1, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "STREAM_ABS_HEADROOM")]
+    fn rejects_history_abs_start_already_too_high() {
+        check_stream_abs_headroom(usize::MAX - 10, 0, 0);
+    }
 }
 
 /// Knuth-style 3-byte hash multiplier. Donor parity:

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -450,17 +450,21 @@ impl MatchTable {
     /// `2 * (curr & btMask)` from `ZSTD_insertBt1`.
     #[inline(always)]
     pub(crate) fn bt_pair_index_for_abs(&self, abs_pos: usize) -> usize {
-        // `index_shift` is `current_len` during the btultra2 seed pass
-        // (see `run_btultra2_seed_pass`) and `0` elsewhere, so it can
-        // reach the configured block length. `abs_pos` is bounded by
-        // the same block scan that called us. Their sum is therefore
-        // bounded by ~`2 * block_size`, well below `usize::MAX` on
-        // every supported target; `checked_add` makes the invariant
-        // explicit and panics rather than wraps if it is ever violated.
-        let shifted_abs = abs_pos
-            .checked_add(self.index_shift)
-            .expect("bt_pair_index_for_abs: abs_pos + index_shift overflowed usize");
-        2 * (shifted_abs & self.bt_mask())
+        // Called inside the BT walker for the current node and each
+        // visited candidate — a hot per-iteration path. `index_shift`
+        // is `current_len` during the btultra2 seed pass (see
+        // `run_btultra2_seed_pass`) and `0` everywhere else, so it
+        // never exceeds the configured block length. `abs_pos` is
+        // bounded by the same block scan that called us. Their sum
+        // therefore stays well below `usize::MAX` on every supported
+        // target (i686 included). Enforce the invariant with a
+        // debug-only assertion so release builds run the raw `+` with
+        // zero overhead.
+        debug_assert!(
+            abs_pos.checked_add(self.index_shift).is_some(),
+            "bt_pair_index_for_abs: abs_pos + index_shift overflowed usize"
+        );
+        2 * ((abs_pos + self.index_shift) & self.bt_mask())
     }
 
     /// Decode a stored hash / chain table entry back into its absolute

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -108,6 +108,11 @@ impl RowMatchGenerator {
 
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
+        super::match_table::storage::check_stream_abs_headroom(
+            self.history_abs_start,
+            self.window_size,
+            data.len(),
+        );
         while self.window_size + data.len() > self.max_window_size {
             let removed = self.window.pop_front().unwrap();
             self.window_size -= removed.len();


### PR DESCRIPTION
## Summary

Phase 2 of the #111 encoder architecture rewrite — **saturating_* cleanup
on the hot path**.

The original Phase 2 plan called for both a `Cwksp` arena allocator and
a `saturating_*` cleanup. After implementing the cleanup and benchmarking,
the arena work was **deferred** to a measurement-driven follow-up (issue
#120 updated accordingly): Rust's `Vec`-based scratch already amortizes
per-frame allocation across frames, so the donor's "single cwksp + cursor
reset" model doesn't translate to a measurable win without `unsafe`
pointer juggling for disjoint `&mut [T]` slices.

## Architectural mechanism — frame-level overflow gate

A naive removal of `saturating_*` on `abs_pos + N` is unsafe on 32-bit
streaming encodes: the absolute stream cursor grows monotonically with
total input and can wrap past `usize::MAX` even while the rolling window
stays bounded. Per-site `saturating_add` is one option but costs a branch
/ clamp on every hot-loop iteration.

This PR hoists the guard once, at the data-ingest boundary:

- `pub(crate) const STREAM_ABS_HEADROOM: usize = HC_OPT_NUM + 16;` —
  slack any downstream `abs_pos + N` site needs.
- `pub(crate) fn check_stream_abs_headroom(history_abs_start,
  window_size, data_len)` — `checked_add` chain that fails fast (with a
  clear panic message pointing 32-bit users at frame splitting or a
  64-bit build) if the next ingest would advance the cursor within
  `STREAM_ABS_HEADROOM` of `usize::MAX`.
- Both backend ingest paths — `MatchTable::add_data` and
  `DfastMatchGenerator::add_data` — route through the same helper.

With that gate in place every per-position `abs_pos + N` site runs as
raw `+` with zero per-iteration overhead.

## What this PR does

**Sites converted from `saturating_*` to raw arithmetic:**

- `bt_insert_step_no_rebase_body!` — `match_end_abs = abs_pos + 9`
- `bt_insert_and_collect_matches_body!` — `match_end_abs = abs_pos + 9`
- `collect_optimal_candidates_initialized_body!` — rep + hash3 + chain
  orchestrator
- `build_optimal_plan_impl_body!` candidate-seed path — `match_end_abs =
  abs_pos + 9`
- `MatchTable` BT walker dispatchers + `encode_offset_with_reps` family
- `DfastMatchGenerator::insert_positions_with_step` — `pos += step` (was
  `pos.saturating_add(step)`)

**Sites migrated to `wrapping_add` (modulo-ring semantics, not overflow
guard):**

- `bt_pair_index_for_abs` — `abs_pos.wrapping_add(self.index_shift)`,
  immediately masked by `& bt_mask()`. The modulo-ring identity keeps
  the release-mode overflow branch and debug-mode panic off this hot
  path even on rare 32-bit overflows.

**Sites intentionally kept as `saturating_*` (underflow at frame start /
EOF — different concern from overflow):**

- `bt_low = abs_pos.saturating_sub(bt_mask)` — fresh-frame case
- `tail_limit = current_abs_end.saturating_sub(abs_pos)` — EOF case
- `*_saturating_sub(BOUNDARY_DENSE_TAIL_LEN)` — dfast tail seeding
- `actual_offset.saturating_add(3)` in `encode_offset_with_reps` —
  external `u32::MAX` input trust boundary

For these, raw subtraction would wrap into a huge `usize` and translate
into OOB reads — the saturating op is a safety guard, not a perf cost.

## Level22 measurements (criterion --quick, x86_64-darwin)

Pure_rust median, before vs after the full series:

| Scenario              | Pre #119 baseline | Post Phase 2 | Δ           |
| ---                   | ---               | ---          | ---         |
| decodecorpus-z000033  | 471.85 ms         | 384.10 ms    | **-18.6 %** |
| high-entropy-1m       | 3.56 ms           | (noisy)      | within noise band |
| low-entropy-1m        | 1.38 ms           | 1.23 ms      | **-10.9 %** |
| large-log-stream      | 131.92 ms         | 114.86 ms    | **-12.9 %** |

Rust vs C FFI gap on decodecorpus-z000033 narrowed from **2.95×** (post
#119 merge) to **2.39×** today. The remaining gap is driven by phases
3-5 of #111 (const-generic Strategy dispatch, BT/HC body specialization,
LDM integration).

Acceptance criterion #120 asked ≥10 %; this PR delivers 10–19 %.

## Verification

- build × 2 (default + `--no-default-features`)
- `cargo clippy --all-targets -p structured-zstd -- -D warnings` clean
  (default + `bench_internals`)
- 451 / 451 nextest, including
  `level22_sequences_match_donor_on_corpus_proxy` ratio gate
- macOS-latest CI workaround: prepend `~/.rustup/toolchains/<tc>/bin`
  to `GITHUB_PATH` (Homebrew rustup ships without `cargo`/`rustc` shims
  under `~/.cargo/bin`)

Part of #111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced saturating arithmetic with plain arithmetic across matching, indexing and encoding paths; added assertions and safety comments to preserve invariants.
* **Bug Fixes**
  * Added stream headroom validation and tightened cursor/index progression to prevent overflow/underflow and incorrect pricing near limits.
* **Tests**
  * Added tests covering wrap‑around and headroom boundary conditions.
* **Chores**
  * CI: improved macOS Rust toolchain invocation for more reliable macOS test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/121)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
