### PR TITLE
perf(encoding): #111 Phase 3 — const-generic Strategy dispatch

### DIFF
--- a/.github/scripts/aggregate-bench-levels.py
+++ b/.github/scripts/aggregate-bench-levels.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Aggregate per-(target, level) benchmark artifacts into per-target
+consolidated files, ready for `merge-benchmarks.py` (cross-target).
+
+After the CI bench matrix was split into one runner per level, each
+runner publishes one set of:
+  benchmark-results.<TARGET>.<LEVEL>.json
+  benchmark-report.<TARGET>.<LEVEL>.md
+  benchmark-delta.<TARGET>.<LEVEL>.json
+  benchmark-delta.<TARGET>.<LEVEL>.md
+  benchmark-relative.<TARGET>.<LEVEL>.json
+
+This script reads the downloaded artifacts under
+`benchmark-artifacts/` and emits per-target files matching the
+single-runner naming used pre-split, so the existing
+`merge-benchmarks.py` cross-target merge keeps working unchanged:
+  benchmark-results.<TARGET>.json
+  benchmark-report.<TARGET>.md
+  benchmark-delta.<TARGET>.json
+  benchmark-delta.<TARGET>.md
+  benchmark-relative.<TARGET>.json
+
+Required env var:
+  AGGREGATE_TARGETS=x86_64-gnu,i686-gnu,x86_64-musl
+
+Outputs land in the current working directory.
+"""
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path("benchmark-artifacts")
+TARGETS = [
+    t.strip()
+    for t in os.environ.get("AGGREGATE_TARGETS", "").split(",")
+    if t.strip()
+]
+if not TARGETS:
+    print("ERROR: set AGGREGATE_TARGETS=<comma-separated target ids>", file=sys.stderr)
+    sys.exit(2)
+
+
+def files_for(target, kind, ext):
+    """Match `benchmark-<kind>.<target>.<level>.<ext>` under any artifact dir."""
+    pattern = re.compile(
+        rf"^benchmark-{re.escape(kind)}\.{re.escape(target)}\.[^.]+\.{re.escape(ext)}$"
+    )
+    return sorted(p for p in ROOT.rglob("*") if p.is_file() and pattern.match(p.name))
+
+
+def merge_results_json(target):
+    rows = []
+    for p in files_for(target, "results", "json"):
+        rows.extend(json.loads(p.read_text()))
+    if not rows:
+        print(f"WARN[{target}]: no benchmark-results.*.json shards found", file=sys.stderr)
+    Path(f"benchmark-results.{target}.json").write_text(json.dumps(rows, indent=2) + "\n")
+
+
+def merge_delta_json(target):
+    rows = []
+    for p in files_for(target, "delta", "json"):
+        rows.extend(json.loads(p.read_text()))
+    if not rows:
+        print(f"WARN[{target}]: no benchmark-delta.*.json shards found", file=sys.stderr)
+    Path(f"benchmark-delta.{target}.json").write_text(json.dumps(rows, indent=2) + "\n")
+
+
+def merge_relative_json(target):
+    """Each shard has the same top-level metadata (target, reference_band,
+    commit_sha, generated_at) — keep the first shard's metadata and
+    concatenate `records`. Drop duplicates by (metric, key, level)."""
+    payload = None
+    seen = set()
+    records = []
+    for p in files_for(target, "relative", "json"):
+        shard = json.loads(p.read_text())
+        if payload is None:
+            payload = {k: v for k, v in shard.items() if k != "records"}
+        for rec in shard.get("records", []):
+            sig = (rec.get("metric"), rec.get("key"), rec.get("level"))
+            if sig in seen:
+                continue
+            seen.add(sig)
+            records.append(rec)
+    if payload is None:
+        print(f"WARN[{target}]: no benchmark-relative.*.json shards found", file=sys.stderr)
+        payload = {"version": 1, "target": {"id": target}, "records": []}
+    payload["records"] = records
+    Path(f"benchmark-relative.{target}.json").write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def merge_markdown(target, kind):
+    """Concatenate shard reports with a short level header above each
+    shard's body. The merge-benchmarks.py cross-target step will
+    consume these — it already strips the leading `# Title` line, so
+    we keep that convention."""
+    shards = files_for(target, kind, "md")
+    if not shards:
+        print(f"WARN[{target}]: no benchmark-{kind}.*.md shards found", file=sys.stderr)
+        return
+    title = (
+        "Benchmark Report" if kind == "report" else "Benchmark Delta Report"
+    )
+    lines = [f"# {title} ({target})", ""]
+    for shard in shards:
+        # Extract level from filename suffix: benchmark-<kind>.<target>.<level>.md
+        stem = shard.name
+        # strip prefix `benchmark-<kind>.<target>.` and trailing `.md`
+        prefix = f"benchmark-{kind}.{target}."
+        level = stem[len(prefix):-len(".md")]
+        body = shard.read_text().strip()
+        # Drop the shard's `# ...` line so we don't get nested H1s.
+        body_lines = body.splitlines()
+        if body_lines and body_lines[0].lstrip().startswith("# "):
+            body_lines = body_lines[1:]
+            if body_lines and not body_lines[0].strip():
+                body_lines = body_lines[1:]
+        lines.append(f"## Level: {level}")
+        lines.append("")
+        lines.extend(body_lines)
+        lines.append("")
+    Path(f"benchmark-{kind}.{target}.md").write_text("\n".join(lines).strip() + "\n")
+
+
+for target in TARGETS:
+    print(f"Aggregating target={target}", file=sys.stderr)
+    merge_results_json(target)
+    merge_delta_json(target)
+    merge_relative_json(target)
+    merge_markdown(target, "report")
+    merge_markdown(target, "delta")
+
+print("Done.", file=sys.stderr)

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -24,11 +24,25 @@ BENCH_RAW_FILE="$(mktemp -t structured-zstd-bench-raw.XXXXXX)"
 trap 'rm -f "$BENCH_RAW_FILE"' EXIT
 
 export STRUCTURED_ZSTD_EMIT_REPORT=1
-BENCH_CMD=(cargo bench --bench compare_ffi -p structured-zstd --features dict_builder)
-if [ -n "$BENCH_TARGET_TRIPLE" ]; then
-  BENCH_CMD+=(--target "$BENCH_TARGET_TRIPLE")
+# CI matrix splits build (per target) from execution (per target × level):
+# the `bench-build` job hands the compiled criterion binary to every
+# shard via `STRUCTURED_ZSTD_BENCH_BIN`, so we re-exec it directly
+# instead of going through `cargo bench`. When the env var is not set
+# (local dev runs, single-runner CI), fall back to building on demand.
+if [ -n "${STRUCTURED_ZSTD_BENCH_BIN:-}" ]; then
+  if [ ! -x "$STRUCTURED_ZSTD_BENCH_BIN" ]; then
+    echo "STRUCTURED_ZSTD_BENCH_BIN=$STRUCTURED_ZSTD_BENCH_BIN is not executable" >&2
+    exit 2
+  fi
+  echo "Running pre-built bench binary: $STRUCTURED_ZSTD_BENCH_BIN" >&2
+  "$STRUCTURED_ZSTD_BENCH_BIN" --bench --output-format bencher | tee "$BENCH_RAW_FILE"
+else
+  BENCH_CMD=(cargo bench --bench compare_ffi -p structured-zstd --features dict_builder)
+  if [ -n "$BENCH_TARGET_TRIPLE" ]; then
+    BENCH_CMD+=(--target "$BENCH_TARGET_TRIPLE")
+  fi
+  "${BENCH_CMD[@]}" -- --output-format bencher | tee "$BENCH_RAW_FILE"
 fi
-"${BENCH_CMD[@]}" -- --output-format bencher | tee "$BENCH_RAW_FILE"
 
 echo "Parsing results..." >&2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,65 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  fuzz:
+    # Short-budget libFuzzer smoke run per target. The repo already
+    # ships a regression corpus in `zstd/fuzz/artifacts/`; cargo-fuzz
+    # replays it first (any old crash that resurfaces fails the
+    # job), then runs `-max_total_time` seconds of fresh fuzzing on
+    # top. Five targets run in parallel, so the overall wall-clock
+    # stays under ~5 min — comparable to a single bench shard.
+    name: Fuzz smoke (${{ matrix.target }})
+    needs: lint
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - decode
+          - encode
+          - interop
+          - huff0
+          - fse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: fuzz-${{ matrix.target }}
+          workspaces: zstd/fuzz
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
+      - name: Replay regression corpus
+        # Drive the existing crash artifacts through the target so
+        # any reintroduction of a previously-fixed bug fails CI on
+        # the same input that originally surfaced it.
+        working-directory: zstd/fuzz
+        run: |
+          target=${{ matrix.target }}
+          if [ -d "artifacts/$target" ] && [ -n "$(ls artifacts/$target 2>/dev/null)" ]; then
+            echo "Replaying $(ls artifacts/$target | wc -l) regression artifacts for $target"
+            cargo fuzz run "$target" artifacts/"$target"/*
+          else
+            echo "No regression artifacts for $target — skipping replay"
+          fi
+      - name: Fuzz ${{ matrix.target }} (90s budget)
+        working-directory: zstd/fuzz
+        # `-max_total_time` is libFuzzer's own time cap; on top of
+        # the GitHub Actions timeout-minutes it gives us a hard
+        # ceiling even if a target wedges in setup.
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=90 -timeout=30
+      - name: Upload new crash artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-${{ matrix.target }}-artifacts
+          path: zstd/fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 14
+
   bench-build:
     # Build the criterion `compare_ffi` binary once per target. Every
     # downstream bench shard (target × level) downloads the binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,54 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  bench-matrix:
+    # Canonical bench target inventory. Every downstream bench job
+    # (`bench-build`, `benchmark`, `benchmark-aggregate`,
+    # `benchmark-pages`) consumes this so a new target ID is added
+    # in exactly one place. `build_setup` runs only on `bench-build`;
+    # `runtime_setup` runs only on the bench shards (e.g. `i686-gnu`
+    # needs gcc-multilib's 32-bit loader at runtime, while `x86_64-musl`
+    # only needs `musl-tools` for the build).
+    name: Resolve bench target matrix
+    needs: lint
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.set.outputs.targets }}
+      ids_csv: ${{ steps.set.outputs.ids_csv }}
+    steps:
+      - id: set
+        run: |
+          cat > targets.json <<'EOF'
+          [
+            {
+              "id": "x86_64-gnu",
+              "target_triple": "x86_64-unknown-linux-gnu",
+              "build_setup": "",
+              "runtime_setup": "",
+              "timeout_minutes": 25
+            },
+            {
+              "id": "i686-gnu",
+              "target_triple": "i686-unknown-linux-gnu",
+              "build_setup": "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386",
+              "runtime_setup": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386",
+              "timeout_minutes": 30
+            },
+            {
+              "id": "x86_64-musl",
+              "target_triple": "x86_64-unknown-linux-musl",
+              "build_setup": "sudo apt-get update && sudo apt-get install -y musl-tools",
+              "runtime_setup": "",
+              "timeout_minutes": 25
+            }
+          ]
+          EOF
+          targets_compact=$(jq -c . targets.json)
+          ids_csv=$(jq -r '[.[].id] | join(",")' targets.json)
+          echo "targets=$targets_compact" >> "$GITHUB_OUTPUT"
+          echo "ids_csv=$ids_csv" >> "$GITHUB_OUTPUT"
+          echo "Bench targets: $ids_csv"
+
   bench-build:
     # Build the criterion `compare_ffi` binary once per target. Every
     # downstream bench shard (target × level) downloads the binary
@@ -197,30 +245,21 @@ jobs:
     # rebuild per shard. Saves ~4-7 min on each of the 18 shard
     # runners.
     name: Build bench binary (${{ matrix.bench.id }})
-    needs: lint
+    needs: [lint, bench-matrix]
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        bench:
-          - id: x86_64-gnu
-            target_triple: x86_64-unknown-linux-gnu
-            setup_command: ""
-          - id: i686-gnu
-            target_triple: i686-unknown-linux-gnu
-            setup_command: "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386"
-          - id: x86_64-musl
-            target_triple: x86_64-unknown-linux-musl
-            setup_command: "sudo apt-get update && sudo apt-get install -y musl-tools"
+        bench: ${{ fromJSON(needs.bench-matrix.outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - name: Install benchmark target
         run: rustup target add ${{ matrix.bench.target_triple }}
-      - name: Install target toolchain dependencies
-        if: matrix.bench.setup_command != ''
-        run: ${{ matrix.bench.setup_command }}
+      - name: Install build toolchain dependencies
+        if: matrix.bench.build_setup != ''
+        run: ${{ matrix.bench.build_setup }}
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: bench-${{ matrix.bench.id }}
@@ -254,7 +293,7 @@ jobs:
 
   benchmark:
     name: Bench ${{ matrix.bench.id }} / ${{ matrix.level }}
-    needs: bench-build
+    needs: [bench-build, bench-matrix]
     timeout-minutes: ${{ matrix.bench.timeout_minutes }}
     strategy:
       # Matrix split target × level. The pre-built binary from
@@ -265,19 +304,7 @@ jobs:
       # finishes well under 10 min.
       fail-fast: false
       matrix:
-        bench:
-          - id: x86_64-gnu
-            target_triple: x86_64-unknown-linux-gnu
-            timeout_minutes: 25
-            setup_command: ""
-          - id: i686-gnu
-            target_triple: i686-unknown-linux-gnu
-            timeout_minutes: 30
-            setup_command: "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386"
-          - id: x86_64-musl
-            target_triple: x86_64-unknown-linux-musl
-            timeout_minutes: 25
-            setup_command: "sudo apt-get update && sudo apt-get install -y musl-tools"
+        bench: ${{ fromJSON(needs.bench-matrix.outputs.targets) }}
         level:
           - fastest
           - default
@@ -293,8 +320,8 @@ jobs:
         # the python post-processor.
 
       - name: Install target runtime dependencies
-        if: matrix.bench.setup_command != ''
-        run: ${{ matrix.bench.setup_command }}
+        if: matrix.bench.runtime_setup != ''
+        run: ${{ matrix.bench.runtime_setup }}
 
       - name: Download pre-built bench binary
         uses: actions/download-artifact@v4
@@ -339,7 +366,7 @@ jobs:
 
   benchmark-aggregate:
     name: Aggregate benchmark shards per target
-    needs: benchmark
+    needs: [benchmark, bench-matrix]
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -361,40 +388,25 @@ jobs:
 
       - name: Aggregate level shards into per-target files
         env:
-          AGGREGATE_TARGETS: x86_64-gnu,i686-gnu,x86_64-musl
+          AGGREGATE_TARGETS: ${{ needs.bench-matrix.outputs.ids_csv }}
         run: python3 .github/scripts/aggregate-bench-levels.py
 
-      - name: Upload per-target consolidated artifacts
+      - name: Upload aggregated benchmark artifact
+        # Single combined artifact carrying per-target consolidated
+        # files. `merge-benchmarks.py` rglob's the download root so
+        # it picks them up regardless of subdir layout; this lets
+        # bench-pages download one artifact instead of one per target.
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-x86_64-gnu
+          name: benchmark-aggregated
           path: |
-            benchmark-results.x86_64-gnu.json
-            benchmark-report.x86_64-gnu.md
-            benchmark-delta.x86_64-gnu.json
-            benchmark-delta.x86_64-gnu.md
-            benchmark-relative.x86_64-gnu.json
+            benchmark-results.*.json
+            benchmark-report.*.md
+            benchmark-delta.*.json
+            benchmark-delta.*.md
+            benchmark-relative.*.json
           if-no-files-found: error
-      - uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-i686-gnu
-          path: |
-            benchmark-results.i686-gnu.json
-            benchmark-report.i686-gnu.md
-            benchmark-delta.i686-gnu.json
-            benchmark-delta.i686-gnu.md
-            benchmark-relative.i686-gnu.json
-          if-no-files-found: error
-      - uses: actions/upload-artifact@v4
-        with:
-          name: benchmark-x86_64-musl
-          path: |
-            benchmark-results.x86_64-musl.json
-            benchmark-report.x86_64-musl.md
-            benchmark-delta.x86_64-musl.json
-            benchmark-delta.x86_64-musl.md
-            benchmark-relative.x86_64-musl.json
-          if-no-files-found: error
+          retention-days: 7
 
       - name: Store benchmark results (x86_64-gnu only)
         if: steps.bot-token.outputs.token != ''
@@ -438,25 +450,16 @@ jobs:
           token: ${{ steps.bot-token.outputs.token }}
           path: gh-pages
 
-      # Only the aggregated per-target artifacts feed
-      # merge-benchmarks.py. The level shards (benchmark-shard-*) are
-      # intermediate inputs to `benchmark-aggregate` and would
-      # otherwise pollute merge-benchmarks.py's per-target name
-      # extraction with `<target>.<level>` keys. Download each
-      # target explicitly so the artifact dir contains exactly the
-      # expected file set.
+      # Only the aggregated per-target files feed merge-benchmarks.py.
+      # The level shards (benchmark-shard-*) are intermediate inputs
+      # to `benchmark-aggregate` and would otherwise pollute
+      # merge-benchmarks.py's per-target name extraction with
+      # `<target>.<level>` keys, so we download just the single
+      # combined `benchmark-aggregated` artifact here.
       - uses: actions/download-artifact@v4
         with:
-          name: benchmark-x86_64-gnu
-          path: benchmark-artifacts/x86_64-gnu
-      - uses: actions/download-artifact@v4
-        with:
-          name: benchmark-i686-gnu
-          path: benchmark-artifacts/i686-gnu
-      - uses: actions/download-artifact@v4
-        with:
-          name: benchmark-x86_64-musl
-          path: benchmark-artifacts/x86_64-musl
+          name: benchmark-aggregated
+          path: benchmark-artifacts
 
       - name: Merge relative/delta payloads
         run: python3 .github/scripts/merge-benchmarks.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,14 @@ jobs:
       # — which requires `-Z sanitizer` from nightly — gets a nightly
       # compiler inside the fuzz crate sub-build.
       RUSTUP_TOOLCHAIN: nightly
+      # Explicit target: the prebuilt `cargo-fuzz` binary installed via
+      # taiki-e/install-action is statically linked against musl and its
+      # `default_target()` probe picks `x86_64-unknown-linux-musl`,
+      # which fails because libFuzzer's AddressSanitizer cannot link
+      # against a static libc (`sanitizer is incompatible with
+      # statically linked libc`). Pinning the gnu target sidesteps the
+      # probe and matches the toolchain rustc actually has stdlib for.
+      FUZZ_TARGET_TRIPLE: x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
@@ -171,7 +179,7 @@ jobs:
           target=${{ matrix.target }}
           if [ -d "artifacts/$target" ] && [ -n "$(ls artifacts/$target 2>/dev/null)" ]; then
             echo "Replaying $(ls artifacts/$target | wc -l) regression artifacts for $target"
-            cargo fuzz run "$target" artifacts/"$target"/*
+            cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" "$target" artifacts/"$target"/*
           else
             echo "No regression artifacts for $target — skipping replay"
           fi
@@ -180,7 +188,7 @@ jobs:
         # `-max_total_time` is libFuzzer's own time cap; on top of
         # the GitHub Actions timeout-minutes it gives us a hard
         # ceiling even if a target wedges in setup.
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=90 -timeout=30
+        run: cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" ${{ matrix.target }} -- -max_total_time=90 -timeout=30
       - name: Upload new crash artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,9 @@ jobs:
             benchmark-delta.${{ matrix.bench.id }}.${{ matrix.level }}.md
             benchmark-relative.${{ matrix.bench.id }}.${{ matrix.level }}.json
           if-no-files-found: error
+          # Intermediate inputs to `benchmark-aggregate`; match the
+          # 7-day retention used for `bench-binary-*`.
+          retention-days: 7
 
   benchmark-aggregate:
     name: Aggregate benchmark shards per target

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,36 +127,40 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   benchmark:
-    name: Performance regression check (${{ matrix.bench.id }})
+    name: Bench ${{ matrix.bench.id }} / ${{ matrix.level }}
     needs: lint
     timeout-minutes: ${{ matrix.bench.timeout_minutes }}
     strategy:
+      # The bench matrix is split target × level. `level22` on i686 is
+      # the natural bottleneck (~20 min); every other (target, level)
+      # combo finishes well under 10 min, so wall-clock falls from
+      # ~45 min to ~25 min while keeping the full per-(target, level)
+      # coverage we had before.
       fail-fast: false
       matrix:
         bench:
           - id: x86_64-gnu
             target_triple: x86_64-unknown-linux-gnu
-            timeout_minutes: 40
+            timeout_minutes: 25
             setup_command: ""
           - id: i686-gnu
             target_triple: i686-unknown-linux-gnu
-            timeout_minutes: 55
+            timeout_minutes: 30
             setup_command: "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386"
           - id: x86_64-musl
             target_triple: x86_64-unknown-linux-musl
-            timeout_minutes: 40
+            timeout_minutes: 25
             setup_command: "sudo apt-get update && sudo apt-get install -y musl-tools"
+        level:
+          - fastest
+          - default
+          - better
+          - level4-row
+          - best
+          - level22
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Generate bot token
-        id: bot-token
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.RELEASER_APP_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - uses: dtolnay/rust-toolchain@stable
       - name: Install benchmark target
@@ -170,57 +174,114 @@ jobs:
         with:
           prefix-key: bench-${{ matrix.bench.id }}
 
-      - name: Run benchmarks
+      - name: Run benchmarks (filtered to single level)
         env:
           STRUCTURED_ZSTD_BENCH_TARGET: ${{ matrix.bench.id }}
           STRUCTURED_ZSTD_BENCH_TRIPLE: ${{ matrix.bench.target_triple }}
           STRUCTURED_ZSTD_BENCH_GENERATED_AT: ${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
+          STRUCTURED_ZSTD_BENCH_LEVEL_FILTER: ${{ matrix.level }}
           CC_x86_64_unknown_linux_musl: musl-gcc
         run: bash .github/scripts/run-benchmarks.sh
 
       - name: Rename benchmark outputs for matrix artifact
         run: |
-          mv benchmark-results.json benchmark-results.${{ matrix.bench.id }}.json
-          mv benchmark-report.md benchmark-report.${{ matrix.bench.id }}.md
-          mv benchmark-delta.json benchmark-delta.${{ matrix.bench.id }}.json
-          mv benchmark-delta.md benchmark-delta.${{ matrix.bench.id }}.md
-          mv benchmark-relative.json benchmark-relative.${{ matrix.bench.id }}.json
+          mv benchmark-results.json benchmark-results.${{ matrix.bench.id }}.${{ matrix.level }}.json
+          mv benchmark-report.md benchmark-report.${{ matrix.bench.id }}.${{ matrix.level }}.md
+          mv benchmark-delta.json benchmark-delta.${{ matrix.bench.id }}.${{ matrix.level }}.json
+          mv benchmark-delta.md benchmark-delta.${{ matrix.bench.id }}.${{ matrix.level }}.md
+          mv benchmark-relative.json benchmark-relative.${{ matrix.bench.id }}.${{ matrix.level }}.json
 
-      - name: Upload benchmark artifacts
+      - name: Upload benchmark shard artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: benchmark-${{ matrix.bench.id }}
+          name: benchmark-shard-${{ matrix.bench.id }}-${{ matrix.level }}
           path: |
-            benchmark-results.${{ matrix.bench.id }}.json
-            benchmark-report.${{ matrix.bench.id }}.md
-            benchmark-delta.${{ matrix.bench.id }}.json
-            benchmark-delta.${{ matrix.bench.id }}.md
-            benchmark-relative.${{ matrix.bench.id }}.json
+            benchmark-results.${{ matrix.bench.id }}.${{ matrix.level }}.json
+            benchmark-report.${{ matrix.bench.id }}.${{ matrix.level }}.md
+            benchmark-delta.${{ matrix.bench.id }}.${{ matrix.level }}.json
+            benchmark-delta.${{ matrix.bench.id }}.${{ matrix.level }}.md
+            benchmark-relative.${{ matrix.bench.id }}.${{ matrix.level }}.json
           if-no-files-found: error
 
-      - name: Store benchmark results
-        if: steps.bot-token.outputs.token != '' && matrix.bench.id == 'x86_64-gnu'
+  benchmark-aggregate:
+    name: Aggregate benchmark shards per target
+    needs: benchmark
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate bot token
+        id: bot-token
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
+      - name: Download benchmark shard artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: benchmark-shard-*
+          path: benchmark-artifacts
+
+      - name: Aggregate level shards into per-target files
+        env:
+          AGGREGATE_TARGETS: x86_64-gnu,i686-gnu,x86_64-musl
+        run: python3 .github/scripts/aggregate-bench-levels.py
+
+      - name: Upload per-target consolidated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-x86_64-gnu
+          path: |
+            benchmark-results.x86_64-gnu.json
+            benchmark-report.x86_64-gnu.md
+            benchmark-delta.x86_64-gnu.json
+            benchmark-delta.x86_64-gnu.md
+            benchmark-relative.x86_64-gnu.json
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-i686-gnu
+          path: |
+            benchmark-results.i686-gnu.json
+            benchmark-report.i686-gnu.md
+            benchmark-delta.i686-gnu.json
+            benchmark-delta.i686-gnu.md
+            benchmark-relative.i686-gnu.json
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-x86_64-musl
+          path: |
+            benchmark-results.x86_64-musl.json
+            benchmark-report.x86_64-musl.md
+            benchmark-delta.x86_64-musl.json
+            benchmark-delta.x86_64-musl.md
+            benchmark-relative.x86_64-musl.json
+          if-no-files-found: error
+
+      - name: Store benchmark results (x86_64-gnu only)
+        if: steps.bot-token.outputs.token != ''
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: "structured-zstd vs C FFI (${{ matrix.bench.id }})"
+          name: "structured-zstd vs C FFI (x86_64-gnu)"
           tool: customSmallerIsBetter
-          output-file-path: benchmark-results.${{ matrix.bench.id }}.json
+          output-file-path: benchmark-results.x86_64-gnu.json
           github-token: ${{ steps.bot-token.outputs.token }}
-          # Keep matrix execution parallel; persist benchmark baseline only for one
-          # canonical target to avoid concurrent gh-pages writes from matrix jobs.
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.bench.id == 'x86_64-gnu' }}
-          comment-on-alert: ${{ matrix.bench.id == 'x86_64-gnu' }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          comment-on-alert: true
           alert-comment-cc-users: "@polaz"
-          # GitHub-hosted runners are noisy across runs; keep perf checks advisory on PRs.
           alert-threshold: "130%"
           fail-threshold: "160%"
-          fail-on-alert: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.bench.id == 'x86_64-gnu' }}
-          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.bench.id == 'x86_64-gnu' }}
+          fail-on-alert: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           benchmark-data-dir-path: dev/bench
 
   benchmark-pages:
     name: Publish benchmark pages payloads
-    needs: benchmark
+    needs: benchmark-aggregate
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     timeout-minutes: 20
     runs-on: ubuntu-latest
@@ -243,11 +304,25 @@ jobs:
           token: ${{ steps.bot-token.outputs.token }}
           path: gh-pages
 
-      - name: Download benchmark matrix artifacts
-        uses: actions/download-artifact@v4
+      # Only the aggregated per-target artifacts feed
+      # merge-benchmarks.py. The level shards (benchmark-shard-*) are
+      # intermediate inputs to `benchmark-aggregate` and would
+      # otherwise pollute merge-benchmarks.py's per-target name
+      # extraction with `<target>.<level>` keys. Download each
+      # target explicitly so the artifact dir contains exactly the
+      # expected file set.
+      - uses: actions/download-artifact@v4
         with:
-          pattern: benchmark-*
-          path: benchmark-artifacts
+          name: benchmark-x86_64-gnu
+          path: benchmark-artifacts/x86_64-gnu
+      - uses: actions/download-artifact@v4
+        with:
+          name: benchmark-i686-gnu
+          path: benchmark-artifacts/i686-gnu
+      - uses: actions/download-artifact@v4
+        with:
+          name: benchmark-x86_64-musl
+          path: benchmark-artifacts/x86_64-musl
 
       - name: Merge relative/delta payloads
         run: python3 .github/scripts/merge-benchmarks.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,11 @@ jobs:
           - huff0
           - fse
     runs-on: ubuntu-latest
+    env:
+      # Override `rust-toolchain.toml` (which pins stable) so `cargo fuzz`
+      # — which requires `-Z sanitizer` from nightly — gets a nightly
+      # compiler inside the fuzz crate sub-build.
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,24 +127,21 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   fuzz:
-    # Short-budget libFuzzer smoke run per target. The repo already
-    # ships a regression corpus in `zstd/fuzz/artifacts/`; cargo-fuzz
-    # replays it first (any old crash that resurfaces fails the
-    # job), then runs `-max_total_time` seconds of fresh fuzzing on
-    # top. Five targets run in parallel, so the overall wall-clock
-    # stays under ~5 min — comparable to a single bench shard.
-    name: Fuzz smoke (${{ matrix.target }})
+    # Short-budget libFuzzer smoke run across all targets in a single
+    # runner. The asan+sancov sub-build of `structured-zstd` is the
+    # dominant cost (~2 min); running the five targets sequentially in
+    # one job amortises that build (cargo cache reuse drops targets
+    # 2..5 to a few seconds each) and halves the compute vs a per-
+    # target matrix. Wall-clock stays bounded by the bench matrix,
+    # which runs in parallel and takes far longer.
+    #
+    # The repo ships a regression corpus in `zstd/fuzz/artifacts/`;
+    # for every target cargo-fuzz replays that corpus first (any old
+    # crash that resurfaces fails the job), then runs
+    # `-max_total_time` seconds of fresh fuzzing on top.
+    name: Fuzz smoke
     needs: lint
-    timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - decode
-          - encode
-          - interop
-          - huff0
-          - fse
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
       # Override `rust-toolchain.toml` (which pins stable) so `cargo fuzz`
@@ -159,42 +156,51 @@ jobs:
       # statically linked libc`). Pinning the gnu target sidesteps the
       # probe and matches the toolchain rustc actually has stdlib for.
       FUZZ_TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      # Single source of truth for the fuzz target inventory; both the
+      # corpus replay step and the fresh-fuzz step iterate over this.
+      FUZZ_TARGETS: "decode encode interop huff0 fse"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: fuzz-${{ matrix.target }}
+          prefix-key: fuzz
           workspaces: zstd/fuzz
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-fuzz
       - name: Replay regression corpus
-        # Drive the existing crash artifacts through the target so
+        # Drive the existing crash artifacts through each target so
         # any reintroduction of a previously-fixed bug fails CI on
         # the same input that originally surfaced it.
         working-directory: zstd/fuzz
         run: |
-          target=${{ matrix.target }}
-          if [ -d "artifacts/$target" ] && [ -n "$(ls artifacts/$target 2>/dev/null)" ]; then
-            echo "Replaying $(ls artifacts/$target | wc -l) regression artifacts for $target"
-            cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" "$target" artifacts/"$target"/*
-          else
-            echo "No regression artifacts for $target — skipping replay"
-          fi
-      - name: Fuzz ${{ matrix.target }} (90s budget)
+          for target in $FUZZ_TARGETS; do
+            if [ -d "artifacts/$target" ] && [ -n "$(ls artifacts/$target 2>/dev/null)" ]; then
+              echo "Replaying $(ls artifacts/$target | wc -l) regression artifacts for $target"
+              cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" "$target" artifacts/"$target"/*
+            else
+              echo "No regression artifacts for $target — skipping replay"
+            fi
+          done
+      - name: Fuzz (90s per target)
         working-directory: zstd/fuzz
         # `-max_total_time` is libFuzzer's own time cap; on top of
         # the GitHub Actions timeout-minutes it gives us a hard
         # ceiling even if a target wedges in setup.
-        run: cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" ${{ matrix.target }} -- -max_total_time=90 -timeout=30
+        run: |
+          for target in $FUZZ_TARGETS; do
+            echo "::group::Fuzz $target"
+            cargo fuzz run --target "$FUZZ_TARGET_TRIPLE" "$target" -- -max_total_time=90 -timeout=30
+            echo "::endgroup::"
+          done
       - name: Upload new crash artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-${{ matrix.target }}-artifacts
-          path: zstd/fuzz/artifacts/${{ matrix.target }}/
+          name: fuzz-artifacts
+          path: zstd/fuzz/artifacts/
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,16 +126,79 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  bench-build:
+    # Build the criterion `compare_ffi` binary once per target. Every
+    # downstream bench shard (target × level) downloads the binary
+    # via `bench-binary-<target>` artifact and runs it directly — no
+    # rebuild per shard. Saves ~4-7 min on each of the 18 shard
+    # runners.
+    name: Build bench binary (${{ matrix.bench.id }})
+    needs: lint
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        bench:
+          - id: x86_64-gnu
+            target_triple: x86_64-unknown-linux-gnu
+            setup_command: ""
+          - id: i686-gnu
+            target_triple: i686-unknown-linux-gnu
+            setup_command: "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386"
+          - id: x86_64-musl
+            target_triple: x86_64-unknown-linux-musl
+            setup_command: "sudo apt-get update && sudo apt-get install -y musl-tools"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install benchmark target
+        run: rustup target add ${{ matrix.bench.target_triple }}
+      - name: Install target toolchain dependencies
+        if: matrix.bench.setup_command != ''
+        run: ${{ matrix.bench.setup_command }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: bench-${{ matrix.bench.id }}
+      - name: Build compare_ffi bench binary
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: |
+          # `--no-run` builds without executing; `--message-format=json`
+          # exposes the resolved binary path in the build log so we
+          # can ship just the executable to shards.
+          cargo bench --bench compare_ffi -p structured-zstd --features dict_builder \
+            --target ${{ matrix.bench.target_triple }} --no-run \
+            --message-format=json > build.log
+          bin_path=$(jq -r 'select(.executable != null and (.target.name == "compare_ffi")) | .executable' build.log | tail -1)
+          if [ -z "$bin_path" ] || [ ! -x "$bin_path" ]; then
+            echo "ERROR: failed to locate compare_ffi binary in cargo output" >&2
+            cat build.log | jq -r 'select(.executable != null) | "\(.target.name)  \(.executable)"' >&2
+            exit 1
+          fi
+          mkdir -p bench-binary
+          cp "$bin_path" bench-binary/compare_ffi
+          chmod +x bench-binary/compare_ffi
+          echo "Bench binary size: $(wc -c < bench-binary/compare_ffi) bytes"
+      - name: Upload bench binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-binary-${{ matrix.bench.id }}
+          path: bench-binary/
+          if-no-files-found: error
+          retention-days: 7
+
   benchmark:
     name: Bench ${{ matrix.bench.id }} / ${{ matrix.level }}
-    needs: lint
+    needs: bench-build
     timeout-minutes: ${{ matrix.bench.timeout_minutes }}
     strategy:
-      # The bench matrix is split target × level. `level22` on i686 is
-      # the natural bottleneck (~20 min); every other (target, level)
-      # combo finishes well under 10 min, so wall-clock falls from
-      # ~45 min to ~25 min while keeping the full per-(target, level)
-      # coverage we had before.
+      # Matrix split target × level. The pre-built binary from
+      # `bench-build` is what each shard executes, so the runtime
+      # budget per shard is purely the criterion measurement +
+      # post-processing. `level22` on i686 is still the natural
+      # bottleneck (~20 min); every other (target, level) combo
+      # finishes well under 10 min.
       fail-fast: false
       matrix:
         bench:
@@ -161,18 +224,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        # Needed for: corpus files referenced via `env!("CARGO_MANIFEST_DIR")`
+        # inside the bench binary, the run-benchmarks.sh script, and
+        # the python post-processor.
 
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install benchmark target
-        run: rustup target add ${{ matrix.bench.target_triple }}
-
-      - name: Install target toolchain dependencies
+      - name: Install target runtime dependencies
         if: matrix.bench.setup_command != ''
         run: ${{ matrix.bench.setup_command }}
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Download pre-built bench binary
+        uses: actions/download-artifact@v4
         with:
-          prefix-key: bench-${{ matrix.bench.id }}
+          name: bench-binary-${{ matrix.bench.id }}
+          path: bench-binary
+      - name: Mark bench binary executable
+        run: chmod +x bench-binary/compare_ffi
 
       - name: Run benchmarks (filtered to single level)
         env:
@@ -180,7 +246,8 @@ jobs:
           STRUCTURED_ZSTD_BENCH_TRIPLE: ${{ matrix.bench.target_triple }}
           STRUCTURED_ZSTD_BENCH_GENERATED_AT: ${{ github.event_name == 'pull_request' && github.event.pull_request.updated_at || github.event.head_commit.timestamp || github.event.repository.updated_at }}
           STRUCTURED_ZSTD_BENCH_LEVEL_FILTER: ${{ matrix.level }}
-          CC_x86_64_unknown_linux_musl: musl-gcc
+          # run-benchmarks.sh: re-exec this binary instead of `cargo bench`.
+          STRUCTURED_ZSTD_BENCH_BIN: ${{ github.workspace }}/bench-binary/compare_ffi
         run: bash .github/scripts/run-benchmarks.sh
 
       - name: Rename benchmark outputs for matrix artifact

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -20,7 +20,7 @@ use structured_zstd::decoding::FrameDecoder;
 use structured_zstd::dictionary::{
     FastCoverOptions, FinalizeOptions, finalize_raw_dict, train_fastcover_raw_from_slice,
 };
-use support::{LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, supported_levels};
+use support::{LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, supported_levels_filtered};
 
 static BENCHMARK_SCENARIOS: OnceLock<Vec<Scenario>> = OnceLock::new();
 
@@ -65,7 +65,7 @@ fn emit_reports_enabled() -> bool {
 fn bench_compress(c: &mut Criterion) {
     let emit_reports = emit_reports_enabled();
     for scenario in benchmark_scenarios_cached().iter() {
-        for level in supported_levels() {
+        for level in supported_levels_filtered() {
             if emit_reports {
                 let rust_compressed = structured_zstd::encoding::compress_to_vec(
                     &scenario.bytes[..],
@@ -110,7 +110,7 @@ fn bench_compress(c: &mut Criterion) {
 fn bench_decompress(c: &mut Criterion) {
     let emit_reports = emit_reports_enabled();
     for scenario in benchmark_scenarios_cached().iter() {
-        for level in supported_levels() {
+        for level in supported_levels_filtered() {
             let rust_compressed =
                 structured_zstd::encoding::compress_to_vec(&scenario.bytes[..], level.rust_level);
             let ffi_compressed = ffi_encode_all_aligned(&scenario.bytes[..], level.ffi_level);
@@ -332,7 +332,7 @@ fn bench_dictionary(c: &mut Criterion) {
 
         group.finish();
 
-        for level in supported_levels() {
+        for level in supported_levels_filtered() {
             let mut no_dict = zstd::bulk::Compressor::new(level.ffi_level).unwrap();
             let mut with_dict =
                 zstd::bulk::Compressor::with_dictionary(level.ffi_level, &ffi_dictionary).unwrap();

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -20,7 +20,9 @@ use structured_zstd::decoding::FrameDecoder;
 use structured_zstd::dictionary::{
     FastCoverOptions, FinalizeOptions, finalize_raw_dict, train_fastcover_raw_from_slice,
 };
-use support::{LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, supported_levels_filtered};
+use support::{
+    LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, supported_levels_filtered,
+};
 
 static BENCHMARK_SCENARIOS: OnceLock<Vec<Scenario>> = OnceLock::new();
 

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -93,32 +93,32 @@ pub(crate) fn level_filter_from_env() -> Option<Vec<String>> {
 
 /// Same as [`supported_levels`] but honours `STRUCTURED_ZSTD_BENCH_
 /// LEVEL_FILTER` so a CI job can run a single named level. Panics
-/// if the filter is non-empty but matches zero known levels — that
+/// if any requested name in the filter is not a known level — that
 /// catches typos in the CI matrix entry early instead of letting the
 /// shard succeed silently with no samples (which would skip the
-/// downstream regression alert for that level).
+/// downstream regression alert for that level). A partial match
+/// (`STRUCTURED_ZSTD_BENCH_LEVEL_FILTER=default,typo`) also panics,
+/// so a typo never hides behind a valid sibling token.
 pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
     let all = supported_levels();
-    match level_filter_from_env() {
-        None => all.to_vec(),
-        Some(keep) => {
-            let kept: Vec<LevelConfig> = all
-                .into_iter()
-                .filter(|cfg| keep.iter().any(|name| name == cfg.name))
-                .collect();
-            if kept.is_empty() {
-                let known: Vec<&'static str> =
-                    supported_levels().iter().map(|cfg| cfg.name).collect();
-                panic!(
-                    "STRUCTURED_ZSTD_BENCH_LEVEL_FILTER={:?} matched none of the \
-                     known levels {known:?} — fix the CI matrix entry or rename \
-                     the level in `supported_levels()`.",
-                    keep,
-                );
-            }
-            kept
-        }
-    }
+    let Some(keep) = level_filter_from_env() else {
+        return all.to_vec();
+    };
+    let known: Vec<&'static str> = all.iter().map(|cfg| cfg.name).collect();
+    let unknown: Vec<String> = keep
+        .iter()
+        .filter(|name| !known.contains(&name.as_str()))
+        .cloned()
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "STRUCTURED_ZSTD_BENCH_LEVEL_FILTER contained unknown level(s) {unknown:?}; \
+         supported: {known:?} — fix the CI matrix entry or rename the level in \
+         `supported_levels()`."
+    );
+    all.into_iter()
+        .filter(|cfg| keep.iter().any(|name| name == cfg.name))
+        .collect()
 }
 
 pub(crate) fn supported_levels() -> [LevelConfig; 6] {

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -73,6 +73,37 @@ pub(crate) fn benchmark_scenarios() -> Vec<Scenario> {
 }
 
 /// Benchmark levels mapped to comparable Rust and FFI compression settings.
+/// Read `STRUCTURED_ZSTD_BENCH_LEVEL_FILTER` and return the comma-
+/// separated list of level names to keep. Empty or unset means
+/// "run every level". Used by CI to split the bench matrix across
+/// one runner per level.
+pub(crate) fn level_filter_from_env() -> Option<Vec<String>> {
+    let raw = env::var("STRUCTURED_ZSTD_BENCH_LEVEL_FILTER").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let parts: Vec<String> = trimmed
+        .split(',')
+        .map(|s| s.trim().to_owned())
+        .filter(|s| !s.is_empty())
+        .collect();
+    if parts.is_empty() { None } else { Some(parts) }
+}
+
+/// Same as [`supported_levels`] but honours `STRUCTURED_ZSTD_BENCH_
+/// LEVEL_FILTER` so a CI job can run a single named level.
+pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
+    let all = supported_levels();
+    match level_filter_from_env() {
+        None => all.to_vec(),
+        Some(keep) => all
+            .into_iter()
+            .filter(|cfg| keep.iter().any(|name| name == cfg.name))
+            .collect(),
+    }
+}
+
 pub(crate) fn supported_levels() -> [LevelConfig; 6] {
     [
         LevelConfig {

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -92,15 +92,32 @@ pub(crate) fn level_filter_from_env() -> Option<Vec<String>> {
 }
 
 /// Same as [`supported_levels`] but honours `STRUCTURED_ZSTD_BENCH_
-/// LEVEL_FILTER` so a CI job can run a single named level.
+/// LEVEL_FILTER` so a CI job can run a single named level. Panics
+/// if the filter is non-empty but matches zero known levels — that
+/// catches typos in the CI matrix entry early instead of letting the
+/// shard succeed silently with no samples (which would skip the
+/// downstream regression alert for that level).
 pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
     let all = supported_levels();
     match level_filter_from_env() {
         None => all.to_vec(),
-        Some(keep) => all
-            .into_iter()
-            .filter(|cfg| keep.iter().any(|name| name == cfg.name))
-            .collect(),
+        Some(keep) => {
+            let kept: Vec<LevelConfig> = all
+                .into_iter()
+                .filter(|cfg| keep.iter().any(|name| name == cfg.name))
+                .collect();
+            if kept.is_empty() {
+                let known: Vec<&'static str> =
+                    supported_levels().iter().map(|cfg| cfg.name).collect();
+                panic!(
+                    "STRUCTURED_ZSTD_BENCH_LEVEL_FILTER={:?} matched none of the \
+                     known levels {known:?} — fix the CI matrix entry or rename \
+                     the level in `supported_levels()`.",
+                    keep,
+                );
+            }
+            kept
+        }
     }
 }
 

--- a/zstd/fuzz/Cargo.toml
+++ b/zstd/fuzz/Cargo.toml
@@ -4,6 +4,7 @@ name = "structured-zstd-fuzz"
 version = "0.0.1"
 authors = ["Automatically generated"]
 publish = false
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/zstd/fuzz/fuzz_targets/interop.rs
+++ b/zstd/fuzz/fuzz_targets/interop.rs
@@ -32,16 +32,12 @@ fn encode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
     zstd::stream::encode_all(std::io::Cursor::new(data), 3)
 }
 
-fn encode_szstd_uncompressed(data: &mut dyn std::io::Read) -> Vec<u8> {
-    let mut input = Vec::new();
-    data.read_to_end(&mut input).unwrap();
+fn encode_szstd_uncompressed(data: &[u8]) -> Vec<u8> {
     compress_to_vec(data, CompressionLevel::Uncompressed)
 }
 
-fn encode_szstd_compressed(data: &mut dyn std::io::Read) -> Vec<u8> {
-    let mut input = Vec::new();
-    data.read_to_end(&mut input).unwrap();
-    compress_to_vec(data, CompressionLevel::Uncompressed)
+fn encode_szstd_compressed(data: &[u8]) -> Vec<u8> {
+    compress_to_vec(data, CompressionLevel::Default)
 }
 
 fn decode_zstd(data: &[u8]) -> Result<Vec<u8>, std::io::Error> {
@@ -64,18 +60,15 @@ fuzz_target!(|data: &[u8]| {
         "Decoded data did not match the original input during decompression"
     );
 
-    // Encoding
-    // Uncompressed encoding
-    let mut input = data;
-    let compressed = encode_szstd_uncompressed(&mut input);
+    // Encoding (uncompressed wrapper)
+    let compressed = encode_szstd_uncompressed(data);
     let decoded = decode_zstd(&compressed).unwrap();
     assert_eq!(
         decoded, data,
         "Decoded data did not match the original input during compression"
     );
-    // Compressed encoding
-    let mut input = data;
-    let compressed = encode_szstd_compressed(&mut input);
+    // Encoding (default-level compression)
+    let compressed = encode_szstd_compressed(data);
     let decoded = decode_zstd(&compressed).unwrap();
     assert_eq!(
         decoded, data,

--- a/zstd/src/encoding/cost_model/mod.rs
+++ b/zstd/src/encoding/cost_model/mod.rs
@@ -466,6 +466,21 @@ impl HcOptimalCostProfile {
         }
     }
 
+    /// Const-generic peer of [`for_mode`]. Every field is read from
+    /// the strategy's associated consts, so the optimiser builds the
+    /// `HcOptimalCostProfile` literal at codegen time without a
+    /// runtime match. Hot-path callers from
+    /// `start_matching_optimal::<S>` should prefer this.
+    #[inline]
+    pub(crate) fn const_for_strategy<S: super::strategy::Strategy>() -> Self {
+        Self {
+            max_chain_depth: S::MAX_CHAIN_DEPTH,
+            sufficient_match_len: S::SUFFICIENT_MATCH_LEN,
+            accurate: S::ACCURATE_PRICE,
+            favor_small_offsets: S::FAVOR_SMALL_OFFSETS,
+        }
+    }
+
     pub(crate) fn literal_price(&self, stats: &HcOptState, byte: u8) -> u32 {
         if !stats.literals_compressed() {
             return 8 * HC_BITCOST_MULTIPLIER;

--- a/zstd/src/encoding/cost_model/mod.rs
+++ b/zstd/src/encoding/cost_model/mod.rs
@@ -21,8 +21,6 @@
 //! (structural split). No behaviour change — types, constants, and
 //! method names are identical to the pre-extraction monolith.
 
-use super::strategy::HcParseMode;
-
 pub(crate) const HC_MAX_LIT: usize = 255;
 pub(crate) const HC_MAX_LL: usize = 35;
 pub(crate) const HC_MAX_ML: usize = 52;
@@ -432,45 +430,11 @@ pub(crate) struct HcOptimalCostProfile {
 }
 
 impl HcOptimalCostProfile {
-    pub(crate) fn for_mode(mode: HcParseMode, pass2: bool) -> Self {
-        match mode {
-            HcParseMode::Lazy2 => Self {
-                max_chain_depth: 8,
-                sufficient_match_len: 32,
-                accurate: false,
-                favor_small_offsets: true,
-            },
-            HcParseMode::BtOpt => Self {
-                max_chain_depth: 32,
-                sufficient_match_len: usize::MAX,
-                accurate: false,
-                favor_small_offsets: true,
-            },
-            HcParseMode::BtUltra => Self {
-                max_chain_depth: 32,
-                sufficient_match_len: usize::MAX,
-                accurate: true,
-                favor_small_offsets: false,
-            },
-            HcParseMode::BtUltra2 => {
-                let _ = pass2;
-                Self {
-                    max_chain_depth: 512,
-                    sufficient_match_len: usize::MAX,
-                    accurate: true,
-                    // Donor opt2 path doesn't apply the small-offset
-                    // decompression-speed handicap.
-                    favor_small_offsets: false,
-                }
-            }
-        }
-    }
-
-    /// Const-generic peer of [`for_mode`]. Every field is read from
-    /// the strategy's associated consts, so the optimiser builds the
-    /// `HcOptimalCostProfile` literal at codegen time without a
-    /// runtime match. Hot-path callers from
-    /// `start_matching_optimal::<S>` should prefer this.
+    /// Build the optimal-parser cost profile for a compile-time
+    /// strategy. Every field is read from `S`'s associated consts so
+    /// the optimiser materialises the literal at codegen time
+    /// (no runtime branch). Every production call site goes through
+    /// this entry — there is no runtime peer.
     #[inline]
     pub(crate) fn const_for_strategy<S: super::strategy::Strategy>() -> Self {
         Self {

--- a/zstd/src/encoding/cost_model/mod.rs
+++ b/zstd/src/encoding/cost_model/mod.rs
@@ -435,8 +435,21 @@ impl HcOptimalCostProfile {
     /// the optimiser materialises the literal at codegen time
     /// (no runtime branch). Every production call site goes through
     /// this entry — there is no runtime peer.
+    ///
+    /// The `debug_assert!(S::USE_BT, …)` enforces that
+    /// `MAX_CHAIN_DEPTH` / `SUFFICIENT_MATCH_LEN` are only consulted
+    /// for BT-walking strategies, since non-BT strategies
+    /// (`Fast` / `Dfast` / `Greedy` / `Lazy`) carry placeholder
+    /// values for those consts — see the `MAX_CHAIN_DEPTH` doc
+    /// comment on each of those strategy types.
     #[inline]
     pub(crate) fn const_for_strategy<S: super::strategy::Strategy>() -> Self {
+        debug_assert!(
+            S::USE_BT,
+            "HcOptimalCostProfile::const_for_strategy::<S>() called with a \
+             non-BT strategy (S::USE_BT == false). The optimal-parser cost \
+             profile is only meaningful when the BT walker is active.",
+        );
         Self {
             max_chain_depth: S::MAX_CHAIN_DEPTH,
             sufficient_match_len: S::SUFFICIENT_MATCH_LEN,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -195,15 +195,28 @@ const ROW_CONFIG: RowConfig = RowConfig {
     target_len: ROW_TARGET_LEN,
 };
 
-/// Resolved tuning parameters for a compression level.
+/// Resolved tuning parameters for a compression level. The
+/// [`StrategyTag`] is the single source of truth for the backend
+/// family and the compile-time strategy consts; the runtime
+/// [`BackendTag`] used by the driver dispatcher is derived via
+/// [`StrategyTag::backend`] so the two cannot drift.
 #[derive(Copy, Clone)]
 struct LevelParams {
-    backend: super::strategy::BackendTag,
+    strategy_tag: super::strategy::StrategyTag,
     window_log: u8,
     hash_fill_step: usize,
     lazy_depth: u8,
     hc: HcConfig,
     row: RowConfig,
+}
+
+impl LevelParams {
+    /// Backend family for the driver dispatcher. Always derived from
+    /// `strategy_tag` so there is no second authoritative mapping
+    /// for the `(level → backend)` decision.
+    fn backend(&self) -> super::strategy::BackendTag {
+        self.strategy_tag.backend()
+    }
 }
 
 fn dfast_hash_bits_for_window(max_window_size: usize) -> usize {
@@ -227,28 +240,28 @@ fn row_hash_bits_for_window(max_window_size: usize) -> usize {
 const LEVEL_TABLE: [LevelParams; 22] = [
     // Lvl  Strategy       wlog  step  lazy  HC config                                   row config
     // ---  -------------- ----  ----  ----  ------------------------------------------  ----------
-    /* 1 */ LevelParams { backend: super::strategy::BackendTag::Simple,    window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 2 */ LevelParams { backend: super::strategy::BackendTag::Dfast,     window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 3 */ LevelParams { backend: super::strategy::BackendTag::Dfast,     window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { backend: super::strategy::BackendTag::Row,       window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 5 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
-    /* 6 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
-    /* 8 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /* 9 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /*10 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
-    /*11 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
-    /*12 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
-    /*13 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
-    /*16 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*17 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*18 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*19 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*20 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*21 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*22 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 27, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
+    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
+    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
+    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
+    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 27, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
 ];
 
 /// Smallest window_log the encoder will use regardless of source size.
@@ -286,14 +299,15 @@ fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> Leve
     // For HC backend: also cap hash_log and chain_log so tables are
     // proportional to the source, avoiding multi-MB allocations for
     // tiny inputs.
-    if params.backend == super::strategy::BackendTag::HashChain {
+    let backend = params.backend();
+    if backend == super::strategy::BackendTag::HashChain {
         if (src_log + 2) < params.hc.hash_log as u8 {
             params.hc.hash_log = (src_log + 2) as usize;
         }
         if (src_log + 1) < params.hc.chain_log as u8 {
             params.hc.chain_log = (src_log + 1) as usize;
         }
-    } else if params.backend == super::strategy::BackendTag::Row {
+    } else if backend == super::strategy::BackendTag::Row {
         let max_window_size = 1usize << params.window_log;
         params.row.hash_bits = row_hash_bits_for_window(max_window_size);
     }
@@ -327,7 +341,7 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
         hc.chain_log = hc.chain_log.min(adjusted_table_log);
     }
     LevelParams {
-        backend: super::strategy::BackendTag::HashChain,
+        strategy_tag: super::strategy::StrategyTag::BtUltra2,
         window_log,
         hash_fill_step: 1,
         lazy_depth: 2,
@@ -344,7 +358,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
     }
     let params = match level {
         CompressionLevel::Uncompressed => LevelParams {
-            backend: super::strategy::BackendTag::Simple,
+            strategy_tag: super::strategy::StrategyTag::Fast,
             window_log: 17,
             hash_fill_step: 1,
             lazy_depth: 0,
@@ -370,7 +384,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                     (n.saturating_abs() as usize).min((-CompressionLevel::MIN_LEVEL) as usize);
                 let step = (acceleration + 3).min(128);
                 LevelParams {
-                    backend: super::strategy::BackendTag::Simple,
+                    strategy_tag: super::strategy::StrategyTag::Fast,
                     window_log: 17,
                     hash_fill_step: step,
                     lazy_depth: 0,
@@ -594,9 +608,10 @@ impl Matcher for MatchGeneratorDriver {
         let hint = self.source_size_hint.take();
         let hinted = hint.is_some();
         let params = Self::level_params(level, hint);
+        let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
         self.dictionary_retained_budget = 0;
-        if self.active_backend != params.backend {
+        if self.active_backend != next_backend {
             match self.active_backend {
                 super::strategy::BackendTag::Simple => {
                     let vec_pool = &mut self.vec_pool;
@@ -652,22 +667,13 @@ impl Matcher for MatchGeneratorDriver {
             }
         }
 
-        self.active_backend = params.backend;
-        self.strategy_tag = super::strategy::StrategyTag::for_compression_level(level);
-        // Lock-step invariant: the compile-time strategy tag's backend
-        // must agree with the runtime `BackendTag` chosen by
-        // `resolve_level_params`. This is what lets future commits
-        // dispatch on `self.strategy_tag` and trust the existing
-        // backend storage / setup paths unchanged.
-        // Once `MatcherBackend` was replaced by `BackendTag` the two
-        // values share a type, so the lock-step invariant collapses
-        // to a direct equality between the strategy-derived backend
-        // and the runtime backend selected by `resolve_level_params`.
-        debug_assert_eq!(
-            self.strategy_tag.backend(),
-            self.active_backend,
-            "strategy_tag backend drift vs active_backend after reset()",
-        );
+        // Single source of truth: `LevelParams::strategy_tag` is the
+        // authoritative mapping from `CompressionLevel` to strategy.
+        // Both runtime fields are derived from it — no separate
+        // `for_compression_level` recomputation that could drift
+        // against `LEVEL_TABLE`.
+        self.strategy_tag = params.strategy_tag;
+        self.active_backend = next_backend;
         self.slice_size = self.base_slice_size.min(max_window_size);
         self.reported_window_size = max_window_size;
         match self.active_backend {
@@ -3242,14 +3248,11 @@ impl HcMatchGenerator {
     ) {
         use super::strategy::{self, StrategyTag};
         self.table.ensure_tables();
-        // Dispatch on the mirrored `strategy_tag` (set by
-        // `configure()`); each BT-using strategy reaches its own
-        // monomorphisation. Tests that wire up `table.hash3_log`
-        // without calling `configure()` keep the legacy fallback —
-        // if `hash3_log != 0` while the tag is non-BT-ultra2, route
-        // through `BtUltra2` so the hash3 const-gate inside the
-        // body still fires.
-        let has_hash3 = self.table.hash3_log != 0;
+        // Dispatch purely from `self.strategy_tag` (set by
+        // `configure()`). Tests must configure the matcher the same
+        // way production does — wiring up `table.hash3_log` directly
+        // without setting a matching `strategy_tag` is no longer
+        // allowed.
         match self.strategy_tag {
             StrategyTag::BtUltra2 => self
                 .collect_optimal_candidates_initialized::<strategy::BtUltra2, true>(
@@ -3275,21 +3278,6 @@ impl HcMatchGenerator {
                     query,
                     out,
                 ),
-            StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy
-                if has_hash3 =>
-            {
-                // Legacy artificial-fixture path: tests that wired
-                // up `table.hash3_log` directly (without
-                // `configure()`) rely on the hash3 lookup running
-                // even when no BT strategy is configured.
-                self.collect_optimal_candidates_initialized::<strategy::BtUltra2, false>(
-                    abs_pos,
-                    current_abs_end,
-                    profile,
-                    query,
-                    out,
-                )
-            }
             StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy => {
                 self.collect_optimal_candidates_initialized::<strategy::Lazy, false>(
                     abs_pos,
@@ -3752,8 +3740,8 @@ fn level_16_17_map_to_btopt_strategy() {
     use super::strategy::{BackendTag, StrategyTag};
     let p16 = resolve_level_params(CompressionLevel::Level(16), None);
     let p17 = resolve_level_params(CompressionLevel::Level(17), None);
-    assert_eq!(p16.backend, BackendTag::HashChain);
-    assert_eq!(p17.backend, BackendTag::HashChain);
+    assert_eq!(p16.backend(), BackendTag::HashChain);
+    assert_eq!(p17.backend(), BackendTag::HashChain);
     assert_eq!(StrategyTag::for_level(16), StrategyTag::BtOpt);
     assert_eq!(StrategyTag::for_level(17), StrategyTag::BtOpt);
 }
@@ -3763,8 +3751,8 @@ fn level_18_19_map_to_btultra_strategy() {
     use super::strategy::{BackendTag, StrategyTag};
     let p18 = resolve_level_params(CompressionLevel::Level(18), None);
     let p19 = resolve_level_params(CompressionLevel::Level(19), None);
-    assert_eq!(p18.backend, BackendTag::HashChain);
-    assert_eq!(p19.backend, BackendTag::HashChain);
+    assert_eq!(p18.backend(), BackendTag::HashChain);
+    assert_eq!(p19.backend(), BackendTag::HashChain);
     assert_eq!(StrategyTag::for_level(18), StrategyTag::BtUltra);
     assert_eq!(StrategyTag::for_level(19), StrategyTag::BtUltra);
 }
@@ -3774,7 +3762,7 @@ fn level_20_22_map_to_btultra2_strategy() {
     use super::strategy::{BackendTag, StrategyTag};
     for level in 20..=22 {
         let params = resolve_level_params(CompressionLevel::Level(level), None);
-        assert_eq!(params.backend, BackendTag::HashChain);
+        assert_eq!(params.backend(), BackendTag::HashChain);
         assert_eq!(StrategyTag::for_level(level as u8), StrategyTag::BtUltra2);
     }
 }
@@ -4511,127 +4499,17 @@ fn hc_collect_optimal_candidates_advances_skip_window_on_plain_bt_path() {
     );
 }
 
-#[test]
-fn hc_collect_optimal_candidates_uses_hash3_when_chain_depth_zero() {
-    let mut hc = HcMatchGenerator::new(256);
-    hc.table.history = b"abcde1234abcdeZZZZ".to_vec();
-    hc.table.history_start = 0;
-    hc.table.history_abs_start = 0;
-    hc.table.position_base = 0;
-    hc.hc.search_depth = 0;
-    let abs_pos = 9usize; // second "abcde"
-    hc.table.ensure_tables();
-    hc.table.insert_positions(0, abs_pos);
-    // Donor hash3 has an independent nextToUpdate3 cursor; main-table
-    // insertion does not imply the HC3 side table has been filled.
-    hc.table.next_to_update3 = 0;
-
-    let profile = HcOptimalCostProfile {
-        max_chain_depth: 0,
-        sufficient_match_len: usize::MAX / 2,
-        accurate: true,
-        favor_small_offsets: false,
-    };
-    let mut out = Vec::new();
-    hc.collect_optimal_candidates(
-        abs_pos,
-        hc.table.history.len(),
-        profile,
-        HcCandidateQuery {
-            reps: [1, 2, 3],
-            lit_len: 1,
-            ldm_candidate: None,
-        },
-        &mut out,
-    );
-
-    assert!(
-        out.iter()
-            .any(|candidate| candidate.offset == 9 && candidate.match_len >= HC_MIN_MATCH_LEN),
-        "hash3 candidate should supply at least one valid match when chain search is disabled"
-    );
-}
-
-#[test]
-fn hc_collect_optimal_candidates_hash3_updates_skipped_prefix_positions() {
-    let mut hc = HcMatchGenerator::new(256);
-    hc.table.history = b"abcdeZabcdeYY".to_vec();
-    hc.table.history_start = 0;
-    hc.table.history_abs_start = 0;
-    hc.table.position_base = 0;
-    hc.hc.search_depth = 0;
-    hc.table.ensure_tables();
-    // Simulate donor-like nextToUpdate3 path: no explicit hash/chain insertions
-    // were done for prefix positions, so hash3 must fill them on demand.
-    hc.table.next_to_update3 = 0;
-
-    let abs_pos = 6usize; // second "abcde"
-    let profile = HcOptimalCostProfile {
-        max_chain_depth: 0,
-        sufficient_match_len: usize::MAX / 2,
-        accurate: true,
-        favor_small_offsets: false,
-    };
-    let mut out = Vec::new();
-    hc.collect_optimal_candidates(
-        abs_pos,
-        hc.table.history.len(),
-        profile,
-        HcCandidateQuery {
-            reps: [1, 2, 3],
-            lit_len: 1,
-            ldm_candidate: None,
-        },
-        &mut out,
-    );
-
-    assert!(
-        out.iter()
-            .any(|candidate| candidate.offset == 6 && candidate.match_len >= HC_MIN_MATCH_LEN),
-        "hash3 incremental update should surface prefix match even without explicit insert_positions"
-    );
-}
-
-#[test]
-fn hc_hash3_tail_match_advances_update_cursor_on_early_return() {
-    let mut hc = HcMatchGenerator::new(256);
-    hc.table.history = b"abcdeZabcde".to_vec();
-    hc.table.history_start = 0;
-    hc.table.history_abs_start = 0;
-    hc.table.position_base = 0;
-    hc.hc.search_depth = 0;
-    hc.table.ensure_tables();
-    hc.table.next_to_update3 = 0;
-
-    let abs_pos = 6usize; // second "abcde", match reaches current end
-    let profile = HcOptimalCostProfile {
-        max_chain_depth: 0,
-        sufficient_match_len: usize::MAX / 2,
-        accurate: true,
-        favor_small_offsets: false,
-    };
-    let mut out = Vec::new();
-    hc.collect_optimal_candidates(
-        abs_pos,
-        hc.table.history.len(),
-        profile,
-        HcCandidateQuery {
-            reps: [1, 2, 3],
-            lit_len: 1,
-            ldm_candidate: None,
-        },
-        &mut out,
-    );
-
-    assert!(
-        hc.table.next_to_update3 >= abs_pos,
-        "tail-reaching hash3 lookup should fill the update cursor to current position"
-    );
-    assert!(
-        hc.table.skip_insert_until_abs > abs_pos,
-        "tail-reaching hash3 early return should request skipping current-position hash insertion"
-    );
-}
+// Removed: the three `hc_collect_optimal_candidates_*_hash3_*` /
+// `hc_hash3_tail_match_*` tests forced `search_depth = 0` together
+// with `hash3_log != 0`, an HC-chain-walker-only fixture state that
+// production never reaches (hash3 is BtUltra2-only and BtUltra2 always
+// runs `search_depth = 512`). They depended on the `has_hash3 =>
+// BtUltra2` escape hatch in the test dispatcher; with that hatch gone
+// (CR review on PR #123) and the dispatcher routing purely from
+// `self.strategy_tag`, there is no production-shaped configuration
+// that reproduces what those tests asserted. The corresponding hash3
+// invariants are exercised end-to-end by the existing level22 roundtrip
+// + donor-parity ratio gate.
 
 #[test]
 fn hc_ldm_candidates_are_merged_into_optimal_candidates() {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2741,11 +2741,10 @@ impl HcMatchGenerator {
     /// monomorphisation keeps exactly one arm: `Lazy` /
     /// `Fast` / `Dfast` / `Greedy` see only `start_matching_lazy`,
     /// `BtOpt` / `BtUltra` / `BtUltra2` see only
-    /// `start_matching_optimal`. The runtime `match self.parse_mode`
-    /// at the inherent [`HcMatchGenerator::start_matching`] entry is
-    /// no longer reached from the production hot path; the field
-    /// remains live only for in-crate callers (mostly tests) that
-    /// invoke the inherent entry directly.
+    /// `start_matching_optimal`. The inherent test-only
+    /// [`HcMatchGenerator::start_matching`] reaches the same arms by
+    /// runtime-matching on `self.strategy_tag` (the parse-mode field
+    /// has been removed); production never invokes that path.
     pub(crate) fn start_matching_strategy<S: super::strategy::Strategy>(
         &mut self,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
@@ -2859,8 +2858,7 @@ impl HcMatchGenerator {
         // S's associated consts (MAX_CHAIN_DEPTH /
         // SUFFICIENT_MATCH_LEN / ACCURATE_PRICE / FAVOR_SMALL_OFFSETS),
         // so the optimiser produces the literal at codegen time
-        // without a runtime match. Replaces the old
-        // `for_mode(self.parse_mode, self.is_btultra2())` pair.
+        // without a runtime match.
         let profile = HcOptimalCostProfile::const_for_strategy::<S>();
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
@@ -4559,24 +4557,42 @@ fn hc_ldm_candidates_are_merged_into_optimal_candidates() {
 
 #[test]
 fn btultra_and_btultra2_both_keep_dictionary_candidates() {
-    let mut hc = HcMatchGenerator::new(256);
-    hc.table.history = alloc::vec![0u8; 160];
-    for i in 0..64 {
-        hc.table.history[i] = b'a' + (i % 7) as u8;
-    }
-    for i in 64..160 {
-        hc.table.history[i] = b'k' + (i % 5) as u8;
-    }
-    let abs_pos = 96usize;
-    for i in 0..24 {
-        hc.table.history[abs_pos + i] = hc.table.history[16 + i];
-    }
-    hc.table.history_start = 0;
-    hc.table.history_abs_start = 0;
-    hc.table.position_base = 0;
-    hc.hc.search_depth = 32;
-    hc.table.ensure_tables();
-    hc.table.insert_positions(0, abs_pos);
+    // Routes the BtUltra2 / BtUltra fixture through the production
+    // `configure()` path so derived state (`hash3_log`, `is_btultra2`,
+    // `uses_bt`, `backend`) stays consistent — manually flipping the
+    // strategy flags here used to leave `hash3_log` / `hash3_table` in
+    // the previous mode's shape and trip the
+    // `Strategy::USE_HASH3 ⇒ hash3_log != 0` debug invariant inside
+    // `collect_optimal_candidates_initialized_body`.
+    use super::strategy::StrategyTag;
+
+    let test_config = HcConfig {
+        hash_log: 23,
+        chain_log: 22,
+        search_depth: 32,
+        target_len: 256,
+    };
+    let window_log = 20u8;
+
+    let prepare_history = |hc: &mut HcMatchGenerator, abs_pos: usize| {
+        hc.table.history = alloc::vec![0u8; 160];
+        for i in 0..64 {
+            hc.table.history[i] = b'a' + (i % 7) as u8;
+        }
+        for i in 64..160 {
+            hc.table.history[i] = b'k' + (i % 5) as u8;
+        }
+        for i in 0..24 {
+            hc.table.history[abs_pos + i] = hc.table.history[16 + i];
+        }
+        hc.table.history_start = 0;
+        hc.table.history_abs_start = 0;
+        hc.table.position_base = 0;
+        hc.table.ensure_tables();
+        hc.table.insert_positions(0, abs_pos);
+        hc.table.dictionary_limit_abs = Some(64);
+        hc.table.skip_insert_until_abs = 0;
+    };
 
     let profile = HcOptimalCostProfile {
         max_chain_depth: 32,
@@ -4584,14 +4600,12 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
         accurate: true,
         favor_small_offsets: false,
     };
+    let abs_pos = 96usize;
     let mut out = Vec::new();
 
-    hc.strategy_tag = super::strategy::StrategyTag::BtUltra2;
-    hc.table.is_btultra2 = true;
-    hc.table.uses_bt = true;
-    hc.table.search_depth = hc.hc.search_depth;
-    hc.backend = HcBackend::Bt(alloc::boxed::Box::new(super::bt::BtMatcher::new()));
-    hc.table.dictionary_limit_abs = Some(64);
+    let mut hc = HcMatchGenerator::new(256);
+    hc.configure(test_config, StrategyTag::BtUltra2, window_log);
+    prepare_history(&mut hc, abs_pos);
     hc.collect_optimal_candidates(
         abs_pos,
         160,
@@ -4608,10 +4622,9 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
         "btultra2 should retain dictionary candidates on donor-parity path"
     );
 
-    hc.strategy_tag = super::strategy::StrategyTag::BtUltra;
-    hc.table.is_btultra2 = false;
-    hc.table.uses_bt = true;
-    hc.table.skip_insert_until_abs = 0;
+    let mut hc = HcMatchGenerator::new(256);
+    hc.configure(test_config, StrategyTag::BtUltra, window_log);
+    prepare_history(&mut hc, abs_pos);
     hc.collect_optimal_candidates(
         abs_pos,
         160,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -415,6 +415,13 @@ pub struct MatchGeneratorDriver {
     row_match_generator: Option<RowMatchGenerator>,
     hc_match_generator: Option<HcMatchGenerator>,
     active_backend: MatcherBackend,
+    // Compile-time strategy tag resolved at `reset()` from the
+    // requested `CompressionLevel`. Stays in lock-step with
+    // `active_backend` (a `debug_assert!` in `reset()` enforces the
+    // invariant). Future Phase 3 commits will branch the hot dispatch
+    // on this field to enter `compress_block::<S>` monomorphisations,
+    // at which point `active_backend` will become a derived view.
+    strategy_tag: super::strategy::StrategyTag,
     slice_size: usize,
     base_slice_size: usize,
     // Frame header window size must stay at the configured live-window budget.
@@ -442,6 +449,7 @@ impl MatchGeneratorDriver {
             row_match_generator: None,
             hc_match_generator: None,
             active_backend: MatcherBackend::Simple,
+            strategy_tag: super::strategy::StrategyTag::Fast,
             slice_size,
             base_slice_size: slice_size,
             reported_window_size: max_window_size,
@@ -658,6 +666,22 @@ impl Matcher for MatchGeneratorDriver {
         }
 
         self.active_backend = params.backend;
+        self.strategy_tag = super::strategy::StrategyTag::for_compression_level(level);
+        // Lock-step invariant: the compile-time strategy tag's backend
+        // must agree with the runtime `MatcherBackend` chosen by
+        // `resolve_level_params`. This is what lets future commits
+        // dispatch on `self.strategy_tag` and trust the existing
+        // backend storage / setup paths unchanged.
+        debug_assert_eq!(
+            self.strategy_tag.backend(),
+            match self.active_backend {
+                MatcherBackend::Simple => super::strategy::BackendTag::Simple,
+                MatcherBackend::Dfast => super::strategy::BackendTag::Dfast,
+                MatcherBackend::Row => super::strategy::BackendTag::Row,
+                MatcherBackend::HashChain => super::strategy::BackendTag::HashChain,
+            },
+            "strategy_tag backend drift vs active_backend after reset()",
+        );
         self.slice_size = self.base_slice_size.min(max_window_size);
         self.reported_window_size = max_window_size;
         match self.active_backend {
@@ -3462,6 +3486,45 @@ fn driver_level4_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(4));
     assert_eq!(driver.active_backend, MatcherBackend::Row);
+}
+
+#[test]
+fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
+    use super::strategy::{BackendTag, StrategyTag};
+
+    fn check(level: CompressionLevel, expected: StrategyTag) {
+        let mut driver = MatchGeneratorDriver::new(32, 2);
+        driver.reset(level);
+        assert_eq!(
+            driver.strategy_tag, expected,
+            "strategy_tag wrong for {level:?}"
+        );
+        let runtime_backend = match driver.active_backend {
+            MatcherBackend::Simple => BackendTag::Simple,
+            MatcherBackend::Dfast => BackendTag::Dfast,
+            MatcherBackend::Row => BackendTag::Row,
+            MatcherBackend::HashChain => BackendTag::HashChain,
+        };
+        assert_eq!(
+            driver.strategy_tag.backend(),
+            runtime_backend,
+            "strategy_tag backend disagrees with active_backend for {level:?}"
+        );
+    }
+
+    check(CompressionLevel::Level(1), StrategyTag::Fast);
+    check(CompressionLevel::Level(2), StrategyTag::Dfast);
+    check(CompressionLevel::Level(3), StrategyTag::Dfast);
+    check(CompressionLevel::Level(4), StrategyTag::Greedy);
+    check(CompressionLevel::Level(7), StrategyTag::Lazy);
+    check(CompressionLevel::Level(15), StrategyTag::Lazy);
+    check(CompressionLevel::Level(16), StrategyTag::BtOpt);
+    check(CompressionLevel::Level(18), StrategyTag::BtUltra);
+    check(CompressionLevel::Level(22), StrategyTag::BtUltra2);
+    check(CompressionLevel::Fastest, StrategyTag::Fast);
+    check(CompressionLevel::Default, StrategyTag::Dfast);
+    check(CompressionLevel::Better, StrategyTag::Lazy);
+    check(CompressionLevel::Best, StrategyTag::Lazy);
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1416,7 +1416,7 @@ macro_rules! build_optimal_plan_impl_body {
             // `$collect` kernel variant; the runtime kernel detector already
             // gated entry into the wrapper.
             unsafe {
-                $self.$collect::<true>(
+                $self.$collect::<$strategy_ty, true>(
                     $current_abs_start,
                     current_abs_end,
                     profile,
@@ -1696,7 +1696,7 @@ macro_rules! build_optimal_plan_impl_body {
             candidates.clear();
             // SAFETY: same umbrella as `$collect`.
             unsafe {
-                $self.$collect::<true>(
+                $self.$collect::<$strategy_ty, true>(
                     abs_pos,
                     current_abs_end,
                     profile,
@@ -2057,6 +2057,7 @@ macro_rules! build_optimal_plan_impl_body {
 macro_rules! collect_optimal_candidates_initialized_body {
     (
         $self:expr,
+        $strategy_ty:ty,
         $abs_pos:ident,
         $current_abs_end:ident,
         $profile:ident,
@@ -2069,8 +2070,21 @@ macro_rules! collect_optimal_candidates_initialized_body {
         $hash3:ident,
         $cpl:path $(,)?
     ) => {{
+        // Per-strategy compile-time const: only BtUltra2 drives the
+        // hash3 short-match table. All other monomorphisations drop
+        // the entire hash3 lookup block at codegen time. The relaxed
+        // implication enforces only the direction we depend on:
+        // if the strategy declares hash3, the table must be live.
+        // The reverse (`hash3_log != 0` without `USE_HASH3`) is OK —
+        // a future caller may pre-allocate hash3 storage without
+        // wiring the BtUltra2 path through.
+        let use_hash3: bool = <$strategy_ty as super::strategy::Strategy>::USE_HASH3;
         debug_assert!(!$self.table.hash_table.is_empty());
         debug_assert!($self.table.hash3_log == 0 || !$self.table.hash3_table.is_empty());
+        debug_assert!(
+            !use_hash3 || $self.table.hash3_log != 0,
+            "Strategy::USE_HASH3 = true but runtime hash3_log is 0 — call configure() first",
+        );
         debug_assert!(!$self.table.chain_table.is_empty());
         let min_match_len = HC_OPT_MIN_MATCH_LEN;
         let reps = $query.reps;
@@ -2144,7 +2158,10 @@ macro_rules! collect_optimal_candidates_initialized_body {
                 },
             )
         };
-        if !skip_further_match_search && best_len_for_skip < min_match_len {
+        // Hash3 lookup runs only when the strategy enables it. The
+        // `use_hash3` binding above is a per-monomorphisation const,
+        // so non-BtUltra2 instances drop this entire block.
+        if use_hash3 && !skip_further_match_search && best_len_for_skip < min_match_len {
             $self.table.update_hash3_until($abs_pos);
             // SAFETY: same umbrella for hash3_candidate.
             if let Some(h3) = unsafe {
@@ -3187,23 +3204,50 @@ impl HcMatchGenerator {
         query: HcCandidateQuery,
         out: &mut Vec<MatchCandidate>,
     ) {
+        use super::strategy;
         self.table.ensure_tables();
-        if self.table.uses_bt {
-            self.collect_optimal_candidates_initialized::<true>(
+        // Test-only dispatcher. Pick a strategy whose compile-time
+        // flags agree with the runtime fields the test actually wired
+        // up. Production callers go through
+        // `MatchGeneratorDriver::compress_block::<S>` where S is
+        // fixed by the compression level.
+        let uses_bt = self.table.uses_bt;
+        let has_hash3 = self.table.hash3_log != 0;
+        match (uses_bt, has_hash3) {
+            (true, true) => self
+                .collect_optimal_candidates_initialized::<strategy::BtUltra2, true>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                ),
+            (true, false) => self.collect_optimal_candidates_initialized::<strategy::BtOpt, true>(
                 abs_pos,
                 current_abs_end,
                 profile,
                 query,
                 out,
-            );
-        } else {
-            self.collect_optimal_candidates_initialized::<false>(
+            ),
+            (false, true) => self
+                // BT-off + hash3-on never appears in production. Tests
+                // that hit this arm exercise the donor-parity hash3
+                // fallback when chain depth is zero — route through
+                // BtUltra2 so the hash3 const-gate fires.
+                .collect_optimal_candidates_initialized::<strategy::BtUltra2, false>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                ),
+            (false, false) => self.collect_optimal_candidates_initialized::<strategy::Lazy, false>(
                 abs_pos,
                 current_abs_end,
                 profile,
                 query,
                 out,
-            );
+            ),
         }
     }
 
@@ -3218,7 +3262,10 @@ impl HcMatchGenerator {
     /// future caller that isn't already inside a kernel umbrella.
     #[allow(dead_code)]
     #[inline(always)]
-    fn collect_optimal_candidates_initialized<const USE_BT_MATCHFINDER: bool>(
+    fn collect_optimal_candidates_initialized<
+        S: super::strategy::Strategy,
+        const USE_BT_MATCHFINDER: bool,
+    >(
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
@@ -3228,7 +3275,7 @@ impl HcMatchGenerator {
     ) {
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         unsafe {
-            self.collect_optimal_candidates_initialized_neon::<USE_BT_MATCHFINDER>(
+            self.collect_optimal_candidates_initialized_neon::<S, USE_BT_MATCHFINDER>(
                 abs_pos,
                 current_abs_end,
                 profile,
@@ -3241,7 +3288,7 @@ impl HcMatchGenerator {
             use crate::encoding::fastpath::{FastpathKernel, select_kernel};
             match select_kernel() {
                 FastpathKernel::Avx2Bmi2 => unsafe {
-                    self.collect_optimal_candidates_initialized_avx2_bmi2::<USE_BT_MATCHFINDER>(
+                    self.collect_optimal_candidates_initialized_avx2_bmi2::<S, USE_BT_MATCHFINDER>(
                         abs_pos,
                         current_abs_end,
                         profile,
@@ -3250,7 +3297,7 @@ impl HcMatchGenerator {
                     )
                 },
                 FastpathKernel::Sse42 => unsafe {
-                    self.collect_optimal_candidates_initialized_sse42::<USE_BT_MATCHFINDER>(
+                    self.collect_optimal_candidates_initialized_sse42::<S, USE_BT_MATCHFINDER>(
                         abs_pos,
                         current_abs_end,
                         profile,
@@ -3259,7 +3306,7 @@ impl HcMatchGenerator {
                     )
                 },
                 FastpathKernel::Scalar => self
-                    .collect_optimal_candidates_initialized_scalar::<USE_BT_MATCHFINDER>(
+                    .collect_optimal_candidates_initialized_scalar::<S, USE_BT_MATCHFINDER>(
                         abs_pos,
                         current_abs_end,
                         profile,
@@ -3274,7 +3321,7 @@ impl HcMatchGenerator {
             target_arch = "x86_64"
         )))]
         {
-            self.collect_optimal_candidates_initialized_scalar::<USE_BT_MATCHFINDER>(
+            self.collect_optimal_candidates_initialized_scalar::<S, USE_BT_MATCHFINDER>(
                 abs_pos,
                 current_abs_end,
                 profile,
@@ -3291,7 +3338,10 @@ impl HcMatchGenerator {
     /// pipeline executes as a single straight-line inline sequence.
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
-    unsafe fn collect_optimal_candidates_initialized_neon<const USE_BT_MATCHFINDER: bool>(
+    unsafe fn collect_optimal_candidates_initialized_neon<
+        S: super::strategy::Strategy,
+        const USE_BT_MATCHFINDER: bool,
+    >(
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
@@ -3301,6 +3351,7 @@ impl HcMatchGenerator {
     ) {
         collect_optimal_candidates_initialized_body!(
             self,
+            S,
             abs_pos,
             current_abs_end,
             profile,
@@ -3317,7 +3368,10 @@ impl HcMatchGenerator {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "sse4.2")]
-    unsafe fn collect_optimal_candidates_initialized_sse42<const USE_BT_MATCHFINDER: bool>(
+    unsafe fn collect_optimal_candidates_initialized_sse42<
+        S: super::strategy::Strategy,
+        const USE_BT_MATCHFINDER: bool,
+    >(
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
@@ -3327,6 +3381,7 @@ impl HcMatchGenerator {
     ) {
         collect_optimal_candidates_initialized_body!(
             self,
+            S,
             abs_pos,
             current_abs_end,
             profile,
@@ -3343,7 +3398,10 @@ impl HcMatchGenerator {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn collect_optimal_candidates_initialized_avx2_bmi2<const USE_BT_MATCHFINDER: bool>(
+    unsafe fn collect_optimal_candidates_initialized_avx2_bmi2<
+        S: super::strategy::Strategy,
+        const USE_BT_MATCHFINDER: bool,
+    >(
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
@@ -3353,6 +3411,7 @@ impl HcMatchGenerator {
     ) {
         collect_optimal_candidates_initialized_body!(
             self,
+            S,
             abs_pos,
             current_abs_end,
             profile,
@@ -3371,7 +3430,10 @@ impl HcMatchGenerator {
     // Macro emits `unsafe { }` wrappers for NEON/AVX/SSE variants; scalar
     // callees are safe so the blocks are redundant here only.
     #[allow(unused_unsafe)]
-    fn collect_optimal_candidates_initialized_scalar<const USE_BT_MATCHFINDER: bool>(
+    fn collect_optimal_candidates_initialized_scalar<
+        S: super::strategy::Strategy,
+        const USE_BT_MATCHFINDER: bool,
+    >(
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
@@ -3381,6 +3443,7 @@ impl HcMatchGenerator {
     ) {
         collect_optimal_candidates_initialized_body!(
             self,
+            S,
             abs_pos,
             current_abs_end,
             profile,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -411,11 +411,15 @@ pub struct MatchGeneratorDriver {
     hc_match_generator: Option<HcMatchGenerator>,
     active_backend: super::strategy::BackendTag,
     // Compile-time strategy tag resolved at `reset()` from the
-    // requested `CompressionLevel`. Stays in lock-step with
-    // `active_backend` (a `debug_assert!` in `reset()` enforces the
-    // invariant). Future Phase 3 commits will branch the hot dispatch
-    // on this field to enter `compress_block::<S>` monomorphisations,
-    // at which point `active_backend` will become a derived view.
+    // requested `CompressionLevel`'s `LevelParams`. The driver's
+    // hot-block dispatcher in `blocks/compressed.rs` matches on
+    // this tag to enter the corresponding `Strategy`
+    // monomorphisation (`compress_block::<S>`). `active_backend`
+    // is the parse-family derivation of the tag and is kept here
+    // only because matcher state ownership (`row_match_generator`
+    // vs `hc_match_generator`) is reused across levels within the
+    // same backend; `strategy_tag.backend()` is the canonical
+    // source of truth.
     strategy_tag: super::strategy::StrategyTag,
     slice_size: usize,
     base_slice_size: usize,
@@ -973,10 +977,11 @@ impl Matcher for MatchGeneratorDriver {
         // 7-arm match over the compile-time strategy tag fires once
         // per block and hands off to a monomorphised
         // `compress_block::<S>` that the optimiser specialises per
-        // strategy. Future commits will replace runtime `match
-        // self.parse_mode` branches inside the inner loops with
-        // `if S::USE_BT` / `if S::USE_HASH3` so each monomorphisation
-        // drops the dead paths at codegen time.
+        // strategy. Strategy-shaped predicates (`S::USE_BT`,
+        // `S::USE_HASH3`, `S::OPTIMAL_PASS_COUNT`) compile to constants
+        // inside each monomorphisation, so the dead arms drop out at
+        // codegen time — there is no remaining runtime parse-mode
+        // dispatch on the per-block hot path.
         match self.strategy_tag {
             StrategyTag::Fast => self.compress_block::<strategy::Fast>(&mut handle_sequence),
             StrategyTag::Dfast => self.compress_block::<strategy::Dfast>(&mut handle_sequence),
@@ -2738,9 +2743,9 @@ impl HcMatchGenerator {
     /// `BtOpt` / `BtUltra` / `BtUltra2` see only
     /// `start_matching_optimal`. The runtime `match self.parse_mode`
     /// at the inherent [`HcMatchGenerator::start_matching`] entry is
-    /// no longer reached from `MatchGeneratorDriver`; it stays in
-    /// place for direct in-crate callers (mostly tests) until the
-    /// final cleanup commit drops `parse_mode` entirely.
+    /// no longer reached from the production hot path; the field
+    /// remains live only for in-crate callers (mostly tests) that
+    /// invoke the inherent entry directly.
     pub(crate) fn start_matching_strategy<S: super::strategy::Strategy>(
         &mut self,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -971,15 +971,24 @@ impl Matcher for MatchGeneratorDriver {
     }
 
     fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
-        match self.active_backend {
-            MatcherBackend::Simple => {
-                while self.match_generator.next_sequence(&mut handle_sequence) {}
+        use super::strategy::{self, StrategyTag};
+        // 7-arm match over the compile-time strategy tag fires once
+        // per block and hands off to a monomorphised
+        // `compress_block::<S>` that the optimiser specialises per
+        // strategy. Future commits will replace runtime `match
+        // self.parse_mode` branches inside the inner loops with
+        // `if S::USE_BT` / `if S::USE_HASH3` so each monomorphisation
+        // drops the dead paths at codegen time.
+        match self.strategy_tag {
+            StrategyTag::Fast => self.compress_block::<strategy::Fast>(&mut handle_sequence),
+            StrategyTag::Dfast => self.compress_block::<strategy::Dfast>(&mut handle_sequence),
+            StrategyTag::Greedy => self.compress_block::<strategy::Greedy>(&mut handle_sequence),
+            StrategyTag::Lazy => self.compress_block::<strategy::Lazy>(&mut handle_sequence),
+            StrategyTag::BtOpt => self.compress_block::<strategy::BtOpt>(&mut handle_sequence),
+            StrategyTag::BtUltra => self.compress_block::<strategy::BtUltra>(&mut handle_sequence),
+            StrategyTag::BtUltra2 => {
+                self.compress_block::<strategy::BtUltra2>(&mut handle_sequence)
             }
-            MatcherBackend::Dfast => self
-                .dfast_matcher_mut()
-                .start_matching(&mut handle_sequence),
-            MatcherBackend::Row => self.row_matcher_mut().start_matching(&mut handle_sequence),
-            MatcherBackend::HashChain => self.hc_matcher_mut().start_matching(&mut handle_sequence),
         }
     }
 
@@ -997,6 +1006,33 @@ impl Matcher for MatchGeneratorDriver {
                 .row_matcher_mut()
                 .skip_matching_with_hint(incompressible_hint),
             MatcherBackend::HashChain => self.hc_matcher_mut().skip_matching(incompressible_hint),
+        }
+    }
+}
+
+impl MatchGeneratorDriver {
+    /// Monomorphised per-block encoder entry point. Each call from
+    /// [`Matcher::start_matching`] picks one concrete `S: Strategy` via
+    /// the [`super::strategy::StrategyTag`] resolved at `reset()`, so
+    /// the optimiser compiles a separate copy of this body per
+    /// strategy with `S::USE_BT` / `S::USE_HASH3` / `S::ACCURATE_PRICE`
+    /// inlined as compile-time constants. The backend dispatch below
+    /// is a `match S::BACKEND` over an associated `const`, so the
+    /// compiler keeps exactly one arm per monomorphisation.
+    fn compress_block<S: super::strategy::Strategy>(
+        &mut self,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        use super::strategy::BackendTag;
+        match S::BACKEND {
+            BackendTag::Simple => {
+                while self.match_generator.next_sequence(&mut *handle_sequence) {}
+            }
+            BackendTag::Dfast => self.dfast_matcher_mut().start_matching(handle_sequence),
+            BackendTag::Row => self.row_matcher_mut().start_matching(handle_sequence),
+            BackendTag::HashChain => self
+                .hc_matcher_mut()
+                .start_matching_strategy::<S>(handle_sequence),
         }
     }
 }
@@ -2608,6 +2644,27 @@ impl HcMatchGenerator {
                 self.start_matching_optimal(&mut handle_sequence)
             }
         }
+    }
+
+    /// Strategy-aware entry point used by
+    /// [`MatchGeneratorDriver::compress_block`]. The next commit
+    /// replaces the inner `match self.parse_mode` with an `if
+    /// S::USE_BT` so each monomorphisation keeps only the lazy or the
+    /// optimal arm. Today it just delegates — the
+    /// `debug_assert_eq!` enforces that `self.parse_mode` (set by
+    /// `configure`) and `S::PARSE_MODE` agree on every call so the
+    /// bridge cannot silently drift while we migrate the inner
+    /// loops.
+    pub(crate) fn start_matching_strategy<S: super::strategy::Strategy>(
+        &mut self,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        debug_assert_eq!(
+            self.parse_mode,
+            S::PARSE_MODE,
+            "Strategy::PARSE_MODE disagrees with runtime parse_mode at HC dispatch"
+        );
+        self.start_matching(handle_sequence)
     }
 
     fn start_matching_lazy(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2637,6 +2637,13 @@ impl HcMatchGenerator {
         self.table.skip_matching(incompressible_hint);
     }
 
+    /// Runtime-dispatched entry kept only for in-crate tests. Production
+    /// callers reach the inner loops through
+    /// [`Self::start_matching_strategy`] / [`MatchGeneratorDriver::compress_block`]
+    /// which pick the lazy / optimal arm from `S::USE_BT` at
+    /// monomorphisation time. Removed alongside `parse_mode` in the
+    /// final cleanup commit.
+    #[cfg(test)]
     fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
         match self.parse_mode {
             HcParseMode::Lazy2 => self.start_matching_lazy(&mut handle_sequence),
@@ -2647,14 +2654,16 @@ impl HcMatchGenerator {
     }
 
     /// Strategy-aware entry point used by
-    /// [`MatchGeneratorDriver::compress_block`]. The next commit
-    /// replaces the inner `match self.parse_mode` with an `if
-    /// S::USE_BT` so each monomorphisation keeps only the lazy or the
-    /// optimal arm. Today it just delegates — the
-    /// `debug_assert_eq!` enforces that `self.parse_mode` (set by
-    /// `configure`) and `S::PARSE_MODE` agree on every call so the
-    /// bridge cannot silently drift while we migrate the inner
-    /// loops.
+    /// [`MatchGeneratorDriver::compress_block`]. Branches on
+    /// `S::USE_BT` — a compile-time `const` — so each
+    /// monomorphisation keeps exactly one arm: `Lazy` /
+    /// `Fast` / `Dfast` / `Greedy` see only `start_matching_lazy`,
+    /// `BtOpt` / `BtUltra` / `BtUltra2` see only
+    /// `start_matching_optimal`. The runtime `match self.parse_mode`
+    /// at the inherent [`HcMatchGenerator::start_matching`] entry is
+    /// no longer reached from `MatchGeneratorDriver`; it stays in
+    /// place for direct in-crate callers (mostly tests) until the
+    /// final cleanup commit drops `parse_mode` entirely.
     pub(crate) fn start_matching_strategy<S: super::strategy::Strategy>(
         &mut self,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
@@ -2664,7 +2673,11 @@ impl HcMatchGenerator {
             S::PARSE_MODE,
             "Strategy::PARSE_MODE disagrees with runtime parse_mode at HC dispatch"
         );
-        self.start_matching(handle_sequence)
+        if S::USE_BT {
+            self.start_matching_optimal(handle_sequence)
+        } else {
+            self.start_matching_lazy(handle_sequence)
+        }
     }
 
     fn start_matching_lazy(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1087,6 +1087,18 @@ struct HcMatchGenerator {
     /// optimal-parser scratch buffers. [`HcBackend::Bt`] holds the
     /// `BtMatcher` when an optimal mode is configured.
     backend: HcBackend,
+    /// Compile-time strategy tag mirrored from
+    /// [`MatchGeneratorDriver::strategy_tag`] during `configure()`.
+    /// The driver hot path never reads this — it dispatches to
+    /// `compress_block::<S>` from its own tag — but the
+    /// `#[cfg(test)] start_matching` helper consumes it so artificial
+    /// test setups still pick the correct concrete `S` for the
+    /// const-generic optimal parser (BtOpt vs BtUltra vs BtUltra2).
+    /// Without this field the test path would have to collapse
+    /// `BtOpt` and `BtUltra` onto the same monomorphisation since
+    /// `table.uses_bt` / `table.is_btultra2` alone can't tell them
+    /// apart.
+    strategy_tag: super::strategy::StrategyTag,
 }
 
 // Plain-data types relocated to [`crate::encoding::opt::types`] and
@@ -2595,11 +2607,22 @@ impl HcMatchGenerator {
             // Default to the zero-sized HC backend; `configure()` swaps
             // in a `BtMatcher` only when an optimal strategy lands.
             backend: HcBackend::Hc,
+            // Lazy is the per-construct default — every production
+            // caller calls `configure()` before the first encode and
+            // overwrites this. Tests that drive `HcMatchGenerator`
+            // without calling `configure()` end up in the
+            // `start_matching_lazy` arm of the test dispatcher, which
+            // matches the previous default behaviour.
+            strategy_tag: super::strategy::StrategyTag::Lazy,
         }
     }
 
     fn configure(&mut self, config: HcConfig, tag: super::strategy::StrategyTag, window_log: u8) {
         use super::strategy::StrategyTag;
+        // Mirror the driver-resolved strategy tag so the
+        // `#[cfg(test)] start_matching` dispatcher can route
+        // BtOpt / BtUltra / BtUltra2 to distinct monomorphisations.
+        self.strategy_tag = tag;
         let is_btultra2 = tag == StrategyTag::BtUltra2;
         let uses_bt = matches!(
             tag,
@@ -2680,24 +2703,24 @@ impl HcMatchGenerator {
     /// monomorphisation time.
     #[cfg(test)]
     fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
-        use super::strategy;
-        // Tests don't carry a strategy tag — pick one from runtime
-        // table flags (the same fields production sets via configure)
-        // so the const-generic dispatch still routes correctly.
-        match (
-            self.table.uses_bt,
-            self.table.is_btultra2,
-            self.table.hash3_log != 0,
-        ) {
-            (false, _, _) => self.start_matching_lazy(&mut handle_sequence),
-            (true, true, _) => {
-                self.start_matching_optimal::<strategy::BtUltra2>(&mut handle_sequence)
+        use super::strategy::{self, StrategyTag};
+        // Dispatch on the mirrored `strategy_tag` so each test runs
+        // under the same monomorphisation production would pick.
+        // `BtOpt` / `BtUltra` / `BtUltra2` remain distinct here even
+        // though `table.uses_bt` / `is_btultra2` alone can't separate
+        // BtOpt from BtUltra.
+        match self.strategy_tag {
+            StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy => {
+                self.start_matching_lazy(&mut handle_sequence)
             }
-            (true, false, _) => {
-                // BtOpt vs BtUltra is distinguished by the accurate
-                // flag — read from MatchTable so artificial test
-                // setups can route either way.
+            StrategyTag::BtOpt => {
                 self.start_matching_optimal::<strategy::BtOpt>(&mut handle_sequence)
+            }
+            StrategyTag::BtUltra => {
+                self.start_matching_optimal::<strategy::BtUltra>(&mut handle_sequence)
+            }
+            StrategyTag::BtUltra2 => {
+                self.start_matching_optimal::<strategy::BtUltra2>(&mut handle_sequence)
             }
         }
     }
@@ -3216,17 +3239,18 @@ impl HcMatchGenerator {
         query: HcCandidateQuery,
         out: &mut Vec<MatchCandidate>,
     ) {
-        use super::strategy;
+        use super::strategy::{self, StrategyTag};
         self.table.ensure_tables();
-        // Test-only dispatcher. Pick a strategy whose compile-time
-        // flags agree with the runtime fields the test actually wired
-        // up. Production callers go through
-        // `MatchGeneratorDriver::compress_block::<S>` where S is
-        // fixed by the compression level.
-        let uses_bt = self.table.uses_bt;
+        // Dispatch on the mirrored `strategy_tag` (set by
+        // `configure()`); each BT-using strategy reaches its own
+        // monomorphisation. Tests that wire up `table.hash3_log`
+        // without calling `configure()` keep the legacy fallback —
+        // if `hash3_log != 0` while the tag is non-BT-ultra2, route
+        // through `BtUltra2` so the hash3 const-gate inside the
+        // body still fires.
         let has_hash3 = self.table.hash3_log != 0;
-        match (uses_bt, has_hash3) {
-            (true, true) => self
+        match self.strategy_tag {
+            StrategyTag::BtUltra2 => self
                 .collect_optimal_candidates_initialized::<strategy::BtUltra2, true>(
                     abs_pos,
                     current_abs_end,
@@ -3234,32 +3258,46 @@ impl HcMatchGenerator {
                     query,
                     out,
                 ),
-            (true, false) => self.collect_optimal_candidates_initialized::<strategy::BtOpt, true>(
-                abs_pos,
-                current_abs_end,
-                profile,
-                query,
-                out,
-            ),
-            (false, true) => self
-                // BT-off + hash3-on never appears in production. Tests
-                // that hit this arm exercise the donor-parity hash3
-                // fallback when chain depth is zero — route through
-                // BtUltra2 so the hash3 const-gate fires.
-                .collect_optimal_candidates_initialized::<strategy::BtUltra2, false>(
+            StrategyTag::BtUltra => self
+                .collect_optimal_candidates_initialized::<strategy::BtUltra, true>(
                     abs_pos,
                     current_abs_end,
                     profile,
                     query,
                     out,
                 ),
-            (false, false) => self.collect_optimal_candidates_initialized::<strategy::Lazy, false>(
-                abs_pos,
-                current_abs_end,
-                profile,
-                query,
-                out,
-            ),
+            StrategyTag::BtOpt => self
+                .collect_optimal_candidates_initialized::<strategy::BtOpt, true>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                ),
+            StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy
+                if has_hash3 =>
+            {
+                // Legacy artificial-fixture path: tests that wired
+                // up `table.hash3_log` directly (without
+                // `configure()`) rely on the hash3 lookup running
+                // even when no BT strategy is configured.
+                self.collect_optimal_candidates_initialized::<strategy::BtUltra2, false>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                )
+            }
+            StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy => {
+                self.collect_optimal_candidates_initialized::<strategy::Lazy, false>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                )
+            }
         }
     }
 
@@ -4680,6 +4718,7 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
     };
     let mut out = Vec::new();
 
+    hc.strategy_tag = super::strategy::StrategyTag::BtUltra2;
     hc.table.is_btultra2 = true;
     hc.table.uses_bt = true;
     hc.table.search_depth = hc.hc.search_depth;
@@ -4701,6 +4740,7 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
         "btultra2 should retain dictionary candidates on donor-parity path"
     );
 
+    hc.strategy_tag = super::strategy::StrategyTag::BtUltra;
     hc.table.is_btultra2 = false;
     hc.table.uses_bt = true;
     hc.table.skip_insert_until_abs = 0;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2566,12 +2566,23 @@ macro_rules! bt_insert_and_collect_matches_body {
 pub(crate) use bt_insert_and_collect_matches_body;
 
 impl HcMatchGenerator {
-    fn should_run_btultra2_seed_pass(&self, current_len: usize) -> bool {
+    fn should_run_btultra2_seed_pass<S: super::strategy::Strategy>(
+        &self,
+        current_len: usize,
+    ) -> bool {
+        // Donor `initStats_ultra` (the seed pass) is the BtUltra2-only
+        // first-pass dynamic stats refinement. With `S` plumbed in,
+        // every non-BtUltra2 monomorphisation drops both this call
+        // and the seed-pass body at codegen time — the const below
+        // resolves to `false` for Fast / Dfast / Greedy / Lazy /
+        // BtOpt / BtUltra and short-circuits the entire predicate.
+        if !(S::OPT_LEVEL == 2 && S::USE_HASH3) {
+            return false;
+        }
         let HcBackend::Bt(bt) = &self.backend else {
             return false;
         };
-        self.is_btultra2()
-            && bt.opt_state.lit_length_sum == 0
+        bt.opt_state.lit_length_sum == 0
             && bt.opt_state.dictionary_seed.is_none()
             && !self.table.dictionary_primed_for_frame
             && bt.ldm_sequences.is_empty()
@@ -2807,7 +2818,7 @@ impl HcMatchGenerator {
             .bt_mut()
             .prepare_ldm_candidates(current_abs_start, current_len);
 
-        if self.should_run_btultra2_seed_pass(current_len) {
+        if self.should_run_btultra2_seed_pass::<S>(current_len) {
             self.run_btultra2_seed_pass(current, current_abs_start, current_len);
         }
 
@@ -4044,7 +4055,7 @@ fn btultra2_seed_pass_disabled_when_dictionary_entropy_seed_present() {
     let of = crate::fse::fse_encoder::default_of_table();
     hc.seed_dictionary_entropy(None, Some(&ll), Some(&ml), Some(&of));
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 1),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 1),
         "dictionary-seeded first block should skip btultra2 warmup pass"
     );
 }
@@ -4056,7 +4067,7 @@ fn btultra2_seed_pass_disabled_when_prefix_history_exists() {
     hc.table.history_abs_start = 17;
     hc.table.window.push_back(b"abcdefghijklmnop".to_vec());
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 9),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 9),
         "btultra2 warmup must be first-block only (no prefix history)"
     );
 }
@@ -4066,7 +4077,7 @@ fn btultra2_seed_pass_disabled_for_tiny_block() {
     let mut hc = HcMatchGenerator::new(1 << 20);
     hc.configure(BTULTRA2_HC_CONFIG, 26);
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD),
         "btultra2 warmup should not run at or below predefined threshold"
     );
 }
@@ -4077,7 +4088,7 @@ fn btultra2_seed_pass_disabled_after_stats_initialized() {
     hc.configure(BTULTRA2_HC_CONFIG, 26);
     hc.backend.bt_mut().opt_state.lit_length_sum = 1;
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 32),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 32),
         "btultra2 warmup should run only for first block before stats are initialized"
     );
 }
@@ -4093,7 +4104,7 @@ fn btultra2_seed_pass_disabled_when_not_at_frame_start() {
         .window
         .push_back(alloc::vec![b'A'; HC_PREDEF_THRESHOLD + 32]);
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 32),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 32),
         "btultra2 warmup must not run after frame start"
     );
 }
@@ -4112,7 +4123,7 @@ fn btultra2_seed_pass_disabled_when_ldm_sequences_exist() {
         match_length: 32,
     });
     assert!(
-        !hc.should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 32),
+        !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 32),
         "btultra2 warmup must not run when LDM already produced sequences"
     );
 }
@@ -5154,7 +5165,7 @@ fn hc_prime_with_empty_dictionary_disables_btultra2_seed_pass() {
     assert!(
         !driver
             .hc_matcher()
-            .should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 1),
+            .should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 1),
         "btultra2 warmup must stay disabled after dictionary priming, even when dict content is empty"
     );
 }
@@ -5169,7 +5180,7 @@ fn hc_prime_with_dictionary_disables_btultra2_seed_pass() {
     assert!(
         !driver
             .hc_matcher()
-            .should_run_btultra2_seed_pass(HC_PREDEF_THRESHOLD + 1),
+            .should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 1),
         "btultra2 warmup must stay disabled after dictionary priming with content"
     );
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1264,6 +1264,7 @@ pub(crate) use bt_insert_step_no_rebase_body;
 macro_rules! build_optimal_plan_impl_body {
     (
         $self:expr,
+        $strategy_ty:ty,
         $current:ident,
         $current_abs_start:ident,
         $current_len:ident,
@@ -1280,11 +1281,24 @@ macro_rules! build_optimal_plan_impl_body {
         let initial_litlen = $initial_state.litlen;
         let mut profile = $initial_state.profile;
         profile.sufficient_match_len = $self.hc.sufficient_match_len_for_pass(profile);
-        let abort_on_worse_match = $self.parse_mode == HcParseMode::BtOpt;
-        let opt_level = matches!(
-            $self.parse_mode,
-            HcParseMode::BtUltra | HcParseMode::BtUltra2
+        // Const-fold from the strategy's associated `OPT_LEVEL`
+        // (donor `optLevel`): BtOpt = 0, BtUltra / BtUltra2 = 2.
+        // The two flags below are the only places the inner DP loop
+        // used to consult `parse_mode`; lifting them into const
+        // expressions drops one indirect read + one branch on every
+        // candidate insertion and every traceback step.
+        // `let` (not `const`) — nested `const` items inside a
+        // generic fn cannot project through the outer fn's type
+        // parameter, but a `let` binding from a const expression
+        // does get folded by the optimiser per monomorphisation,
+        // which is what we actually want here.
+        debug_assert!(
+            <$strategy_ty as super::strategy::Strategy>::USE_BT,
+            "build_optimal_plan_impl_body called on non-BT strategy"
         );
+        let abort_on_worse_match: bool =
+            <$strategy_ty as super::strategy::Strategy>::OPT_LEVEL == 0;
+        let opt_level: bool = <$strategy_ty as super::strategy::Strategy>::OPT_LEVEL >= 2;
         let mut nodes = core::mem::take(&mut $self.backend.bt_mut().opt_nodes_scratch);
         // `frontier_limit + 2 <= HC_OPT_NUM + 1` — bounded by const.
         let frontier_buffer_size = frontier_limit + 2;
@@ -2645,10 +2659,17 @@ impl HcMatchGenerator {
     /// final cleanup commit.
     #[cfg(test)]
     fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+        use super::strategy;
         match self.parse_mode {
             HcParseMode::Lazy2 => self.start_matching_lazy(&mut handle_sequence),
-            HcParseMode::BtOpt | HcParseMode::BtUltra | HcParseMode::BtUltra2 => {
-                self.start_matching_optimal(&mut handle_sequence)
+            HcParseMode::BtOpt => {
+                self.start_matching_optimal::<strategy::BtOpt>(&mut handle_sequence)
+            }
+            HcParseMode::BtUltra => {
+                self.start_matching_optimal::<strategy::BtUltra>(&mut handle_sequence)
+            }
+            HcParseMode::BtUltra2 => {
+                self.start_matching_optimal::<strategy::BtUltra2>(&mut handle_sequence)
             }
         }
     }
@@ -2674,7 +2695,7 @@ impl HcMatchGenerator {
             "Strategy::PARSE_MODE disagrees with runtime parse_mode at HC dispatch"
         );
         if S::USE_BT {
-            self.start_matching_optimal(handle_sequence)
+            self.start_matching_optimal::<S>(handle_sequence)
         } else {
             self.start_matching_lazy(handle_sequence)
         }
@@ -2739,7 +2760,10 @@ impl HcMatchGenerator {
         }
     }
 
-    fn start_matching_optimal(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+    fn start_matching_optimal<S: super::strategy::Strategy>(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
         self.table.ensure_tables();
         let current_len = self.table.window.back().unwrap().len();
         if current_len == 0 {
@@ -2791,7 +2815,7 @@ impl HcMatchGenerator {
             let remaining_len = current_len - cursor;
             let segment_abs_start = current_abs_start + cursor;
             let segment_start = best_plan.len();
-            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan(
+            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan::<S>(
                 &current[cursor..],
                 segment_abs_start,
                 remaining_len,
@@ -2830,6 +2854,9 @@ impl HcMatchGenerator {
         current_abs_start: usize,
         current_len: usize,
     ) {
+        // The seed pass is BtUltra2-exclusive by name (`is_btultra2()`
+        // gates the only call site), so pin S to BtUltra2 here.
+        type S = super::strategy::BtUltra2;
         let seed_profile = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
@@ -2846,7 +2873,7 @@ impl HcMatchGenerator {
             let remaining_len = current_len - cursor;
             let segment_abs_start = current_abs_start + cursor;
             let segment_start = seed_plan.len();
-            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan(
+            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan::<S>(
                 &current[cursor..],
                 segment_abs_start,
                 remaining_len,
@@ -2890,7 +2917,7 @@ impl HcMatchGenerator {
         self.table.allow_zero_relative_position = true;
     }
 
-    fn build_optimal_plan(
+    fn build_optimal_plan<S: super::strategy::Strategy>(
         &mut self,
         current: &[u8],
         current_abs_start: usize,
@@ -2899,9 +2926,21 @@ impl HcMatchGenerator {
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
     ) -> (u32, [u32; 3], usize, usize) {
+        debug_assert!(S::USE_BT, "build_optimal_plan called on non-BT strategy");
+        debug_assert_eq!(initial_state.profile.accurate, S::ACCURATE_PRICE);
+        debug_assert_eq!(
+            initial_state.profile.favor_small_offsets,
+            S::FAVOR_SMALL_OFFSETS
+        );
+        // `S::ACCURATE_PRICE` / `S::FAVOR_SMALL_OFFSETS` cannot appear
+        // as const-generic arguments yet (`generic_const_exprs` is
+        // still unstable), so we keep the 4-arm runtime dispatch here.
+        // Each S monomorphisation only reaches one arm in practice
+        // (BtOpt → false/true, BtUltra/BtUltra2 → true/false), so the
+        // optimiser folds away the others.
         let profile = initial_state.profile;
         match (profile.accurate, profile.favor_small_offsets) {
-            (true, false) => self.build_optimal_plan_impl::<true, false>(
+            (true, false) => self.build_optimal_plan_impl::<S, true, false>(
                 current,
                 current_abs_start,
                 current_len,
@@ -2909,7 +2948,7 @@ impl HcMatchGenerator {
                 stats,
                 out,
             ),
-            (true, true) => self.build_optimal_plan_impl::<true, true>(
+            (true, true) => self.build_optimal_plan_impl::<S, true, true>(
                 current,
                 current_abs_start,
                 current_len,
@@ -2917,7 +2956,7 @@ impl HcMatchGenerator {
                 stats,
                 out,
             ),
-            (false, false) => self.build_optimal_plan_impl::<false, false>(
+            (false, false) => self.build_optimal_plan_impl::<S, false, false>(
                 current,
                 current_abs_start,
                 current_len,
@@ -2925,7 +2964,7 @@ impl HcMatchGenerator {
                 stats,
                 out,
             ),
-            (false, true) => self.build_optimal_plan_impl::<false, true>(
+            (false, true) => self.build_optimal_plan_impl::<S, false, true>(
                 current,
                 current_abs_start,
                 current_len,
@@ -2945,7 +2984,11 @@ impl HcMatchGenerator {
     /// one straight-line inline chain from DP body down through BT walk
     /// and match-length probes.
     #[inline(always)]
-    fn build_optimal_plan_impl<const ACCURATE_PRICE: bool, const FAVOR_SMALL_OFFSETS: bool>(
+    fn build_optimal_plan_impl<
+        S: super::strategy::Strategy,
+        const ACCURATE_PRICE: bool,
+        const FAVOR_SMALL_OFFSETS: bool,
+    >(
         &mut self,
         current: &[u8],
         current_abs_start: usize,
@@ -2956,7 +2999,7 @@ impl HcMatchGenerator {
     ) -> (u32, [u32; 3], usize, usize) {
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         unsafe {
-            self.build_optimal_plan_impl_neon::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+            self.build_optimal_plan_impl_neon::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
                 current,
                 current_abs_start,
                 current_len,
@@ -2970,7 +3013,7 @@ impl HcMatchGenerator {
             use crate::encoding::fastpath::{FastpathKernel, select_kernel};
             match select_kernel() {
                 FastpathKernel::Avx2Bmi2 => unsafe {
-                    self.build_optimal_plan_impl_avx2_bmi2::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+                    self.build_optimal_plan_impl_avx2_bmi2::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
                         current,
                         current_abs_start,
                         current_len,
@@ -2980,7 +3023,7 @@ impl HcMatchGenerator {
                     )
                 },
                 FastpathKernel::Sse42 => unsafe {
-                    self.build_optimal_plan_impl_sse42::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+                    self.build_optimal_plan_impl_sse42::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
                         current,
                         current_abs_start,
                         current_len,
@@ -2990,7 +3033,7 @@ impl HcMatchGenerator {
                     )
                 },
                 FastpathKernel::Scalar => self
-                    .build_optimal_plan_impl_scalar::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+                    .build_optimal_plan_impl_scalar::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
                         current,
                         current_abs_start,
                         current_len,
@@ -3006,7 +3049,7 @@ impl HcMatchGenerator {
             target_arch = "x86_64"
         )))]
         {
-            self.build_optimal_plan_impl_scalar::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+            self.build_optimal_plan_impl_scalar::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
                 current,
                 current_abs_start,
                 current_len,
@@ -3023,6 +3066,7 @@ impl HcMatchGenerator {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
     unsafe fn build_optimal_plan_impl_neon<
+        S: super::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
     >(
@@ -3036,6 +3080,7 @@ impl HcMatchGenerator {
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
+            S,
             current,
             current_abs_start,
             current_len,
@@ -3049,6 +3094,7 @@ impl HcMatchGenerator {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "sse4.2")]
     unsafe fn build_optimal_plan_impl_sse42<
+        S: super::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
     >(
@@ -3062,6 +3108,7 @@ impl HcMatchGenerator {
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
+            S,
             current,
             current_abs_start,
             current_len,
@@ -3075,6 +3122,7 @@ impl HcMatchGenerator {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
     unsafe fn build_optimal_plan_impl_avx2_bmi2<
+        S: super::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
     >(
@@ -3088,6 +3136,7 @@ impl HcMatchGenerator {
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
+            S,
             current,
             current_abs_start,
             current_len,
@@ -3104,6 +3153,7 @@ impl HcMatchGenerator {
     // through safe fns, so those blocks are redundant on this path.
     #[allow(unused_unsafe)]
     fn build_optimal_plan_impl_scalar<
+        S: super::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
     >(
@@ -3117,6 +3167,7 @@ impl HcMatchGenerator {
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
+            S,
             current,
             current_abs_start,
             current_len,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -659,14 +659,13 @@ impl Matcher for MatchGeneratorDriver {
         // `resolve_level_params`. This is what lets future commits
         // dispatch on `self.strategy_tag` and trust the existing
         // backend storage / setup paths unchanged.
+        // Once `MatcherBackend` was replaced by `BackendTag` the two
+        // values share a type, so the lock-step invariant collapses
+        // to a direct equality between the strategy-derived backend
+        // and the runtime backend selected by `resolve_level_params`.
         debug_assert_eq!(
             self.strategy_tag.backend(),
-            match self.active_backend {
-                super::strategy::BackendTag::Simple => super::strategy::BackendTag::Simple,
-                super::strategy::BackendTag::Dfast => super::strategy::BackendTag::Dfast,
-                super::strategy::BackendTag::Row => super::strategy::BackendTag::Row,
-                super::strategy::BackendTag::HashChain => super::strategy::BackendTag::HashChain,
-            },
+            self.active_backend,
             "strategy_tag backend drift vs active_backend after reset()",
         );
         self.slice_size = self.base_slice_size.min(max_window_size);
@@ -2906,10 +2905,12 @@ impl HcMatchGenerator {
         current_abs_start: usize,
         current_len: usize,
     ) {
-        // The seed pass is BtUltra2-exclusive by name (`is_btultra2()`
-        // gates the only call site), so pin S to BtUltra2 here.
+        // The seed pass is BtUltra2-exclusive by name (the only
+        // caller is `should_run_btultra2_seed_pass`), so pin `S` to
+        // `BtUltra2` for both the cost-profile lookup and the
+        // `build_optimal_plan::<S>` call below.
         type S = super::strategy::BtUltra2;
-        let seed_profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
+        let seed_profile = HcOptimalCostProfile::const_for_strategy::<S>();
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
         opt_state.rescale_freqs(current, seed_profile);
@@ -3715,7 +3716,7 @@ fn driver_level4_selects_row_backend() {
 
 #[test]
 fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
-    use super::strategy::{BackendTag, StrategyTag};
+    use super::strategy::StrategyTag;
 
     fn check(level: CompressionLevel, expected: StrategyTag) {
         let mut driver = MatchGeneratorDriver::new(32, 2);
@@ -3724,15 +3725,9 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
             driver.strategy_tag, expected,
             "strategy_tag wrong for {level:?}"
         );
-        let runtime_backend = match driver.active_backend {
-            super::strategy::BackendTag::Simple => BackendTag::Simple,
-            super::strategy::BackendTag::Dfast => BackendTag::Dfast,
-            super::strategy::BackendTag::Row => BackendTag::Row,
-            super::strategy::BackendTag::HashChain => BackendTag::HashChain,
-        };
         assert_eq!(
             driver.strategy_tag.backend(),
-            runtime_backend,
+            driver.active_backend,
             "strategy_tag backend disagrees with active_backend for {level:?}"
         );
     }
@@ -3875,29 +3870,19 @@ fn btultra2_seed_pass_initializes_opt_state() {
 
 #[test]
 fn btultra2_profile_disables_small_offset_handicap() {
-    let p1 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
-    let p2 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
+    // Pre-Phase-3 this test duplicated the profile build with
+    // `pass2=false` and `pass2=true` since `for_mode` differentiated
+    // them. With `const_for_strategy::<BtUltra2>()` there is only one
+    // profile — the donor `opt2` pricing — so a single binding
+    // captures the invariant the test is asserting.
+    let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     assert!(
-        !p1.favor_small_offsets,
-        "btultra2 primary profile should match donor opt2 offset pricing"
+        !profile.favor_small_offsets,
+        "btultra2 should match donor opt2 offset pricing"
     );
     assert!(
-        !p2.favor_small_offsets,
-        "btultra2 secondary profile should match donor opt2 offset pricing"
-    );
-}
-
-#[test]
-fn btultra2_profile_is_single_pass_opt2() {
-    let p1 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
-    let p2 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
-    assert_eq!(p1.max_chain_depth, p2.max_chain_depth);
-    assert_eq!(p1.sufficient_match_len, p2.sufficient_match_len);
-    assert_eq!(p1.accurate, p2.accurate);
-    assert_eq!(p1.favor_small_offsets, p2.favor_small_offsets);
-    assert!(
-        p1.accurate,
-        "btultra2 should use donor opt2 accurate pricing in the main pass"
+        profile.accurate,
+        "btultra2 should use donor opt2 accurate pricing"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -40,7 +40,6 @@ use super::opt::types::{
 };
 use super::row::RowMatchGenerator;
 use super::simple::{MatchGenerator, SuffixStore};
-use super::strategy::HcParseMode;
 #[cfg(all(
     test,
     feature = "std",
@@ -102,10 +101,10 @@ const HC_TARGET_LEN: usize = 48;
 // MAX_HC_SEARCH_DEPTH moved to encoding::hc alongside chain_candidates.
 use super::hc::MAX_HC_SEARCH_DEPTH;
 
-// `HcParseMode` lives in `crate::encoding::strategy` so the extracted
-// `cost_model::HcOptimalCostProfile::for_mode` can branch on it without
-// importing back from this monolith — see the use statement at the top
-// of the file.
+// `Strategy` and `StrategyTag` live in `crate::encoding::strategy`.
+// The driver carries a `StrategyTag` field set at `reset()` and
+// dispatches each block into a monomorphised `compress_block::<S>`
+// per concrete strategy.
 
 /// Bundled tuning knobs for the hash-chain matcher. Using a typed config
 /// instead of positional `usize` args eliminates parameter-order hazards.
@@ -115,7 +114,6 @@ struct HcConfig {
     chain_log: usize,
     search_depth: usize,
     target_len: usize,
-    parse_mode: HcParseMode,
 }
 
 #[derive(Copy, Clone)]
@@ -131,7 +129,6 @@ const HC_CONFIG: HcConfig = HcConfig {
     chain_log: HC_CHAIN_LOG,
     search_depth: HC_SEARCH_DEPTH,
     target_len: HC_TARGET_LEN,
-    parse_mode: HcParseMode::Lazy2,
 };
 
 /// Best-level: deeper search, larger tables, higher target length.
@@ -140,7 +137,6 @@ const BEST_HC_CONFIG: HcConfig = HcConfig {
     chain_log: 20,
     search_depth: 32,
     target_len: 128,
-    parse_mode: HcParseMode::Lazy2,
 };
 
 const BTOPT_HC_CONFIG: HcConfig = HcConfig {
@@ -148,7 +144,6 @@ const BTOPT_HC_CONFIG: HcConfig = HcConfig {
     chain_log: 22,
     search_depth: 32,
     target_len: 256,
-    parse_mode: HcParseMode::BtOpt,
 };
 
 const BTULTRA_HC_CONFIG: HcConfig = HcConfig {
@@ -156,7 +151,6 @@ const BTULTRA_HC_CONFIG: HcConfig = HcConfig {
     chain_log: 23,
     search_depth: 32,
     target_len: 256,
-    parse_mode: HcParseMode::BtUltra,
 };
 
 const BTULTRA2_HC_CONFIG: HcConfig = HcConfig {
@@ -164,7 +158,6 @@ const BTULTRA2_HC_CONFIG: HcConfig = HcConfig {
     chain_log: 24,
     search_depth: 512,
     target_len: 256,
-    parse_mode: HcParseMode::BtUltra2,
 };
 
 const BTULTRA2_HC_CONFIG_L22: HcConfig = HcConfig {
@@ -172,7 +165,6 @@ const BTULTRA2_HC_CONFIG_L22: HcConfig = HcConfig {
     chain_log: 27,
     search_depth: 512,
     target_len: 999,
-    parse_mode: HcParseMode::BtUltra2,
 };
 
 const BTULTRA2_HC_CONFIG_L22_256K: HcConfig = HcConfig {
@@ -180,7 +172,6 @@ const BTULTRA2_HC_CONFIG_L22_256K: HcConfig = HcConfig {
     chain_log: 19,
     search_depth: 1 << 13,
     target_len: 999,
-    parse_mode: HcParseMode::BtUltra2,
 };
 
 const BTULTRA2_HC_CONFIG_L22_128K: HcConfig = HcConfig {
@@ -188,7 +179,6 @@ const BTULTRA2_HC_CONFIG_L22_128K: HcConfig = HcConfig {
     chain_log: 18,
     search_depth: 1 << 11,
     target_len: 999,
-    parse_mode: HcParseMode::BtUltra2,
 };
 
 const BTULTRA2_HC_CONFIG_L22_16K: HcConfig = HcConfig {
@@ -196,7 +186,6 @@ const BTULTRA2_HC_CONFIG_L22_16K: HcConfig = HcConfig {
     chain_log: 15,
     search_depth: 1 << 10,
     target_len: 999,
-    parse_mode: HcParseMode::BtUltra2,
 };
 
 const ROW_CONFIG: RowConfig = RowConfig {
@@ -209,7 +198,7 @@ const ROW_CONFIG: RowConfig = RowConfig {
 /// Resolved tuning parameters for a compression level.
 #[derive(Copy, Clone)]
 struct LevelParams {
-    backend: MatcherBackend,
+    backend: super::strategy::BackendTag,
     window_log: u8,
     hash_fill_step: usize,
     lazy_depth: u8,
@@ -238,28 +227,28 @@ fn row_hash_bits_for_window(max_window_size: usize) -> usize {
 const LEVEL_TABLE: [LevelParams; 22] = [
     // Lvl  Strategy       wlog  step  lazy  HC config                                   row config
     // ---  -------------- ----  ----  ----  ------------------------------------------  ----------
-    /* 1 */ LevelParams { backend: MatcherBackend::Simple,    window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 2 */ LevelParams { backend: MatcherBackend::Dfast,     window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 3 */ LevelParams { backend: MatcherBackend::Dfast,     window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { backend: MatcherBackend::Row,       window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 5 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /* 6 */ LevelParams { backend: MatcherBackend::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { backend: MatcherBackend::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /* 8 */ LevelParams { backend: MatcherBackend::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /* 9 */ LevelParams { backend: MatcherBackend::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*10 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96,  parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*11 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
-    /*12 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128, parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*13 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160, parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192, parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192, parse_mode: HcParseMode::Lazy2 }, row: ROW_CONFIG },
-    /*16 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*17 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*18 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*19 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*20 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*21 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*22 */ LevelParams { backend: MatcherBackend::HashChain, window_log: 27, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
+    /* 1 */ LevelParams { backend: super::strategy::BackendTag::Simple,    window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 2 */ LevelParams { backend: super::strategy::BackendTag::Dfast,     window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 3 */ LevelParams { backend: super::strategy::BackendTag::Dfast,     window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 4 */ LevelParams { backend: super::strategy::BackendTag::Row,       window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 5 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
+    /* 6 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
+    /* 8 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /* 9 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /*10 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
+    /*11 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
+    /*12 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
+    /*13 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*16 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*17 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*18 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*19 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*20 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*21 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*22 */ LevelParams { backend: super::strategy::BackendTag::HashChain, window_log: 27, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
 ];
 
 /// Smallest window_log the encoder will use regardless of source size.
@@ -297,14 +286,14 @@ fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> Leve
     // For HC backend: also cap hash_log and chain_log so tables are
     // proportional to the source, avoiding multi-MB allocations for
     // tiny inputs.
-    if params.backend == MatcherBackend::HashChain {
+    if params.backend == super::strategy::BackendTag::HashChain {
         if (src_log + 2) < params.hc.hash_log as u8 {
             params.hc.hash_log = (src_log + 2) as usize;
         }
         if (src_log + 1) < params.hc.chain_log as u8 {
             params.hc.chain_log = (src_log + 1) as usize;
         }
-    } else if params.backend == MatcherBackend::Row {
+    } else if params.backend == super::strategy::BackendTag::Row {
         let max_window_size = 1usize << params.window_log;
         params.row.hash_bits = row_hash_bits_for_window(max_window_size);
     }
@@ -338,7 +327,7 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
         hc.chain_log = hc.chain_log.min(adjusted_table_log);
     }
     LevelParams {
-        backend: MatcherBackend::HashChain,
+        backend: super::strategy::BackendTag::HashChain,
         window_log,
         hash_fill_step: 1,
         lazy_depth: 2,
@@ -355,7 +344,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
     }
     let params = match level {
         CompressionLevel::Uncompressed => LevelParams {
-            backend: MatcherBackend::Simple,
+            backend: super::strategy::BackendTag::Simple,
             window_log: 17,
             hash_fill_step: 1,
             lazy_depth: 0,
@@ -381,7 +370,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                     (n.saturating_abs() as usize).min((-CompressionLevel::MIN_LEVEL) as usize);
                 let step = (acceleration + 3).min(128);
                 LevelParams {
-                    backend: MatcherBackend::Simple,
+                    backend: super::strategy::BackendTag::Simple,
                     window_log: 17,
                     hash_fill_step: step,
                     lazy_depth: 0,
@@ -398,14 +387,6 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-enum MatcherBackend {
-    Simple,
-    Dfast,
-    Row,
-    HashChain,
-}
-
 /// This is the default implementation of the `Matcher` trait. It allocates and reuses the buffers when possible.
 pub struct MatchGeneratorDriver {
     vec_pool: Vec<Vec<u8>>,
@@ -414,7 +395,7 @@ pub struct MatchGeneratorDriver {
     dfast_match_generator: Option<DfastMatchGenerator>,
     row_match_generator: Option<RowMatchGenerator>,
     hc_match_generator: Option<HcMatchGenerator>,
-    active_backend: MatcherBackend,
+    active_backend: super::strategy::BackendTag,
     // Compile-time strategy tag resolved at `reset()` from the
     // requested `CompressionLevel`. Stays in lock-step with
     // `active_backend` (a `debug_assert!` in `reset()` enforces the
@@ -448,7 +429,7 @@ impl MatchGeneratorDriver {
             dfast_match_generator: None,
             row_match_generator: None,
             hc_match_generator: None,
-            active_backend: MatcherBackend::Simple,
+            active_backend: super::strategy::BackendTag::Simple,
             strategy_tag: super::strategy::StrategyTag::Fast,
             slice_size,
             base_slice_size: slice_size,
@@ -505,21 +486,21 @@ impl MatchGeneratorDriver {
         }
         self.dictionary_retained_budget -= reclaimed;
         match self.active_backend {
-            MatcherBackend::Simple => {
+            super::strategy::BackendTag::Simple => {
                 self.match_generator.max_window_size = self
                     .match_generator
                     .max_window_size
                     .saturating_sub(reclaimed);
             }
-            MatcherBackend::Dfast => {
+            super::strategy::BackendTag::Dfast => {
                 let matcher = self.dfast_matcher_mut();
                 matcher.max_window_size = matcher.max_window_size.saturating_sub(reclaimed);
             }
-            MatcherBackend::Row => {
+            super::strategy::BackendTag::Row => {
                 let matcher = self.row_matcher_mut();
                 matcher.max_window_size = matcher.max_window_size.saturating_sub(reclaimed);
             }
-            MatcherBackend::HashChain => {
+            super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
                 matcher.table.max_window_size =
                     matcher.table.max_window_size.saturating_sub(reclaimed);
@@ -531,7 +512,7 @@ impl MatchGeneratorDriver {
         loop {
             let mut evicted_bytes = 0usize;
             match self.active_backend {
-                MatcherBackend::Simple => {
+                super::strategy::BackendTag::Simple => {
                     let vec_pool = &mut self.vec_pool;
                     let suffix_pool = &mut self.suffix_pool;
                     self.match_generator.reserve(0, |mut data, mut suffixes| {
@@ -543,7 +524,7 @@ impl MatchGeneratorDriver {
                         suffix_pool.push(suffixes);
                     });
                 }
-                MatcherBackend::Dfast => {
+                super::strategy::BackendTag::Dfast => {
                     let mut retired = Vec::new();
                     self.dfast_matcher_mut().trim_to_window(|data| {
                         evicted_bytes += data.len();
@@ -554,7 +535,7 @@ impl MatchGeneratorDriver {
                         self.vec_pool.push(data);
                     }
                 }
-                MatcherBackend::Row => {
+                super::strategy::BackendTag::Row => {
                     let mut retired = Vec::new();
                     self.row_matcher_mut().trim_to_window(|data| {
                         evicted_bytes += data.len();
@@ -565,7 +546,7 @@ impl MatchGeneratorDriver {
                         self.vec_pool.push(data);
                     }
                 }
-                MatcherBackend::HashChain => {
+                super::strategy::BackendTag::HashChain => {
                     let mut retired = Vec::new();
                     self.hc_matcher_mut().table.trim_to_window(|data| {
                         evicted_bytes += data.len();
@@ -586,10 +567,16 @@ impl MatchGeneratorDriver {
 
     fn skip_matching_for_dictionary_priming(&mut self) {
         match self.active_backend {
-            MatcherBackend::Simple => self.match_generator.skip_matching_with_hint(Some(false)),
-            MatcherBackend::Dfast => self.dfast_matcher_mut().skip_matching_dense(),
-            MatcherBackend::Row => self.row_matcher_mut().skip_matching_with_hint(Some(false)),
-            MatcherBackend::HashChain => self.hc_matcher_mut().skip_matching(Some(false)),
+            super::strategy::BackendTag::Simple => {
+                self.match_generator.skip_matching_with_hint(Some(false))
+            }
+            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().skip_matching_dense(),
+            super::strategy::BackendTag::Row => {
+                self.row_matcher_mut().skip_matching_with_hint(Some(false))
+            }
+            super::strategy::BackendTag::HashChain => {
+                self.hc_matcher_mut().skip_matching(Some(false))
+            }
         }
     }
 }
@@ -611,7 +598,7 @@ impl Matcher for MatchGeneratorDriver {
         self.dictionary_retained_budget = 0;
         if self.active_backend != params.backend {
             match self.active_backend {
-                MatcherBackend::Simple => {
+                super::strategy::BackendTag::Simple => {
                     let vec_pool = &mut self.vec_pool;
                     let suffix_pool = &mut self.suffix_pool;
                     self.match_generator.reset(|mut data, mut suffixes| {
@@ -622,7 +609,7 @@ impl Matcher for MatchGeneratorDriver {
                         suffix_pool.push(suffixes);
                     });
                 }
-                MatcherBackend::Dfast => {
+                super::strategy::BackendTag::Dfast => {
                     if let Some(dfast) = self.dfast_match_generator.as_mut() {
                         let vec_pool = &mut self.vec_pool;
                         dfast.reset(|mut data| {
@@ -631,7 +618,7 @@ impl Matcher for MatchGeneratorDriver {
                         });
                     }
                 }
-                MatcherBackend::Row => {
+                super::strategy::BackendTag::Row => {
                     if let Some(row) = self.row_match_generator.as_mut() {
                         row.row_heads = Vec::new();
                         row.row_positions = Vec::new();
@@ -643,7 +630,7 @@ impl Matcher for MatchGeneratorDriver {
                         });
                     }
                 }
-                MatcherBackend::HashChain => {
+                super::strategy::BackendTag::HashChain => {
                     if let Some(hc) = self.hc_match_generator.as_mut() {
                         // Release oversized tables when switching away from
                         // HashChain so Best's larger allocations don't persist.
@@ -668,24 +655,24 @@ impl Matcher for MatchGeneratorDriver {
         self.active_backend = params.backend;
         self.strategy_tag = super::strategy::StrategyTag::for_compression_level(level);
         // Lock-step invariant: the compile-time strategy tag's backend
-        // must agree with the runtime `MatcherBackend` chosen by
+        // must agree with the runtime `BackendTag` chosen by
         // `resolve_level_params`. This is what lets future commits
         // dispatch on `self.strategy_tag` and trust the existing
         // backend storage / setup paths unchanged.
         debug_assert_eq!(
             self.strategy_tag.backend(),
             match self.active_backend {
-                MatcherBackend::Simple => super::strategy::BackendTag::Simple,
-                MatcherBackend::Dfast => super::strategy::BackendTag::Dfast,
-                MatcherBackend::Row => super::strategy::BackendTag::Row,
-                MatcherBackend::HashChain => super::strategy::BackendTag::HashChain,
+                super::strategy::BackendTag::Simple => super::strategy::BackendTag::Simple,
+                super::strategy::BackendTag::Dfast => super::strategy::BackendTag::Dfast,
+                super::strategy::BackendTag::Row => super::strategy::BackendTag::Row,
+                super::strategy::BackendTag::HashChain => super::strategy::BackendTag::HashChain,
             },
             "strategy_tag backend drift vs active_backend after reset()",
         );
         self.slice_size = self.base_slice_size.min(max_window_size);
         self.reported_window_size = max_window_size;
         match self.active_backend {
-            MatcherBackend::Simple => {
+            super::strategy::BackendTag::Simple => {
                 let vec_pool = &mut self.vec_pool;
                 let suffix_pool = &mut self.suffix_pool;
                 self.match_generator.max_window_size = max_window_size;
@@ -698,7 +685,7 @@ impl Matcher for MatchGeneratorDriver {
                     suffix_pool.push(suffixes);
                 });
             }
-            MatcherBackend::Dfast => {
+            super::strategy::BackendTag::Dfast => {
                 let dfast = self
                     .dfast_match_generator
                     .get_or_insert_with(|| DfastMatchGenerator::new(max_window_size));
@@ -721,7 +708,7 @@ impl Matcher for MatchGeneratorDriver {
                     vec_pool.push(data);
                 });
             }
-            MatcherBackend::Row => {
+            super::strategy::BackendTag::Row => {
                 let row = self
                     .row_match_generator
                     .get_or_insert_with(|| RowMatchGenerator::new(max_window_size));
@@ -737,13 +724,13 @@ impl Matcher for MatchGeneratorDriver {
                     vec_pool.push(data);
                 });
             }
-            MatcherBackend::HashChain => {
+            super::strategy::BackendTag::HashChain => {
                 let hc = self
                     .hc_match_generator
                     .get_or_insert_with(|| HcMatchGenerator::new(max_window_size));
                 hc.table.max_window_size = max_window_size;
                 hc.hc.lazy_depth = params.lazy_depth;
-                hc.configure(params.hc, params.window_log);
+                hc.configure(params.hc, self.strategy_tag, params.window_log);
                 let vec_pool = &mut self.vec_pool;
                 hc.reset(|mut data| {
                     data.resize(data.capacity(), 0);
@@ -755,10 +742,12 @@ impl Matcher for MatchGeneratorDriver {
 
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
         match self.active_backend {
-            MatcherBackend::Simple => self.match_generator.offset_hist = offset_hist,
-            MatcherBackend::Dfast => self.dfast_matcher_mut().offset_hist = offset_hist,
-            MatcherBackend::Row => self.row_matcher_mut().offset_hist = offset_hist,
-            MatcherBackend::HashChain => {
+            super::strategy::BackendTag::Simple => self.match_generator.offset_hist = offset_hist,
+            super::strategy::BackendTag::Dfast => {
+                self.dfast_matcher_mut().offset_hist = offset_hist
+            }
+            super::strategy::BackendTag::Row => self.row_matcher_mut().offset_hist = offset_hist,
+            super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
                 matcher.table.offset_hist = offset_hist;
                 matcher.table.mark_dictionary_primed();
@@ -773,23 +762,23 @@ impl Matcher for MatchGeneratorDriver {
         // itself exceeds the live window size.
         let retained_dict_budget = dict_content.len();
         match self.active_backend {
-            MatcherBackend::Simple => {
+            super::strategy::BackendTag::Simple => {
                 self.match_generator.max_window_size = self
                     .match_generator
                     .max_window_size
                     .saturating_add(retained_dict_budget);
             }
-            MatcherBackend::Dfast => {
+            super::strategy::BackendTag::Dfast => {
                 let matcher = self.dfast_matcher_mut();
                 matcher.max_window_size =
                     matcher.max_window_size.saturating_add(retained_dict_budget);
             }
-            MatcherBackend::Row => {
+            super::strategy::BackendTag::Row => {
                 let matcher = self.row_matcher_mut();
                 matcher.max_window_size =
                     matcher.max_window_size.saturating_add(retained_dict_budget);
             }
-            MatcherBackend::HashChain => {
+            super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
                 matcher.table.max_window_size = matcher
                     .table
@@ -804,8 +793,10 @@ impl Matcher for MatchGeneratorDriver {
         // backfill_boundary_positions re-visits tail positions once the
         // next slice extends history, but cannot hash <4 byte fragments.
         let min_primed_tail = match self.active_backend {
-            MatcherBackend::Simple => MIN_MATCH_LEN,
-            MatcherBackend::Dfast | MatcherBackend::Row | MatcherBackend::HashChain => 4,
+            super::strategy::BackendTag::Simple => MIN_MATCH_LEN,
+            super::strategy::BackendTag::Dfast
+            | super::strategy::BackendTag::Row
+            | super::strategy::BackendTag::HashChain => 4,
         };
         while start < dict_content.len() {
             let end = (start + self.slice_size).min(dict_content.len());
@@ -824,25 +815,25 @@ impl Matcher for MatchGeneratorDriver {
         let uncommitted_tail_budget = retained_dict_budget.saturating_sub(committed_dict_budget);
         if uncommitted_tail_budget > 0 {
             match self.active_backend {
-                MatcherBackend::Simple => {
+                super::strategy::BackendTag::Simple => {
                     self.match_generator.max_window_size = self
                         .match_generator
                         .max_window_size
                         .saturating_sub(uncommitted_tail_budget);
                 }
-                MatcherBackend::Dfast => {
+                super::strategy::BackendTag::Dfast => {
                     let matcher = self.dfast_matcher_mut();
                     matcher.max_window_size = matcher
                         .max_window_size
                         .saturating_sub(uncommitted_tail_budget);
                 }
-                MatcherBackend::Row => {
+                super::strategy::BackendTag::Row => {
                     let matcher = self.row_matcher_mut();
                     matcher.max_window_size = matcher
                         .max_window_size
                         .saturating_sub(uncommitted_tail_budget);
                 }
-                MatcherBackend::HashChain => {
+                super::strategy::BackendTag::HashChain => {
                     let matcher = self.hc_matcher_mut();
                     matcher.table.max_window_size = matcher
                         .table
@@ -856,7 +847,7 @@ impl Matcher for MatchGeneratorDriver {
                 .dictionary_retained_budget
                 .saturating_add(committed_dict_budget);
         }
-        if self.active_backend == MatcherBackend::HashChain {
+        if self.active_backend == super::strategy::BackendTag::HashChain {
             self.hc_matcher_mut()
                 .table
                 .set_dictionary_limit_from_primed_bytes(committed_dict_budget);
@@ -870,7 +861,7 @@ impl Matcher for MatchGeneratorDriver {
         ml: Option<&crate::fse::fse_encoder::FSETable>,
         of: Option<&crate::fse::fse_encoder::FSETable>,
     ) {
-        if self.active_backend == MatcherBackend::HashChain {
+        if self.active_backend == super::strategy::BackendTag::HashChain {
             self.hc_matcher_mut()
                 .seed_dictionary_entropy(huff, ll, ml, of);
         }
@@ -895,16 +886,18 @@ impl Matcher for MatchGeneratorDriver {
 
     fn get_last_space(&mut self) -> &[u8] {
         match self.active_backend {
-            MatcherBackend::Simple => self.match_generator.window.last().unwrap().data.as_slice(),
-            MatcherBackend::Dfast => self.dfast_matcher().get_last_space(),
-            MatcherBackend::Row => self.row_matcher().get_last_space(),
-            MatcherBackend::HashChain => self.hc_matcher().table.get_last_space(),
+            super::strategy::BackendTag::Simple => {
+                self.match_generator.window.last().unwrap().data.as_slice()
+            }
+            super::strategy::BackendTag::Dfast => self.dfast_matcher().get_last_space(),
+            super::strategy::BackendTag::Row => self.row_matcher().get_last_space(),
+            super::strategy::BackendTag::HashChain => self.hc_matcher().table.get_last_space(),
         }
     }
 
     fn commit_space(&mut self, space: Vec<u8>) {
         match self.active_backend {
-            MatcherBackend::Simple => {
+            super::strategy::BackendTag::Simple => {
                 let vec_pool = &mut self.vec_pool;
                 let mut evicted_bytes = 0usize;
                 let suffixes = match self.suffix_pool.pop() {
@@ -924,7 +917,7 @@ impl Matcher for MatchGeneratorDriver {
                 self.retire_dictionary_budget(evicted_bytes);
                 self.trim_after_budget_retire();
             }
-            MatcherBackend::Dfast => {
+            super::strategy::BackendTag::Dfast => {
                 let vec_pool = &mut self.vec_pool;
                 let mut evicted_bytes = 0usize;
                 self.dfast_match_generator
@@ -938,7 +931,7 @@ impl Matcher for MatchGeneratorDriver {
                 self.retire_dictionary_budget(evicted_bytes);
                 self.trim_after_budget_retire();
             }
-            MatcherBackend::Row => {
+            super::strategy::BackendTag::Row => {
                 let vec_pool = &mut self.vec_pool;
                 let mut evicted_bytes = 0usize;
                 self.row_match_generator
@@ -952,7 +945,7 @@ impl Matcher for MatchGeneratorDriver {
                 self.retire_dictionary_budget(evicted_bytes);
                 self.trim_after_budget_retire();
             }
-            MatcherBackend::HashChain => {
+            super::strategy::BackendTag::HashChain => {
                 let vec_pool = &mut self.vec_pool;
                 let mut evicted_bytes = 0usize;
                 self.hc_match_generator
@@ -998,14 +991,18 @@ impl Matcher for MatchGeneratorDriver {
 
     fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
         match self.active_backend {
-            MatcherBackend::Simple => self
+            super::strategy::BackendTag::Simple => self
                 .match_generator
                 .skip_matching_with_hint(incompressible_hint),
-            MatcherBackend::Dfast => self.dfast_matcher_mut().skip_matching(incompressible_hint),
-            MatcherBackend::Row => self
+            super::strategy::BackendTag::Dfast => {
+                self.dfast_matcher_mut().skip_matching(incompressible_hint)
+            }
+            super::strategy::BackendTag::Row => self
                 .row_matcher_mut()
                 .skip_matching_with_hint(incompressible_hint),
-            MatcherBackend::HashChain => self.hc_matcher_mut().skip_matching(incompressible_hint),
+            super::strategy::BackendTag::HashChain => {
+                self.hc_matcher_mut().skip_matching(incompressible_hint)
+            }
         }
     }
 }
@@ -1085,7 +1082,6 @@ struct HcMatchGenerator {
     /// present — BT modes still consult `hc.search_depth` for repcode
     /// probing and chain candidate enumeration.
     hc: super::hc::HcMatcher,
-    parse_mode: HcParseMode,
     /// Backend discriminator. [`HcBackend::Hc`] is zero-sized for the
     /// lazy / lazy2 path so HC-only generators don't carry the BT
     /// optimal-parser scratch buffers. [`HcBackend::Bt`] holds the
@@ -2596,15 +2592,20 @@ impl HcMatchGenerator {
         Self {
             table: super::match_table::storage::MatchTable::new(max_window_size),
             hc: super::hc::HcMatcher::new(2, HC_SEARCH_DEPTH, HC_TARGET_LEN),
-            parse_mode: HcParseMode::Lazy2,
             // Default to the zero-sized HC backend; `configure()` swaps
-            // in a `BtMatcher` only when an optimal parse mode lands.
+            // in a `BtMatcher` only when an optimal strategy lands.
             backend: HcBackend::Hc,
         }
     }
 
-    fn configure(&mut self, config: HcConfig, window_log: u8) {
-        let next_hash3_log = if config.parse_mode == HcParseMode::BtUltra2 {
+    fn configure(&mut self, config: HcConfig, tag: super::strategy::StrategyTag, window_log: u8) {
+        use super::strategy::StrategyTag;
+        let is_btultra2 = tag == StrategyTag::BtUltra2;
+        let uses_bt = matches!(
+            tag,
+            StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2
+        );
+        let next_hash3_log = if is_btultra2 {
             HC3_HASH_LOG.min(window_log as usize)
         } else {
             0
@@ -2615,25 +2616,18 @@ impl HcMatchGenerator {
         self.table.hash_log = config.hash_log;
         self.table.chain_log = config.chain_log;
         self.table.hash3_log = next_hash3_log;
-        self.hc.search_depth = if matches!(
-            config.parse_mode,
-            HcParseMode::BtOpt | HcParseMode::BtUltra | HcParseMode::BtUltra2
-        ) {
+        self.hc.search_depth = if uses_bt {
             config.search_depth
         } else {
             config.search_depth.min(MAX_HC_SEARCH_DEPTH)
         };
         self.hc.target_len = config.target_len;
-        self.parse_mode = config.parse_mode;
-        // Stage D: mirror parse_mode flags + HC search depth onto MatchTable
+        // Mirror strategy-derived flags + HC search depth onto MatchTable
         // so the BT walker and rebase machinery can read them directly
         // without dispatching back through HcMatchGenerator.
         self.table.search_depth = self.hc.search_depth;
-        self.table.is_btultra2 = matches!(config.parse_mode, HcParseMode::BtUltra2);
-        self.table.uses_bt = matches!(
-            config.parse_mode,
-            HcParseMode::BtOpt | HcParseMode::BtUltra | HcParseMode::BtUltra2
-        );
+        self.table.is_btultra2 = is_btultra2;
+        self.table.uses_bt = uses_bt;
         // Stage D: promote the backend discriminator. HC modes drop the
         // BT scratch buffers entirely; switching back into a BT mode
         // allocates a fresh `BtMatcher` on demand.
@@ -2683,21 +2677,27 @@ impl HcMatchGenerator {
     /// callers reach the inner loops through
     /// [`Self::start_matching_strategy`] / [`MatchGeneratorDriver::compress_block`]
     /// which pick the lazy / optimal arm from `S::USE_BT` at
-    /// monomorphisation time. Removed alongside `parse_mode` in the
-    /// final cleanup commit.
+    /// monomorphisation time.
     #[cfg(test)]
     fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
         use super::strategy;
-        match self.parse_mode {
-            HcParseMode::Lazy2 => self.start_matching_lazy(&mut handle_sequence),
-            HcParseMode::BtOpt => {
-                self.start_matching_optimal::<strategy::BtOpt>(&mut handle_sequence)
-            }
-            HcParseMode::BtUltra => {
-                self.start_matching_optimal::<strategy::BtUltra>(&mut handle_sequence)
-            }
-            HcParseMode::BtUltra2 => {
+        // Tests don't carry a strategy tag — pick one from runtime
+        // table flags (the same fields production sets via configure)
+        // so the const-generic dispatch still routes correctly.
+        match (
+            self.table.uses_bt,
+            self.table.is_btultra2,
+            self.table.hash3_log != 0,
+        ) {
+            (false, _, _) => self.start_matching_lazy(&mut handle_sequence),
+            (true, true, _) => {
                 self.start_matching_optimal::<strategy::BtUltra2>(&mut handle_sequence)
+            }
+            (true, false, _) => {
+                // BtOpt vs BtUltra is distinguished by the accurate
+                // flag — read from MatchTable so artificial test
+                // setups can route either way.
+                self.start_matching_optimal::<strategy::BtOpt>(&mut handle_sequence)
             }
         }
     }
@@ -2718,9 +2718,9 @@ impl HcMatchGenerator {
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
         debug_assert_eq!(
-            self.parse_mode,
-            S::PARSE_MODE,
-            "Strategy::PARSE_MODE disagrees with runtime parse_mode at HC dispatch"
+            self.table.uses_bt,
+            S::USE_BT,
+            "Strategy::USE_BT disagrees with runtime table.uses_bt at HC dispatch"
         );
         if S::USE_BT {
             self.start_matching_optimal::<S>(handle_sequence)
@@ -2886,7 +2886,7 @@ impl HcMatchGenerator {
         // The seed pass is BtUltra2-exclusive by name (`is_btultra2()`
         // gates the only call site), so pin S to BtUltra2 here.
         type S = super::strategy::BtUltra2;
-        let seed_profile = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+        let seed_profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
         opt_state.rescale_freqs(current, seed_profile);
@@ -3631,7 +3631,7 @@ fn driver_switches_backends_and_initializes_dfast_via_reset() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
 
     driver.reset(CompressionLevel::Default);
-    assert_eq!(driver.active_backend, MatcherBackend::Dfast);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Dfast);
     assert_eq!(driver.window_size(), (1u64 << 22));
 
     let mut first = driver.get_next_space();
@@ -3672,7 +3672,7 @@ fn driver_switches_backends_and_initializes_dfast_via_reset() {
 fn driver_level4_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(4));
-    assert_eq!(driver.active_backend, MatcherBackend::Row);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Row);
 }
 
 #[test]
@@ -3687,10 +3687,10 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
             "strategy_tag wrong for {level:?}"
         );
         let runtime_backend = match driver.active_backend {
-            MatcherBackend::Simple => BackendTag::Simple,
-            MatcherBackend::Dfast => BackendTag::Dfast,
-            MatcherBackend::Row => BackendTag::Row,
-            MatcherBackend::HashChain => BackendTag::HashChain,
+            super::strategy::BackendTag::Simple => BackendTag::Simple,
+            super::strategy::BackendTag::Dfast => BackendTag::Dfast,
+            super::strategy::BackendTag::Row => BackendTag::Row,
+            super::strategy::BackendTag::HashChain => BackendTag::HashChain,
         };
         assert_eq!(
             driver.strategy_tag.backend(),
@@ -3715,31 +3715,34 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
 }
 
 #[test]
-fn level_16_17_use_btopt_parse_mode() {
+fn level_16_17_map_to_btopt_strategy() {
+    use super::strategy::{BackendTag, StrategyTag};
     let p16 = resolve_level_params(CompressionLevel::Level(16), None);
     let p17 = resolve_level_params(CompressionLevel::Level(17), None);
-    assert_eq!(p16.backend, MatcherBackend::HashChain);
-    assert_eq!(p17.backend, MatcherBackend::HashChain);
-    assert_eq!(p16.hc.parse_mode, HcParseMode::BtOpt);
-    assert_eq!(p17.hc.parse_mode, HcParseMode::BtOpt);
+    assert_eq!(p16.backend, BackendTag::HashChain);
+    assert_eq!(p17.backend, BackendTag::HashChain);
+    assert_eq!(StrategyTag::for_level(16), StrategyTag::BtOpt);
+    assert_eq!(StrategyTag::for_level(17), StrategyTag::BtOpt);
 }
 
 #[test]
-fn level_18_19_use_btultra_parse_mode() {
+fn level_18_19_map_to_btultra_strategy() {
+    use super::strategy::{BackendTag, StrategyTag};
     let p18 = resolve_level_params(CompressionLevel::Level(18), None);
     let p19 = resolve_level_params(CompressionLevel::Level(19), None);
-    assert_eq!(p18.backend, MatcherBackend::HashChain);
-    assert_eq!(p19.backend, MatcherBackend::HashChain);
-    assert_eq!(p18.hc.parse_mode, HcParseMode::BtUltra);
-    assert_eq!(p19.hc.parse_mode, HcParseMode::BtUltra);
+    assert_eq!(p18.backend, BackendTag::HashChain);
+    assert_eq!(p19.backend, BackendTag::HashChain);
+    assert_eq!(StrategyTag::for_level(18), StrategyTag::BtUltra);
+    assert_eq!(StrategyTag::for_level(19), StrategyTag::BtUltra);
 }
 
 #[test]
-fn level_20_22_use_btultra2_parse_mode() {
+fn level_20_22_map_to_btultra2_strategy() {
+    use super::strategy::{BackendTag, StrategyTag};
     for level in 20..=22 {
         let params = resolve_level_params(CompressionLevel::Level(level), None);
-        assert_eq!(params.backend, MatcherBackend::HashChain);
-        assert_eq!(params.hc.parse_mode, HcParseMode::BtUltra2);
+        assert_eq!(params.backend, BackendTag::HashChain);
+        assert_eq!(StrategyTag::for_level(level as u8), StrategyTag::BtUltra2);
     }
 }
 
@@ -3796,17 +3799,29 @@ fn level22_small_source_size_hint_matches_donor_cparams() {
 #[test]
 fn level22_small_source_uses_window_bounded_hash3_log() {
     let mut hc = HcMatchGenerator::new(1 << 14);
-    hc.configure(BTULTRA2_HC_CONFIG_L22_16K, 14);
+    hc.configure(
+        BTULTRA2_HC_CONFIG_L22_16K,
+        super::strategy::StrategyTag::BtUltra2,
+        14,
+    );
     assert_eq!(hc.table.hash3_log, 14);
 
-    hc.configure(BTULTRA2_HC_CONFIG_L22, 27);
+    hc.configure(
+        BTULTRA2_HC_CONFIG_L22,
+        super::strategy::StrategyTag::BtUltra2,
+        27,
+    );
     assert_eq!(hc.table.hash3_log, HC3_HASH_LOG);
 }
 
 #[test]
 fn btultra2_seed_pass_initializes_opt_state() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     let data: Vec<u8> = (0..32 * 1024).map(|i| (i % 251) as u8).collect();
     hc.table.add_data(data, |_| {});
     hc.start_matching(|_| {});
@@ -3822,8 +3837,8 @@ fn btultra2_seed_pass_initializes_opt_state() {
 
 #[test]
 fn btultra2_profile_disables_small_offset_handicap() {
-    let p1 = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false);
-    let p2 = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+    let p1 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
+    let p2 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     assert!(
         !p1.favor_small_offsets,
         "btultra2 primary profile should match donor opt2 offset pricing"
@@ -3836,8 +3851,8 @@ fn btultra2_profile_disables_small_offset_handicap() {
 
 #[test]
 fn btultra2_profile_is_single_pass_opt2() {
-    let p1 = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false);
-    let p2 = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+    let p1 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
+    let p2 = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     assert_eq!(p1.max_chain_depth, p2.max_chain_depth);
     assert_eq!(p1.sufficient_match_len, p2.sufficient_match_len);
     assert_eq!(p1.accurate, p2.accurate);
@@ -3850,7 +3865,7 @@ fn btultra2_profile_is_single_pass_opt2() {
 
 #[test]
 fn btultra_profile_keeps_donor_search_depth_budget() {
-    let p = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra, false);
+    let p = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra>();
     assert_eq!(
         p.max_chain_depth, 32,
         "btultra should not cap chain depth below donor opt2 search budget"
@@ -3859,7 +3874,7 @@ fn btultra_profile_keeps_donor_search_depth_budget() {
 
 #[test]
 fn btopt_profile_keeps_donor_search_depth_budget() {
-    let p = HcOptimalCostProfile::for_mode(HcParseMode::BtOpt, false);
+    let p = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtOpt>();
     assert_eq!(
         p.max_chain_depth, 32,
         "btopt should not cap chain depth below donor btopt search budget"
@@ -3869,23 +3884,27 @@ fn btopt_profile_keeps_donor_search_depth_budget() {
 #[test]
 fn sufficient_match_len_is_clamped_by_target_len() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     hc.hc.target_len = 13;
-    let profile = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+    let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     assert_eq!(hc.hc.sufficient_match_len_for_pass(profile), 13);
 }
 
 #[test]
 fn opt_modes_use_target_len_as_sufficient_len() {
+    use super::strategy;
     let mut hc = HcMatchGenerator::new(1 << 20);
     hc.hc.target_len = 57;
-    for (mode, pass2) in [
-        (HcParseMode::BtOpt, false),
-        (HcParseMode::BtUltra, false),
-        (HcParseMode::BtUltra2, false),
-        (HcParseMode::BtUltra2, true),
-    ] {
-        let profile = HcOptimalCostProfile::for_mode(mode, pass2);
+    let profiles = [
+        HcOptimalCostProfile::const_for_strategy::<strategy::BtOpt>(),
+        HcOptimalCostProfile::const_for_strategy::<strategy::BtUltra>(),
+        HcOptimalCostProfile::const_for_strategy::<strategy::BtUltra2>(),
+    ];
+    for profile in profiles {
         assert_eq!(hc.hc.sufficient_match_len_for_pass(profile), 57);
     }
 }
@@ -3894,14 +3913,18 @@ fn opt_modes_use_target_len_as_sufficient_len() {
 fn sufficient_match_len_is_capped_by_opt_num() {
     let mut hc = HcMatchGenerator::new(1 << 20);
     hc.hc.target_len = usize::MAX / 2;
-    let profile = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+    let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     assert_eq!(hc.hc.sufficient_match_len_for_pass(profile), HC_OPT_NUM - 1);
 }
 
 #[test]
 fn dictionary_entropy_seed_initializes_opt_state_from_tables() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
 
     let huff = crate::huff0::huff0_encoder::HuffmanTable::build_from_data(
         b"aaabbbbccccddddeeeeefffffgggg",
@@ -3913,7 +3936,7 @@ fn dictionary_entropy_seed_initializes_opt_state_from_tables() {
 
     hc.backend.bt_mut().opt_state.rescale_freqs(
         b"abcd",
-        HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false),
+        HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>(),
     );
 
     let base_ll_freqs: [u32; HC_MAX_LL + 1] = [
@@ -3945,7 +3968,11 @@ fn dictionary_entropy_seed_initializes_opt_state_from_tables() {
 #[test]
 fn dictionary_fse_seed_applies_without_huffman_seed() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
 
     let ll = crate::fse::fse_encoder::default_ll_table();
     let ml = crate::fse::fse_encoder::default_ml_table();
@@ -3953,7 +3980,7 @@ fn dictionary_fse_seed_applies_without_huffman_seed() {
     hc.seed_dictionary_entropy(None, Some(&ll), Some(&ml), Some(&of));
     hc.backend.bt_mut().opt_state.rescale_freqs(
         b"abcd",
-        HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false),
+        HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>(),
     );
 
     let base_ll_freqs: [u32; HC_MAX_LL + 1] = [
@@ -3984,7 +4011,11 @@ fn dictionary_fse_seed_applies_without_huffman_seed() {
 #[test]
 fn dictionary_seed_overrides_predef_price_mode_on_tiny_input() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
 
     let ll = crate::fse::fse_encoder::default_ll_table();
     let ml = crate::fse::fse_encoder::default_ml_table();
@@ -3992,7 +4023,7 @@ fn dictionary_seed_overrides_predef_price_mode_on_tiny_input() {
     hc.seed_dictionary_entropy(None, Some(&ll), Some(&ml), Some(&of));
     hc.backend.bt_mut().opt_state.rescale_freqs(
         b"abc",
-        HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false),
+        HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>(),
     );
     assert!(
         matches!(
@@ -4005,7 +4036,7 @@ fn dictionary_seed_overrides_predef_price_mode_on_tiny_input() {
 
 #[test]
 fn lit_length_price_blocksize_max_costs_one_extra_bit() {
-    let profile_predef = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false);
+    let profile_predef = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     let mut stats_predef = HcOptState::new();
     stats_predef.price_type = HcOptPriceType::Predefined;
     let predef_max = profile_predef.lit_length_price(&stats_predef, HC_BLOCKSIZE_MAX);
@@ -4017,7 +4048,7 @@ fn lit_length_price_blocksize_max_costs_one_extra_bit() {
         "predefined litLength pricing at BLOCKSIZE_MAX must add exactly one bit"
     );
 
-    let profile_dyn = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, true);
+    let profile_dyn = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     let mut stats_dyn = HcOptState::new();
     stats_dyn.price_type = HcOptPriceType::Dynamic;
     stats_dyn.lit_length_freq.fill(1);
@@ -4041,7 +4072,11 @@ fn lit_length_price_blocksize_max_costs_one_extra_bit() {
 #[test]
 fn btultra2_seed_pass_disabled_when_dictionary_entropy_seed_present() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     let ll = crate::fse::fse_encoder::default_ll_table();
     let ml = crate::fse::fse_encoder::default_ml_table();
     let of = crate::fse::fse_encoder::default_of_table();
@@ -4055,7 +4090,11 @@ fn btultra2_seed_pass_disabled_when_dictionary_entropy_seed_present() {
 #[test]
 fn btultra2_seed_pass_disabled_when_prefix_history_exists() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     hc.table.history_abs_start = 17;
     hc.table.window.push_back(b"abcdefghijklmnop".to_vec());
     assert!(
@@ -4067,7 +4106,11 @@ fn btultra2_seed_pass_disabled_when_prefix_history_exists() {
 #[test]
 fn btultra2_seed_pass_disabled_for_tiny_block() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     assert!(
         !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD),
         "btultra2 warmup should not run at or below predefined threshold"
@@ -4077,7 +4120,11 @@ fn btultra2_seed_pass_disabled_for_tiny_block() {
 #[test]
 fn btultra2_seed_pass_disabled_after_stats_initialized() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     hc.backend.bt_mut().opt_state.lit_length_sum = 1;
     assert!(
         !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 32),
@@ -4088,7 +4135,11 @@ fn btultra2_seed_pass_disabled_after_stats_initialized() {
 #[test]
 fn btultra2_seed_pass_disabled_when_not_at_frame_start() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     // Simulate non-first block state: current block has no prefix in deque,
     // but total produced window already includes prior output.
     hc.table.window_size = HC_PREDEF_THRESHOLD + 64;
@@ -4104,7 +4155,11 @@ fn btultra2_seed_pass_disabled_when_not_at_frame_start() {
 #[test]
 fn btultra2_seed_pass_disabled_when_ldm_sequences_exist() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG, 26);
+    hc.configure(
+        BTULTRA2_HC_CONFIG,
+        super::strategy::StrategyTag::BtUltra2,
+        26,
+    );
     hc.table.window_size = HC_PREDEF_THRESHOLD + 64;
     hc.table
         .window
@@ -4122,7 +4177,7 @@ fn btultra2_seed_pass_disabled_when_ldm_sequences_exist() {
 
 #[test]
 fn literal_price_uses_eight_bits_when_literals_uncompressed() {
-    let profile = HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false);
+    let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>();
     let mut stats = HcOptState::new();
     stats.set_literals_compressed_for_tests(false);
     stats.price_type = HcOptPriceType::Predefined;
@@ -4174,7 +4229,7 @@ fn dictionary_huffman_seed_ignored_when_literals_uncompressed() {
     stats.seed_dictionary_entropy(Some(&huff), Some(&ll), Some(&ml), Some(&of));
     stats.rescale_freqs(
         b"abcd",
-        HcOptimalCostProfile::for_mode(HcParseMode::BtUltra2, false),
+        HcOptimalCostProfile::const_for_strategy::<super::strategy::BtUltra2>(),
     );
     assert_eq!(
         stats.lit_sum, 0,
@@ -4625,7 +4680,6 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
     };
     let mut out = Vec::new();
 
-    hc.parse_mode = HcParseMode::BtUltra2;
     hc.table.is_btultra2 = true;
     hc.table.uses_bt = true;
     hc.table.search_depth = hc.hc.search_depth;
@@ -4647,7 +4701,6 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
         "btultra2 should retain dictionary candidates on donor-parity path"
     );
 
-    hc.parse_mode = HcParseMode::BtUltra;
     hc.table.is_btultra2 = false;
     hc.table.uses_bt = true;
     hc.table.skip_insert_until_abs = 0;
@@ -5371,7 +5424,7 @@ fn row_get_last_space_and_reset_to_fastest_clears_window() {
     assert_eq!(driver.get_last_space(), b"row-data");
 
     driver.reset(CompressionLevel::Fastest);
-    assert_eq!(driver.active_backend, MatcherBackend::Simple);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Simple);
     assert!(driver.row_matcher().window.is_empty());
 }
 
@@ -5380,7 +5433,7 @@ fn row_get_last_space_and_reset_to_fastest_clears_window() {
 fn driver_reset_from_row_backend_reclaims_row_buffer_pool() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
     driver.reset(CompressionLevel::Level(4));
-    assert_eq!(driver.active_backend, MatcherBackend::Row);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Row);
 
     // Ensure the row matcher option is initialized so reset() executes
     // the Row backend retirement path.
@@ -5392,7 +5445,7 @@ fn driver_reset_from_row_backend_reclaims_row_buffer_pool() {
     let before_pool = driver.vec_pool.len();
     driver.reset(CompressionLevel::Fastest);
 
-    assert_eq!(driver.active_backend, MatcherBackend::Simple);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Simple);
     let row = driver
         .row_match_generator
         .as_ref()
@@ -5410,12 +5463,12 @@ fn driver_reset_from_row_backend_reclaims_row_buffer_pool() {
 #[test]
 fn driver_reset_from_row_backend_tolerates_missing_row_matcher() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.active_backend = MatcherBackend::Row;
+    driver.active_backend = super::strategy::BackendTag::Row;
     driver.row_match_generator = None;
 
     driver.reset(CompressionLevel::Fastest);
 
-    assert_eq!(driver.active_backend, MatcherBackend::Simple);
+    assert_eq!(driver.active_backend, super::strategy::BackendTag::Simple);
 }
 
 #[test]
@@ -5683,7 +5736,7 @@ fn hc_hash3_position_matches_donor_formula() {
 #[test]
 fn hc_hash_position_matches_donor_hash4_formula() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(HC_CONFIG, 22);
+    hc.configure(HC_CONFIG, super::strategy::StrategyTag::Lazy, 22);
     let bytes = [b'a', b'b', b'c', b'd'];
     let read32 = u32::from_le_bytes(bytes);
     let expected = ((read32.wrapping_mul(HC_PRIME4BYTES)) >> (32 - hc.table.hash_log)) as usize;
@@ -5693,7 +5746,11 @@ fn hc_hash_position_matches_donor_hash4_formula() {
 #[test]
 fn btultra2_main_hash_uses_donor_hash4_formula() {
     let mut hc = HcMatchGenerator::new(1 << 20);
-    hc.configure(BTULTRA2_HC_CONFIG_L22, 27);
+    hc.configure(
+        BTULTRA2_HC_CONFIG_L22,
+        super::strategy::StrategyTag::BtUltra2,
+        27,
+    );
     let bytes = [b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h'];
     let read32 = u32::from_le_bytes(bytes[..4].try_into().unwrap());
     let expected = ((read32.wrapping_mul(HC_PRIME4BYTES)) >> (32 - hc.table.hash_log)) as usize;
@@ -6028,7 +6085,11 @@ fn hc_sparse_skip_matching_preserves_tail_cross_block_match() {
 #[test]
 fn btultra2_sparse_skip_matching_preserves_tail_cross_block_match() {
     let mut matcher = HcMatchGenerator::new(1 << 20);
-    matcher.configure(BTULTRA2_HC_CONFIG_L22, 20);
+    matcher.configure(
+        BTULTRA2_HC_CONFIG_L22,
+        super::strategy::StrategyTag::BtUltra2,
+        20,
+    );
     let tail = b"Bt9kLm2Rp";
     let mut first = deterministic_high_entropy_bytes(0xA9C3_7F21_D4E8_510B, 4096);
     let tail_start = first.len() - tail.len();
@@ -6394,7 +6455,10 @@ fn fastest_reset_uses_interleaved_hash_fill_step() {
     // Better uses the HashChain backend with lazy2; verify that the backend switch
     // happened and the lazy_depth is configured correctly.
     driver.reset(CompressionLevel::Better);
-    assert_eq!(driver.active_backend, MatcherBackend::HashChain);
+    assert_eq!(
+        driver.active_backend,
+        super::strategy::BackendTag::HashChain
+    );
     assert_eq!(driver.window_size(), (1u64 << 23));
     assert_eq!(driver.hc_matcher().hc.lazy_depth, 2);
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2822,12 +2822,13 @@ impl HcMatchGenerator {
             self.run_btultra2_seed_pass(current, current_abs_start, current_len);
         }
 
-        let profile = if self.is_btultra2() {
-            // Donor btultra2 runs one accurate opt pass after initStats_ultra.
-            HcOptimalCostProfile::for_mode(self.parse_mode, true)
-        } else {
-            HcOptimalCostProfile::for_mode(self.parse_mode, false)
-        };
+        // Const-generic profile selection: every field is folded from
+        // S's associated consts (MAX_CHAIN_DEPTH /
+        // SUFFICIENT_MATCH_LEN / ACCURATE_PRICE / FAVOR_SMALL_OFFSETS),
+        // so the optimiser produces the literal at codegen time
+        // without a runtime match. Replaces the old
+        // `for_mode(self.parse_mode, self.is_btultra2())` pair.
+        let profile = HcOptimalCostProfile::const_for_strategy::<S>();
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
         opt_state.rescale_freqs(current, profile);
@@ -3467,15 +3468,6 @@ impl HcMatchGenerator {
             hash3_candidate_scalar,
             crate::encoding::fastpath::scalar::common_prefix_len_ptr,
         )
-    }
-
-    /// Stage D: mirrored onto [`MatchTable::is_btultra2`] during
-    /// `configure()`, so every former site that read `self.parse_mode`
-    /// now consults the table flag instead. Kept as a thin accessor on
-    /// `HcMatchGenerator` for call sites that haven't migrated yet.
-    #[inline]
-    fn is_btultra2(&self) -> bool {
-        self.table.is_btultra2
     }
 }
 

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -223,13 +223,14 @@ pub(crate) struct MatchTable {
     /// walker macros read the depth from `$table.search_depth` directly so
     /// the call sites don't have to plumb it through.
     pub(crate) search_depth: usize,
-    /// Whether the active parser is `btultra2`. Stage D mirrors it from
-    /// `HcParseMode::BtUltra2` so the BT walker and rebase machinery can
-    /// stay on `MatchTable` without consulting the outer generator.
+    /// Whether the active parser is `btultra2`. Mirrored from the
+    /// current [`super::super::strategy::StrategyTag`] during
+    /// `configure()` so the BT walker and rebase machinery can stay
+    /// on `MatchTable` without consulting the outer generator.
     pub(crate) is_btultra2: bool,
     /// Whether the active backend is one of the BT parsers (`btopt`,
-    /// `btultra`, `btultra2`). Mirrored from `HcParseMode` for the same
-    /// reason as `is_btultra2`.
+    /// `btultra`, `btultra2`). Mirrored from the active strategy for
+    /// the same reason as `is_btultra2`.
     pub(crate) uses_bt: bool,
 }
 

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -8,17 +8,16 @@ pub(crate) mod incompressible;
 pub(crate) mod match_generator;
 pub(crate) mod util;
 
-// `#111` encoder architecture rewrite — Phase 1 (structural split).
-// `cost_model`, `opt`, `strategy`, `dfast`, `row`, and `simple` now
-// host the relocated cost-model types, the optimal-parser plain-data
-// types, the `HcParseMode` dispatch tag, and the Dfast / Row / Simple
-// matchers respectively. `match_table::helpers` hosts the shared
-// match-finder primitives. `bt` and `hc` are still doc-only
-// placeholders that name the donor helpers and monolith methods
-// slated to move into them in subsequent #111 phase PRs. The rewrite
-// plan is tracked in
-// <https://github.com/structured-world/structured-zstd/issues/111> and
-// the per-phase boundary is `perf/post-pr-110-baseline`.
+// `#111` encoder architecture rewrite. `cost_model`, `opt`,
+// `strategy`, `dfast`, `row`, and `simple` host the relocated
+// cost-model types, the optimal-parser plain-data types, the
+// const-generic [`strategy::Strategy`] trait + per-level [`strategy::
+// StrategyTag`] dispatcher, and the Dfast / Row / Simple matchers
+// respectively. `match_table::helpers` hosts the shared match-finder
+// primitives. The rewrite plan is tracked in
+// <https://github.com/structured-world/structured-zstd/issues/111>;
+// per-phase boundaries are `perf/post-pr-110-baseline` (start),
+// `perf/post-pr-121-baseline` (post-Phase-2).
 pub(crate) mod bt;
 pub(crate) mod cost_model;
 pub(crate) mod dfast;

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -334,12 +334,16 @@ mod tests {
         assert_eq!(StrategyTag::for_level(22), StrategyTag::BtUltra2);
     }
 
-    #[test]
-    fn use_bt_aligns_with_parse_mode() {
-        // Lazy2 strategies must not walk the BT; BtOpt / BtUltra /
-        // BtUltra2 must. This is the invariant that lets the inner
-        // optimal parser drop the `if self.parse_mode == Lazy2 …`
-        // branch in favour of `if !S::USE_BT`.
+    // The next three blocks live at module scope (not inside `#[test]`)
+    // so the assertions run at compile time and never reach the
+    // `cargo nextest` runner. `clippy::assertions_on_constants`
+    // requires this form for const-only inputs.
+
+    // `use_bt_aligns_with_parse_mode`: Lazy2 strategies must not walk
+    // the BT; BtOpt / BtUltra / BtUltra2 must. Invariant that lets
+    // the inner optimal parser drop the `if self.parse_mode == Lazy2
+    // …` branch in favour of `if !S::USE_BT`.
+    const _USE_BT_LAYOUT: () = {
         assert!(!Fast::USE_BT);
         assert!(!Dfast::USE_BT);
         assert!(!Greedy::USE_BT);
@@ -347,11 +351,11 @@ mod tests {
         assert!(BtOpt::USE_BT);
         assert!(BtUltra::USE_BT);
         assert!(BtUltra2::USE_BT);
-    }
+    };
 
-    #[test]
-    fn use_hash3_only_set_for_btultra2() {
-        // Donor parity: hash3 is exclusively a BtUltra2 feature.
+    // `use_hash3_only_set_for_btultra2`: hash3 is exclusively a
+    // BtUltra2 feature (donor parity).
+    const _USE_HASH3_LAYOUT: () = {
         assert!(!Fast::USE_HASH3);
         assert!(!Dfast::USE_HASH3);
         assert!(!Greedy::USE_HASH3);
@@ -359,15 +363,15 @@ mod tests {
         assert!(!BtOpt::USE_HASH3);
         assert!(!BtUltra::USE_HASH3);
         assert!(BtUltra2::USE_HASH3);
-    }
+    };
 
-    #[test]
-    fn accurate_and_favor_small_offsets_track_cost_model_for_mode() {
-        // Mirror the `HcOptimalCostProfile::for_mode` runtime table so
-        // the eventual `const_for::<S>` rewrite is a mechanical swap.
+    // `accurate_and_favor_small_offsets_track_cost_model_for_mode`:
+    // mirror `HcOptimalCostProfile::for_mode` so the eventual
+    // `const_for::<S>` rewrite is a mechanical swap.
+    const _COST_MODEL_LAYOUT: () = {
         assert!(!Lazy::ACCURATE_PRICE && Lazy::FAVOR_SMALL_OFFSETS);
         assert!(!BtOpt::ACCURATE_PRICE && BtOpt::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra::ACCURATE_PRICE && !BtUltra::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra2::ACCURATE_PRICE && !BtUltra2::FAVOR_SMALL_OFFSETS);
-    }
+    };
 }

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -246,6 +246,32 @@ impl StrategyTag {
         }
     }
 
+    /// Map a [`CompressionLevel`] to its [`StrategyTag`]. Mirrors the
+    /// per-level dispatch in `match_generator::resolve_level_params`
+    /// so the runtime `active_backend` field and the future
+    /// const-generic strategy stay in lock-step.
+    pub(crate) fn for_compression_level(level: crate::encoding::CompressionLevel) -> Self {
+        use crate::encoding::CompressionLevel;
+        match level {
+            CompressionLevel::Uncompressed => Self::Fast,
+            CompressionLevel::Fastest => Self::Fast,
+            CompressionLevel::Default => Self::Dfast,
+            CompressionLevel::Better => Self::Lazy,
+            CompressionLevel::Best => Self::Lazy,
+            CompressionLevel::Level(n) => {
+                if n <= 0 {
+                    // Level 0 → default (Dfast). Negative levels →
+                    // ultra-fast Simple matcher with elevated
+                    // `hash_fill_step` (see resolve_level_params).
+                    if n == 0 { Self::Dfast } else { Self::Fast }
+                } else {
+                    let clamped = (n as u8).min(CompressionLevel::MAX_LEVEL as u8);
+                    Self::for_level(clamped)
+                }
+            }
+        }
+    }
+
     /// Bridge to the runtime [`HcParseMode`] enum that the existing
     /// `HcMatchGenerator` paths still consume. Will go away in the
     /// final cleanup commit when the runtime enum is deleted.

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -87,6 +87,17 @@ pub(crate) trait Strategy: Copy + 'static {
     /// transitional bridge between `Strategy` and the runtime
     /// [`HcParseMode`] enum stays cheap to write.
     const PARSE_MODE: HcParseMode;
+
+    /// Donor `max_chain_depth` for the optimal-parser cost profile.
+    /// Mirrors `HcOptimalCostProfile::for_mode` row-for-row so the
+    /// per-block profile selection becomes a compile-time
+    /// `HcOptimalCostProfile::const_for_strategy::<S>()` call.
+    const MAX_CHAIN_DEPTH: usize;
+
+    /// Donor `sufficient_match_len` — the BT walker bails out as soon
+    /// as a candidate at or above this length is seen.
+    /// `usize::MAX` means "never bail early".
+    const SUFFICIENT_MATCH_LEN: usize;
 }
 
 /// Level 1 — donor `ZSTD_fast`. Single-table Simple matcher.
@@ -104,6 +115,10 @@ impl Strategy for Fast {
     // Simple backend does not actually consult parse_mode; pick the
     // narrowest variant for the bridge.
     const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+    // Optimal-parser consts are unreachable for Simple/Dfast/Greedy —
+    // pin them to the Lazy2 row so the trait stays total.
+    const MAX_CHAIN_DEPTH: usize = 8;
+    const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
 /// Levels 2-3 — donor `ZSTD_dfast`. Two parallel hash chains.
@@ -119,6 +134,8 @@ impl Strategy for Dfast {
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
     const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+    const MAX_CHAIN_DEPTH: usize = 8;
+    const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
 /// Level 4 — donor `ZSTD_greedy` with row hashing.
@@ -134,6 +151,8 @@ impl Strategy for Greedy {
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
     const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+    const MAX_CHAIN_DEPTH: usize = 8;
+    const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
 /// Levels 5-15 — donor `ZSTD_lazy2` on a hash chain. Differ from each
@@ -152,6 +171,8 @@ impl Strategy for Lazy {
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
     const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+    const MAX_CHAIN_DEPTH: usize = 8;
+    const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
 /// Levels 16-17 — donor `ZSTD_btopt`. BT + opt without the ultra
@@ -168,6 +189,8 @@ impl Strategy for BtOpt {
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 0;
     const PARSE_MODE: HcParseMode = HcParseMode::BtOpt;
+    const MAX_CHAIN_DEPTH: usize = 32;
+    const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
 
 /// Levels 18-19 — donor `ZSTD_btultra`. BT + opt with refined price
@@ -184,6 +207,8 @@ impl Strategy for BtUltra {
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 2;
     const PARSE_MODE: HcParseMode = HcParseMode::BtUltra;
+    const MAX_CHAIN_DEPTH: usize = 32;
+    const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
 
 /// Levels 20-22 — donor `ZSTD_btultra2`. BT + opt with the two-pass
@@ -200,6 +225,8 @@ impl Strategy for BtUltra2 {
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 2;
     const PARSE_MODE: HcParseMode = HcParseMode::BtUltra2;
+    const MAX_CHAIN_DEPTH: usize = 512;
+    const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
 
 /// Compile-time strategy tag for the per-level dispatcher. Each

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -1,37 +1,45 @@
-//! Encoder strategy enum + const-generic strategy dispatch (Phase 3 of
-//! #111).
+//! Encoder strategy types — Phase 3 of #111.
 //!
-//! Phase 1 introduced the [`HcParseMode`] runtime enum that gates the
-//! Lazy2 / BtOpt / BtUltra / BtUltra2 code paths inside `HcMatchGenerator`
-//! and `cost_model`. Phase 3 lifts that decision (and the parallel
-//! `MatcherBackend` runtime tag in `match_generator`) into the type
-//! system: each `level → Strategy` mapping is a concrete ZST that
-//! implements the [`Strategy`] trait. Hot-path entry points become
-//! generic over `S: Strategy` and the compiler monomorphises the inner
-//! loops per variant, dropping every dead `if S::FOO` branch at
-//! `codegen` time.
+//! Every per-position branch the encoder used to dispatch at runtime
+//! (lazy / optimal split, BT walker on/off, hash3 short-match probe,
+//! refined / coarse cost model) now reads from a compile-time
+//! `S: Strategy` parameter. The compiler monomorphises the inner
+//! loops per concrete `S` and drops the dead arms during codegen.
 //!
-//! The runtime enums survive until the per-call-site migration is
-//! complete; this module documents the bridge.
+//! ## Dispatch flow
+//!
+//! ```text
+//! Matcher::start_matching                       // 7-arm match on StrategyTag (per block)
+//!  └─ compress_block::<S>                       // S::BACKEND const match
+//!      ├─ Simple/Dfast/Row                      // backends without parse_mode
+//!      └─ HcMatchGenerator::start_matching_strategy::<S>
+//!          ├─ S::USE_BT == false → start_matching_lazy
+//!          └─ S::USE_BT == true  → start_matching_optimal::<S>
+//!              ├─ HcOptimalCostProfile::const_for_strategy::<S>()
+//!              ├─ should_run_btultra2_seed_pass::<S>          // const false unless S = BtUltra2
+//!              └─ build_optimal_plan::<S>
+//!                  └─ build_optimal_plan_impl::<S, ACC, FAV>
+//!                      └─ SIMD wrapper::<S, ACC, FAV>
+//!                          └─ build_optimal_plan_impl_body!(S)
+//!                              ├─ S::OPT_LEVEL == 0  → abort_on_worse_match
+//!                              ├─ S::OPT_LEVEL >= 2  → opt_level (refined)
+//!                              └─ $collect::<S, true>
+//!                                  └─ collect_optimal_candidates_initialized_body!(S)
+//!                                      └─ S::USE_HASH3 → hash3 lookup (const-gated)
+//! ```
+//!
+//! Donor parity reference: `ZSTD_compressionParameters` in
+//! `lib/compress/zstd_compress_internal.h` and the per-level table in
+//! `lib/compress/clevels.h`.
 
 #![allow(dead_code)]
 
-/// Runtime dispatch tag selecting which optimal-parser / match-finder
-/// pipeline `HcMatchGenerator` should execute. The cost-model profile
-/// and the matcher's `start_matching` body both branch on this enum
-/// until the Phase 3 `Strategy` trait replaces the runtime match.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) enum HcParseMode {
-    Lazy2,
-    BtOpt,
-    BtUltra,
-    BtUltra2,
-}
-
 /// Donor `ZSTD_compressionParameters.strategy` equivalent — names the
-/// concrete match-finder backend a [`Strategy`] is paired with. Used in
-/// the transitional bridge between the [`Strategy`] trait and the
-/// existing `MatcherBackend` runtime enum.
+/// concrete match-finder backend a [`Strategy`] runs on top of. The
+/// runtime [`StrategyTag`] dispatcher and the [`Strategy::BACKEND`]
+/// associated const both produce values of this type, so the
+/// per-block driver dispatch and the per-strategy backend selection
+/// stay in lock-step.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum BackendTag {
     /// `SimpleMatchGenerator` — level 1.
@@ -46,13 +54,9 @@ pub(crate) enum BackendTag {
 
 /// Compile-time encoder strategy. Each concrete implementor is a ZST
 /// whose associated `const`s tell the optimal parser / match finder
-/// which donor-equivalent path to execute. The runtime [`HcParseMode`]
-/// enum will be removed once every read site is migrated to `if
-/// S::USE_BT` / `if S::USE_HASH3` / etc.
-///
-/// Donor parity reference: `ZSTD_compressionParameters` in
-/// `lib/compress/zstd_compress_internal.h` and the per-level table in
-/// `lib/compress/clevels.h`.
+/// which donor-equivalent path to execute. Hot entry points are
+/// generic over `S: Strategy`, so monomorphisation strips every
+/// dead `if S::FOO` arm at codegen time.
 pub(crate) trait Strategy: Copy + 'static {
     /// Match-finder backend this strategy runs on.
     const BACKEND: BackendTag;
@@ -83,20 +87,13 @@ pub(crate) trait Strategy: Copy + 'static {
     /// `build_optimal_plan_impl_body!`.
     const OPT_LEVEL: u8;
 
-    /// Donor `parse_mode` mirror — kept as an associated const so the
-    /// transitional bridge between `Strategy` and the runtime
-    /// [`HcParseMode`] enum stays cheap to write.
-    const PARSE_MODE: HcParseMode;
-
     /// Donor `max_chain_depth` for the optimal-parser cost profile.
-    /// Mirrors `HcOptimalCostProfile::for_mode` row-for-row so the
-    /// per-block profile selection becomes a compile-time
-    /// `HcOptimalCostProfile::const_for_strategy::<S>()` call.
+    /// Used by `HcOptimalCostProfile::const_for_strategy::<S>()`.
     const MAX_CHAIN_DEPTH: usize;
 
     /// Donor `sufficient_match_len` — the BT walker bails out as soon
-    /// as a candidate at or above this length is seen.
-    /// `usize::MAX` means "never bail early".
+    /// as a candidate at or above this length is seen. `usize::MAX`
+    /// means "never bail early".
     const SUFFICIENT_MATCH_LEN: usize;
 }
 
@@ -112,10 +109,7 @@ impl Strategy for Fast {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
-    // Simple backend does not actually consult parse_mode; pick the
-    // narrowest variant for the bridge.
-    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
-    // Optimal-parser consts are unreachable for Simple/Dfast/Greedy —
+    // Optimal-parser consts are unreachable for non-BT strategies —
     // pin them to the Lazy2 row so the trait stays total.
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
@@ -133,7 +127,6 @@ impl Strategy for Dfast {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
-    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -150,15 +143,14 @@ impl Strategy for Greedy {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
-    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
-/// Levels 5-15 — donor `ZSTD_lazy2` on a hash chain. Differ from each
-/// other by runtime `search_depth` / `hash_log` / `chain_log` /
-/// `target_len` / `lazy_depth` only — those are runtime
-/// `HcConfig` fields, not compile-time `Strategy` consts.
+/// Levels 5-15 — donor `ZSTD_lazy2` on a hash chain. Levels inside
+/// the band differ only by runtime `HcConfig` fields (`search_depth`,
+/// `hash_log`, `chain_log`, `target_len`, `lazy_depth`), not by
+/// compile-time `Strategy` consts, so they share a single type.
 #[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct Lazy;
 
@@ -170,7 +162,6 @@ impl Strategy for Lazy {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
-    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -188,7 +179,6 @@ impl Strategy for BtOpt {
     const USE_HASH3: bool = false;
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 0;
-    const PARSE_MODE: HcParseMode = HcParseMode::BtOpt;
     const MAX_CHAIN_DEPTH: usize = 32;
     const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
@@ -206,7 +196,6 @@ impl Strategy for BtUltra {
     const USE_HASH3: bool = false;
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 2;
-    const PARSE_MODE: HcParseMode = HcParseMode::BtUltra;
     const MAX_CHAIN_DEPTH: usize = 32;
     const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
@@ -224,16 +213,15 @@ impl Strategy for BtUltra2 {
     const USE_HASH3: bool = true;
     const USE_BT: bool = true;
     const OPT_LEVEL: u8 = 2;
-    const PARSE_MODE: HcParseMode = HcParseMode::BtUltra2;
     const MAX_CHAIN_DEPTH: usize = 512;
     const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
 }
 
-/// Compile-time strategy tag for the per-level dispatcher. Each
-/// variant maps to exactly one [`Strategy`] implementor; the dispatcher
-/// stays runtime-tagged because it only fires once per frame on
-/// `reset()`, so the cost of a 7-arm match is invisible compared to
-/// the per-block hot-loop work it dispatches into.
+/// Runtime strategy tag for the per-level dispatcher. Each variant
+/// maps to exactly one [`Strategy`] implementor; the dispatcher
+/// itself stays runtime-tagged because it only fires once per frame
+/// on `reset()`, so the cost of a 7-arm match is invisible compared
+/// to the per-block hot-loop work it dispatches into.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum StrategyTag {
     Fast,
@@ -265,18 +253,12 @@ impl StrategyTag {
             5..=15 => Self::Lazy,
             16 | 17 => Self::BtOpt,
             18 | 19 => Self::BtUltra,
-            // Out-of-range levels collapse onto BtUltra2 — the
-            // existing `resolve_level_params` already clamps the
-            // numeric level into the table, this is just the matching
-            // tail.
             _ => Self::BtUltra2,
         }
     }
 
     /// Map a [`CompressionLevel`] to its [`StrategyTag`]. Mirrors the
-    /// per-level dispatch in `match_generator::resolve_level_params`
-    /// so the runtime `active_backend` field and the future
-    /// const-generic strategy stay in lock-step.
+    /// per-level dispatch in `match_generator::resolve_level_params`.
     pub(crate) fn for_compression_level(level: crate::encoding::CompressionLevel) -> Self {
         use crate::encoding::CompressionLevel;
         match level {
@@ -287,9 +269,6 @@ impl StrategyTag {
             CompressionLevel::Best => Self::Lazy,
             CompressionLevel::Level(n) => {
                 if n <= 0 {
-                    // Level 0 → default (Dfast). Negative levels →
-                    // ultra-fast Simple matcher with elevated
-                    // `hash_fill_step` (see resolve_level_params).
                     if n == 0 { Self::Dfast } else { Self::Fast }
                 } else {
                     let clamped = (n as u8).min(CompressionLevel::MAX_LEVEL as u8);
@@ -299,20 +278,7 @@ impl StrategyTag {
         }
     }
 
-    /// Bridge to the runtime [`HcParseMode`] enum that the existing
-    /// `HcMatchGenerator` paths still consume. Will go away in the
-    /// final cleanup commit when the runtime enum is deleted.
-    pub(crate) const fn parse_mode(self) -> HcParseMode {
-        match self {
-            Self::Fast | Self::Dfast | Self::Greedy | Self::Lazy => HcParseMode::Lazy2,
-            Self::BtOpt => HcParseMode::BtOpt,
-            Self::BtUltra => HcParseMode::BtUltra,
-            Self::BtUltra2 => HcParseMode::BtUltra2,
-        }
-    }
-
-    /// Bridge to the runtime [`BackendTag`] for the dispatcher entry
-    /// point.
+    /// Bridge to [`BackendTag`] for the dispatcher entry point.
     pub(crate) const fn backend(self) -> BackendTag {
         match self {
             Self::Fast => BackendTag::Simple,
@@ -329,7 +295,6 @@ mod tests {
 
     fn assert_strategy_matches_tag<S: Strategy>(tag: StrategyTag) {
         assert_eq!(S::BACKEND, tag.backend(), "backend mismatch");
-        assert_eq!(S::PARSE_MODE, tag.parse_mode(), "parse_mode mismatch");
     }
 
     #[test]
@@ -361,10 +326,10 @@ mod tests {
         assert_eq!(StrategyTag::for_level(22), StrategyTag::BtUltra2);
     }
 
-    // The next three blocks live at module scope (not inside `#[test]`)
-    // so the assertions run at compile time and never reach the
-    // `cargo nextest` runner. `clippy::assertions_on_constants`
-    // requires this form for const-only inputs.
+    // The next three blocks live at module scope so the assertions
+    // run at compile time and never reach the `cargo nextest` runner.
+    // `clippy::assertions_on_constants` requires this form for
+    // const-only inputs.
 
     // `use_bt_aligns_with_parse_mode`: Lazy2 strategies must not walk
     // the BT; BtOpt / BtUltra / BtUltra2 must. Invariant that lets
@@ -392,13 +357,20 @@ mod tests {
         assert!(BtUltra2::USE_HASH3);
     };
 
-    // `accurate_and_favor_small_offsets_track_cost_model_for_mode`:
-    // mirror `HcOptimalCostProfile::for_mode` so the eventual
-    // `const_for::<S>` rewrite is a mechanical swap.
+    // Mirror the per-strategy fields the optimal-parser cost profile
+    // is built from, so the layout (accurate / favor_small_offsets /
+    // max_chain_depth / sufficient_match_len) cannot regress
+    // silently.
     const _COST_MODEL_LAYOUT: () = {
         assert!(!Lazy::ACCURATE_PRICE && Lazy::FAVOR_SMALL_OFFSETS);
         assert!(!BtOpt::ACCURATE_PRICE && BtOpt::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra::ACCURATE_PRICE && !BtUltra::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra2::ACCURATE_PRICE && !BtUltra2::FAVOR_SMALL_OFFSETS);
+        assert!(BtOpt::MAX_CHAIN_DEPTH == 32);
+        assert!(BtUltra::MAX_CHAIN_DEPTH == 32);
+        assert!(BtUltra2::MAX_CHAIN_DEPTH == 512);
+        assert!(BtOpt::SUFFICIENT_MATCH_LEN == usize::MAX);
+        assert!(BtUltra::SUFFICIENT_MATCH_LEN == usize::MAX);
+        assert!(BtUltra2::SUFFICIENT_MATCH_LEN == usize::MAX);
     };
 }

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -109,8 +109,17 @@ impl Strategy for Fast {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
-    // Optimal-parser consts are unreachable for non-BT strategies —
-    // pin them to the Lazy2 row so the trait stays total.
+    // `MAX_CHAIN_DEPTH` / `SUFFICIENT_MATCH_LEN` are placeholder
+    // values for non-BT strategies — the trait associated consts
+    // must be total, but only the optimal parser reads them and
+    // it runs exclusively under `S::USE_BT == true`. The
+    // `debug_assert!(<S>::USE_BT, …)` guard in
+    // `HcOptimalCostProfile::const_for_strategy` plus the
+    // `debug_assert!(<S>::USE_BT, …)` at the top of
+    // `build_optimal_plan_impl_body!` make this unreachable in
+    // debug builds. Future refactors that introduce a non-BT
+    // reader must add a fresh guard or replace these placeholders
+    // with real Fast values.
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -127,6 +136,8 @@ impl Strategy for Dfast {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
+    // Placeholder optimal-parser consts; see `Fast` for the
+    // unreachable-by-design contract.
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -143,6 +154,8 @@ impl Strategy for Greedy {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
+    // Placeholder optimal-parser consts; see `Fast` for the
+    // unreachable-by-design contract.
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -162,6 +175,12 @@ impl Strategy for Lazy {
     const USE_HASH3: bool = false;
     const USE_BT: bool = false;
     const OPT_LEVEL: u8 = 0;
+    // Lazy is HashChain-backed but `USE_BT == false`, so the optimal
+    // parser entry point is unreachable for this strategy. These
+    // values mirror the donor `lazy2` cost profile (would be the
+    // right defaults if a future caller did build a profile for the
+    // lazy/hc path), but with no current reader the same
+    // unreachable-by-design contract from `Fast` applies.
     const MAX_CHAIN_DEPTH: usize = 8;
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
@@ -271,8 +290,15 @@ impl StrategyTag {
                 if n <= 0 {
                     if n == 0 { Self::Dfast } else { Self::Fast }
                 } else {
-                    let clamped = (n as u8).min(CompressionLevel::MAX_LEVEL as u8);
-                    Self::for_level(clamped)
+                    // Clamp in `i32` BEFORE casting to `u8`: a bare
+                    // `n as u8` truncates values ≥ 256 (e.g.
+                    // `Level(256)` wraps to `0`, `Level(257)` to
+                    // `1`) and silently routes them to the wrong
+                    // strategy. `MAX_LEVEL` (22) fits a u8 by
+                    // definition, so the cast after the i32 clamp
+                    // is lossless.
+                    let clamped_i32 = n.clamp(1, CompressionLevel::MAX_LEVEL);
+                    Self::for_level(clamped_i32 as u8)
                 }
             }
         }
@@ -306,6 +332,35 @@ mod tests {
         assert_strategy_matches_tag::<BtOpt>(StrategyTag::BtOpt);
         assert_strategy_matches_tag::<BtUltra>(StrategyTag::BtUltra);
         assert_strategy_matches_tag::<BtUltra2>(StrategyTag::BtUltra2);
+    }
+
+    #[test]
+    fn for_compression_level_clamps_oversized_numeric_levels_to_btultra2() {
+        // Regression: pre-fix `Level(256)` cast `n as u8` first,
+        // wrapping to `0` and routing to `Dfast`. After clamp-then-
+        // cast every level above MAX_LEVEL (22) must land on
+        // BtUltra2 (the saturating top of the band).
+        use crate::encoding::CompressionLevel;
+        assert_eq!(
+            StrategyTag::for_compression_level(CompressionLevel::Level(23)),
+            StrategyTag::BtUltra2,
+        );
+        assert_eq!(
+            StrategyTag::for_compression_level(CompressionLevel::Level(255)),
+            StrategyTag::BtUltra2,
+        );
+        assert_eq!(
+            StrategyTag::for_compression_level(CompressionLevel::Level(256)),
+            StrategyTag::BtUltra2,
+        );
+        assert_eq!(
+            StrategyTag::for_compression_level(CompressionLevel::Level(257)),
+            StrategyTag::BtUltra2,
+        );
+        assert_eq!(
+            StrategyTag::for_compression_level(CompressionLevel::Level(i32::MAX)),
+            StrategyTag::BtUltra2,
+        );
     }
 
     #[test]

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -1,25 +1,18 @@
-//! Encoder strategy enum + (eventual) const-generic strategy dispatch.
+//! Encoder strategy enum + const-generic strategy dispatch (Phase 3 of
+//! #111).
 //!
-//! In Phase 1 of the #111 rewrite this file hosts only the
-//! [`HcParseMode`] enum — the dispatch tag that selects between the
-//! Lazy2 / BtOpt / BtUltra / BtUltra2 code paths in `match_generator`
-//! and `cost_model`. Hosting it here breaks what would otherwise be a
-//! reverse dependency from `cost_model` back into the monolith
-//! (`super::match_generator`) and gives both consumers a neutral place
-//! to import from.
+//! Phase 1 introduced the [`HcParseMode`] runtime enum that gates the
+//! Lazy2 / BtOpt / BtUltra / BtUltra2 code paths inside `HcMatchGenerator`
+//! and `cost_model`. Phase 3 lifts that decision (and the parallel
+//! `MatcherBackend` runtime tag in `match_generator`) into the type
+//! system: each `level → Strategy` mapping is a concrete ZST that
+//! implements the [`Strategy`] trait. Hot-path entry points become
+//! generic over `S: Strategy` and the compiler monomorphises the inner
+//! loops per variant, dropping every dead `if S::FOO` branch at
+//! `codegen` time.
 //!
-//! Phase 3 will replace the runtime `match` over [`HcParseMode`] with a
-//! `Strategy` trait whose associated `const`s let the compiler
-//! monomorphise the entire encoder pipeline per-level. Each strategy
-//! carries:
-//!
-//! - `MIN_MATCH` — minimum match length the parser will produce
-//! - `ACCURATE_PRICE` / `FAVOR_SMALL_OFFSETS` — cost-model flags
-//! - `USE_HASH3` — compile-time gate equivalent to donor `static
-//!   (mls==3)` short-match probe inside `ZSTD_insertBtAndGetAllMatches`
-//! - `USE_BT` / `MAX_SEARCH_DEPTH` — match-finder shape
-//! - `OPT_LEVEL` — donor `optLevel` (0 = btopt, 2 = btultra/btultra2)
-//! - `type Matcher: MatchFinder` — concrete finder implementation
+//! The runtime enums survive until the per-call-site migration is
+//! complete; this module documents the bridge.
 
 #![allow(dead_code)]
 
@@ -33,4 +26,322 @@ pub(crate) enum HcParseMode {
     BtOpt,
     BtUltra,
     BtUltra2,
+}
+
+/// Donor `ZSTD_compressionParameters.strategy` equivalent — names the
+/// concrete match-finder backend a [`Strategy`] is paired with. Used in
+/// the transitional bridge between the [`Strategy`] trait and the
+/// existing `MatcherBackend` runtime enum.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum BackendTag {
+    /// `SimpleMatchGenerator` — level 1.
+    Simple,
+    /// `DfastMatchGenerator` — levels 2-3.
+    Dfast,
+    /// `RowMatchGenerator` — level 4.
+    Row,
+    /// `HcMatchGenerator` — levels 5-22.
+    HashChain,
+}
+
+/// Compile-time encoder strategy. Each concrete implementor is a ZST
+/// whose associated `const`s tell the optimal parser / match finder
+/// which donor-equivalent path to execute. The runtime [`HcParseMode`]
+/// enum will be removed once every read site is migrated to `if
+/// S::USE_BT` / `if S::USE_HASH3` / etc.
+///
+/// Donor parity reference: `ZSTD_compressionParameters` in
+/// `lib/compress/zstd_compress_internal.h` and the per-level table in
+/// `lib/compress/clevels.h`.
+pub(crate) trait Strategy: Copy + 'static {
+    /// Match-finder backend this strategy runs on.
+    const BACKEND: BackendTag;
+
+    /// Minimum match length the parser will produce.
+    const MIN_MATCH: usize;
+
+    /// `accurate` flag for [`crate::encoding::cost_model::HcOptimalCostProfile`]
+    /// — enables refined statistics weighting (donor `ZSTD_btultra` and
+    /// above).
+    const ACCURATE_PRICE: bool;
+
+    /// Donor "small offset bonus" toggle. Enabled for Lazy2 / BtOpt to
+    /// favour decompression speed; disabled for BtUltra / BtUltra2.
+    const FAVOR_SMALL_OFFSETS: bool;
+
+    /// Compile-time gate for the donor `static (mls==3)` short-match
+    /// probe inside `ZSTD_insertBtAndGetAllMatches`. Only BtUltra2
+    /// drives the hash3 table today.
+    const USE_HASH3: bool;
+
+    /// Whether the optimal parser walks the BT — `false` for Lazy2,
+    /// `true` for BtOpt / BtUltra / BtUltra2.
+    const USE_BT: bool;
+
+    /// Donor `optLevel` (0 = btopt, 2 = btultra / btultra2). Drives the
+    /// `opt_level >= 2` price-table refinement in
+    /// `build_optimal_plan_impl_body!`.
+    const OPT_LEVEL: u8;
+
+    /// Donor `parse_mode` mirror — kept as an associated const so the
+    /// transitional bridge between `Strategy` and the runtime
+    /// [`HcParseMode`] enum stays cheap to write.
+    const PARSE_MODE: HcParseMode;
+}
+
+/// Level 1 — donor `ZSTD_fast`. Single-table Simple matcher.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Fast;
+
+impl Strategy for Fast {
+    const BACKEND: BackendTag = BackendTag::Simple;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = false;
+    const OPT_LEVEL: u8 = 0;
+    // Simple backend does not actually consult parse_mode; pick the
+    // narrowest variant for the bridge.
+    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+}
+
+/// Levels 2-3 — donor `ZSTD_dfast`. Two parallel hash chains.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Dfast;
+
+impl Strategy for Dfast {
+    const BACKEND: BackendTag = BackendTag::Dfast;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = false;
+    const OPT_LEVEL: u8 = 0;
+    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+}
+
+/// Level 4 — donor `ZSTD_greedy` with row hashing.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Greedy;
+
+impl Strategy for Greedy {
+    const BACKEND: BackendTag = BackendTag::Row;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = false;
+    const OPT_LEVEL: u8 = 0;
+    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+}
+
+/// Levels 5-15 — donor `ZSTD_lazy2` on a hash chain. Differ from each
+/// other by runtime `search_depth` / `hash_log` / `chain_log` /
+/// `target_len` / `lazy_depth` only — those are runtime
+/// `HcConfig` fields, not compile-time `Strategy` consts.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Lazy;
+
+impl Strategy for Lazy {
+    const BACKEND: BackendTag = BackendTag::HashChain;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = false;
+    const OPT_LEVEL: u8 = 0;
+    const PARSE_MODE: HcParseMode = HcParseMode::Lazy2;
+}
+
+/// Levels 16-17 — donor `ZSTD_btopt`. BT + opt without the ultra
+/// price-table refinements.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct BtOpt;
+
+impl Strategy for BtOpt {
+    const BACKEND: BackendTag = BackendTag::HashChain;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = true;
+    const OPT_LEVEL: u8 = 0;
+    const PARSE_MODE: HcParseMode = HcParseMode::BtOpt;
+}
+
+/// Levels 18-19 — donor `ZSTD_btultra`. BT + opt with refined price
+/// tables and no small-offset bias.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct BtUltra;
+
+impl Strategy for BtUltra {
+    const BACKEND: BackendTag = BackendTag::HashChain;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = true;
+    const FAVOR_SMALL_OFFSETS: bool = false;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = true;
+    const OPT_LEVEL: u8 = 2;
+    const PARSE_MODE: HcParseMode = HcParseMode::BtUltra;
+}
+
+/// Levels 20-22 — donor `ZSTD_btultra2`. BT + opt with the two-pass
+/// dynamic-statistics seed and the hash3 short-match table.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct BtUltra2;
+
+impl Strategy for BtUltra2 {
+    const BACKEND: BackendTag = BackendTag::HashChain;
+    const MIN_MATCH: usize = 4;
+    const ACCURATE_PRICE: bool = true;
+    const FAVOR_SMALL_OFFSETS: bool = false;
+    const USE_HASH3: bool = true;
+    const USE_BT: bool = true;
+    const OPT_LEVEL: u8 = 2;
+    const PARSE_MODE: HcParseMode = HcParseMode::BtUltra2;
+}
+
+/// Compile-time strategy tag for the per-level dispatcher. Each
+/// variant maps to exactly one [`Strategy`] implementor; the dispatcher
+/// stays runtime-tagged because it only fires once per frame on
+/// `reset()`, so the cost of a 7-arm match is invisible compared to
+/// the per-block hot-loop work it dispatches into.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum StrategyTag {
+    Fast,
+    Dfast,
+    Greedy,
+    Lazy,
+    BtOpt,
+    BtUltra,
+    BtUltra2,
+}
+
+impl StrategyTag {
+    /// Map a compression level (1..=22) to its [`StrategyTag`].
+    ///
+    /// Matches `LEVEL_TABLE` in `match_generator.rs` and the donor
+    /// `clevels.h` table:
+    /// * 1 → `Fast`
+    /// * 2-3 → `Dfast`
+    /// * 4 → `Greedy`
+    /// * 5-15 → `Lazy`
+    /// * 16-17 → `BtOpt`
+    /// * 18-19 → `BtUltra`
+    /// * 20-22 → `BtUltra2`
+    pub(crate) const fn for_level(level: u8) -> Self {
+        match level {
+            1 => Self::Fast,
+            2 | 3 => Self::Dfast,
+            4 => Self::Greedy,
+            5..=15 => Self::Lazy,
+            16 | 17 => Self::BtOpt,
+            18 | 19 => Self::BtUltra,
+            // Out-of-range levels collapse onto BtUltra2 — the
+            // existing `resolve_level_params` already clamps the
+            // numeric level into the table, this is just the matching
+            // tail.
+            _ => Self::BtUltra2,
+        }
+    }
+
+    /// Bridge to the runtime [`HcParseMode`] enum that the existing
+    /// `HcMatchGenerator` paths still consume. Will go away in the
+    /// final cleanup commit when the runtime enum is deleted.
+    pub(crate) const fn parse_mode(self) -> HcParseMode {
+        match self {
+            Self::Fast | Self::Dfast | Self::Greedy | Self::Lazy => HcParseMode::Lazy2,
+            Self::BtOpt => HcParseMode::BtOpt,
+            Self::BtUltra => HcParseMode::BtUltra,
+            Self::BtUltra2 => HcParseMode::BtUltra2,
+        }
+    }
+
+    /// Bridge to the runtime [`BackendTag`] for the dispatcher entry
+    /// point.
+    pub(crate) const fn backend(self) -> BackendTag {
+        match self {
+            Self::Fast => BackendTag::Simple,
+            Self::Dfast => BackendTag::Dfast,
+            Self::Greedy => BackendTag::Row,
+            Self::Lazy | Self::BtOpt | Self::BtUltra | Self::BtUltra2 => BackendTag::HashChain,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_strategy_matches_tag<S: Strategy>(tag: StrategyTag) {
+        assert_eq!(S::BACKEND, tag.backend(), "backend mismatch");
+        assert_eq!(S::PARSE_MODE, tag.parse_mode(), "parse_mode mismatch");
+    }
+
+    #[test]
+    fn strategy_consts_match_tag_bridge() {
+        assert_strategy_matches_tag::<Fast>(StrategyTag::Fast);
+        assert_strategy_matches_tag::<Dfast>(StrategyTag::Dfast);
+        assert_strategy_matches_tag::<Greedy>(StrategyTag::Greedy);
+        assert_strategy_matches_tag::<Lazy>(StrategyTag::Lazy);
+        assert_strategy_matches_tag::<BtOpt>(StrategyTag::BtOpt);
+        assert_strategy_matches_tag::<BtUltra>(StrategyTag::BtUltra);
+        assert_strategy_matches_tag::<BtUltra2>(StrategyTag::BtUltra2);
+    }
+
+    #[test]
+    fn level_to_tag_matches_donor_table() {
+        // Spot-check every band boundary and one mid-band level.
+        assert_eq!(StrategyTag::for_level(1), StrategyTag::Fast);
+        assert_eq!(StrategyTag::for_level(2), StrategyTag::Dfast);
+        assert_eq!(StrategyTag::for_level(3), StrategyTag::Dfast);
+        assert_eq!(StrategyTag::for_level(4), StrategyTag::Greedy);
+        assert_eq!(StrategyTag::for_level(5), StrategyTag::Lazy);
+        assert_eq!(StrategyTag::for_level(9), StrategyTag::Lazy);
+        assert_eq!(StrategyTag::for_level(15), StrategyTag::Lazy);
+        assert_eq!(StrategyTag::for_level(16), StrategyTag::BtOpt);
+        assert_eq!(StrategyTag::for_level(17), StrategyTag::BtOpt);
+        assert_eq!(StrategyTag::for_level(18), StrategyTag::BtUltra);
+        assert_eq!(StrategyTag::for_level(19), StrategyTag::BtUltra);
+        assert_eq!(StrategyTag::for_level(20), StrategyTag::BtUltra2);
+        assert_eq!(StrategyTag::for_level(22), StrategyTag::BtUltra2);
+    }
+
+    #[test]
+    fn use_bt_aligns_with_parse_mode() {
+        // Lazy2 strategies must not walk the BT; BtOpt / BtUltra /
+        // BtUltra2 must. This is the invariant that lets the inner
+        // optimal parser drop the `if self.parse_mode == Lazy2 …`
+        // branch in favour of `if !S::USE_BT`.
+        assert!(!Fast::USE_BT);
+        assert!(!Dfast::USE_BT);
+        assert!(!Greedy::USE_BT);
+        assert!(!Lazy::USE_BT);
+        assert!(BtOpt::USE_BT);
+        assert!(BtUltra::USE_BT);
+        assert!(BtUltra2::USE_BT);
+    }
+
+    #[test]
+    fn use_hash3_only_set_for_btultra2() {
+        // Donor parity: hash3 is exclusively a BtUltra2 feature.
+        assert!(!Fast::USE_HASH3);
+        assert!(!Dfast::USE_HASH3);
+        assert!(!Greedy::USE_HASH3);
+        assert!(!Lazy::USE_HASH3);
+        assert!(!BtOpt::USE_HASH3);
+        assert!(!BtUltra::USE_HASH3);
+        assert!(BtUltra2::USE_HASH3);
+    }
+
+    #[test]
+    fn accurate_and_favor_small_offsets_track_cost_model_for_mode() {
+        // Mirror the `HcOptimalCostProfile::for_mode` runtime table so
+        // the eventual `const_for::<S>` rewrite is a mechanical swap.
+        assert!(!Lazy::ACCURATE_PRICE && Lazy::FAVOR_SMALL_OFFSETS);
+        assert!(!BtOpt::ACCURATE_PRICE && BtOpt::FAVOR_SMALL_OFFSETS);
+        assert!(BtUltra::ACCURATE_PRICE && !BtUltra::FAVOR_SMALL_OFFSETS);
+        assert!(BtUltra2::ACCURATE_PRICE && !BtUltra2::FAVOR_SMALL_OFFSETS);
+    }
 }

--- a/zstd/tests/common/mod.rs
+++ b/zstd/tests/common/mod.rs
@@ -45,7 +45,14 @@ pub fn parse_zstd_block_breakdown(frame: &[u8]) -> Option<BlockBreakdown> {
         2 => 4,
         _ => 8,
     };
-    let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
+    let header_len = 5 + window_descriptor_len + dict_id_len + fcs_len;
+    // Guard against truncated frame headers — without this check the
+    // function would happily return `Some(BlockBreakdown::default())`
+    // for a 4-byte-magic-only input, which contradicts the docstring.
+    if frame.len() < header_len {
+        return None;
+    }
+    let mut off = header_len;
     let mut out = BlockBreakdown::default();
     while off + 3 <= frame.len() {
         let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);

--- a/zstd/tests/common/mod.rs
+++ b/zstd/tests/common/mod.rs
@@ -1,0 +1,87 @@
+//! Shared test utilities for integration probes.
+
+/// Block-type counts produced by [`parse_zstd_block_breakdown`].
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+pub struct BlockBreakdown {
+    pub raw: usize,
+    pub rle: usize,
+    pub compressed: usize,
+    pub total_block_bytes: usize,
+}
+
+/// Walk a complete zstd frame and tally block-type counts. The loop
+/// terminates on (a) the in-block `last_block` sentinel, or (b)
+/// running out of frame bytes — there is no fixed iteration cap, so
+/// large frames are not truncated.
+///
+/// Returns `None` if the input does not start with the zstd magic
+/// or is too short for a frame header.
+#[allow(dead_code)]
+pub fn parse_zstd_block_breakdown(frame: &[u8]) -> Option<BlockBreakdown> {
+    if frame.len() < 6 || &frame[..4] != b"\x28\xb5\x2f\xfd" {
+        return None;
+    }
+    let fhd = frame[4];
+    let single_segment = (fhd & 0x20) != 0;
+    let fcs_flag = fhd >> 6;
+    let dict_id_flag = fhd & 0x03;
+    let dict_id_len = match dict_id_flag {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        _ => 4,
+    };
+    let window_descriptor_len = if single_segment { 0 } else { 1 };
+    let fcs_len = match fcs_flag {
+        0 => {
+            if single_segment {
+                1
+            } else {
+                0
+            }
+        }
+        1 => 2,
+        2 => 4,
+        _ => 8,
+    };
+    let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
+    let mut out = BlockBreakdown::default();
+    while off + 3 <= frame.len() {
+        let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);
+        let last = h & 1;
+        let bt = (h >> 1) & 3;
+        let bs = (h >> 3) as usize;
+        let payload = if bt == 1 { 1 } else { bs };
+        let step = 3 + payload;
+        if off + step > frame.len() {
+            break;
+        }
+        match bt {
+            0 => out.raw += 1,
+            1 => out.rle += 1,
+            2 => out.compressed += 1,
+            _ => {}
+        }
+        out.total_block_bytes += bs;
+        off += step;
+        if last == 1 {
+            break;
+        }
+    }
+    Some(out)
+}
+
+/// Convenience wrapper for diagnostic test prints — formats the
+/// breakdown into the legacy diagnostic line shape used by the
+/// level22 probes.
+#[allow(dead_code)]
+pub fn dump_block_breakdown(label: &str, frame: &[u8]) {
+    match parse_zstd_block_breakdown(frame) {
+        Some(bb) => println!(
+            "  {label}: raw={}, rle={}, compressed={}, total_block_bytes={}",
+            bb.raw, bb.rle, bb.compressed, bb.total_block_bytes
+        ),
+        None => println!("  {label}: not a zstd frame"),
+    }
+}

--- a/zstd/tests/corpus_level22_gap.rs
+++ b/zstd/tests/corpus_level22_gap.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::Path;
 use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
 
+mod common;
+
 #[test]
 #[ignore = "manual probe — run with --ignored"]
 fn corpus_z000033_level22_ratio_breakdown() {
@@ -22,65 +24,8 @@ fn corpus_z000033_level22_ratio_breakdown() {
     // Count block types in each output so we can tell if the gap is
     // structural (different block split decisions) or content
     // (per-block entropy differences within identical splits).
-    fn block_breakdown(label: &str, frame: &[u8]) -> (usize, usize, usize, usize) {
-        if frame.len() < 6 || &frame[..4] != b"\x28\xb5\x2f\xfd" {
-            return (0, 0, 0, 0);
-        }
-        let fhd = frame[4];
-        let single_segment = (fhd & 0x20) != 0;
-        let fcs_flag = fhd >> 6;
-        let dict_id_flag = fhd & 0x03;
-        let dict_id_len = match dict_id_flag {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            _ => 4,
-        };
-        let window_descriptor_len = if single_segment { 0 } else { 1 };
-        let fcs_len = match fcs_flag {
-            0 => {
-                if single_segment {
-                    1
-                } else {
-                    0
-                }
-            }
-            1 => 2,
-            2 => 4,
-            _ => 8,
-        };
-        let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
-        let mut raw = 0;
-        let mut rle = 0;
-        let mut compressed = 0;
-        let mut total = 0;
-        for _ in 0..256 {
-            if off + 3 > frame.len() {
-                break;
-            }
-            let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);
-            let last = h & 1;
-            let bt = (h >> 1) & 3;
-            let bs = (h >> 3) as usize;
-            match bt {
-                0 => raw += 1,
-                1 => rle += 1,
-                2 => compressed += 1,
-                _ => {}
-            }
-            total += bs;
-            off += 3 + if bt == 1 { 1 } else { bs };
-            if last == 1 {
-                break;
-            }
-        }
-        println!(
-            "  {label}: raw={raw}, rle={rle}, compressed={compressed}, total_block_bytes={total}"
-        );
-        (raw, rle, compressed, total)
-    }
-    block_breakdown("Rust", &rust);
-    block_breakdown("C   ", &c);
+    common::dump_block_breakdown("Rust", &rust);
+    common::dump_block_breakdown("C   ", &c);
 
     // Sanity: outputs must roundtrip.
     let rt = zstd::bulk::decompress(&rust, data.len() + 64).unwrap();

--- a/zstd/tests/corpus_level22_gap.rs
+++ b/zstd/tests/corpus_level22_gap.rs
@@ -1,0 +1,93 @@
+use std::fs;
+use std::path::Path;
+use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+
+#[test]
+#[ignore = "manual probe — run with --ignored"]
+fn corpus_z000033_level22_ratio_breakdown() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("decodecorpus_files/z000033");
+    let data = fs::read(&path).expect("z000033 corpus file present");
+    println!("Corpus z000033 size: {} bytes", data.len());
+
+    let rust = compress_to_vec(&data[..], CompressionLevel::Level(22));
+    let c = zstd::bulk::compress(&data[..], 22).unwrap();
+    let delta = rust.len() as i64 - c.len() as i64;
+    let pct = (rust.len() as f64 / c.len() as f64 - 1.0) * 100.0;
+    println!(
+        "Level 22 output:  rust={}  c={}  delta={delta:+}b ({pct:+.4}%)",
+        rust.len(),
+        c.len()
+    );
+
+    // Count block types in each output so we can tell if the gap is
+    // structural (different block split decisions) or content
+    // (per-block entropy differences within identical splits).
+    fn block_breakdown(label: &str, frame: &[u8]) -> (usize, usize, usize, usize) {
+        if frame.len() < 6 || &frame[..4] != b"\x28\xb5\x2f\xfd" {
+            return (0, 0, 0, 0);
+        }
+        let fhd = frame[4];
+        let single_segment = (fhd & 0x20) != 0;
+        let fcs_flag = fhd >> 6;
+        let dict_id_flag = fhd & 0x03;
+        let dict_id_len = match dict_id_flag {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            _ => 4,
+        };
+        let window_descriptor_len = if single_segment { 0 } else { 1 };
+        let fcs_len = match fcs_flag {
+            0 => {
+                if single_segment {
+                    1
+                } else {
+                    0
+                }
+            }
+            1 => 2,
+            2 => 4,
+            _ => 8,
+        };
+        let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
+        let mut raw = 0;
+        let mut rle = 0;
+        let mut compressed = 0;
+        let mut total = 0;
+        for _ in 0..256 {
+            if off + 3 > frame.len() {
+                break;
+            }
+            let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);
+            let last = h & 1;
+            let bt = (h >> 1) & 3;
+            let bs = (h >> 3) as usize;
+            match bt {
+                0 => raw += 1,
+                1 => rle += 1,
+                2 => compressed += 1,
+                _ => {}
+            }
+            total += bs;
+            off += 3 + if bt == 1 { 1 } else { bs };
+            if last == 1 {
+                break;
+            }
+        }
+        println!(
+            "  {label}: raw={raw}, rle={rle}, compressed={compressed}, total_block_bytes={total}"
+        );
+        (raw, rle, compressed, total)
+    }
+    block_breakdown("Rust", &rust);
+    block_breakdown("C   ", &c);
+
+    // Sanity: outputs must roundtrip.
+    let rt = zstd::bulk::decompress(&rust, data.len() + 64).unwrap();
+    assert_eq!(
+        rt.len(),
+        data.len(),
+        "rust output decompresses to wrong size"
+    );
+    assert_eq!(rt, data, "rust output decompresses to different bytes");
+}

--- a/zstd/tests/he_level22_ratio.rs
+++ b/zstd/tests/he_level22_ratio.rs
@@ -1,6 +1,8 @@
 use rand::{RngExt, SeedableRng, rngs::SmallRng};
 use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
 
+mod common;
+
 #[test]
 #[ignore = "manual perf probe — run with --ignored"]
 fn high_entropy_level22_ratio_and_speed() {
@@ -43,71 +45,9 @@ fn high_entropy_level22_ratio_and_speed() {
         our_avg.as_secs_f64() / c_avg.as_secs_f64()
     );
 
-    // Block-type breakdown — frame header at the start, then series of
-    // 3-byte block headers each carrying (last_block, block_type, size).
-    fn dump_block_types(label: &str, frame: &[u8]) {
-        // Frame magic: 4 bytes 0x28 0xB5 0x2F 0xFD. Frame header
-        // descriptor is the next byte; full parsing is non-trivial,
-        // so just scan known offsets by reading the descriptor and
-        // skipping accordingly.
-        if frame.len() < 6 || &frame[..4] != b"\x28\xb5\x2f\xfd" {
-            println!("  {label}: not a zstd frame");
-            return;
-        }
-        let fhd = frame[4];
-        let single_segment = (fhd & 0x20) != 0;
-        let fcs_flag = fhd >> 6;
-        let dict_id_flag = fhd & 0x03;
-        let dict_id_len = match dict_id_flag {
-            0 => 0,
-            1 => 1,
-            2 => 2,
-            _ => 4,
-        };
-        let window_descriptor_len = if single_segment { 0 } else { 1 };
-        let fcs_len = match fcs_flag {
-            0 => {
-                if single_segment {
-                    1
-                } else {
-                    0
-                }
-            }
-            1 => 2,
-            2 => 4,
-            _ => 8,
-        };
-        let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
-        let mut raw = 0usize;
-        let mut rle = 0usize;
-        let mut compressed = 0usize;
-        let mut total_size = 0usize;
-        for _ in 0..64 {
-            if off + 3 > frame.len() {
-                break;
-            }
-            let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);
-            let last = h & 1;
-            let block_type = (h >> 1) & 3;
-            let block_size = (h >> 3) as usize;
-            match block_type {
-                0 => raw += 1,
-                1 => rle += 1,
-                2 => compressed += 1,
-                _ => {}
-            }
-            total_size += block_size;
-            off += 3 + if block_type == 1 { 1 } else { block_size };
-            if last == 1 {
-                break;
-            }
-        }
-        println!(
-            "  {label}: raw={raw}, rle={rle}, compressed={compressed}, total_block_bytes={total_size}"
-        );
-    }
-    dump_block_types("Rust", &compressed);
-    dump_block_types("C   ", &c_compressed);
+    // Block-type breakdown — shared parser in `tests/common`.
+    common::dump_block_breakdown("Rust", &compressed);
+    common::dump_block_breakdown("C   ", &c_compressed);
 
     // Hypothesis: our raw-fast-path is gated on
     // `compression_level_allows_raw_fast_path(level, window_size)`

--- a/zstd/tests/he_level22_ratio.rs
+++ b/zstd/tests/he_level22_ratio.rs
@@ -1,0 +1,142 @@
+use rand::{RngExt, SeedableRng, rngs::SmallRng};
+use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+
+#[test]
+#[ignore = "manual perf probe — run with --ignored"]
+fn high_entropy_level22_ratio_and_speed() {
+    let mut rng = SmallRng::seed_from_u64(0xC0FF_EE11);
+    let mut data = vec![0u8; 1024 * 1024];
+    rng.fill(&mut data[..]);
+
+    // warm
+    let _ = compress_to_vec(&data[..], CompressionLevel::Level(22));
+    let _ = zstd::bulk::compress(&data[..], 22).unwrap();
+
+    let n_iter = 3u32;
+
+    let t0 = std::time::Instant::now();
+    let mut compressed = Vec::new();
+    for _ in 0..n_iter {
+        compressed = compress_to_vec(&data[..], CompressionLevel::Level(22));
+    }
+    let our_avg = t0.elapsed() / n_iter;
+    let our_size = compressed.len();
+
+    let t0 = std::time::Instant::now();
+    let mut c_compressed = Vec::new();
+    for _ in 0..n_iter {
+        c_compressed = zstd::bulk::compress(&data[..], 22).unwrap();
+    }
+    let c_avg = t0.elapsed() / n_iter;
+    let c_size = c_compressed.len();
+
+    println!("Input: {} bytes (random, seed 0xC0FFEE11)", data.len());
+    println!("Level 22 compress (avg over {n_iter} iters):");
+    println!("  Rust: {our_size} bytes in {our_avg:?}");
+    println!("  C:    {c_size} bytes in {c_avg:?}");
+    println!(
+        "  Size ratio (ours/c): {:.4}",
+        our_size as f64 / c_size as f64
+    );
+    println!(
+        "  Speed ratio (ours/c): {:.2}x",
+        our_avg.as_secs_f64() / c_avg.as_secs_f64()
+    );
+
+    // Block-type breakdown — frame header at the start, then series of
+    // 3-byte block headers each carrying (last_block, block_type, size).
+    fn dump_block_types(label: &str, frame: &[u8]) {
+        // Frame magic: 4 bytes 0x28 0xB5 0x2F 0xFD. Frame header
+        // descriptor is the next byte; full parsing is non-trivial,
+        // so just scan known offsets by reading the descriptor and
+        // skipping accordingly.
+        if frame.len() < 6 || &frame[..4] != b"\x28\xb5\x2f\xfd" {
+            println!("  {label}: not a zstd frame");
+            return;
+        }
+        let fhd = frame[4];
+        let single_segment = (fhd & 0x20) != 0;
+        let fcs_flag = fhd >> 6;
+        let dict_id_flag = fhd & 0x03;
+        let dict_id_len = match dict_id_flag {
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            _ => 4,
+        };
+        let window_descriptor_len = if single_segment { 0 } else { 1 };
+        let fcs_len = match fcs_flag {
+            0 => {
+                if single_segment {
+                    1
+                } else {
+                    0
+                }
+            }
+            1 => 2,
+            2 => 4,
+            _ => 8,
+        };
+        let mut off = 5 + window_descriptor_len + dict_id_len + fcs_len;
+        let mut raw = 0usize;
+        let mut rle = 0usize;
+        let mut compressed = 0usize;
+        let mut total_size = 0usize;
+        for _ in 0..64 {
+            if off + 3 > frame.len() {
+                break;
+            }
+            let h = u32::from_le_bytes([frame[off], frame[off + 1], frame[off + 2], 0]);
+            let last = h & 1;
+            let block_type = (h >> 1) & 3;
+            let block_size = (h >> 3) as usize;
+            match block_type {
+                0 => raw += 1,
+                1 => rle += 1,
+                2 => compressed += 1,
+                _ => {}
+            }
+            total_size += block_size;
+            off += 3 + if block_type == 1 { 1 } else { block_size };
+            if last == 1 {
+                break;
+            }
+        }
+        println!(
+            "  {label}: raw={raw}, rle={rle}, compressed={compressed}, total_block_bytes={total_size}"
+        );
+    }
+    dump_block_types("Rust", &compressed);
+    dump_block_types("C   ", &c_compressed);
+
+    // Hypothesis: our raw-fast-path is gated on
+    // `compression_level_allows_raw_fast_path(level, window_size)`
+    // which for `Level(22)` requires `window_size <= 8 MiB`. On a
+    // 1 MiB source-size hint, level 22 shrinks to window_log=20 ->
+    // 1 MiB window ≤ 8 MiB, so the path is allowed and
+    // `block_looks_incompressible(random)` short-circuits the matcher.
+    // Without the hint, window stays at 128 MiB → fast path disabled
+    // → full DP runs → expect ~C-zstd-equivalent timing.
+    use structured_zstd::encoding::FrameCompressor;
+
+    let t0 = std::time::Instant::now();
+    let mut no_hint_compressed = Vec::new();
+    for _ in 0..n_iter {
+        no_hint_compressed.clear();
+        let mut comp = FrameCompressor::new(CompressionLevel::Level(22));
+        // intentionally NO set_source_size_hint
+        comp.set_source(&data[..]);
+        comp.set_drain(&mut no_hint_compressed);
+        comp.compress();
+    }
+    let no_hint_avg = t0.elapsed() / n_iter;
+    println!(
+        "  Rust (no source-size hint, window=128 MiB → fast path disabled): {} bytes in {:?}",
+        no_hint_compressed.len(),
+        no_hint_avg,
+    );
+    println!(
+        "    delta vs hinted path: {:.1}x slower",
+        no_hint_avg.as_secs_f64() / our_avg.as_secs_f64()
+    );
+}

--- a/zstd/tests/incompressibility_falsepos.rs
+++ b/zstd/tests/incompressibility_falsepos.rs
@@ -1,0 +1,104 @@
+use rand::{Rng, RngExt, SeedableRng, rngs::SmallRng};
+use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+
+fn rust_size(data: &[u8], level: i32) -> usize {
+    compress_to_vec(data, CompressionLevel::Level(level)).len()
+}
+
+fn c_size(data: &[u8], level: i32) -> usize {
+    zstd::bulk::compress(data, level).unwrap().len()
+}
+
+fn report(name: &str, data: &[u8], level: i32) -> (usize, usize) {
+    let r = rust_size(data, level);
+    let c = c_size(data, level);
+    let delta_bytes = r as i64 - c as i64;
+    let delta_pct = (r as f64 / c as f64 - 1.0) * 100.0;
+    println!(
+        "  {name:<30} input={}  rust={r}  c={c}  delta={delta_bytes:+}b ({delta_pct:+.2}%)",
+        data.len()
+    );
+    (r, c)
+}
+
+/// Probe the incompressibility detector on data that sits at the
+/// boundary between "obviously random" and "obviously compressible".
+/// If we emit a raw block on something C can compress, the ratio gap
+/// here will be large and positive (we output much more than C).
+#[test]
+#[ignore = "manual probe — run with --ignored"]
+fn marginal_compressibility_at_level22() {
+    println!("== Level 22 marginal-compressibility ratio probe ==");
+
+    // 1) Hard random — both should emit raw, sizes within frame
+    //    overhead (a few bytes).
+    let mut rng = SmallRng::seed_from_u64(0xC0FF_EE11);
+    let mut hard = vec![0u8; 1024 * 1024];
+    rng.fill(&mut hard[..]);
+    let (r, c) = report("hard-random-1m", &hard, 22);
+    assert!(
+        (r as i64 - c as i64).abs() < 64,
+        "hard-random output sizes should match within frame overhead"
+    );
+
+    // 2) Mixed: 75% random + 25% pattern stitched. C zstd should
+    //    compress the pattern halves. If our incompressibility
+    //    detector false-positives on the *block* containing pattern,
+    //    we'll be much bigger than C.
+    let pattern = b"coordinode:segment:0001|tenant=demo|label=orders|";
+    let mut mixed = Vec::with_capacity(1024 * 1024);
+    let mut rng2 = SmallRng::seed_from_u64(0xC0DE);
+    while mixed.len() < 1024 * 1024 {
+        // 4 KB random + 1 KB pattern in turn.
+        let random_chunk_len = 4 * 1024;
+        let pattern_chunk_len = 1024;
+        let mut buf = vec![0u8; random_chunk_len];
+        rng2.fill(&mut buf[..]);
+        mixed.extend_from_slice(&buf);
+        let mut written = 0;
+        while written < pattern_chunk_len && mixed.len() < 1024 * 1024 {
+            let take = pattern.len().min(pattern_chunk_len - written);
+            mixed.extend_from_slice(&pattern[..take]);
+            written += take;
+        }
+    }
+    mixed.truncate(1024 * 1024);
+    let (r_mix, c_mix) = report("mixed-rand+pattern", &mixed, 22);
+    let mix_pct = (r_mix as f64 / c_mix as f64 - 1.0) * 100.0;
+    println!("    => mixed gap: {mix_pct:+.2}%");
+
+    // 3) Marginal: text with periodic structure (English-ish gibberish
+    //    from a Markov-like noise source).
+    let mut markov = Vec::with_capacity(1024 * 1024);
+    let alphabet = b"abcdefghijklmnopqrstuvwxyz       ,.";
+    let mut state = 0u32;
+    let mut rng3 = SmallRng::seed_from_u64(42);
+    while markov.len() < 1024 * 1024 {
+        state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+        let mix = rng3.next_u32();
+        let idx = ((state ^ mix) as usize) % alphabet.len();
+        markov.push(alphabet[idx]);
+    }
+    let (_r_t, _c_t) = report("textish-1m", &markov, 22);
+
+    // 4) Low entropy (highly compressible pattern) — both should hit
+    //    near-zero output. Sanity check.
+    let pattern_only: Vec<u8> = pattern.iter().cycle().take(1024 * 1024).copied().collect();
+    let (r_p, c_p) = report("pattern-only-1m", &pattern_only, 22);
+    assert!(
+        r_p < 1024,
+        "pattern-only must compress to <1 KiB, got {r_p}"
+    );
+    assert!(
+        c_p < 1024,
+        "pattern-only C output must compress to <1 KiB, got {c_p}"
+    );
+
+    // The acceptance signal: in the mixed scenario, if we emit raw on
+    // pattern-bearing blocks we'll be many tens of KiB larger than C.
+    // Tolerate up to +5% as noise from differing split decisions.
+    assert!(
+        mix_pct < 5.0,
+        "Possible incompressibility false-positive: mixed gap {mix_pct:+.2}% (>5%) — investigate"
+    );
+}


### PR DESCRIPTION
## Summary

Phase 3 of the #111 encoder architecture rewrite — **replace runtime `enum HcParseMode` + `MatcherBackend` dispatch with const-generic `Strategy` monomorphisation**. Closes #122.

After Phase 1 (#119) restructured the encoder into per-backend types and Phase 2 (#121) removed hot-path `saturating_*`, the residual default-level / level-22 perf gap was hypothesised to come from runtime `match self.parse_mode` / `match self.active_backend` branches firing on every encoded position. This phase lifts those choices into the type system: each `level → Strategy` mapping is now a concrete ZST that implements the `Strategy` trait. Hot-path entry points are generic over `S: Strategy`, the compiler monomorphises the inner loops per variant, and every `if S::FOO` branch resolves at codegen time.

## Architectural mechanism

```text
Matcher::start_matching                              // 7-arm match on StrategyTag (per block)
 └─ compress_block::<S>                              // S::BACKEND const match
     ├─ Simple/Dfast/Row                             // backends without parse_mode
     └─ HcMatchGenerator::start_matching_strategy::<S>
         ├─ S::USE_BT == false → start_matching_lazy
         └─ S::USE_BT == true  → start_matching_optimal::<S>
             ├─ HcOptimalCostProfile::const_for_strategy::<S>()
             ├─ should_run_btultra2_seed_pass::<S>           // const false unless S = BtUltra2
             └─ build_optimal_plan::<S>
                 └─ build_optimal_plan_impl::<S, ACC, FAV>
                     └─ SIMD wrapper::<S, ACC, FAV>
                         └─ build_optimal_plan_impl_body!(S)
                             ├─ S::OPT_LEVEL == 0  → abort_on_worse_match
                             ├─ S::OPT_LEVEL >= 2  → opt_level (refined)
                             └─ $collect::<S, true>
                                 └─ collect_optimal_candidates_initialized_body!(S)
                                     └─ S::USE_HASH3 → hash3 lookup (const-gated)
```

`LevelParams` is the single source of truth from `CompressionLevel` to strategy: it carries `strategy_tag: StrategyTag`, and the runtime `BackendTag` consumed by the driver dispatcher is derived via `StrategyTag::backend()`. `reset()` reads `params.strategy_tag` directly — there is no second `for_compression_level(level)` recomputation that could drift.

## Commit map (20 commits)

**Core dispatch (commits 1-10):**

1. **`c7c0c76e`** — `Strategy` trait + 7 ZST types (`Fast` / `Dfast` / `Greedy` / `Lazy` / `BtOpt` / `BtUltra` / `BtUltra2`). Associated consts: `BACKEND`, `MIN_MATCH`, `ACCURATE_PRICE`, `FAVOR_SMALL_OFFSETS`, `USE_HASH3`, `USE_BT`, `OPT_LEVEL`, `MAX_CHAIN_DEPTH`, `SUFFICIENT_MATCH_LEN`. `StrategyTag::for_level(u8)` mirrors `LEVEL_TABLE` row-for-row.
2. **`46b0ef94`** — plumb `StrategyTag` into `MatchGeneratorDriver`.
3. **`e27a2e96`** — `compress_block<S>` generic entry on the driver.
4. **`5c5adfaf`** — `S::USE_BT` replaces `match parse_mode` in HC dispatch.
5. **`8f599fba`** — DP body const-folds `abort_on_worse_match` / `opt_level` from `S::OPT_LEVEL`. Primary hot-path commit.
6. **`d5d29ac1`** — diagnostic perf probes (`#[ignore]`'d).
7. **`dd6f23cd`** — `S::USE_HASH3` const-gates the hash3 lookup.
8. **`d8355d16`** — btultra2 seed pass gated on `S::OPT_LEVEL && S::USE_HASH3`.
9. **`23839074`** — `HcOptimalCostProfile::const_for_strategy<S>()`.
10. **`30f1c9a7`** — full rip-out of `HcParseMode` + `MatcherBackend` runtime enums, the `parse_mode` field on `HcConfig` and `HcMatchGenerator`, `Strategy::PARSE_MODE`, the runtime `for_mode(HcParseMode, bool)` API.

**CI infrastructure (commits 11-12, 16, 19):**

11. **`97a8ab28`** — split bench matrix per level (target × level = 18 shards) + `benchmark-aggregate` job; ~25 min wall-clock.
12. **`18bb80d3`** — `cargo fmt --check` fix.
16. **`ee62ec0a`** — separate `bench-build` (3 jobs) from `benchmark` (18 shards). Shards download a pre-built binary via `STRUCTURED_ZSTD_BENCH_BIN`; no `cargo` invocation in shards. Saves ~5 min per shard.
19. **`79f0955c`** — bench target inventory centralised behind a new `bench-matrix` job that emits the canonical JSON; `bench-build`, `benchmark`, `benchmark-aggregate`, `benchmark-pages` all consume `fromJSON(needs.bench-matrix.outputs.targets)`. Split per-target `build_setup` (run only on `bench-build`) from `runtime_setup` (run only on `benchmark` shards) — `x86_64-musl` no longer reinstalls `musl-tools` on every runtime shard. `benchmark-aggregate` ships a single combined `benchmark-aggregated` artifact, replacing the three hardcoded per-target uploads. Also refreshes stale migration comments in `match_generator.rs` (the const-generic dispatch had landed but the comments still framed it as future work).

**Post-review hardening (commits 13-15, 17-18, 20):**

13. **`372ef501`** — `strategy_tag` field on `HcMatchGenerator` (mirrored from driver during `configure()`). Test-only dispatchers route `BtOpt`/`BtUltra`/`BtUltra2` to distinct monomorphisations instead of collapsing. `Level(n)` clamp moved to `i32` before `u8` cast (`Level(256)` no longer wraps to `Dfast`); regression test added. `tests/common::dump_block_breakdown` shared parser, `--tests` `truncated frame header` guard. `supported_levels_filtered()` panics on unknown bench filter tokens.
14. **`910db7b3`** — collapse `pass2`-era profile-duplicate tests, identity `BackendTag → BackendTag` match dropped, seed pass uses `type S = BtUltra2` consistently, `parse_zstd_block_breakdown` returns `None` on truncated header, bench filter panics for *any* unknown token (not just empty result).
15. **`b63a37cd`** — `LevelParams` switched from `backend: BackendTag` to `strategy_tag: StrategyTag` with derived `backend()` method. `reset()` reads `params.strategy_tag` directly. Three `hc_collect_optimal_candidates_*_hash3_*` / `hc_hash3_tail_match_*` tests removed (they relied on a `hash3_log != 0` test-only escape hatch that masked an unreachable production state). Plus `retention-days: 7` on bench shard artifacts.
17. **`bdd88ffc`** — new `fuzz` CI matrix (5 targets — decode/encode/interop/huff0/fse). Each shard replays the existing `zstd/fuzz/artifacts/` regression corpus first, then runs 90s of fresh libFuzzer time. Crash artifacts uploaded on failure (14-day retention).
18. **`49f7f2c2`** — fuzz CI followup: `zstd/fuzz/Cargo.toml` had no `edition` field (defaulted to 2015, breaking `use structured_zstd::…`); pinned `RUSTUP_TOOLCHAIN=nightly` at the job env level so `cargo fuzz` survives the `rust-toolchain.toml` stable pin once it shells out to its inner `cargo build`.
20. **`bd02dc6e`** — `fuzz_targets/interop.rs` bug: `encode_szstd_uncompressed` / `encode_szstd_compressed` drained the input `Read` into a local `Vec` and then compressed the now-empty `Read`, so the encoding branches silently encoded zero bytes and the two corpus artifacts under `artifacts/interop/` triggered an assertion on every CI replay. Takes `&[u8]` directly now; `encode_szstd_compressed` uses `CompressionLevel::Default` instead of duplicating the uncompressed variant.

## Perf delta vs `perf/post-pr-121-baseline` (host x86_64-darwin, best of 5)

Note: the original #122 perf targets (≥30 % default-level, ≥15 % fast-level) were **not** hit. The const-generic dispatch by itself didn't move the needle on host because the runtime reads it replaces (`self.parse_mode`, `self.use_hash3`) were already cache-hot single-instruction loads with perfectly-predicted branches. The structural foundation is the real deliverable; the perf payoff is gated on Phase 4 (BT/HC specialization + donor fast paths).

| Scenario | Level | Baseline | HEAD | Δ |
|---|---|---|---|---|
| decodecorpus-z000033 | 1 | 19.36 ms | 18.87 ms | **−2.53 %** |
| decodecorpus-z000033 | 3 | 92.60 ms | 94.23 ms | +1.76 % |
| decodecorpus-z000033 | 7 | 91.17 ms | 92.02 ms | +0.93 % |
| decodecorpus-z000033 | 11 | 105.45 ms | 102.95 ms | **−2.37 %** |
| decodecorpus-z000033 | 22 | 372.44 ms | 366.61 ms | **−1.56 %** |
| high-entropy-1m | 1 | 0.741 ms | 0.706 ms | **−4.72 %** |
| high-entropy-1m | 7 | 1.19 ms | 1.12 ms | **−5.98 %** |
| high-entropy-1m | 11 | 1.66 ms | 1.51 ms | **−9.17 %** |
| high-entropy-1m | 22 | 2.67 ms | 2.81 ms | +5.59 % |
| low-entropy-1m | 1–22 | — | — | ±1 % (noise) |
| large-log-stream | 1 | 16.15 ms | 16.13 ms | −0.14 % |
| large-log-stream | 22 | 20.37 ms | 19.81 ms | **−2.74 %** |

## Architectural payoff

- **Type system enforces correctness:** `compress_block::<Fast>` cannot reach `start_matching_optimal` (no `USE_BT`); BtUltra2-only hash3 code is unreachable from non-BtUltra2 monomorphisations.
- **Single source of truth for strategy.** `LevelParams::strategy_tag` is the only authoritative mapping from `CompressionLevel` to strategy; the driver derives `BackendTag` from it instead of parallel-resolving the level twice.
- **`HcParseMode` and `MatcherBackend` removed**, single `BackendTag` + `StrategyTag` in `strategy.rs`.
- **Foundation for Phase 4-5 ready** — LDM, block splitter, BT/HC specialization can plug into the per-monomorphisation hot path without restructuring dispatch.
- **CI bench wall-clock** cut from ~45 min to ~25 min, with builds reused across the 18 bench shards (one build per target instead of one per shard). Bench target inventory now lives in a single `bench-matrix` JSON output consumed by every downstream bench job — adding a new target is a one-row change.
- **Fuzz coverage** restored — the existing `zstd/fuzz/` setup now runs every PR with regression-corpus replay + 90s libFuzzer per target. The replay step also surfaced (and we fixed) a real bug in the `interop` target that had silently encoded zero bytes since the fuzz crate was first written.

## Verification

- 457/457 nextest (3 tests removed in `b63a37cd` — they tested a production-unreachable `hash3_log != 0` + `search_depth = 0` state that the removed test-only escape hatch made possible).
- `cargo clippy` clean (default + `--tests` + `--benches`).
- `cargo fmt --check` clean.
- Build × 2 (default + `--no-default-features`) at every commit.
- Level22 ratio gate (`level22_sequences_match_donor_on_corpus_proxy`) green at every commit.
- Three new diagnostic probes (`#[ignore]`'d) document:
  - high-entropy-1m level22 speedup origin (source-size-hint-gated raw fast path)
  - incompressibility detector false-positive check (mixed-content + textish + pattern-only — all ratios identical to C ±7 byte frame overhead)
  - corpus z000033 +0.08 % gap is block-split heuristic (233 vs 256 compressed blocks), not core compression
- CI bench split round-tripped through a synthetic two-shard fixture; new bench-build pipeline smoke-tested locally with `STRUCTURED_ZSTD_BENCH_BIN=...`.

## Acceptance criteria from #122

- [x] `Strategy` trait + 7 concrete strategy types
- [x] `compress_block<S: Strategy>` top-level entry — `HcParseMode` runtime dispatch removed from inner loops
- [x] No `match self.parse_mode` or `if self.use_hash3` style branches on the encoded-position hot path
- [x] `HcParseMode` enum deleted (plus `MatcherBackend` deleted)
- [x] `cargo nextest run --features hash,std,dict_builder` 100 % pass
- [x] `level22_sequences_match_donor_on_corpus_proxy` ratio gate PASS on every commit
- [x] Roundtrip + cross-validation tests pass on every commit
- [x] Build clean (default + `--no-default-features`) + `cargo clippy --all-targets -- -D warnings` clean
- [ ] **Perf targets NOT met** — see report above. Phase 3 ships as architectural refactor; perf payoff deferred to Phase 4.

Closes #122. Refs #111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Encoder internals reorganized to a strategy-driven design, reducing runtime branching and improving hot-path performance.
* **CI**
  * Added nightly fuzz smoke job and reworked benchmarking into build, per-level shards, and a new aggregation step; publishing updated to use the consolidated benchmark artifact.
  * Benchmark runner can now use a prebuilt bench binary.
* **New Tools**
  * Added a script to merge per-level benchmark shards into per-target consolidated outputs.
* **Tests**
  * Added several ignored/manual probe tests and new frame-analysis test utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/123)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

