### PR TITLE
perf(encoding): #18 Phase 5 — LDM producer (gear hash + bucket table + search/emit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ structured-zstd = "0.0.20"
 ```rust
 use structured_zstd::encoding::{compress_to_vec, CompressionLevel};
 
-let compressed = compress_to_vec(b"hello world", CompressionLevel::from_level(7));
+let compressed = compress_to_vec(&b"hello world"[..], CompressionLevel::from_level(7));
 ```
 
 For `no_std` builds disable the default features:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml/badge.svg)](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/structured-zstd.svg)](https://crates.io/crates/structured-zstd)
 [![docs.rs](https://docs.rs/structured-zstd/badge.svg)](https://docs.rs/structured-zstd)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/structured-world/structured-zstd/blob/main/LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -1,88 +1,84 @@
 # structured-zstd
 
-Pure Rust zstd implementation — managed fork of [ruzstd](https://github.com/KillingSpark/zstd-rs).
+**Pure-Rust Zstandard codec with a production-grade decoder, dictionary handle reuse, and an actively-improved encoder. Builds with plain `cargo` — no cmake, no system zstd, no FFI. `no_std` ready for embedded.**
 
 [![CI](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml/badge.svg)](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/structured-zstd.svg)](https://crates.io/crates/structured-zstd)
 [![docs.rs](https://docs.rs/structured-zstd/badge.svg)](https://docs.rs/structured-zstd)
-[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/structured-world/structured-zstd/blob/main/LICENSE)
 
-## Benchmarks Dashboard
+## Quick start
 
-Historical benchmark charts are published to GitHub Pages:
+```toml
+[dependencies]
+structured-zstd = "0.0.20"
+```
 
-- [Performance dashboard](https://structured-world.github.io/structured-zstd/dev/bench/)
-- [Latest relative payload](https://structured-world.github.io/structured-zstd/dev/bench/benchmark-relative.json)
-- [Latest benchmark delta report](https://structured-world.github.io/structured-zstd/dev/bench/benchmark-delta.md)
-- [Latest full benchmark report](https://structured-world.github.io/structured-zstd/dev/bench/benchmark-report.md)
+```rust
+use structured_zstd::encoding::{compress_to_vec, CompressionLevel};
 
-Note: the root Pages URL can be empty; benchmark charts live under `/dev/bench/`.
+let compressed = compress_to_vec(b"hello world", CompressionLevel::from_level(7));
+```
 
-## Managed Fork
+For `no_std` builds disable the default features:
 
-This is a **maintained fork** of [KillingSpark/zstd-rs](https://github.com/KillingSpark/zstd-rs) (ruzstd) by [Structured World Foundation](https://sw.foundation). We maintain additional features and hardening for the [CoordiNode](https://github.com/structured-world/coordinode) database engine.
+```toml
+[dependencies]
+structured-zstd = { version = "0.0.20", default-features = false }
+```
 
-**Fork goals:**
-- Dictionary compression improvements (critical for per-label trained dictionaries in LSM-tree)
-- Performance parity with C zstd for decompression (currently 1.4-3.5x slower)
-- Full numeric compression levels (0 = default, 1–22 plus negative ultra-fast, with C zstd-compatible level numbering/API; not exact strategy/ratio parity at every level)
-- No FFI — pure `cargo build`, no cmake/system libraries (ADR-013 compliance)
+## Status
 
-**Upstream relationship:** We periodically sync with upstream but maintain an independent development trajectory focused on CoordiNode requirements.
+### Decoder — production-ready
 
-## What is this
+Complete [RFC 8878](https://www.rfc-editor.org/rfc/rfc8878) implementation, including dictionary-backed streams, raw / RLE / compressed blocks, and the full Zstandard frame format with optional content checksums.
 
-A pure Rust implementation of the Zstandard compression format, as defined in [RFC 8878](https://www.rfc-editor.org/rfc/rfc8878.pdf).
+### Encoder — full level range, active parity work
 
-This crate contains a fully operational decompressor and a compressor that is usable but does not yet match the speed, ratio, or configurability of the original C library.
+All standard compression levels are wired and produce valid Zstandard frames decodable by both this crate and upstream C zstd:
 
-## Current Status
+- **Named presets:** `Fastest` (≈1), `Default` (≈3), `Better` (≈7), `Best` (≈11)
+- **Numeric levels:** `0..=22` and negative ultra-fast levels via `CompressionLevel::from_level(n)` — C zstd-compatible numbering
+- **Streaming encoder** via `std::io::Write`
+- **Dictionary compression** with the same dictionary format C zstd consumes
+- **Frame Content Size** — `FrameCompressor` writes FCS automatically; `StreamingEncoder` requires `set_pledged_content_size()` before the first write
+- **Content checksums** opt-in
 
-### Decompression
+The encoder is undergoing an architectural rewrite — see [#111](https://github.com/structured-world/structured-zstd/issues/111) for the roadmap.
 
-Complete RFC 8878 implementation. Performance: ~1.4-3.5x slower than C zstd depending on data compressibility.
+### Dictionary training
 
-### Compression
+Behind the `dict_builder` feature flag, the `dictionary` module can:
 
-- [x] Uncompressed blocks
-- [x] Fastest (roughly level 1)
-- [x] Default (roughly level 3)
-- [x] Better (roughly level 7)
-- [x] Best (roughly level 11)
-- [x] Numeric levels `0` (default), `1–22`, and negative ultra-fast levels via `CompressionLevel::from_level(n)` (C zstd-compatible numbering)
-- [x] Checksums
-- [x] Frame Content Size — `FrameCompressor` writes FCS automatically; `StreamingEncoder` requires `set_pledged_content_size()` before first write
-- [x] Dictionary compression
-- [x] Streaming encoder (`io::Write`)
-
-### Compression Strategy Coverage
-
-Implemented strategy/back-end coverage:
-- Level 1: simple matcher (`Simple`)
-- Levels 2-3: `Dfast`
-- Level 4: row matcher (`Row`)
-- Levels 5-15: hash-chain matcher (`HashChain`) with lazy/lazy2 tuning
-- Levels 16-17: `btopt`-style price parser on top of hash-chain candidates
-- Levels 18-19: `btultra`-style price parser profile
-- Levels 20-22: `btultra2`-style dual-profile pass (choose lower-cost parse)
-
-Still not implemented as dedicated family:
-- `greedy`
-
-### Dictionary Generation
-
-When the `dict_builder` feature is enabled, the `dictionary` module can:
 - build raw dictionaries with COVER (`create_raw_dict_from_source`)
 - build raw dictionaries with FastCOVER (`create_fastcover_raw_dict_from_source`)
-- finalize raw content into full zstd dictionary format (`finalize_raw_dict`)
-- train+finalize in one pure-Rust flow (`create_fastcover_dict_from_source`)
-- propagate I/O failures from dictionary-building APIs via `io::Result` return values
+- finalize raw content into the full zstd dictionary format (`finalize_raw_dict`)
+- train + finalize in one pure-Rust flow (`create_fastcover_dict_from_source`)
 
-## Benchmarking
+<details>
+<summary>Internal: compression strategy backends</summary>
 
-Performance tracking lives in [BENCHMARKS.md](BENCHMARKS.md). The suite compares `structured-zstd` against the C reference across small payloads, entropy extremes, a `100 MiB` large-stream scenario, repository corpus fixtures, and optional local Silesia corpora. CI benchmark runs are now published as a multi-target matrix (`x86_64-gnu`, `i686-gnu`, `x86_64-musl`) and expose a relative-first payload (`benchmark-relative.json`) for dashboard filtering by `target/stage/scenario/level/source`.
+| Level range | Backend |
+|-------------|---------|
+| 1           | `Simple` matcher |
+| 2-3         | `Dfast` |
+| 4           | `Row` matcher |
+| 5-15        | `HashChain` with lazy / lazy2 tuning |
+| 16-17       | `btopt`-style price parser on top of hash-chain candidates |
+| 18-19       | `btultra`-style price parser profile |
+| 20-22       | `btultra2`-style dual-profile pass (choose lower-cost parse) |
 
-Benchmark report files are generated by `.github/scripts/run-benchmarks.sh` and are kept as ignored local/CI artifacts rather than tracked files in this repository.
+The `greedy` family is not implemented as a dedicated strategy yet — its target ratios are covered by adjacent levels.
+
+</details>
+
+## Performance
+
+Per-merge benchmarks publish to GitHub Pages: **[structured-world.github.io/structured-zstd/dev/bench](https://structured-world.github.io/structured-zstd/dev/bench/)**.
+
+The CI matrix covers `x86_64-linux-gnu`, `i686-linux-gnu`, and `x86_64-musl`; the dashboard exposes per-target / stage / scenario / level filtering. The encoder architecture rewrite ([#111](https://github.com/structured-world/structured-zstd/issues/111)) is the active surface for compression-side work; the public benchmark report tracks the delta vs upstream C zstd over time.
+
+See [BENCHMARKS.md](https://github.com/structured-world/structured-zstd/blob/main/BENCHMARKS.md) for the methodology — small payloads, entropy extremes, a `100 MiB` large-stream scenario, repository corpus fixtures, and optional local Silesia corpora.
 
 ## Usage
 
@@ -124,7 +120,7 @@ let mut result = Vec::new();
 decoder.read_to_end(&mut result).unwrap();
 ```
 
-### Dictionary-backed Decompression API
+### Dictionary-backed decompression
 
 ```rust,no_run
 use structured_zstd::decoding::{DictionaryHandle, FrameDecoder, StreamingDecoder};
@@ -154,7 +150,11 @@ let mut sink = Vec::new();
 stream.read_to_end(&mut sink).unwrap();
 ```
 
-## Support the Project
+## Project relationship
+
+Maintained fork of [KillingSpark/zstd-rs](https://github.com/KillingSpark/zstd-rs) (ruzstd) by the [Structured World Foundation](https://sw.foundation). We sync periodically with upstream but maintain an independent development trajectory focused on the [CoordiNode](https://github.com/structured-world/coordinode) database engine's per-label dictionary needs.
+
+## Support the project
 
 <div align="center">
 
@@ -166,6 +166,4 @@ USDT (TRC-20): `TFDsezHa1cBkoeZT5q2T49Wp66K8t2DmdA`
 
 ## License
 
-Apache License 2.0
-
-Contributions will be published under the same Apache 2.0 license.
+Apache License 2.0. Contributions will be published under the same Apache 2.0 license.

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -17,12 +17,18 @@ readme = "README.md"
 keywords = ["zstd", "zstandard", "decompression", "compression", "pure-rust"]
 categories = ["compression"]
 
-# docs.rs builds the crate with all features enabled so feature-gated items
-# (e.g. the `dictionary` module behind `dict_builder`) appear in the published
-# documentation. The `--cfg docsrs` flag activates the `#[cfg_attr(docsrs,
-# doc(cfg(...)))]` annotations that render feature badges on each item.
+# docs.rs builds the crate with the public feature set so feature-gated
+# items (e.g. the `dictionary` module behind `dict_builder`) appear in the
+# published documentation. We list the public features explicitly rather
+# than using `all-features = true` because the manifest also exposes
+# `rustc-dep-of-std` (libstd-build-only — swaps in `rustc-std-workspace-*`
+# crates), `bench_internals` (widens the API surface for benches), and
+# `fuzz_exports` (widens it for fuzz targets); none of these should appear
+# on docs.rs. The `--cfg docsrs` flag activates the
+# `#[cfg_attr(docsrs, doc(cfg(...)))]` annotations that render feature
+# badges on each item.
 [package.metadata.docs.rs]
-all-features = true
+features = ["std", "hash", "dict_builder"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -17,6 +17,14 @@ readme = "README.md"
 keywords = ["zstd", "zstandard", "decompression", "compression", "pure-rust"]
 categories = ["compression"]
 
+# docs.rs builds the crate with all features enabled so feature-gated items
+# (e.g. the `dictionary` module behind `dict_builder`) appear in the published
+# documentation. The `--cfg docsrs` flag activates the `#[cfg_attr(docsrs,
+# doc(cfg(...)))]` annotations that render feature badges on each item.
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 # Locked behind the `hash` feature flag
 twox-hash = { version = "2.0", default-features = false, features = ["xxhash64"], optional = true }

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -1,6 +1,25 @@
-//! Structures and utilities used for decoding zstd formatted data.
+//! RFC 8878 Zstandard decoder.
 //!
-//! Use [`DictionaryHandle`] for pre-parsed dictionary reuse across repeated decode paths.
+//! Three entry points are exposed, each with progressively lower-level
+//! control:
+//!
+//! * [`StreamingDecoder`] — implements [`crate::io::Read`] over a compressed
+//!   byte stream, transparently parsing the frame header and concatenated
+//!   frames. The typical choice for application code.
+//! * [`FrameDecoder`] — single-frame interface; use when the caller manages
+//!   the input buffer manually (zero-copy slices, network framing, etc).
+//! * [`DictionaryHandle`] — pre-parsed dictionary handle. Parse the
+//!   dictionary bytes once with [`DictionaryHandle::decode_dict`] and reuse
+//!   the handle across every subsequent decode; saves the per-frame
+//!   dictionary parse cost when the same dictionary is used many times in a
+//!   row.
+//!
+//! Both [`StreamingDecoder`] and [`FrameDecoder`] expose
+//! `_with_dictionary_handle` / `_with_dict_bytes` variants so the dictionary
+//! path can either reuse a parsed handle or pass raw bytes per frame.
+//!
+//! Errors surface through [`errors::FrameDecoderError`] and the per-decoder
+//! error types in the [`errors`] submodule.
 
 pub mod errors;
 mod frame_decoder;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -14,9 +14,17 @@
 //!   dictionary parse cost when the same dictionary is used many times in a
 //!   row.
 //!
-//! Both [`StreamingDecoder`] and [`FrameDecoder`] expose
-//! `_with_dictionary_handle` / `_with_dict_bytes` variants so the dictionary
-//! path can either reuse a parsed handle or pass raw bytes per frame.
+//! Both decoders expose dictionary-aware constructors / methods,
+//! though the exact naming differs:
+//!
+//! * [`StreamingDecoder::new_with_dictionary_handle`] /
+//!   [`StreamingDecoder::new_with_dictionary_bytes`]
+//! * [`FrameDecoder::decode_all_with_dict_handle`] /
+//!   [`FrameDecoder::decode_all_with_dict_bytes`]
+//!
+//! The `_handle` variants reuse a previously parsed
+//! [`DictionaryHandle`]; the `_bytes` variants parse the dictionary
+//! per call (suitable for one-off decodes).
 //!
 //! Errors surface through [`errors::FrameDecoderError`] and the per-decoder
 //! error types in the [`errors`] submodule.

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -20,6 +20,7 @@
 use alloc::vec::Vec;
 
 use super::cost_model::{HC_MAX_LIT, HcOptState, HcOptimalCostProfile};
+#[cfg(feature = "hash")]
 use super::ldm::LdmProducer;
 use super::opt::ldm::{HcOptLdmState, HcRawSeq, HcRawSeqStore};
 use super::opt::types::{HcOptimalNode, HcOptimalPlanBuffers, HcOptimalSequence, MatchCandidate};
@@ -70,7 +71,13 @@ pub(crate) struct BtMatcher {
     /// `prepare_ldm_candidates` call for a frame. `None` while LDM
     /// is opt-out (current default) so the table allocation only
     /// happens for callers that opt in. See
-    /// [`super::ldm::LdmProducer`].
+    /// [`super::ldm::LdmProducer`]. Gated behind the `hash`
+    /// feature because the producer's per-window XXH64 hashing
+    /// depends on the optional `twox-hash` dependency; under
+    /// `default-features = false` the field disappears and the
+    /// `prepare_ldm_candidates` body shrinks to the legacy
+    /// `ldm_sequences.clear()` stub.
+    #[cfg(feature = "hash")]
     pub(crate) ldm_producer: Option<LdmProducer>,
 }
 
@@ -123,6 +130,7 @@ impl BtMatcher {
             opt_ml_price_generation: Vec::new(),
             opt_ml_price_stamp: 0,
             ldm_sequences: Vec::new(),
+            #[cfg(feature = "hash")]
             ldm_producer: None,
         }
     }
@@ -146,6 +154,7 @@ impl BtMatcher {
         self.opt_ml_price_generation.clear();
         self.opt_ml_price_stamp = 0;
         self.ldm_sequences.clear();
+        #[cfg(feature = "hash")]
         if let Some(producer) = self.ldm_producer.as_mut() {
             producer.clear();
         }
@@ -359,6 +368,7 @@ impl BtMatcher {
         current_len: usize,
     ) {
         self.ldm_sequences.clear();
+        #[cfg(feature = "hash")]
         if let Some(producer) = self.ldm_producer.as_mut() {
             debug_assert!(current_abs_start >= history_abs_start);
             let block_end_abs = current_abs_start
@@ -370,6 +380,19 @@ impl BtMatcher {
                 current_abs_start,
                 block_end_abs,
                 &mut self.ldm_sequences,
+            );
+        }
+        #[cfg(not(feature = "hash"))]
+        {
+            // Under `default-features = false` (no `hash`),
+            // `LdmProducer` is not compiled — `live_history` /
+            // `history_abs_start` / `current_abs_start` /
+            // `current_len` would otherwise be unused.
+            let _ = (
+                live_history,
+                history_abs_start,
+                current_abs_start,
+                current_len,
             );
         }
     }
@@ -700,6 +723,7 @@ mod ldm_helper_tests {
     /// panic on the `history[block_start..block_end]` slice access
     /// inside `generate_into`.
     #[test]
+    #[cfg(feature = "hash")]
     fn prepare_ldm_candidates_translates_absolute_positions_to_slice_indices() {
         use crate::encoding::ldm::{LdmProducer, params::LdmParams};
 

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -701,13 +701,23 @@ mod ldm_helper_tests {
     /// inside `generate_into`.
     #[test]
     fn prepare_ldm_candidates_translates_absolute_positions_to_slice_indices() {
-        use crate::encoding::ldm::LdmProducer;
+        use crate::encoding::ldm::{LdmProducer, params::LdmParams};
 
         let mut bt = BtMatcher::new();
-        // Activate the producer with a small-but-real parameter
-        // set. The table allocation is bounded by hash_log so this
-        // stays cheap.
-        bt.ldm_producer = Some(LdmProducer::with_window_and_strategy(27, 9));
+        // Activate the producer with hand-tuned small params —
+        // the donor btultra2 defaults (`with_window_and_strategy(27, 9)`)
+        // would allocate `1 << 23 = 8M` entries × 8 bytes = 64 MiB
+        // for a table this test never actually populates beyond a
+        // handful of entries. Build a 10-bit hash log instead so
+        // the table is ~8 KiB — keeps the suite stable under
+        // parallel nextest on 32-bit / memory-tight CI shards.
+        bt.ldm_producer = Some(LdmProducer::new(LdmParams {
+            window_log: 27,
+            hash_log: 10,
+            hash_rate_log: 4,
+            min_match_length: 32,
+            bucket_size_log: 4,
+        }));
 
         // 256 bytes of arbitrary content — enough for the gear
         // hash to make progress against the donor btultra2

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -378,9 +378,25 @@ impl BtMatcher {
         #[cfg(feature = "hash")]
         if let Some(producer) = self.ldm_producer.as_mut() {
             debug_assert!(current_abs_start >= history_abs_start);
-            let block_end_abs = current_abs_start
-                .saturating_add(current_len)
-                .min(history_abs_start + live_history.len());
+            // MatchTable invariant: `live_history.len() ==
+            // window_size`, and `current_abs_start =
+            // history_abs_start + window_size − current_len`
+            // (match_generator.rs around line 1330). The two
+            // sides below must coincide; using `min(...)` would
+            // silently truncate the scanned range and mask an
+            // invariant violation. Raw `+` is safe — the frame-
+            // level `check_stream_abs_headroom`
+            // (`match_table/storage.rs:50`) guarantees
+            // `history_abs_start + window_size +
+            // STREAM_ABS_HEADROOM ≤ usize::MAX`.
+            debug_assert_eq!(
+                current_abs_start + current_len,
+                history_abs_start + live_history.len(),
+                "MatchTable invariant violation: current block range \
+                 `[current_abs_start, +current_len)` must coincide with the \
+                 live-history end (window_size == live_history.len())"
+            );
+            let block_end_abs = current_abs_start + current_len;
             producer.generate_into(
                 live_history,
                 history_abs_start,

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -351,8 +351,10 @@ impl BtMatcher {
     /// coordinates** (so its bucket-table entries remain valid
     /// across window evictions — entries inserted by an earlier
     /// view of the frame are filtered by the staleness check
-    /// `entry.offset <= history_abs_start`). The caller is
-    /// expected to pass:
+    /// `entry.offset < history_abs_start`, i.e. inclusive lower
+    /// bound: entries at exactly `history_abs_start` survive,
+    /// see `ldm::search::FindBestMatchInputs::lowest_index_abs`).
+    /// The caller is expected to pass:
     ///
     /// * `live_history` — the contiguous *live* slice of the
     ///   per-frame `MatchTable::history` (`&history[history_start..]`).

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -67,16 +67,23 @@ pub(crate) struct BtMatcher {
     /// parser. Built per-block during `start_matching_optimal` and
     /// drained as the parser advances.
     pub(crate) ldm_sequences: Vec<HcRawSeq>,
-    /// LDM producer — populated lazily on the first
-    /// `prepare_ldm_candidates` call for a frame. `None` while LDM
-    /// is opt-out (current default) so the table allocation only
-    /// happens for callers that opt in. See
-    /// [`super::ldm::LdmProducer`]. Gated behind the `hash`
-    /// feature because the producer's per-window XXH64 hashing
-    /// depends on the optional `twox-hash` dependency; under
-    /// `default-features = false` the field disappears and the
-    /// `prepare_ldm_candidates` body shrinks to the legacy
-    /// `ldm_sequences.clear()` stub.
+    /// LDM producer — `None` while LDM is opt-out (current
+    /// default) so the table allocation only happens for callers
+    /// that opt in. The producer is **never auto-constructed**:
+    /// every `CompressionLevel` preset leaves this field as
+    /// `None`, matching upstream `libzstd.so.1` where
+    /// `ZSTD_compress(..., level)` never enables LDM. The
+    /// opt-in surface (Rust parameter API, see #27) builds an
+    /// `LdmProducer` from caller-supplied params and assigns it
+    /// here at frame setup time; `prepare_ldm_candidates` only
+    /// consumes the field, it does not construct it. See
+    /// [`super::ldm::LdmProducer`].
+    ///
+    /// Gated behind the `hash` feature because the producer's
+    /// per-window XXH64 hashing depends on the optional
+    /// `twox-hash` dependency; under `default-features = false`
+    /// the field disappears and the `prepare_ldm_candidates`
+    /// body shrinks to the legacy `ldm_sequences.clear()` stub.
     #[cfg(feature = "hash")]
     pub(crate) ldm_producer: Option<LdmProducer>,
 }

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -20,6 +20,7 @@
 use alloc::vec::Vec;
 
 use super::cost_model::{HC_MAX_LIT, HcOptState, HcOptimalCostProfile};
+use super::ldm::LdmProducer;
 use super::opt::ldm::{HcOptLdmState, HcRawSeq, HcRawSeqStore};
 use super::opt::types::{HcOptimalNode, HcOptimalPlanBuffers, HcOptimalSequence, MatchCandidate};
 
@@ -65,6 +66,12 @@ pub(crate) struct BtMatcher {
     /// parser. Built per-block during `start_matching_optimal` and
     /// drained as the parser advances.
     pub(crate) ldm_sequences: Vec<HcRawSeq>,
+    /// LDM producer — populated lazily on the first
+    /// `prepare_ldm_candidates` call for a frame. `None` while LDM
+    /// is opt-out (current default) so the table allocation only
+    /// happens for callers that opt in. See
+    /// [`super::ldm::LdmProducer`].
+    pub(crate) ldm_producer: Option<LdmProducer>,
 }
 
 impl BtMatcher {
@@ -116,6 +123,7 @@ impl BtMatcher {
             opt_ml_price_generation: Vec::new(),
             opt_ml_price_stamp: 0,
             ldm_sequences: Vec::new(),
+            ldm_producer: None,
         }
     }
 
@@ -138,6 +146,9 @@ impl BtMatcher {
         self.opt_ml_price_generation.clear();
         self.opt_ml_price_stamp = 0;
         self.ldm_sequences.clear();
+        if let Some(producer) = self.ldm_producer.as_mut() {
+            producer.clear();
+        }
     }
 
     /// Donor parity: `ZSTD_optLdm_skipRawSeqStoreBytes`. Fast-forward the
@@ -305,15 +316,29 @@ impl BtMatcher {
         result
     }
 
-    /// Donor parity: `ZSTD_ldm_blockCompress` would seed external
+    /// Donor parity: `ZSTD_ldm_blockCompress` seeds external
     /// long-distance match candidates here when `enableLdm ==
-    /// ZSTD_ps_enable`. This Rust encoder does not expose the donor's
-    /// LDM producer / runtime switch yet, so every level-22 frame
-    /// starts with an empty `ldm_sequences` buffer — keep the clear
-    /// to defend against carry-over if a producer is added later.
-    pub(crate) fn prepare_ldm_candidates(&mut self, current_abs_start: usize, current_len: usize) {
+    /// ZSTD_ps_enable`. The default Rust encoder still keeps LDM
+    /// disabled (`ldm_producer = None`); when an external caller
+    /// opts in (#18 Phase 5 wiring — feature flag + threshold land
+    /// after the search/verify commit), the producer is delegated
+    /// to via [`LdmProducer::generate_into`].
+    ///
+    /// While `ldm_producer.is_none()` the behaviour matches the
+    /// pre-Phase-5 stub: a defensive clear of [`Self::ldm_sequences`]
+    /// so cross-frame carry-over is impossible if a producer is
+    /// activated mid-session.
+    pub(crate) fn prepare_ldm_candidates(
+        &mut self,
+        history: &[u8],
+        current_abs_start: usize,
+        current_len: usize,
+    ) {
         self.ldm_sequences.clear();
-        let _ = (current_abs_start, current_len);
+        if let Some(producer) = self.ldm_producer.as_mut() {
+            let end = current_abs_start.saturating_add(current_len);
+            producer.generate_into(history, current_abs_start, end, &mut self.ldm_sequences);
+        }
     }
 
     /// Donor parity: `ZSTD_storeSeq` — encode `actual_offset` into the

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -329,37 +329,48 @@ impl BtMatcher {
     /// so cross-frame carry-over is impossible if a producer is
     /// activated mid-session.
     ///
-    /// # Coordinate translation (PR #139 review fix)
+    /// # Coordinate convention (PR #139 review feedback)
     ///
-    /// The caller supplies `history` as a slice into the
-    /// per-frame `MatchTable::history` Vec, plus the producer's
-    /// absolute stream position `current_abs_start` and the
-    /// per-block `history_abs_start` from the match table. The
-    /// producer interprets its `block_start` / `block_end`
-    /// arguments as INDICES INTO `history`, so this method
-    /// translates the absolute pair via `abs - history_abs_start`
-    /// before delegating. Without that translation the producer
-    /// would index out of bounds (or worse, silently into the
-    /// wrong byte range) as soon as `history_abs_start != 0` after
-    /// window eviction.
+    /// The producer operates entirely in **absolute stream
+    /// coordinates** (so its bucket-table entries remain valid
+    /// across window evictions — entries inserted by an earlier
+    /// view of the frame are filtered by the staleness check
+    /// `entry.offset <= history_abs_start`). The caller is
+    /// expected to pass:
+    ///
+    /// * `live_history` — the contiguous *live* slice of the
+    ///   per-frame `MatchTable::history` (`&history[history_start..]`).
+    ///   `live_history[0]` corresponds to absolute position
+    ///   `history_abs_start`.
+    /// * `history_abs_start` — absolute stream position of
+    ///   `live_history[0]`.
+    /// * `current_abs_start` / `current_len` — absolute span of
+    ///   the block to scan.
+    ///
+    /// `prepare_ldm_candidates` forwards these absolute
+    /// coordinates straight to [`LdmProducer::generate_into`]; the
+    /// abs→slice translation happens inside the producer only at
+    /// the moment of `live_history[..]` indexing.
     pub(crate) fn prepare_ldm_candidates(
         &mut self,
-        history: &[u8],
+        live_history: &[u8],
         history_abs_start: usize,
         current_abs_start: usize,
         current_len: usize,
     ) {
         self.ldm_sequences.clear();
         if let Some(producer) = self.ldm_producer.as_mut() {
-            // Translate absolute → slice index. The caller is
-            // responsible for ensuring `current_abs_start >=
-            // history_abs_start` (the optimal driver derives both
-            // from the same `MatchTable`, so the invariant holds
-            // structurally).
             debug_assert!(current_abs_start >= history_abs_start);
-            let block_start = current_abs_start - history_abs_start;
-            let block_end = block_start.saturating_add(current_len).min(history.len());
-            producer.generate_into(history, block_start, block_end, &mut self.ldm_sequences);
+            let block_end_abs = current_abs_start
+                .saturating_add(current_len)
+                .min(history_abs_start + live_history.len());
+            producer.generate_into(
+                live_history,
+                history_abs_start,
+                current_abs_start,
+                block_end_abs,
+                &mut self.ldm_sequences,
+            );
         }
     }
 

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -320,24 +320,46 @@ impl BtMatcher {
     /// long-distance match candidates here when `enableLdm ==
     /// ZSTD_ps_enable`. The default Rust encoder still keeps LDM
     /// disabled (`ldm_producer = None`); when an external caller
-    /// opts in (#18 Phase 5 wiring — feature flag + threshold land
-    /// after the search/verify commit), the producer is delegated
-    /// to via [`LdmProducer::generate_into`].
+    /// opts in (#18 Phase 5 wiring — see #27 for the parameter
+    /// surface), the producer is delegated to via
+    /// [`LdmProducer::generate_into`].
     ///
     /// While `ldm_producer.is_none()` the behaviour matches the
     /// pre-Phase-5 stub: a defensive clear of [`Self::ldm_sequences`]
     /// so cross-frame carry-over is impossible if a producer is
     /// activated mid-session.
+    ///
+    /// # Coordinate translation (PR #139 review fix)
+    ///
+    /// The caller supplies `history` as a slice into the
+    /// per-frame `MatchTable::history` Vec, plus the producer's
+    /// absolute stream position `current_abs_start` and the
+    /// per-block `history_abs_start` from the match table. The
+    /// producer interprets its `block_start` / `block_end`
+    /// arguments as INDICES INTO `history`, so this method
+    /// translates the absolute pair via `abs - history_abs_start`
+    /// before delegating. Without that translation the producer
+    /// would index out of bounds (or worse, silently into the
+    /// wrong byte range) as soon as `history_abs_start != 0` after
+    /// window eviction.
     pub(crate) fn prepare_ldm_candidates(
         &mut self,
         history: &[u8],
+        history_abs_start: usize,
         current_abs_start: usize,
         current_len: usize,
     ) {
         self.ldm_sequences.clear();
         if let Some(producer) = self.ldm_producer.as_mut() {
-            let end = current_abs_start.saturating_add(current_len);
-            producer.generate_into(history, current_abs_start, end, &mut self.ldm_sequences);
+            // Translate absolute → slice index. The caller is
+            // responsible for ensuring `current_abs_start >=
+            // history_abs_start` (the optimal driver derives both
+            // from the same `MatchTable`, so the invariant holds
+            // structurally).
+            debug_assert!(current_abs_start >= history_abs_start);
+            let block_start = current_abs_start - history_abs_start;
+            let block_end = block_start.saturating_add(current_len).min(history.len());
+            producer.generate_into(history, block_start, block_end, &mut self.ldm_sequences);
         }
     }
 
@@ -647,6 +669,54 @@ mod ldm_helper_tests {
             pos_in_sequence: 0,
             size,
         }
+    }
+
+    /// Regression test for PR #139 Copilot review — threads #1/#2:
+    /// `prepare_ldm_candidates` must translate the absolute
+    /// `current_abs_start` (`history_abs_start + window_size -
+    /// current_len`) into a slice index inside the supplied
+    /// `history` slice. Before the fix, the code passed
+    /// `current_abs_start` directly as `block_start` to
+    /// `LdmProducer::generate_into`, which would index out of
+    /// bounds (or into the wrong byte range) as soon as
+    /// `history_abs_start != 0` after window eviction.
+    ///
+    /// We construct a `BtMatcher` with an active `LdmProducer`
+    /// whose table starts empty, hand it a small `history` slice,
+    /// and call `prepare_ldm_candidates` with absolute coordinates
+    /// shifted by a non-zero `history_abs_start`. The call must
+    /// complete without panic — under the pre-fix code it would
+    /// panic on the `history[block_start..block_end]` slice access
+    /// inside `generate_into`.
+    #[test]
+    fn prepare_ldm_candidates_translates_absolute_positions_to_slice_indices() {
+        use crate::encoding::ldm::LdmProducer;
+
+        let mut bt = BtMatcher::new();
+        // Activate the producer with a small-but-real parameter
+        // set. The table allocation is bounded by hash_log so this
+        // stays cheap.
+        bt.ldm_producer = Some(LdmProducer::with_window_and_strategy(27, 9));
+
+        // 256 bytes of arbitrary content — enough for the gear
+        // hash to make progress against the donor btultra2
+        // `min_match_length = 32`.
+        let history: alloc::vec::Vec<u8> = (0u8..=255).collect();
+
+        // Simulate a frame whose window has already evicted some
+        // bytes: `history_abs_start = 1024`, and the current block
+        // covers absolute `[1024, 1280)` which maps to slice
+        // `[0, 256)` inside `history`.
+        let history_abs_start = 1024usize;
+        let current_abs_start = 1024usize;
+        let current_len = history.len();
+
+        // Pre-fix: would panic with `slice index out of bounds`
+        // on `history[1024..1280]`. Post-fix: translates to
+        // `[0..256]` and runs cleanly.
+        bt.prepare_ldm_candidates(&history, history_abs_start, current_abs_start, current_len);
+        // Cross-block fixture isn't engineered to emit a match —
+        // the assertion is simply that the call succeeded.
     }
 
     #[test]

--- a/zstd/src/encoding/ldm/gear_hash.rs
+++ b/zstd/src/encoding/ldm/gear_hash.rs
@@ -100,6 +100,15 @@ impl GearHashState {
     /// the module-level docs.
     pub(crate) fn new(min_match_length: usize, hash_rate_log: u32) -> Self {
         let max_bits_in_mask = min_match_length.min(64) as u32;
+        // Defensive clamp to 63: the degenerate-path shift
+        // `1u64 << hash_rate_log` would panic at 64. Every
+        // production caller routes through `LdmParams::adjust_for`
+        // (`hash_rate_log = LDM_HASH_RLOG - strategy/3` → 4..7) or
+        // `window_log - hash_log` (donor-bounded to 0..27), so the
+        // clamp is unreachable today; it guards against future
+        // callers / param-API misuse picking up the function
+        // directly.
+        let hash_rate_log = hash_rate_log.min(63);
         let stop_mask = if hash_rate_log > 0 && hash_rate_log <= max_bits_in_mask {
             ((1u64 << hash_rate_log) - 1) << (max_bits_in_mask - hash_rate_log)
         } else {

--- a/zstd/src/encoding/ldm/gear_hash.rs
+++ b/zstd/src/encoding/ldm/gear_hash.rs
@@ -34,8 +34,11 @@
 //!
 //! # Constants
 //!
-//! * [`LDM_BUCKET_SIZE_LOG`] — donor `#define` (matches
-//!   `ZSTD_LDM_BUCKETSIZELOG_MAX` upper bound, sized identically).
+//! * [`LDM_BUCKET_SIZE_LOG`] — donor `#define` (= 4, the default /
+//!   lower bound used by `LdmParams::adjust_for`'s `BOUNDED`
+//!   clamp; the donor upper bound is the separate
+//!   `ZSTD_LDM_BUCKETSIZELOG_MAX = 8` constant, exposed as
+//!   `params::LDM_BUCKETSIZELOG_MAX`).
 //! * [`LDM_MIN_MATCH_LENGTH`] — donor `#define`.
 //! * [`LDM_HASH_RLOG`] — donor `#define` (default hash-rate log).
 //! * [`LDM_BATCH_SIZE`] — donor `#define` from

--- a/zstd/src/encoding/ldm/gear_hash.rs
+++ b/zstd/src/encoding/ldm/gear_hash.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(GEAR_TAB[0], 0xf5b8f72c5f77775c, "GEAR_TAB[0]");
         // Mid-table anchor (donor row 14 col 0 → index 42).
         assert_eq!(GEAR_TAB[42], 0x869cb54a8749c161, "GEAR_TAB[42]");
-        // Quarter-table anchor (donor row 21 col 2 → index 65).
+        // Three-quarter anchor (donor row 26 col 2 → index 80).
         assert_eq!(GEAR_TAB[80], 0x3bed519cbcb4e1e1, "GEAR_TAB[80]");
         // Last entry: index 255 (donor zstd_ldm_geartab.h:103).
         assert_eq!(GEAR_TAB[255], 0x2b4da14f2613d8f4, "GEAR_TAB[255]");

--- a/zstd/src/encoding/ldm/gear_hash.rs
+++ b/zstd/src/encoding/ldm/gear_hash.rs
@@ -1,0 +1,531 @@
+//! Gear rolling hash for LDM split-point detection.
+//!
+//! Direct port of `ZSTD_ldm_gear_*` from `lib/compress/zstd_ldm.c`
+//! v1.5.7. The 256-entry permutation table [`GEAR_TAB`] is reproduced
+//! verbatim from `lib/compress/zstd_ldm_geartab.h` so split points
+//! computed from any byte stream match the donor bit-for-bit — a
+//! prerequisite for the ratio-parity goal of #111 Phase 5.
+//!
+//! # Algorithm
+//!
+//! State is a single 64-bit accumulator. For every byte `b` the
+//! update is:
+//!
+//! ```text
+//! hash ← (hash << 1) + GEAR_TAB[b]
+//! ```
+//!
+//! Because every entry of the table is a fixed `u64` independent of
+//! position, bit `n` of `hash` after `k` updates depends on the last
+//! `min(n, k)` bytes — a content-defined window without any explicit
+//! ring buffer. A "split point" is signalled whenever
+//! `(hash & stop_mask) == 0`. Donor [`init`] derives `stop_mask` so
+//! that on average one split occurs every `2 ^ hash_rate_log` bytes,
+//! and the active bits sit at the high end of the rolling window
+//! (`min(min_match_length, 64)` bits) — biasing splits toward
+//! content-defined boundaries of at least `min_match_length` bytes
+//! whenever the parameter ranges allow it.
+//!
+//! # Donor anchors
+//!
+//! * `ZSTD_ldm_gear_init`  → [`GearHashState::new`]
+//! * `ZSTD_ldm_gear_reset` → [`reset`]
+//! * `ZSTD_ldm_gear_feed`  → [`feed`]
+//!
+//! # Constants
+//!
+//! * [`LDM_BUCKET_SIZE_LOG`] — donor `#define` (matches
+//!   `ZSTD_LDM_BUCKETSIZELOG_MAX` upper bound, sized identically).
+//! * [`LDM_MIN_MATCH_LENGTH`] — donor `#define`.
+//! * [`LDM_HASH_RLOG`] — donor `#define` (default hash-rate log).
+//! * [`LDM_BATCH_SIZE`] — donor `#define` from
+//!   `zstd_compress_internal.h`. Caps the per-call split count so the
+//!   caller's `splits` buffer never overflows.
+
+/// Bucket size log for the LDM hash table.
+///
+/// Donor: `lib/compress/zstd_ldm.c:19` (`#define LDM_BUCKET_SIZE_LOG 4`).
+pub(crate) const LDM_BUCKET_SIZE_LOG: u32 = 4;
+
+/// Default minimum LDM match length in bytes.
+///
+/// Donor: `lib/compress/zstd_ldm.c:20`
+/// (`#define LDM_MIN_MATCH_LENGTH 64`). Defines both the gear-hash
+/// window depth (and therefore the maximum bit weight used for the
+/// `stop_mask` placement) and the floor on accepted match lengths.
+pub(crate) const LDM_MIN_MATCH_LENGTH: usize = 64;
+
+/// Default hash-rate log (one split every `2 ^ LDM_HASH_RLOG` bytes
+/// on average).
+///
+/// Donor: `lib/compress/zstd_ldm.c:21` (`#define LDM_HASH_RLOG 7`).
+pub(crate) const LDM_HASH_RLOG: u32 = 7;
+
+/// Maximum number of splits the donor `gear_feed` produces per call.
+///
+/// Donor: `lib/compress/zstd_compress_internal.h:335`
+/// (`#define LDM_BATCH_SIZE 64`). The caller-owned `splits` array
+/// must hold at least this many entries.
+pub(crate) const LDM_BATCH_SIZE: usize = 64;
+
+/// Initial rolling-hash value used by donor `ZSTD_ldm_gear_init`:
+/// `state->rolling = ~(U32)0;` — the low 32 bits set, high 32 bits
+/// zero. Splitting this out so callers can re-seed mid-stream
+/// (mirroring donor's behaviour at frame / block boundaries).
+pub(crate) const GEAR_HASH_INIT: u64 = 0xFFFF_FFFF;
+
+/// Gear rolling-hash state — `(rolling, stop_mask)`.
+///
+/// Mirrors donor `ldmRollingHashState_t` from
+/// `lib/compress/zstd_ldm.c:23-26`. Kept `Copy` so the per-block
+/// state can be cheaply snapshotted before a speculative scan.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct GearHashState {
+    /// 64-bit rolling accumulator. Updated as `hash = (hash << 1) +
+    /// GEAR_TAB[byte]` for every input byte.
+    pub(crate) rolling: u64,
+    /// Donor `stopMask`. A split is registered when
+    /// `(rolling & stop_mask) == 0`.
+    pub(crate) stop_mask: u64,
+}
+
+impl GearHashState {
+    /// Build a fresh state for the requested LDM parameters.
+    ///
+    /// Donor: `ZSTD_ldm_gear_init` (`zstd_ldm.c:32`). `min_match_length`
+    /// is clamped to `64` (the donor uses
+    /// `MIN(params->minMatchLength, 64)` because the hash window can
+    /// expose at most 64 useful bits) and the resulting mask sits at
+    /// the high end of that window when `hash_rate_log` fits — see
+    /// the module-level docs.
+    pub(crate) fn new(min_match_length: usize, hash_rate_log: u32) -> Self {
+        let max_bits_in_mask = min_match_length.min(64) as u32;
+        let stop_mask = if hash_rate_log > 0 && hash_rate_log <= max_bits_in_mask {
+            ((1u64 << hash_rate_log) - 1) << (max_bits_in_mask - hash_rate_log)
+        } else {
+            // Degenerate path: simply honour the requested hash rate
+            // without trying to bias toward `min_match_length` bits.
+            // Donor `zstd_ldm.c:56`.
+            (1u64 << hash_rate_log) - 1
+        };
+        Self {
+            rolling: GEAR_HASH_INIT,
+            stop_mask,
+        }
+    }
+}
+
+/// Feed `min_match_length` bytes through the rolling hash WITHOUT
+/// emitting any splits.
+///
+/// Donor: `ZSTD_ldm_gear_reset` (`zstd_ldm.c:65`). Used at block
+/// boundaries and after a skip so the rolling window is primed
+/// against the new context before split detection resumes.
+///
+/// `min_match_length` is named after the parameter that controls it
+/// in the donor — the actual length consumed is `data.len()` capped
+/// implicitly by the caller's bounds (donor requires
+/// `data.len() >= min_match_length`; this Rust port lets the caller
+/// pass an arbitrary slice for unit testing and skip flexibility).
+pub(crate) fn reset(state: &mut GearHashState, data: &[u8]) {
+    let mut hash = state.rolling;
+    let mut n = 0;
+    // Donor unrolls the inner loop four-wide; we keep the same shape
+    // so the bounds check fires identically and the per-iteration
+    // arithmetic monomorphises to the same instruction sequence on
+    // every backend.
+    while n + 3 < data.len() {
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n + 1] as usize]);
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n + 2] as usize]);
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n + 3] as usize]);
+        n += 4;
+    }
+    while n < data.len() {
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+    }
+    state.rolling = hash;
+}
+
+/// Feed `data` through the rolling hash, recording every position
+/// where `(rolling & stop_mask) == 0` into `splits` until either the
+/// data is exhausted or `splits.len()` reaches [`LDM_BATCH_SIZE`].
+///
+/// Each entry written to `splits` is a 1-based offset *into `data`*
+/// (the byte index just past the split), matching the donor's
+/// `splits[*numSplits] = n` semantics where `n` is the post-increment
+/// byte count.
+///
+/// Returns `(bytes_consumed, splits_written)`. The caller is expected
+/// to advance its input cursor by `bytes_consumed` and re-call when
+/// the previous batch has been drained — exactly the donor's outer
+/// loop in `ZSTD_ldm_generateSequences_internal`.
+///
+/// # Panics
+///
+/// Panics if `splits` is shorter than [`LDM_BATCH_SIZE`] — the donor
+/// pre-condition is that the array has at least `LDM_BATCH_SIZE` slots
+/// reserved, and feeding into a shorter buffer would silently drop
+/// splits.
+pub(crate) fn feed(state: &mut GearHashState, data: &[u8], splits: &mut [usize]) -> (usize, usize) {
+    assert!(
+        splits.len() >= LDM_BATCH_SIZE,
+        "splits buffer must hold at least LDM_BATCH_SIZE entries \
+         (donor pre-condition: zstd_ldm.c:96)"
+    );
+    let mut hash = state.rolling;
+    let mask = state.stop_mask;
+    let mut n: usize = 0;
+    let mut num_splits: usize = 0;
+
+    // 4-wide unrolled head. Donor `zstd_ldm.c:118-123`. Each iteration
+    // increments `n` first, then tests the post-update hash so the
+    // split index points to the byte AFTER the matched window — this
+    // matches `splits[*numSplits] = n` in donor (n already
+    // incremented).
+    while n + 3 < data.len() {
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+        if hash & mask == 0 {
+            splits[num_splits] = n;
+            num_splits += 1;
+            if num_splits == LDM_BATCH_SIZE {
+                state.rolling = hash;
+                return (n, num_splits);
+            }
+        }
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+        if hash & mask == 0 {
+            splits[num_splits] = n;
+            num_splits += 1;
+            if num_splits == LDM_BATCH_SIZE {
+                state.rolling = hash;
+                return (n, num_splits);
+            }
+        }
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+        if hash & mask == 0 {
+            splits[num_splits] = n;
+            num_splits += 1;
+            if num_splits == LDM_BATCH_SIZE {
+                state.rolling = hash;
+                return (n, num_splits);
+            }
+        }
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+        if hash & mask == 0 {
+            splits[num_splits] = n;
+            num_splits += 1;
+            if num_splits == LDM_BATCH_SIZE {
+                state.rolling = hash;
+                return (n, num_splits);
+            }
+        }
+    }
+    // Tail loop for the remaining 0..3 bytes. Donor `zstd_ldm.c:124-126`.
+    while n < data.len() {
+        hash = (hash << 1).wrapping_add(GEAR_TAB[data[n] as usize]);
+        n += 1;
+        if hash & mask == 0 {
+            splits[num_splits] = n;
+            num_splits += 1;
+            if num_splits == LDM_BATCH_SIZE {
+                state.rolling = hash;
+                return (n, num_splits);
+            }
+        }
+    }
+    state.rolling = hash;
+    (n, num_splits)
+}
+
+/// 256-entry random-permutation table from donor
+/// `lib/compress/zstd_ldm_geartab.h`. Reproduced verbatim — DO NOT
+/// REGENERATE: byte-parity of split points (and therefore LDM ratio
+/// parity vs upstream) depends on every entry matching the donor
+/// value exactly.
+#[rustfmt::skip]
+pub(crate) const GEAR_TAB: [u64; 256] = [
+    0xf5b8f72c5f77775c, 0x84935f266b7ac412, 0xb647ada9ca730ccc,
+    0xb065bb4b114fb1de, 0x34584e7e8c3a9fd0, 0x4e97e17c6ae26b05,
+    0x3a03d743bc99a604, 0xcecd042422c4044f, 0x76de76c58524259e,
+    0x9c8528f65badeaca, 0x86563706e2097529, 0x2902475fa375d889,
+    0xafb32a9739a5ebe6, 0xce2714da3883e639, 0x021eaf821722e69e,
+    0x0037b628620b628,  0x049a8d455d88caf5, 0x8556d711e6958140,
+    0x04f7ae74fc605c1f, 0x829f0c3468bd3a20, 0x4ffdc885c625179e,
+    0x8473de048a3daf1b, 0x51008822b05646b2, 0x69d75d12b2d1cc5f,
+    0x8c9d4a19159154bc, 0xc3cc10f4abbd4003, 0xd06ddc1cecb97391,
+    0xbe48e6e7ed80302e, 0x3481db31cee03547, 0xacc3f67cdaa1d210,
+    0x65cb771d8c7f96cc, 0x8eb27177055723dd, 0xc789950d44cd94be,
+    0x934feadc3700b12b, 0x5e485f11edbdf182, 0x1e2e2a46fd64767a,
+    0x2969ca71d82efa7c, 0x9d46e9935ebbba2e, 0xe056b67e05e6822b,
+    0x94d73f55739d03a0, 0xcd7010bdb69b5a03, 0x455ef9fcd79b82f4,
+    0x869cb54a8749c161, 0x38d1a4fa6185d225, 0xb475166f94bbe9bb,
+    0xa4143548720959f1, 0x7aed4780ba6b26ba, 0xd0ce264439e02312,
+    0x84366d746078d508, 0xa8ce973c72ed17be, 0x21c323a29a430b01,
+    0x9962d617e3af80ee, 0xab0ce91d9c8cf75b, 0x530e8ee6d19a4dbc,
+    0x2ef68c0cf53f5d72, 0xc03a681640a85506, 0x496e4e9f9c310967,
+    0x78580472b59b14a0, 0x273824c23b388577, 0x66bf923ad45cb553,
+    0x47ae1a5a2492ba86, 0x35e304569e229659, 0x4765182a46870b6f,
+    0x6cbab625e9099412, 0xddac9a2e598522c1, 0x7172086e666624f2,
+    0xdf5003ca503b7837, 0x88c0c1db78563d09, 0x58d51865acfc289d,
+    0x177671aec65224f1, 0xfb79d8a241e967d7, 0x2be1e101cad9a49a,
+    0x6625682f6e29186b, 0x399553457ac06e50, 0x035dffb4c23abb74,
+    0x429db2591f54aade, 0xc52802a8037d1009, 0x6acb27381f0b25f3,
+    0xf45e2551ee4f823b, 0x8b0ea2d99580c2f7, 0x3bed519cbcb4e1e1,
+    0x0ff452823dbb010a, 0x9d42ed614f3dd267, 0x5b9313c06257c57b,
+    0xa114b8008b5e1442, 0xc1fe311c11c13d4b, 0x66e8763ea34c5568,
+    0x8b982af1c262f05d, 0xee8876faaa75fbb7, 0x8a62a4d0d172bb2a,
+    0xc13d94a3b7449a97, 0x6dbbba9dc15d037c, 0xc786101f1d92e0f1,
+    0xd78681a907a0b79b, 0xf61aaf2962c9abb9, 0x2cfd16fcd3cb7ad9,
+    0x868c5b6744624d21, 0x25e650899c74ddd7, 0xba042af4a7c37463,
+    0x4eb1a539465a3eca, 0xbe09dbf03b05d5ca, 0x774e5a362b5472ba,
+    0x47a1221229d183cd, 0x504b0ca18ef5a2df, 0xdffbdfbde2456eb9,
+    0x46cd2b2fbee34634, 0xf2aef8fe819d98c3, 0x357f5276d4599d61,
+    0x24a5483879c453e3, 0x088026889192b4b9, 0x28da96671782dbec,
+    0x4ef37c40588e9aaa, 0x8837b90651bc9fb3, 0xc164f741d3f0e5d6,
+    0xbc135a0a704b70ba, 0x069cd868f7622ada, 0xbc37ba89e0b9c0ab,
+    0x47c14a01323552f6, 0x4f00794bacee98bb, 0x7107de7d637a69d5,
+    0x88af793bb6f2255e, 0xf3c6466b8799b598, 0xc288c616aa7f3b59,
+    0x81ca63cf42fca3fd, 0x88d85ace36a2674b, 0x0d056bd3792389e7,
+    0xe55c396c4e9dd32d, 0xbefb504571e6c0a6, 0x96ab32115e91e8cc,
+    0xbf8acb18de8f38d1, 0x66dae58801672606, 0x833b6017872317fb,
+    0xb87c16f2d1c92864, 0xdb766a74e58b669c, 0x89659f85c61417be,
+    0xc8daad856011ea0c, 0x76a4b565b6fe7eae, 0xa469d085f6237312,
+    0xaaf0365683a3e96c, 0x4dbb746f8424f7b8, 0x0638755af4e4acc1,
+    0x3d7807f5bde64486, 0x17be6d8f5bbb7639, 0x0903f0cd44dc35dc,
+    0x67b672eafdf1196c, 0xa676ff93ed4c82f1, 0x521d1004c5053d9d,
+    0x37ba9ad09ccc9202, 0x84e54d297aacfb51, 0x0a0b4b776a143445,
+    0x0820d471e20b348e, 0x1874383cb83d46dc, 0x97edeec7a1efe11c,
+    0xb330e50b1bdc42aa, 0x1dd91955ce70e032, 0xa514cdb88f2939d5,
+    0x2791233fd90db9d3, 0x7b670a4cc50f7a9b, 0x77c07d2a05c6dfa5,
+    0xe3778b6646d0a6fa, 0xb39c8eda47b56749, 0x933ed448addbef28,
+    0xaf846af6ab7d0bf4, 0x0e5af208eb666e49, 0x5e6622f73534cd6a,
+    0x297daeca42ef5b6e, 0x862daef3d35539a6, 0xe68722498f8e1ea9,
+    0x981c53093dc0d572, 0xfa09b0bfbf86fbf5, 0x30b1e96166219f15,
+    0x70e7d466bdc4fb83, 0x5a66736e35f2a8e9, 0xcddb59d2b7c1baef,
+    0xd6c7d247d26d8996, 0xea4e39eac8de1ba3, 0x539c8bb19fa3aff2,
+    0x09f90e4c5fd508d8, 0xa34e5956fbaf3385, 0x2e2f8e151d3ef375,
+    0x173691e9b83faec1, 0xb85a8d56bf016379, 0x8382381267408ae3,
+    0xb90f901bbdc0096d, 0x7c6ad32933bcec65, 0x76bb5e2f2c8ad595,
+    0x390f851a6cf46d28, 0xc3e6064da1c2da72, 0xc52a0c101cfa5389,
+    0xd78eaf84a3fbc530, 0x3781b9e2288b997e, 0x73c2f6dea83d05c4,
+    0x04228e364c5b5ed7, 0x9d7a3edf0da43911, 0x8edcfeda24686756,
+    0x5e7667a7b7a9b3a1, 0x4c4f389fa143791d, 0xb08bc1023da7cddc,
+    0x7ab4be3ae529b1cc, 0x754e6132dbe74ff9, 0x71635442a839df45,
+    0x2f6fb1643fbe52de, 0x961e0a42cf7a8177, 0xf3b45d83d89ef2ea,
+    0xee3de4cf4a6e3e9b, 0xcd6848542c3295e7, 0xe4cee1664c78662f,
+    0x9947548b474c68c4, 0x25d73777a5ed8b0b, 0x00c915b1d636b7fc,
+    0x21c2ba75d9b0d2da, 0x5f6b5dcf608a64a1, 0xdcf333255ff9570c,
+    0x633b922418ced4ee, 0xc136dde0b004b34a, 0x58cc83b05d4b2f5a,
+    0x5eb424dda28e42d2, 0x62df47369739cd98, 0xb4e0b42485e4ce17,
+    0x16e1f0c1f9a8d1e7, 0x8ec3916707560ebf, 0x62ba6e2df2cc9db3,
+    0xcbf9f4ff77d83a16, 0x78d9d7d07d2bbcc4, 0xef554ce1e02c41f4,
+    0x8d7581127eccf94d, 0xa9b53336cb3c8a05, 0x38c42c0bf45c4f91,
+    0x640893cdf4488863, 0x80ec34bc575ea568, 0x39f324f5b48eaa40,
+    0xe9d9ed1f8eff527f, 0x9224fc058cc5a214, 0xbaba00b04cfe7741,
+    0x309a9f120fcf52af, 0xa558f3ec65626212, 0x424bec8b7adabe2f,
+    0x41622513a6aea433, 0xb88da2d5324ca798, 0xd287733b245528a4,
+    0x9a44697e6d68aec3, 0x7b1093be2f49bb28, 0x50bbec632e3d8aad,
+    0x6cd90723e1ea8283, 0x897b9e7431b02bf3, 0x219efdcb338a7047,
+    0x3b0311f0a27c0656, 0xdb17bf91c0db96e7, 0x8cd4fd6b4e85a5b2,
+    0xfab071054ba6409d, 0x40d6fe831fa9dfd9, 0xaf358debad7d791e,
+    0xeb8d0e25a65e3e58, 0xbbcbd3df14e08580, 0x0cf751f27ecdab2b,
+    0x2b4da14f2613d8f4,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    /// Sanity-check the verbatim port of `ZSTD_ldm_gearTab`. If these
+    /// anchors regress every downstream LDM split point drifts
+    /// relative to upstream output.
+    ///
+    /// Indices were cross-verified by parsing donor
+    /// `lib/compress/zstd_ldm_geartab.h` and computing each entry's
+    /// positional index (donor layout: 3 entries per source line
+    /// starting at line 18, except the final line which holds the
+    /// 256th element). The full 256-entry table was also
+    /// byte-compared against the parsed donor at build time during
+    /// the port (zero mismatches).
+    #[test]
+    fn gear_tab_anchor_entries_match_donor_geartab_header() {
+        // First entry (donor zstd_ldm_geartab.h:18).
+        assert_eq!(GEAR_TAB[0], 0xf5b8f72c5f77775c, "GEAR_TAB[0]");
+        // Mid-table anchor (donor row 14 col 0 → index 42).
+        assert_eq!(GEAR_TAB[42], 0x869cb54a8749c161, "GEAR_TAB[42]");
+        // Quarter-table anchor (donor row 21 col 2 → index 65).
+        assert_eq!(GEAR_TAB[80], 0x3bed519cbcb4e1e1, "GEAR_TAB[80]");
+        // Last entry: index 255 (donor zstd_ldm_geartab.h:103).
+        assert_eq!(GEAR_TAB[255], 0x2b4da14f2613d8f4, "GEAR_TAB[255]");
+    }
+
+    /// `stop_mask` derivation under the *common* parameter set
+    /// (`min_match_length = 64`, `hash_rate_log = 7`): donor
+    /// `zstd_ldm.c:52-53` produces
+    /// `(((1 << 7) - 1)) << (64 - 7) = 0x7F << 57 = 0xFE00_0000_0000_0000`.
+    #[test]
+    fn stop_mask_default_params_matches_donor_high_bit_window() {
+        let state = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        assert_eq!(
+            state.stop_mask, 0xFE00_0000_0000_0000,
+            "default stop_mask must put the 7 active bits at the \
+             top of the 64-bit window (donor zstd_ldm.c:52-53)"
+        );
+        assert_eq!(state.rolling, GEAR_HASH_INIT);
+    }
+
+    /// Degenerate path: when `hash_rate_log > min_match_length`
+    /// donor `zstd_ldm.c:55-56` falls back to the low-bit mask
+    /// `(1 << hash_rate_log) - 1` without trying to bias the bits
+    /// upward. Guards against silent drift if the params clamp ever
+    /// gets reworked.
+    #[test]
+    fn stop_mask_degenerate_path_returns_low_bit_mask() {
+        let state = GearHashState::new(4, 8); // hash_rate_log > min_match
+        assert_eq!(
+            state.stop_mask,
+            (1u64 << 8) - 1,
+            "fallback mask must equal (1 << hash_rate_log) - 1 \
+             (donor zstd_ldm.c:56)"
+        );
+    }
+
+    /// `hash_rate_log == 0` also lands on the degenerate branch
+    /// (`> 0` precondition fails) → mask becomes `0`. Every byte
+    /// then qualifies as a split point. Matches donor behaviour.
+    #[test]
+    fn stop_mask_hash_rate_log_zero_disables_filter() {
+        let state = GearHashState::new(LDM_MIN_MATCH_LENGTH, 0);
+        assert_eq!(state.stop_mask, 0);
+    }
+
+    /// Verify the rolling update against a hand-traced two-byte
+    /// stream. Donor recurrence is `hash = (hash << 1) +
+    /// GEAR_TAB[byte]`. Starting from `GEAR_HASH_INIT = 0xFFFF_FFFF`:
+    ///
+    ///   after byte 0x00:
+    ///     hash = (0xFFFF_FFFF << 1) + GEAR_TAB[0]
+    ///          = 0x0000_0001_FFFF_FFFE + 0xf5b8f72c5f77775c
+    ///          = 0xf5b8_f72e_5f77_775a
+    ///   after byte 0x01:
+    ///     hash = (0xf5b8_f72e_5f77_775a << 1) + GEAR_TAB[1]
+    ///          = 0xeb71_ee5c_beee_eeb4 + 0x84935f266b7ac412
+    ///          = 0x7005_4d83_2a69_b2c6
+    #[test]
+    fn reset_two_byte_stream_matches_hand_traced_recurrence() {
+        let mut state = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        reset(&mut state, &[0x00, 0x01]);
+        let expected = (((GEAR_HASH_INIT.wrapping_shl(1)).wrapping_add(GEAR_TAB[0])) << 1)
+            .wrapping_add(GEAR_TAB[1]);
+        assert_eq!(
+            state.rolling, expected,
+            "rolling recurrence (hash << 1) + GEAR_TAB[byte] regressed"
+        );
+    }
+
+    /// `reset` must be order-equivalent to the unrolled `feed` body
+    /// modulo the split detection — feeding the same bytes through
+    /// both APIs leaves the same `rolling` value. Guards against
+    /// drift in the 4-wide unrolled head.
+    #[test]
+    fn reset_and_feed_produce_identical_rolling_state() {
+        let data: alloc::vec::Vec<u8> = (0u8..73).collect(); // crosses the 4-wide boundary
+        let mut s_reset = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        reset(&mut s_reset, &data);
+
+        let mut s_feed = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        // `feed` with a mask that never matches → no early return,
+        // exercises exactly the same recurrence as `reset`. Use a
+        // mask of `u64::MAX` so the all-zeros condition is
+        // unreachable for the constructed stream.
+        s_feed.stop_mask = u64::MAX;
+        let mut splits = vec![0usize; LDM_BATCH_SIZE];
+        let (consumed, num) = feed(&mut s_feed, &data, &mut splits);
+        assert_eq!(consumed, data.len());
+        assert_eq!(num, 0, "u64::MAX mask must never trigger a split");
+        assert_eq!(
+            s_feed.rolling, s_reset.rolling,
+            "reset and feed must agree on the rolling state after \
+             identical input — guards the 4-wide unroll"
+        );
+    }
+
+    /// `feed` with a zero mask flags every byte as a split. The
+    /// number of recorded splits is therefore `min(data.len(),
+    /// LDM_BATCH_SIZE)`, the consumed-byte count matches, and each
+    /// `splits[i]` is `i + 1` (donor stores the 1-based post-byte
+    /// offset).
+    #[test]
+    fn feed_zero_mask_records_split_per_byte_up_to_batch_cap() {
+        let data: alloc::vec::Vec<u8> = vec![0u8; LDM_BATCH_SIZE * 2];
+        let mut state = GearHashState::new(LDM_MIN_MATCH_LENGTH, 0);
+        // Defensive: `new` with hash_rate_log == 0 already sets
+        // stop_mask = 0, but re-assert here so the intent is obvious.
+        assert_eq!(state.stop_mask, 0);
+
+        let mut splits = vec![0usize; LDM_BATCH_SIZE];
+        let (consumed, num) = feed(&mut state, &data, &mut splits);
+        assert_eq!(num, LDM_BATCH_SIZE, "batch cap must be honoured");
+        assert_eq!(
+            consumed, LDM_BATCH_SIZE,
+            "consumed must equal LDM_BATCH_SIZE"
+        );
+        for (i, &s) in splits.iter().enumerate() {
+            assert_eq!(
+                s,
+                i + 1,
+                "donor records 1-based post-byte indices \
+                 (zstd_ldm.c:111); splits[{i}] should be {}",
+                i + 1
+            );
+        }
+    }
+
+    /// Feeding in two consecutive chunks must produce the same
+    /// rolling state as feeding the concatenation. Guards against
+    /// state corruption between calls (the donor allows the caller
+    /// to drain its `splits` buffer and resume mid-stream).
+    #[test]
+    fn feed_concatenation_invariant() {
+        let part_a: alloc::vec::Vec<u8> = (0u8..30).collect();
+        let part_b: alloc::vec::Vec<u8> = (30u8..73).collect();
+        let mut joined = part_a.clone();
+        joined.extend_from_slice(&part_b);
+
+        let mut splits_a = vec![0usize; LDM_BATCH_SIZE];
+        let mut splits_b = vec![0usize; LDM_BATCH_SIZE];
+        let mut splits_joined = vec![0usize; LDM_BATCH_SIZE];
+
+        let mut s_chunked = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        let _ = feed(&mut s_chunked, &part_a, &mut splits_a);
+        let _ = feed(&mut s_chunked, &part_b, &mut splits_b);
+
+        let mut s_joined = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        let _ = feed(&mut s_joined, &joined, &mut splits_joined);
+
+        assert_eq!(
+            s_chunked.rolling, s_joined.rolling,
+            "chunked feed must leave the same rolling state as a single feed"
+        );
+    }
+
+    /// `splits` buffer too small must panic — donor pre-condition
+    /// enforced. Without this assertion a short buffer would
+    /// silently truncate at runtime once the inner branches start
+    /// indexing past the end.
+    #[test]
+    #[should_panic(expected = "LDM_BATCH_SIZE")]
+    fn feed_panics_on_undersized_splits_buffer() {
+        let data = [0u8; 8];
+        let mut state = GearHashState::new(LDM_MIN_MATCH_LENGTH, LDM_HASH_RLOG);
+        let mut splits = vec![0usize; LDM_BATCH_SIZE - 1];
+        let _ = feed(&mut state, &data, &mut splits);
+    }
+}

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -35,7 +35,8 @@
 //!   `ldm_producer: Option<LdmProducer>` field on `BtMatcher` that
 //!   stays `None` by default. The forthcoming parameter-API issue
 //!   (#27) plugs into that field; the C ABI work in #126 / #127
-//!   wires `ZSTD_c_enableLdm` through the same surface.
+//!   wires `ZSTD_c_enableLongDistanceMatching` through the same
+//!   surface.
 //!
 //! Therefore the `level22_sequences_match_donor_on_corpus_proxy`
 //! ratio gate continues to compare two LDM-OFF outputs (ours vs

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -77,7 +77,7 @@ pub(crate) mod table;
 use gear_hash::{GearHashState, LDM_BATCH_SIZE};
 use params::LdmParams;
 use search::{FindBestMatchInputs, find_best_match};
-use table::{LdmEntry, LdmHashTable};
+use table::LdmHashTable;
 
 /// Donor `XXH64` seed for the per-window LDM hash
 /// (`zstd_ldm.c:315`: `XXH64(split, minMatchLength, 0)`).
@@ -293,23 +293,19 @@ impl LdmProducer {
                 let hash_id = (xxhash as u32) & hash_id_mask;
                 let checksum = (xxhash >> 32) as u32;
 
-                // Store the entry's offset in ABSOLUTE coordinates
-                // so it survives window eviction — `find_best_
-                // match` translates to slice indices at lookup
-                // time and the staleness check `offset <=
-                // lowest_index_abs` (where the caller passes the
-                // current `history_abs_start`) filters entries
-                // that fall out of the window.
-                let new_entry = LdmEntry {
-                    offset: split_abs as u32,
-                    checksum,
-                };
+                // The table stores positions as `u32` offsets
+                // relative to its internal `position_base` (donor
+                // rebase scheme — see `table.rs`); ensure room
+                // before every insert so streams beyond
+                // `u32::MAX` rebase transparently.
+                self.hash_table.ensure_room_for(split_abs);
 
                 // Donor `zstd_ldm.c:420-426`: if this split would
                 // emit a sequence overlapping the previous one,
                 // just record it and move on.
                 if split_abs < anchor_abs {
-                    self.hash_table.insert(hash_id, new_entry);
+                    self.hash_table
+                        .insert_absolute(hash_id, split_abs, checksum);
                     continue;
                 }
 
@@ -332,7 +328,7 @@ impl LdmProducer {
                         history_abs_start,
                         split_abs,
                         anchor_abs,
-                        lowest_index_abs: history_abs_start as u32,
+                        lowest_index_abs: history_abs_start,
                         min_match_length: min_match,
                     },
                 );
@@ -340,28 +336,31 @@ impl LdmProducer {
                 let Some(best) = best else {
                     // Donor `zstd_ldm.c:468-473`: no match → just
                     // insert the new entry and continue.
-                    self.hash_table.insert(hash_id, new_entry);
+                    self.hash_table
+                        .insert_absolute(hash_id, split_abs, checksum);
                     continue;
                 };
 
                 // Match found. Donor `zstd_ldm.c:475-488`.
                 // `best.match_pos` is absolute; `split_abs` is
                 // absolute; their difference is a true
-                // back-reference distance, immune to window
-                // sliding.
-                let offset = (split_abs as u32) - best.match_pos;
+                // back-reference distance immune to window
+                // sliding and to the table's internal `u32`
+                // rebase shifts.
+                let offset = split_abs - best.match_pos;
                 let lit_length = split_abs - best.backward_len - anchor_abs;
                 let match_length = best.total_len();
                 out.push(HcRawSeq {
                     lit_length,
-                    offset: offset as usize,
+                    offset,
                     match_length,
                 });
 
                 // Insert AFTER finding the match so the lookup
                 // doesn't clobber `bestEntry` (donor `zstd_ldm.c:
                 // 490-492`).
-                self.hash_table.insert(hash_id, new_entry);
+                self.hash_table
+                    .insert_absolute(hash_id, split_abs, checksum);
 
                 // Advance anchor past the matched bytes (donor
                 // `zstd_ldm.c:494`).
@@ -405,13 +404,17 @@ impl LdmProducer {
 mod tests {
     use super::*;
 
-    /// `LdmProducer::new` must allocate without panic for a
-    /// representative parameter set (level 22 / btultra2 / window
-    /// 27 — the level the project's ratio gate targets).
+    /// `LdmParams::adjust_for` must derive a representative
+    /// donor-btultra2 parameter set at window_log=27. Checked via
+    /// the parameter struct alone — instantiating the producer
+    /// at these knobs would allocate `1 << 23 = 8M` table entries
+    /// (~64 MiB), which slows nextest under parallelism and risks
+    /// OOM on 32-bit CI shards. The producer-construction smoke
+    /// path is exercised by every other test in this module with
+    /// a smaller hand-tuned `LdmParams`.
     #[test]
     fn producer_constructs_with_donor_default_params() {
-        let producer = LdmProducer::with_window_and_strategy(27, 9);
-        let p = producer.params();
+        let p = LdmParams::adjust_for(27, 9);
         // Donor defaults at btultra2: minMatch halved, hash_rate_log
         // = 4, bucket_size_log clamps to 8. See params::tests for
         // the per-knob derivations.
@@ -421,12 +424,28 @@ mod tests {
         assert_eq!(p.bucket_size_log, 8);
     }
 
+    /// Compact `LdmParams` for unit-test producer construction —
+    /// keeps the table allocation at ~8 KiB instead of the
+    /// donor-btultra2 64 MiB so parallel nextest stays stable.
+    /// `min_match_length = 32` (half of donor floor) matches the
+    /// btultra2 derivation so engineered fixtures still trigger
+    /// long-range matches at 32-byte windows.
+    fn test_params() -> LdmParams {
+        LdmParams {
+            window_log: 27,
+            hash_log: 10,
+            hash_rate_log: 4,
+            min_match_length: 32,
+            bucket_size_log: 4,
+        }
+    }
+
     /// `clear` after `generate_into` rewinds the rolling hash to
     /// the canonical init value — guards the frame-boundary
     /// contract.
     #[test]
     fn clear_resets_rolling_hash_state() {
-        let mut producer = LdmProducer::with_window_and_strategy(27, 3);
+        let mut producer = LdmProducer::new(test_params());
         let mut out = Vec::new();
         // Feed a non-empty chunk so the rolling hash advances.
         let data = [0xAAu8; 256];
@@ -460,7 +479,7 @@ mod tests {
         // 128 KiB+ fixture to comfortably trigger a split inside
         // the payload, which slows the test without adding
         // coverage.
-        let mut producer = LdmProducer::with_window_and_strategy(27, 9);
+        let mut producer = LdmProducer::new(test_params());
         let p = producer.params();
         assert_eq!(p.min_match_length, 32);
 
@@ -550,7 +569,7 @@ mod tests {
     /// back-reference.
     #[test]
     fn generate_into_preserves_bucket_entries_across_history_slide() {
-        let mut producer = LdmProducer::with_window_and_strategy(27, 9);
+        let mut producer = LdmProducer::new(test_params());
         let p = producer.params();
         assert_eq!(p.min_match_length, 32);
 
@@ -667,7 +686,7 @@ mod tests {
     /// against an off-by-one in the bounds check.
     #[test]
     fn generate_into_empty_range_is_noop() {
-        let mut producer = LdmProducer::with_window_and_strategy(27, 3);
+        let mut producer = LdmProducer::new(test_params());
         let mut out = Vec::new();
         let data = [0u8; 128];
         let pre = producer.hash_state.rolling;

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -164,9 +164,10 @@ impl LdmProducer {
     /// **absolute stream coordinates** so the bucket table stays
     /// valid across window evictions: after a slide,
     /// `history_abs_start` advances and any entry inserted by an
-    /// earlier window is filtered by the `entry.offset <=
-    /// lowest_index_abs` staleness check in
-    /// [`find_best_match`].
+    /// earlier window is filtered by the inclusive lower-bound
+    /// staleness check `entry.offset < lowest_index_abs` in
+    /// [`find_best_match`] (entries at exactly
+    /// `lowest_index_abs == history_abs_start` survive).
     ///
     /// Implements the donor pipeline from
     /// `ZSTD_ldm_generateSequences_internal`
@@ -586,8 +587,10 @@ mod tests {
     ///      entries from call 1 must remain reachable: their
     ///      absolute offsets still point at the SAME bytes
     ///      (now further left in the live slice), and the
-    ///      staleness check `entry.offset <= history_abs_start`
-    ///      keeps them in-window.
+    ///      inclusive lower-bound staleness check
+    ///      `entry.offset < history_abs_start` keeps them
+    ///      in-window (entries at exactly `history_abs_start`
+    ///      survive).
     ///
     /// If the producer had stored slice-relative indices
     /// instead, call 2 would either miss the long-range match

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -1,0 +1,305 @@
+//! Long-distance-match (LDM) producer.
+//!
+//! Implements the donor's `lib/compress/zstd_ldm.c` pipeline:
+//!
+//! 1. [`gear_hash`] — gear rolling hash over a 256-entry random
+//!    permutation table picks content-defined split points
+//!    (`(hash & stopMask) == 0`).
+//! 2. [`table`] — bucket-based hash table indexed by the gear-hash
+//!    checksum, holding `1 << bucket_size_log` candidate positions
+//!    per bucket.
+//! 3. *(planned)* `search` — verify + extend a candidate forward
+//!    and backward across the LDM window.
+//! 4. [`params`] — [`LdmParams`] derived from `windowLog` /
+//!    `strategy` (`ZSTD_ldm_adjustParameters` parity).
+//!
+//! Aggregate [`LdmProducer`] holds the rolling-hash state, the
+//! bucket table, and the per-call scratch buffers. The downstream
+//! consumer (`bt::ldm_sequences`) was plumbed during Phase 1 (#119)
+//! — Phase 5 swaps the `prepare_ldm_candidates` no-op stub for a
+//! real producer that fills that buffer.
+//!
+//! Current state (Phase 5 foundations commit):
+//! * `LdmProducer::new` allocates the table + initialises the
+//!   rolling-hash state from caller params;
+//! * `LdmProducer::clear` resets the bucket cursors + the rolling
+//!   hash so a fresh frame starts clean;
+//! * `LdmProducer::generate_into` is the planned entry point that
+//!   walks the input, finds splits, inserts new candidates, and
+//!   emits verified matches as [`HcRawSeq`] entries. The verify +
+//!   extend logic lands in the next commit of #111 Phase 5; this
+//!   commit ships the structural skeleton and parameter plumbing.
+//!
+//! Donor parity anchors:
+//! * `lib/compress/zstd_ldm.c` v1.5.7
+//! * `lib/compress/zstd_ldm.h`
+//! * `lib/compress/zstd_ldm_geartab.h` — the 256 × `u64` permutation
+//!   table reproduced verbatim in [`gear_hash::GEAR_TAB`] to preserve
+//!   byte-for-byte split-point compatibility.
+
+// Phase 5 of #111 lands in two PR-sized chunks. This first chunk
+// ships the gear-hash primitive, parameter derivation, bucket
+// table, and the `LdmProducer` fill path (gear walk + XXH64 +
+// bucket insert) — all donor-cited with full unit coverage. The
+// verify + extend pass that drains the bucket into `HcRawSeq`
+// entries and the activation gate (`window_log >= 27` à la donor
+// `ZSTD_window_size > maxDistance`) land in the second chunk; in
+// the meantime several `pub(crate)` items (the `bucket` lookup,
+// the `bucket_mask` accessor, the `LDM_HASHLOG_MIN/MAX` bounds,
+// the `params::bounded` helper) are reachable only through tests.
+// `bt/mod.rs` carries the same `#![allow(dead_code)]` marker for
+// the same Phase-1 transitional reason.
+#![allow(dead_code)]
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::hash::Hasher;
+use twox_hash::XxHash64;
+
+use super::opt::ldm::HcRawSeq;
+
+pub(crate) mod gear_hash;
+pub(crate) mod params;
+pub(crate) mod table;
+
+use gear_hash::{GearHashState, LDM_BATCH_SIZE};
+use params::LdmParams;
+use table::{LdmEntry, LdmHashTable};
+
+/// Donor `XXH64` seed for the per-window LDM hash
+/// (`zstd_ldm.c:315`: `XXH64(split, minMatchLength, 0)`).
+const LDM_XXH64_SEED: u64 = 0;
+
+/// LDM sequence producer — owns the rolling-hash state, bucket
+/// table, and scratch buffers needed to scan an input block and
+/// emit a stream of [`HcRawSeq`] candidates consumed by the
+/// optimal parser.
+///
+/// Construction allocates the table (sized by [`LdmParams`]); the
+/// per-call work is dominated by the hash walk and bucket lookups.
+/// Designed to be re-used across blocks within a frame — call
+/// [`Self::clear`] only when starting a new frame (so the
+/// long-range history accumulated across blocks is preserved
+/// within a frame, mirroring donor's `ldmState_t` lifecycle).
+pub(crate) struct LdmProducer {
+    /// Parameter set this producer was built with. Used by the
+    /// split walker (next commit) to honour `min_match_length` /
+    /// `hash_rate_log` / bucket sizing.
+    params: LdmParams,
+    /// Rolling-hash state. Re-initialised on [`Self::clear`].
+    hash_state: GearHashState,
+    /// Bucket table indexed by the high bits of the per-window
+    /// XXH64. See [`table`] for layout details.
+    hash_table: LdmHashTable,
+    /// Scratch buffer for `gear_hash::feed` (`LDM_BATCH_SIZE`
+    /// entries per donor pre-condition). Kept in the producer so
+    /// hot calls don't re-allocate.
+    splits_scratch: Vec<usize>,
+}
+
+impl LdmProducer {
+    /// Build a fresh producer for the given parameter set.
+    ///
+    /// Allocates the bucket hash table (`1 << params.hash_log`
+    /// entries) and seeds the rolling-hash state from
+    /// `params.min_match_length` / `params.hash_rate_log`. The
+    /// `splits_scratch` buffer is sized to [`LDM_BATCH_SIZE`] so
+    /// every subsequent `gear_hash::feed` call sees a buffer
+    /// satisfying the donor pre-condition without re-allocation.
+    pub(crate) fn new(params: LdmParams) -> Self {
+        let hash_state = GearHashState::new(params.min_match_length as usize, params.hash_rate_log);
+        let hash_table = LdmHashTable::new(params.hash_log, params.bucket_size_log);
+        Self {
+            params,
+            hash_state,
+            hash_table,
+            splits_scratch: vec![0usize; LDM_BATCH_SIZE],
+        }
+    }
+
+    /// Re-derive parameters from a `(window_log, strategy)` pair
+    /// using [`LdmParams::adjust_for`]. Convenience wrapper.
+    pub(crate) fn with_window_and_strategy(window_log: u32, strategy: u32) -> Self {
+        Self::new(LdmParams::adjust_for(window_log, strategy))
+    }
+
+    /// Reset bucket cursors, zero the hash entries, and re-seed
+    /// the rolling-hash state. Use at frame boundaries.
+    pub(crate) fn clear(&mut self) {
+        self.hash_table.clear();
+        self.hash_state = GearHashState::new(
+            self.params.min_match_length as usize,
+            self.params.hash_rate_log,
+        );
+    }
+
+    /// Read-only view of the parameter set for diagnostics / tests.
+    pub(crate) fn params(&self) -> LdmParams {
+        self.params
+    }
+
+    /// Scan `history[block_start..block_end]` against accumulated
+    /// long-range candidates and append every accepted match into
+    /// `out` as an [`HcRawSeq`].
+    ///
+    /// `history` is the full per-frame byte slice (so back
+    /// references can be resolved up to `block_start`).
+    /// `block_start` / `block_end` mark the bounds of the input
+    /// chunk this call is responsible for; the producer never
+    /// emits sequences whose match references bytes at or after
+    /// `block_end`.
+    ///
+    /// **Current implementation status (Phase 5 foundations):**
+    /// The fill / insert half of the donor pipeline is live in
+    /// this commit:
+    ///
+    /// 1. walk `history[block_start..block_end]` through the gear
+    ///    rolling hash;
+    /// 2. for every split point, hash the preceding
+    ///    `min_match_length`-byte window with XXH64 (donor
+    ///    `zstd_ldm.c:315`) and insert the `(offset, high32)`
+    ///    pair into the bucket table.
+    ///
+    /// The verify + extend step that reads back the bucket and
+    /// emits [`HcRawSeq`] entries lands in the next Phase 5
+    /// commit. For now `out` is left untouched — call behaviour
+    /// matches the previous no-op stub, but the bucket table is
+    /// populated so the follow-up emit pass already has long-range
+    /// candidates to read.
+    pub(crate) fn generate_into(
+        &mut self,
+        history: &[u8],
+        block_start: usize,
+        block_end: usize,
+        _out: &mut Vec<HcRawSeq>,
+    ) {
+        debug_assert!(block_start <= block_end);
+        debug_assert!(block_end <= history.len());
+        if block_end <= block_start {
+            return;
+        }
+        let min_match = self.params.min_match_length as usize;
+        // hBits: donor `zstd_ldm.c:295`
+        // (`hBits = params.hashLog - bucketSizeLog`). Pre-compute
+        // so the hot loop is a mask-and-shift rather than a per-
+        // iteration subtract.
+        let h_bits = self
+            .params
+            .hash_log
+            .saturating_sub(self.params.bucket_size_log);
+        let hash_id_mask: u32 = if h_bits >= 32 {
+            u32::MAX
+        } else {
+            (1u32 << h_bits).wrapping_sub(1)
+        };
+
+        let mut cursor = block_start;
+        while cursor < block_end {
+            let chunk = &history[cursor..block_end];
+            let (consumed, num_splits) =
+                gear_hash::feed(&mut self.hash_state, chunk, &mut self.splits_scratch);
+
+            // Insert pass — donor `ZSTD_ldm_fillHashTable`
+            // (`zstd_ldm.c:289-325`). Each split index `s` is the
+            // post-byte offset INSIDE `chunk`; the matched window
+            // starts at `chunk_abs + s - min_match_length`. If
+            // `s < min_match_length` we have no window yet (donor
+            // `if (ip + splits[n] >= istart + minMatchLength)`).
+            for &s in &self.splits_scratch[..num_splits] {
+                if s < min_match {
+                    continue;
+                }
+                let window_start = cursor + s - min_match;
+                let window_end = window_start + min_match;
+                if window_end > block_end {
+                    // Defensive — donor's loop walks `ip..iend` so
+                    // `window_end <= iend` is guaranteed; the cap
+                    // here is paranoid against caller bugs.
+                    continue;
+                }
+                let mut hasher = XxHash64::with_seed(LDM_XXH64_SEED);
+                hasher.write(&history[window_start..window_end]);
+                let xxhash = hasher.finish();
+                let hash_id = (xxhash as u32) & hash_id_mask;
+                let checksum = (xxhash >> 32) as u32;
+                self.hash_table.insert(
+                    hash_id,
+                    LdmEntry {
+                        offset: window_start as u32,
+                        checksum,
+                    },
+                );
+            }
+
+            // Donor's outer `while (ip < iend)` advances by the
+            // number of bytes the gear hash consumed; if the batch
+            // filled up before reaching the end of the chunk the
+            // loop re-enters with the new cursor. `max(1)` defends
+            // against a pathological `consumed == 0` (impossible by
+            // construction — `gear_feed` always advances by at
+            // least one byte if `chunk` is non-empty — but keeps
+            // the loop monotonic).
+            cursor += consumed.max(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `LdmProducer::new` must allocate without panic for a
+    /// representative parameter set (level 22 / btultra2 / window
+    /// 27 — the level the project's ratio gate targets).
+    #[test]
+    fn producer_constructs_with_donor_default_params() {
+        let producer = LdmProducer::with_window_and_strategy(27, 9);
+        let p = producer.params();
+        // Donor defaults at btultra2: minMatch halved, hash_rate_log
+        // = 4, bucket_size_log clamps to 8. See params::tests for
+        // the per-knob derivations.
+        assert_eq!(p.window_log, 27);
+        assert_eq!(p.min_match_length, 32);
+        assert_eq!(p.hash_rate_log, 4);
+        assert_eq!(p.bucket_size_log, 8);
+    }
+
+    /// `clear` after `generate_into` rewinds the rolling hash to
+    /// the canonical init value — guards the frame-boundary
+    /// contract.
+    #[test]
+    fn clear_resets_rolling_hash_state() {
+        let mut producer = LdmProducer::with_window_and_strategy(27, 3);
+        let mut out = Vec::new();
+        // Feed a non-empty chunk so the rolling hash advances.
+        let data = [0xAAu8; 256];
+        producer.generate_into(&data, 0, data.len(), &mut out);
+        let advanced = producer.hash_state.rolling;
+        assert_ne!(
+            advanced,
+            gear_hash::GEAR_HASH_INIT,
+            "rolling hash should have moved after generate_into"
+        );
+        producer.clear();
+        assert_eq!(
+            producer.hash_state.rolling,
+            gear_hash::GEAR_HASH_INIT,
+            "clear must rewind to GEAR_HASH_INIT"
+        );
+    }
+
+    /// `generate_into` with an empty range is a no-op — emits
+    /// nothing and leaves the rolling hash untouched. Guards
+    /// against an off-by-one in the bounds check.
+    #[test]
+    fn generate_into_empty_range_is_noop() {
+        let mut producer = LdmProducer::with_window_and_strategy(27, 3);
+        let mut out = Vec::new();
+        let data = [0u8; 128];
+        let pre = producer.hash_state.rolling;
+        producer.generate_into(&data, 64, 64, &mut out);
+        assert!(out.is_empty());
+        assert_eq!(producer.hash_state.rolling, pre);
+    }
+}

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -151,16 +151,21 @@ impl LdmProducer {
         self.params
     }
 
-    /// Scan `history[block_start..block_end]` against accumulated
-    /// long-range candidates and append every accepted match into
-    /// `out` as an [`HcRawSeq`].
+    /// Scan the absolute range `[block_start_abs, block_end_abs)`
+    /// inside `live_history` against accumulated long-range
+    /// candidates and append every accepted match into `out` as
+    /// an [`HcRawSeq`].
     ///
-    /// `history` is the full per-frame byte slice — back
-    /// references reach all the way back to byte 0 (the
-    /// prefix-only path described in [`search`]). `block_start`
-    /// / `block_end` mark the bounds of the input chunk this
-    /// call is responsible for; the producer never emits a
-    /// sequence whose `split + forward` reaches past `block_end`.
+    /// `live_history` is the per-frame *live* byte slice — `live_
+    /// history[0]` is the byte at absolute stream position
+    /// `history_abs_start`. Every cross-block invariant
+    /// (`anchor`, `ip`, `entry.offset`) is maintained in
+    /// **absolute stream coordinates** so the bucket table stays
+    /// valid across window evictions: after a slide,
+    /// `history_abs_start` advances and any entry inserted by an
+    /// earlier window is filtered by the `entry.offset <=
+    /// lowest_index_abs` staleness check in
+    /// [`find_best_match`].
     ///
     /// Implements the donor pipeline from
     /// `ZSTD_ldm_generateSequences_internal`
@@ -193,18 +198,20 @@ impl LdmProducer {
     /// in [`search`].
     pub(crate) fn generate_into(
         &mut self,
-        history: &[u8],
-        block_start: usize,
-        block_end: usize,
+        live_history: &[u8],
+        history_abs_start: usize,
+        block_start_abs: usize,
+        block_end_abs: usize,
         out: &mut Vec<HcRawSeq>,
     ) {
-        debug_assert!(block_start <= block_end);
-        debug_assert!(block_end <= history.len());
+        debug_assert!(history_abs_start <= block_start_abs);
+        debug_assert!(block_start_abs <= block_end_abs);
+        debug_assert!(block_end_abs <= history_abs_start + live_history.len());
 
         let min_match = self.params.min_match_length as usize;
         // Donor `zstd_ldm.c:377-378`: nothing to do if the block
         // can't fit a single LDM window.
-        if block_end.saturating_sub(block_start) < min_match {
+        if block_end_abs.saturating_sub(block_start_abs) < min_match {
             return;
         }
 
@@ -218,29 +225,38 @@ impl LdmProducer {
         // `hash_id_mask` and the actual bucket count.
         let hash_id_mask: u32 = self.hash_table.bucket_mask();
 
+        // abs→slice helper. The closure body folds to a single
+        // sub instruction at the call site.
+        let to_idx = |abs: usize| abs - history_abs_start;
+
         // Re-init + reset against the first min_match bytes —
         // donor `zstd_ldm.c:381-383`. The table itself is
         // preserved across blocks; only the rolling hash is
         // wound back.
         self.hash_state = GearHashState::new(min_match, self.params.hash_rate_log);
+        let reset_start_idx = to_idx(block_start_abs);
         gear_hash::reset(
             &mut self.hash_state,
-            &history[block_start..block_start + min_match],
+            &live_history[reset_start_idx..reset_start_idx + min_match],
         );
 
         // Anchor: leftmost byte the producer can still emit as
-        // literal. Donor `BYTE const* anchor = istart;`.
-        let mut anchor = block_start;
+        // literal. Donor `BYTE const* anchor = istart;` — kept in
+        // absolute coordinates so emitted seq positions stay
+        // consistent across blocks within a frame.
+        let mut anchor_abs = block_start_abs;
         // `ip` (current input cursor): we start AFTER the reset
         // window. Donor `ip += minMatchLength;`.
-        let mut ip = block_start + min_match;
+        let mut ip_abs = block_start_abs + min_match;
         // Donor caps the outer walk at `iend - HASH_READ_SIZE`
         // (`zstd_ldm.c:366`). HASH_READ_SIZE = 8 in donor.
         const HASH_READ_SIZE: usize = 8;
-        let ilimit = block_end.saturating_sub(HASH_READ_SIZE);
+        let ilimit_abs = block_end_abs.saturating_sub(HASH_READ_SIZE);
 
-        while ip < ilimit {
-            let chunk = &history[ip..ilimit];
+        while ip_abs < ilimit_abs {
+            let chunk_idx = to_idx(ip_abs);
+            let chunk_end_idx = to_idx(ilimit_abs);
+            let chunk = &live_history[chunk_idx..chunk_end_idx];
             let (hashed, num_splits) =
                 gear_hash::feed(&mut self.hash_state, chunk, &mut self.splits_scratch);
 
@@ -250,30 +266,40 @@ impl LdmProducer {
             // `splits_scratch` and recompute the per-split state
             // in pass two — Rust's optimiser folds the duplicated
             // work). Pass two is the verify + emit + insert loop.
-            let mut split_idx = 0usize;
-            while split_idx < num_splits {
-                let s = self.splits_scratch[split_idx];
-                split_idx += 1;
+            let mut split_n = 0usize;
+            while split_n < num_splits {
+                let s = self.splits_scratch[split_n];
+                split_n += 1;
                 // Donor `zstd_ldm.c:313`:
                 //   if (ip + splits[n] >= istart + minMatchLength)
-                // Since `ip - block_start >= min_match` after the
-                // reset, the window-start subtraction never
-                // underflows. Belt-and-braces defensive guard:
-                if s + ip < block_start + min_match {
+                // Since `ip_abs - block_start_abs >= min_match`
+                // after the reset, the window-start subtraction
+                // never underflows. Belt-and-braces defensive
+                // guard:
+                if s + ip_abs < block_start_abs + min_match {
                     continue;
                 }
-                let split_abs = ip + s - min_match;
-                let window_end = split_abs + min_match;
-                if window_end > block_end {
+                let split_abs = ip_abs + s - min_match;
+                let window_end_abs = split_abs + min_match;
+                if window_end_abs > block_end_abs {
                     continue;
                 }
 
+                let split_idx = to_idx(split_abs);
+                let window_end_idx = to_idx(window_end_abs);
                 let mut hasher = XxHash64::with_seed(LDM_XXH64_SEED);
-                hasher.write(&history[split_abs..window_end]);
+                hasher.write(&live_history[split_idx..window_end_idx]);
                 let xxhash = hasher.finish();
                 let hash_id = (xxhash as u32) & hash_id_mask;
                 let checksum = (xxhash >> 32) as u32;
 
+                // Store the entry's offset in ABSOLUTE coordinates
+                // so it survives window eviction — `find_best_
+                // match` translates to slice indices at lookup
+                // time and the staleness check `offset <=
+                // lowest_index_abs` (where the caller passes the
+                // current `history_abs_start`) filters entries
+                // that fall out of the window.
                 let new_entry = LdmEntry {
                     offset: split_abs as u32,
                     checksum,
@@ -282,24 +308,31 @@ impl LdmProducer {
                 // Donor `zstd_ldm.c:420-426`: if this split would
                 // emit a sequence overlapping the previous one,
                 // just record it and move on.
-                if split_abs < anchor {
+                if split_abs < anchor_abs {
                     self.hash_table.insert(hash_id, new_entry);
                     continue;
                 }
 
                 // Search bucket for the best forward+backward
-                // match. `lowest_index_abs = 0` matches our
-                // prefix-only invariant (every entry with
-                // `offset > 0` is in-window).
+                // match. `lowest_index_abs = history_abs_start`
+                // — entries inserted before the current window
+                // (i.e. by a previous, now-evicted frame view)
+                // are stale and filtered. Within a single frame
+                // `history_abs_start` stays constant so all
+                // entries inserted by this call are kept; the
+                // mechanism becomes load-bearing only when the
+                // caller drives multiple compress_block windows
+                // through the same producer.
                 let best = find_best_match(
                     &self.hash_table,
                     hash_id,
                     checksum,
                     FindBestMatchInputs {
-                        history,
+                        live_history,
+                        history_abs_start,
                         split_abs,
-                        anchor_abs: anchor,
-                        lowest_index_abs: 0,
+                        anchor_abs,
+                        lowest_index_abs: history_abs_start as u32,
                         min_match_length: min_match,
                     },
                 );
@@ -312,8 +345,12 @@ impl LdmProducer {
                 };
 
                 // Match found. Donor `zstd_ldm.c:475-488`.
+                // `best.match_pos` is absolute; `split_abs` is
+                // absolute; their difference is a true
+                // back-reference distance, immune to window
+                // sliding.
                 let offset = (split_abs as u32) - best.match_pos;
-                let lit_length = split_abs - best.backward_len - anchor;
+                let lit_length = split_abs - best.backward_len - anchor_abs;
                 let match_length = best.total_len();
                 out.push(HcRawSeq {
                     lit_length,
@@ -328,31 +365,34 @@ impl LdmProducer {
 
                 // Advance anchor past the matched bytes (donor
                 // `zstd_ldm.c:494`).
-                anchor = split_abs + best.forward_len;
+                anchor_abs = split_abs + best.forward_len;
 
                 // Donor `zstd_ldm.c:496-508`: when the emitted
                 // match extends past the already-hashed window,
                 // skip ahead by re-resetting the rolling hash on
                 // the bytes preceding the new anchor.
-                if anchor > ip + hashed {
-                    let reset_start = anchor.saturating_sub(min_match);
-                    if reset_start + min_match <= block_end {
+                if anchor_abs > ip_abs + hashed {
+                    let reset_start_abs = anchor_abs.saturating_sub(min_match);
+                    if reset_start_abs + min_match <= block_end_abs
+                        && reset_start_abs >= history_abs_start
+                    {
+                        let reset_idx = to_idx(reset_start_abs);
                         self.hash_state = GearHashState::new(min_match, self.params.hash_rate_log);
                         gear_hash::reset(
                             &mut self.hash_state,
-                            &history[reset_start..reset_start + min_match],
+                            &live_history[reset_idx..reset_idx + min_match],
                         );
                         // Continue the outer `while (ip < ilimit)`
                         // loop at `anchor`. Donor: `ip = anchor -
                         // hashed;` so the upcoming `ip += hashed`
                         // lands exactly at `anchor`.
-                        ip = anchor.saturating_sub(hashed);
+                        ip_abs = anchor_abs.saturating_sub(hashed).max(history_abs_start);
                     }
                     break;
                 }
             }
 
-            ip = ip.saturating_add(hashed).max(ip + 1);
+            ip_abs = ip_abs.saturating_add(hashed).max(ip_abs + 1);
         }
 
         // Donor returns `iend - anchor` (the "leftover" tail),
@@ -390,7 +430,7 @@ mod tests {
         let mut out = Vec::new();
         // Feed a non-empty chunk so the rolling hash advances.
         let data = [0xAAu8; 256];
-        producer.generate_into(&data, 0, data.len(), &mut out);
+        producer.generate_into(&data, 0, 0, data.len(), &mut out);
         let advanced = producer.hash_state.rolling;
         assert_ne!(
             advanced,
@@ -451,7 +491,7 @@ mod tests {
         history.extend_from_slice(&payload);
 
         let mut out = Vec::new();
-        producer.generate_into(&history, 0, history.len(), &mut out);
+        producer.generate_into(&history, 0, 0, history.len(), &mut out);
 
         assert!(
             !out.is_empty(),
@@ -481,6 +521,147 @@ mod tests {
         );
     }
 
+    /// Regression test for PR #139 round-2 review (CodeRabbit +
+    /// Copilot, Major): the producer must store **absolute stream
+    /// positions** in its bucket-table entries so that long-range
+    /// matches accumulated by one block remain valid after a
+    /// window eviction shifts `history_abs_start` forward.
+    ///
+    /// Setup: same 4 KiB payload appears twice in the per-frame
+    /// history. We invoke `generate_into` twice:
+    ///   1. First call covers absolute range `[0, payload_end_0)`
+    ///      — the producer's bucket table accumulates entries
+    ///      whose `offset` fields hold absolute positions inside
+    ///      the first payload copy.
+    ///   2. Second call advances `history_abs_start` (simulates
+    ///      window eviction) and covers the absolute range
+    ///      containing the second payload copy. The bucket-table
+    ///      entries from call 1 must remain reachable: their
+    ///      absolute offsets still point at the SAME bytes
+    ///      (now further left in the live slice), and the
+    ///      staleness check `entry.offset <= history_abs_start`
+    ///      keeps them in-window.
+    ///
+    /// If the producer had stored slice-relative indices
+    /// instead, call 2 would either miss the long-range match
+    /// entirely (slice indices from call 1 would point into the
+    /// wrong bytes after the slide) or underflow `offset =
+    /// split_abs − best.match_pos` and emit a corrupt
+    /// back-reference.
+    #[test]
+    fn generate_into_preserves_bucket_entries_across_history_slide() {
+        let mut producer = LdmProducer::with_window_and_strategy(27, 9);
+        let p = producer.params();
+        assert_eq!(p.min_match_length, 32);
+
+        const PAYLOAD: usize = 4096;
+        const GAP_A: usize = 32 * 1024;
+        const GAP_B: usize = 32 * 1024;
+
+        // Deterministic non-trivial payload.
+        let mut prng: u32 = 0xC0FFEEEE;
+        let payload: alloc::vec::Vec<u8> = (0..PAYLOAD)
+            .map(|_| {
+                prng = prng.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+                (prng >> 16) as u8
+            })
+            .collect();
+
+        // Build the full frame in one Vec — represents the
+        // contiguous live history visible to the encoder before
+        // any eviction.
+        let mut frame = alloc::vec::Vec::with_capacity(2 * PAYLOAD + GAP_A + GAP_B);
+        frame.extend_from_slice(&payload);
+        frame.extend((0..GAP_A).map(|i| (i % 251) as u8));
+        frame.extend_from_slice(&payload);
+        frame.extend((0..GAP_B).map(|i| ((i + 17) % 241) as u8));
+
+        // Call 1: cover the first half of the frame —
+        // history_abs_start = 0, walks the first payload copy
+        // and the start of the first gap. The bucket table
+        // populates with absolute offsets inside payload #1.
+        let mut out1 = Vec::new();
+        let split_at = PAYLOAD + GAP_A;
+        producer.generate_into(&frame[..split_at], 0, 0, split_at, &mut out1);
+
+        // Call 2: simulate a window slide. The encoder retired
+        // the leading `eviction` bytes from the live history;
+        // the surviving slice is `frame[eviction..]` and its
+        // byte 0 sits at absolute position `eviction`. The
+        // second payload copy is at absolute position `PAYLOAD
+        // + GAP_A`, which after the slide is at index
+        // `PAYLOAD + GAP_A − eviction` inside the slice.
+        let eviction = PAYLOAD / 2; // arbitrary — payload #1 partially evicted
+        let live = &frame[eviction..];
+        let history_abs_start = eviction;
+        let block_start_abs = PAYLOAD + GAP_A; // start of payload #2
+        let block_end_abs = block_start_abs + PAYLOAD;
+
+        let mut out2 = Vec::new();
+        producer.generate_into(
+            live,
+            history_abs_start,
+            block_start_abs,
+            block_end_abs,
+            &mut out2,
+        );
+
+        // The long-range match must still fire — entries from
+        // call 1 in the surviving tail of payload #1
+        // (`absolute [eviction, PAYLOAD)`) are still in-window
+        // and still point at the right bytes. If the producer
+        // had stored slice-relative offsets, call 2 would
+        // either miss or emit corrupt offsets.
+        assert!(
+            !out2.is_empty(),
+            "cross-slide long-range match must survive a window eviction"
+        );
+        // Every emitted match must (a) clear the min_match
+        // floor, and (b) point at bytes that still live inside
+        // the post-slide history. The latter is the actual
+        // round-2 review-fix invariant: if the producer had
+        // stored slice-relative offsets, entries inserted by
+        // call 1 would now reference the wrong absolute bytes
+        // and `offset = split_abs − stale_match_pos` could
+        // underflow `u32` and emit an offset > live_history
+        // length.
+        let live_len = live.len();
+        for seq in &out2 {
+            assert!(
+                seq.match_length >= p.min_match_length as usize,
+                "every emitted match must reach min_match_length (got {})",
+                seq.match_length
+            );
+            assert!(
+                seq.offset <= live_len,
+                "back-ref offset {} must stay within the live \
+                 history (= {} bytes); offsets larger than this \
+                 are the smoking gun for stale slice-relative \
+                 entries surviving the eviction",
+                seq.offset,
+                live_len
+            );
+        }
+
+        // At least one emitted sequence MUST hit a long-range
+        // back-reference (offset >= GAP_A, i.e. crossing from
+        // payload #2 back into payload #1's surviving tail).
+        // This is the long-range win LDM exists to capture and
+        // the round-2 fix has to preserve.
+        let crossed_gap = out2.iter().any(|s| s.offset >= GAP_A);
+        assert!(
+            crossed_gap,
+            "at least one emitted sequence must hit a back-ref of \
+             >= GAP_A ({GAP_A}) — that's the long-range match \
+             into the surviving tail of payload #1 the bucket \
+             entries from call 1 are supposed to produce; \
+             offsets observed: {:?}",
+            out2.iter()
+                .map(|s| s.offset)
+                .collect::<alloc::vec::Vec<_>>()
+        );
+    }
+
     /// `generate_into` with an empty range is a no-op — emits
     /// nothing and leaves the rolling hash untouched. Guards
     /// against an off-by-one in the bounds check.
@@ -490,7 +671,7 @@ mod tests {
         let mut out = Vec::new();
         let data = [0u8; 128];
         let pre = producer.hash_state.rolling;
-        producer.generate_into(&data, 64, 64, &mut out);
+        producer.generate_into(&data, 0, 64, 64, &mut out);
         assert!(out.is_empty());
         assert_eq!(producer.hash_state.rolling, pre);
     }

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -399,15 +399,26 @@ impl LdmProducer {
                 }
             }
 
-            // Guarantee forward progress even when `hashed == 0`
-            // (gear_feed in practice always advances by at least
-            // one byte over a non-empty chunk, but the saturating
-            // fallback below keeps the outer `while` loop
-            // monotonic against any future regression).
-            // Both operands of `.max(..)` use `saturating_add` so
-            // `ip_abs` near `usize::MAX` saturates rather than
-            // overflowing the inner `ip_abs + 1`.
-            ip_abs = ip_abs.saturating_add(hashed).max(ip_abs.saturating_add(1));
+            // Guarantee forward progress even when `hashed == 0`:
+            // `gear_feed` always advances by at least one byte
+            // over a non-empty chunk, but `hashed.max(1)` keeps
+            // the outer `while` loop monotonic against any
+            // future regression of that invariant.
+            //
+            // Raw `+` is safe — every callsite reaches LDM via
+            // `bt::prepare_ldm_candidates`, whose
+            // `current_abs_start` / `block_end_abs` are derived
+            // from a `MatchTable` that has already passed
+            // `check_stream_abs_headroom`
+            // (`match_table/storage.rs:50`). That frame-level
+            // guard guarantees `history_abs_start + window_size +
+            // STREAM_ABS_HEADROOM ≤ usize::MAX`, a much stronger
+            // bound than this single-byte add needs. Within the
+            // `while ip_abs < ilimit_abs` loop body the
+            // post-update value also stays ≤ `ilimit_abs ≤
+            // history_abs_start + live_history.len()`, so neither
+            // operand can overflow `usize`.
+            ip_abs += hashed.max(1);
         }
 
         // Donor returns `iend - anchor` (the "leftover" tail),

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -8,27 +8,38 @@
 //! 2. [`table`] — bucket-based hash table indexed by the gear-hash
 //!    checksum, holding `1 << bucket_size_log` candidate positions
 //!    per bucket.
-//! 3. *(planned)* `search` — verify + extend a candidate forward
-//!    and backward across the LDM window.
+//! 3. [`search`] — verify + extend a candidate forward and
+//!    backward across the LDM window (prefix-only path; the
+//!    two-segment `extDict` variant is deferred).
 //! 4. [`params`] — [`LdmParams`] derived from `windowLog` /
 //!    `strategy` (`ZSTD_ldm_adjustParameters` parity).
 //!
 //! Aggregate [`LdmProducer`] holds the rolling-hash state, the
 //! bucket table, and the per-call scratch buffers. The downstream
-//! consumer (`bt::ldm_sequences`) was plumbed during Phase 1 (#119)
-//! — Phase 5 swaps the `prepare_ldm_candidates` no-op stub for a
-//! real producer that fills that buffer.
+//! consumer (`bt::ldm_sequences`) was plumbed during Phase 1
+//! (#119) — Phase 5 swaps the `prepare_ldm_candidates` no-op stub
+//! for a real producer that fills that buffer.
 //!
-//! Current state (Phase 5 foundations commit):
-//! * `LdmProducer::new` allocates the table + initialises the
-//!   rolling-hash state from caller params;
-//! * `LdmProducer::clear` resets the bucket cursors + the rolling
-//!   hash so a fresh frame starts clean;
-//! * `LdmProducer::generate_into` is the planned entry point that
-//!   walks the input, finds splits, inserts new candidates, and
-//!   emits verified matches as [`HcRawSeq`] entries. The verify +
-//!   extend logic lands in the next commit of #111 Phase 5; this
-//!   commit ships the structural skeleton and parameter plumbing.
+//! # Activation policy (distro-grade parity)
+//!
+//! `LdmProducer` is **never activated automatically by a
+//! [`super::CompressionLevel`] preset.** This mirrors upstream
+//! `libzstd.so.1` behaviour: `ZSTD_compress(..., level)` keeps
+//! LDM off at every standard level (1..22). Activation is an
+//! explicit user opt-in:
+//!
+//! * upstream — `ZSTD_CCtx_setParameter(cctx,
+//!   ZSTD_c_enableLongDistanceMatching, ZSTD_ps_enable)`;
+//! * `zstd` CLI — `zstd --long[=N]`;
+//! * Rust port (this crate) — the Phase-5 surface ships an
+//!   `ldm_producer: Option<LdmProducer>` field on `BtMatcher` that
+//!   stays `None` by default. The forthcoming parameter-API issue
+//!   (#27) plugs into that field; the C ABI work in #126 / #127
+//!   wires `ZSTD_c_enableLdm` through the same surface.
+//!
+//! Therefore the `level22_sequences_match_donor_on_corpus_proxy`
+//! ratio gate continues to compare two LDM-OFF outputs (ours vs
+//! upstream `ZSTD_compress(..., 22)`) — byte-parity invariant.
 //!
 //! Donor parity anchors:
 //! * `lib/compress/zstd_ldm.c` v1.5.7
@@ -37,18 +48,17 @@
 //!   table reproduced verbatim in [`gear_hash::GEAR_TAB`] to preserve
 //!   byte-for-byte split-point compatibility.
 
-// Phase 5 of #111 lands in two PR-sized chunks. This first chunk
-// ships the gear-hash primitive, parameter derivation, bucket
-// table, and the `LdmProducer` fill path (gear walk + XXH64 +
-// bucket insert) — all donor-cited with full unit coverage. The
-// verify + extend pass that drains the bucket into `HcRawSeq`
-// entries and the activation gate (`window_log >= 27` à la donor
-// `ZSTD_window_size > maxDistance`) land in the second chunk; in
-// the meantime several `pub(crate)` items (the `bucket` lookup,
-// the `bucket_mask` accessor, the `LDM_HASHLOG_MIN/MAX` bounds,
-// the `params::bounded` helper) are reachable only through tests.
-// `bt/mod.rs` carries the same `#![allow(dead_code)]` marker for
-// the same Phase-1 transitional reason.
+// Phase 5 of #111 ships the full LDM producer (gear hash + params
+// + bucket table + verify/extend search + aggregate driver) in
+// two commits. By distro-parity design (see the module docs
+// above), no `CompressionLevel` preset activates the producer —
+// `BtMatcher::ldm_producer` stays `None` until #27 (Rust
+// parameter API) or #126/#127 (C ABI) plug the user opt-in.
+// Several `pub(crate)` accessors (`LDM_HASHLOG_MIN/MAX`,
+// `params::bounded`, `bucket_mask`) are therefore reachable only
+// via the unit test suite until the parameter API lands; the
+// `#![allow(dead_code)]` matches the same transitional marker in
+// `bt/mod.rs` introduced during Phase 1.
 #![allow(dead_code)]
 
 use alloc::vec;
@@ -61,10 +71,12 @@ use super::opt::ldm::HcRawSeq;
 
 pub(crate) mod gear_hash;
 pub(crate) mod params;
+pub(crate) mod search;
 pub(crate) mod table;
 
 use gear_hash::{GearHashState, LDM_BATCH_SIZE};
 use params::LdmParams;
+use search::{FindBestMatchInputs, find_best_match};
 use table::{LdmEntry, LdmHashTable};
 
 /// Donor `XXH64` seed for the per-window LDM hash
@@ -143,47 +155,60 @@ impl LdmProducer {
     /// long-range candidates and append every accepted match into
     /// `out` as an [`HcRawSeq`].
     ///
-    /// `history` is the full per-frame byte slice (so back
-    /// references can be resolved up to `block_start`).
-    /// `block_start` / `block_end` mark the bounds of the input
-    /// chunk this call is responsible for; the producer never
-    /// emits sequences whose match references bytes at or after
-    /// `block_end`.
+    /// `history` is the full per-frame byte slice — back
+    /// references reach all the way back to byte 0 (the
+    /// prefix-only path described in [`search`]). `block_start`
+    /// / `block_end` mark the bounds of the input chunk this
+    /// call is responsible for; the producer never emits a
+    /// sequence whose `split + forward` reaches past `block_end`.
     ///
-    /// **Current implementation status (Phase 5 foundations):**
-    /// The fill / insert half of the donor pipeline is live in
-    /// this commit:
+    /// Implements the donor pipeline from
+    /// `ZSTD_ldm_generateSequences_internal`
+    /// (`zstd_ldm.c:346-515`) in three phases:
     ///
-    /// 1. walk `history[block_start..block_end]` through the gear
-    ///    rolling hash;
-    /// 2. for every split point, hash the preceding
-    ///    `min_match_length`-byte window with XXH64 (donor
-    ///    `zstd_ldm.c:315`) and insert the `(offset, high32)`
-    ///    pair into the bucket table.
+    /// 1. **Init** — re-seed the rolling hash and prime it with
+    ///    the first `min_match_length` bytes of the block
+    ///    (donor `zstd_ldm.c:381-383`). Donor resets the hash
+    ///    state at every `generateSequences_internal` call; the
+    ///    bucket table is preserved across blocks within a frame
+    ///    so long-range candidates accumulated by earlier blocks
+    ///    remain reachable.
+    /// 2. **Feed batch** — call [`gear_hash::feed`] to fill the
+    ///    `splits_scratch` buffer with up to [`LDM_BATCH_SIZE`]
+    ///    split positions (donor `zstd_ldm.c:390-391`).
+    /// 3. **Per-split verify + emit** — for every split, hash the
+    ///    preceding `min_match_length`-byte window (donor seed
+    ///    0, XXH64), look up the bucket, run [`find_best_match`]
+    ///    to score every entry by forward + backward match
+    ///    length, and either emit an [`HcRawSeq`] + insert the
+    ///    new entry (match found) or insert-only (donor
+    ///    `zstd_ldm.c:393-510`). When a match overlaps the
+    ///    already-hashed range donor re-resets the rolling hash
+    ///    and re-enters the outer loop from `anchor` (donor
+    ///    `zstd_ldm.c:497-508` — the "all-zeros repetition speed
+    ///    boost").
     ///
-    /// The verify + extend step that reads back the bucket and
-    /// emits [`HcRawSeq`] entries lands in the next Phase 5
-    /// commit. For now `out` is left untouched — call behaviour
-    /// matches the previous no-op stub, but the bucket table is
-    /// populated so the follow-up emit pass already has long-range
-    /// candidates to read.
+    /// The producer covers the **prefix-only** path; the
+    /// two-segment `extDict` variant is documented and deferred
+    /// in [`search`].
     pub(crate) fn generate_into(
         &mut self,
         history: &[u8],
         block_start: usize,
         block_end: usize,
-        _out: &mut Vec<HcRawSeq>,
+        out: &mut Vec<HcRawSeq>,
     ) {
         debug_assert!(block_start <= block_end);
         debug_assert!(block_end <= history.len());
-        if block_end <= block_start {
+
+        let min_match = self.params.min_match_length as usize;
+        // Donor `zstd_ldm.c:377-378`: nothing to do if the block
+        // can't fit a single LDM window.
+        if block_end.saturating_sub(block_start) < min_match {
             return;
         }
-        let min_match = self.params.min_match_length as usize;
-        // hBits: donor `zstd_ldm.c:295`
-        // (`hBits = params.hashLog - bucketSizeLog`). Pre-compute
-        // so the hot loop is a mask-and-shift rather than a per-
-        // iteration subtract.
+
+        // hBits = hashLog - bucketSizeLog. Donor `zstd_ldm.c:354`.
         let h_bits = self
             .params
             .hash_log
@@ -194,54 +219,146 @@ impl LdmProducer {
             (1u32 << h_bits).wrapping_sub(1)
         };
 
-        let mut cursor = block_start;
-        while cursor < block_end {
-            let chunk = &history[cursor..block_end];
-            let (consumed, num_splits) =
+        // Re-init + reset against the first min_match bytes —
+        // donor `zstd_ldm.c:381-383`. The table itself is
+        // preserved across blocks; only the rolling hash is
+        // wound back.
+        self.hash_state = GearHashState::new(min_match, self.params.hash_rate_log);
+        gear_hash::reset(
+            &mut self.hash_state,
+            &history[block_start..block_start + min_match],
+        );
+
+        // Anchor: leftmost byte the producer can still emit as
+        // literal. Donor `BYTE const* anchor = istart;`.
+        let mut anchor = block_start;
+        // `ip` (current input cursor): we start AFTER the reset
+        // window. Donor `ip += minMatchLength;`.
+        let mut ip = block_start + min_match;
+        // Donor caps the outer walk at `iend - HASH_READ_SIZE`
+        // (`zstd_ldm.c:366`). HASH_READ_SIZE = 8 in donor.
+        const HASH_READ_SIZE: usize = 8;
+        let ilimit = block_end.saturating_sub(HASH_READ_SIZE);
+
+        while ip < ilimit {
+            let chunk = &history[ip..ilimit];
+            let (hashed, num_splits) =
                 gear_hash::feed(&mut self.hash_state, chunk, &mut self.splits_scratch);
 
-            // Insert pass — donor `ZSTD_ldm_fillHashTable`
-            // (`zstd_ldm.c:289-325`). Each split index `s` is the
-            // post-byte offset INSIDE `chunk`; the matched window
-            // starts at `chunk_abs + s - min_match_length`. If
-            // `s < min_match_length` we have no window yet (donor
-            // `if (ip + splits[n] >= istart + minMatchLength)`).
-            for &s in &self.splits_scratch[..num_splits] {
-                if s < min_match {
+            // Two-pass over the batch like donor. The first pass
+            // prepares (hash, checksum) for every split (donor
+            // does it for PREFETCH_L1; we leave the entries in
+            // `splits_scratch` and recompute the per-split state
+            // in pass two — Rust's optimiser folds the duplicated
+            // work). Pass two is the verify + emit + insert loop.
+            let mut split_idx = 0usize;
+            while split_idx < num_splits {
+                let s = self.splits_scratch[split_idx];
+                split_idx += 1;
+                // Donor `zstd_ldm.c:313`:
+                //   if (ip + splits[n] >= istart + minMatchLength)
+                // Since `ip - block_start >= min_match` after the
+                // reset, the window-start subtraction never
+                // underflows. Belt-and-braces defensive guard:
+                if s + ip < block_start + min_match {
                     continue;
                 }
-                let window_start = cursor + s - min_match;
-                let window_end = window_start + min_match;
+                let split_abs = ip + s - min_match;
+                let window_end = split_abs + min_match;
                 if window_end > block_end {
-                    // Defensive — donor's loop walks `ip..iend` so
-                    // `window_end <= iend` is guaranteed; the cap
-                    // here is paranoid against caller bugs.
                     continue;
                 }
+
                 let mut hasher = XxHash64::with_seed(LDM_XXH64_SEED);
-                hasher.write(&history[window_start..window_end]);
+                hasher.write(&history[split_abs..window_end]);
                 let xxhash = hasher.finish();
                 let hash_id = (xxhash as u32) & hash_id_mask;
                 let checksum = (xxhash >> 32) as u32;
-                self.hash_table.insert(
+
+                let new_entry = LdmEntry {
+                    offset: split_abs as u32,
+                    checksum,
+                };
+
+                // Donor `zstd_ldm.c:420-426`: if this split would
+                // emit a sequence overlapping the previous one,
+                // just record it and move on.
+                if split_abs < anchor {
+                    self.hash_table.insert(hash_id, new_entry);
+                    continue;
+                }
+
+                // Search bucket for the best forward+backward
+                // match. `lowest_index_abs = 0` matches our
+                // prefix-only invariant (every entry with
+                // `offset > 0` is in-window).
+                let best = find_best_match(
+                    &self.hash_table,
                     hash_id,
-                    LdmEntry {
-                        offset: window_start as u32,
-                        checksum,
+                    checksum,
+                    FindBestMatchInputs {
+                        history,
+                        split_abs,
+                        anchor_abs: anchor,
+                        lowest_index_abs: 0,
+                        min_match_length: min_match,
                     },
                 );
+
+                let Some(best) = best else {
+                    // Donor `zstd_ldm.c:468-473`: no match → just
+                    // insert the new entry and continue.
+                    self.hash_table.insert(hash_id, new_entry);
+                    continue;
+                };
+
+                // Match found. Donor `zstd_ldm.c:475-488`.
+                let offset = (split_abs as u32) - best.match_pos;
+                let lit_length = split_abs - best.backward_len - anchor;
+                let match_length = best.total_len();
+                out.push(HcRawSeq {
+                    lit_length,
+                    offset: offset as usize,
+                    match_length,
+                });
+
+                // Insert AFTER finding the match so the lookup
+                // doesn't clobber `bestEntry` (donor `zstd_ldm.c:
+                // 490-492`).
+                self.hash_table.insert(hash_id, new_entry);
+
+                // Advance anchor past the matched bytes (donor
+                // `zstd_ldm.c:494`).
+                anchor = split_abs + best.forward_len;
+
+                // Donor `zstd_ldm.c:496-508`: when the emitted
+                // match extends past the already-hashed window,
+                // skip ahead by re-resetting the rolling hash on
+                // the bytes preceding the new anchor.
+                if anchor > ip + hashed {
+                    let reset_start = anchor.saturating_sub(min_match);
+                    if reset_start + min_match <= block_end {
+                        self.hash_state = GearHashState::new(min_match, self.params.hash_rate_log);
+                        gear_hash::reset(
+                            &mut self.hash_state,
+                            &history[reset_start..reset_start + min_match],
+                        );
+                        // Continue the outer `while (ip < ilimit)`
+                        // loop at `anchor`. Donor: `ip = anchor -
+                        // hashed;` so the upcoming `ip += hashed`
+                        // lands exactly at `anchor`.
+                        ip = anchor.saturating_sub(hashed);
+                    }
+                    break;
+                }
             }
 
-            // Donor's outer `while (ip < iend)` advances by the
-            // number of bytes the gear hash consumed; if the batch
-            // filled up before reaching the end of the chunk the
-            // loop re-enters with the new cursor. `max(1)` defends
-            // against a pathological `consumed == 0` (impossible by
-            // construction — `gear_feed` always advances by at
-            // least one byte if `chunk` is non-empty — but keeps
-            // the loop monotonic).
-            cursor += consumed.max(1);
+            ip = ip.saturating_add(hashed).max(ip + 1);
         }
+
+        // Donor returns `iend - anchor` (the "leftover" tail),
+        // which our caller doesn't currently need; the optimal
+        // parser drains `out` based on the sequences alone.
     }
 }
 
@@ -286,6 +403,82 @@ mod tests {
             producer.hash_state.rolling,
             gear_hash::GEAR_HASH_INIT,
             "clear must rewind to GEAR_HASH_INIT"
+        );
+    }
+
+    /// End-to-end producer pipeline: a long-range repetition
+    /// (two copies of a 4 KiB random-like payload separated by
+    /// 64 KiB of unique filler) must emit at least one
+    /// [`HcRawSeq`] whose `offset` equals the distance between
+    /// the copies and whose `match_length` reaches at least the
+    /// donor `min_match_length` floor. Validates that
+    /// gear-hash → bucket-insert → checksum-filter → forward /
+    /// backward extend → emit all hold together.
+    #[test]
+    fn generate_into_emits_long_range_match_on_repeated_payload() {
+        // Use level 22 / btultra2 / windowLog 27 to get the
+        // halved min_match (32) — the default 64 would require a
+        // 128 KiB+ fixture to comfortably trigger a split inside
+        // the payload, which slows the test without adding
+        // coverage.
+        let mut producer = LdmProducer::with_window_and_strategy(27, 9);
+        let p = producer.params();
+        assert_eq!(p.min_match_length, 32);
+
+        // Build a fixture: payload, gap, payload, sized so the
+        // second payload sits comfortably past the gear hash's
+        // `2 ^ hash_rate_log` ≈ 16-byte expected split spacing.
+        // 4 KiB payload + 64 KiB gap + 4 KiB payload ⇒ ~72 KiB
+        // total, plenty of bytes for multiple split points inside
+        // each copy.
+        const PAYLOAD: usize = 4096;
+        const GAP: usize = 64 * 1024;
+        let mut history = Vec::with_capacity(2 * PAYLOAD + GAP);
+        // Deterministic non-trivial payload: a simple LCG so the
+        // bytes look random to the gear hash but the fixture
+        // remains reproducible across runs.
+        let mut prng: u32 = 0x1234_5678;
+        let payload: alloc::vec::Vec<u8> = (0..PAYLOAD)
+            .map(|_| {
+                prng = prng.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+                (prng >> 16) as u8
+            })
+            .collect();
+        history.extend_from_slice(&payload);
+        // Unique-byte gap: counter mod 251 keeps the gap
+        // statistically distinct from the payload (251 prime so
+        // it doesn't accidentally align with payload bytes).
+        history.extend((0..GAP).map(|i| (i % 251) as u8));
+        history.extend_from_slice(&payload);
+
+        let mut out = Vec::new();
+        producer.generate_into(&history, 0, history.len(), &mut out);
+
+        assert!(
+            !out.is_empty(),
+            "long-range repetition must produce at least one LDM sequence"
+        );
+        // Every emitted sequence must satisfy the donor floor.
+        for seq in &out {
+            assert!(
+                seq.match_length >= p.min_match_length as usize,
+                "every emitted match must reach min_match_length \
+                 (got match_length = {})",
+                seq.match_length
+            );
+        }
+        // At least one emitted sequence must reach across the
+        // gap into the first payload copy — this is the
+        // long-range match LDM exists to capture. Short-distance
+        // matches found inside the first payload (statistically
+        // possible on random-like content) are allowed too, but
+        // the long-range one must show up.
+        let crossing_gap = out.iter().any(|s| s.offset >= GAP);
+        assert!(
+            crossing_gap,
+            "at least one emitted sequence must have offset >= GAP \
+             ({GAP}); offsets observed: {:?}",
+            out.iter().map(|s| s.offset).collect::<alloc::vec::Vec<_>>()
         );
     }
 

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -329,6 +329,14 @@ impl LdmProducer {
                         split_abs,
                         anchor_abs,
                         lowest_index_abs: history_abs_start,
+                        // Cap the forward search at the current
+                        // block's end — donor `iend`. Without
+                        // this bound a match could extend past
+                        // `block_end_abs` into bytes the
+                        // producer hasn't scanned yet, breaking
+                        // the `anchor <= split + forward <=
+                        // block_end_abs` invariant downstream.
+                        iend_abs: block_end_abs,
                         min_match_length: min_match,
                     },
                 );
@@ -391,7 +399,15 @@ impl LdmProducer {
                 }
             }
 
-            ip_abs = ip_abs.saturating_add(hashed).max(ip_abs + 1);
+            // Guarantee forward progress even when `hashed == 0`
+            // (gear_feed in practice always advances by at least
+            // one byte over a non-empty chunk, but the saturating
+            // fallback below keeps the outer `while` loop
+            // monotonic against any future regression).
+            // Both operands of `.max(..)` use `saturating_add` so
+            // `ip_abs` near `usize::MAX` saturates rather than
+            // overflowing the inner `ip_abs + 1`.
+            ip_abs = ip_abs.saturating_add(hashed).max(ip_abs.saturating_add(1));
         }
 
         // Donor returns `iend - anchor` (the "leftover" tail),

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -208,16 +208,15 @@ impl LdmProducer {
             return;
         }
 
-        // hBits = hashLog - bucketSizeLog. Donor `zstd_ldm.c:354`.
-        let h_bits = self
-            .params
-            .hash_log
-            .saturating_sub(self.params.bucket_size_log);
-        let hash_id_mask: u32 = if h_bits >= 32 {
-            u32::MAX
-        } else {
-            (1u32 << h_bits).wrapping_sub(1)
-        };
+        // hBits = hashLog - bucketSizeLog (donor `zstd_ldm.c:354`).
+        // Pull the mask from the table rather than re-deriving from
+        // `params.hash_log / params.bucket_size_log`: the table
+        // applies a `min(bucket_size_log, hash_log)` clamp
+        // (`zstd_ldm.c:176`) which the producer-side recomputation
+        // does not, so any caller that constructs the table with a
+        // `bucket_size_log >= hash_log` would see drift between
+        // `hash_id_mask` and the actual bucket count.
+        let hash_id_mask: u32 = self.hash_table.bucket_mask();
 
         // Re-init + reset against the first min_match bytes —
         // donor `zstd_ldm.c:381-383`. The table itself is

--- a/zstd/src/encoding/ldm/params.rs
+++ b/zstd/src/encoding/ldm/params.rs
@@ -66,7 +66,16 @@ impl LdmParams {
     ///
     /// Returns a fully-initialised `LdmParams` with no zero fields.
     pub(crate) fn adjust_for(window_log: u32, strategy: u32) -> Self {
-        debug_assert!(
+        // Runtime `assert!` (not `debug_assert!`) — the body uses
+        // raw `LDM_HASH_RLOG - (strategy / 3)`, which underflows
+        // `u32` for `strategy >= 24` (`7 - 8 = u32::MAX`) and
+        // yields nonsensical `hash_rate_log` in release builds.
+        // Donor enforces the same precondition as a hard
+        // `assert(1 <= strategy && strategy <= 9)` at
+        // `zstd_ldm.c:149` / `zstd_ldm.c:167`; we mirror that
+        // hardness in our `pub(crate)` surface. The check runs
+        // once per frame so the cost is negligible.
+        assert!(
             (1..=9).contains(&strategy),
             "strategy must be a donor 1..=9 ordinal (donor asserts at \
              zstd_ldm.c:149 + zstd_ldm.c:167)"
@@ -156,6 +165,18 @@ mod tests {
     ///   strategy 3 (greedy)   → 6
     ///   strategy 6 (btlazy2)  → 5
     ///   strategy 9 (btultra2) → 4
+    /// `adjust_for` must panic in BOTH debug and release builds
+    /// when handed an out-of-range strategy (donor 1..=9). The
+    /// inner `LDM_HASH_RLOG - (strategy / 3)` would otherwise
+    /// underflow `u32` for `strategy >= 24` and produce
+    /// nonsensical params. Regression for PR #139 round-10
+    /// review (Copilot).
+    #[test]
+    #[should_panic(expected = "strategy must be a donor 1..=9 ordinal")]
+    fn adjust_for_panics_on_out_of_range_strategy() {
+        let _ = LdmParams::adjust_for(27, 24);
+    }
+
     #[test]
     fn adjust_strategy_to_hash_rate_log_matches_donor_table() {
         assert_eq!(LdmParams::adjust_for(27, 1).hash_rate_log, 7);

--- a/zstd/src/encoding/ldm/params.rs
+++ b/zstd/src/encoding/ldm/params.rs
@@ -1,0 +1,223 @@
+//! LDM tuning parameters and donor-parity defaults.
+//!
+//! Direct port of `ldmParams_t` (`zstd_compress_internal.h`) and the
+//! `ZSTD_ldm_adjustParameters` derivation logic (`zstd_ldm.c:135`),
+//! v1.5.7.
+//!
+//! Donor flow:
+//!
+//! 1. Caller starts with a zeroed `ldmParams_t` (all auto-derive).
+//! 2. [`LdmParams::adjust_for`] fills the zero-valued knobs from
+//!    `windowLog` / `strategy` using the same `BOUNDED` clamps as
+//!    donor.
+//! 3. The returned struct then feeds [`super::gear_hash::GearHashState::new`]
+//!    and the bucket hash table.
+
+use super::gear_hash::{LDM_BUCKET_SIZE_LOG, LDM_HASH_RLOG, LDM_MIN_MATCH_LENGTH};
+
+/// Donor `ZSTD_HASHLOG_MIN` (`zstd.h:1268`).
+pub(crate) const LDM_HASHLOG_MIN: u32 = 6;
+/// Donor `ZSTD_HASHLOG_MAX` (`zstd.h:1267`). Donor caps at
+/// `min(WINDOWLOG_MAX, 30)`; both Rust and donor share the `30` cap
+/// because no platform we target exceeds it.
+pub(crate) const LDM_HASHLOG_MAX: u32 = 30;
+/// Donor `ZSTD_LDM_BUCKETSIZELOG_MAX` (`zstd.h:1300`).
+pub(crate) const LDM_BUCKETSIZELOG_MAX: u32 = 8;
+
+/// Donor strategy ordinal for `ZSTD_btultra`. Triggers the
+/// `minMatchLength /= 2` step in `adjust_for`. Donor `zstd.h`
+/// enumerates strategies as 1..=9 in order:
+/// fast, dfast, greedy, lazy, lazy2, btlazy2, btopt, btultra, btultra2.
+pub(crate) const STRATEGY_BTULTRA: u32 = 8;
+
+/// LDM parameter set fed to both the gear-hash producer and the
+/// bucket hash table. Field semantics mirror donor `ldmParams_t`.
+///
+/// All-zero `LdmParams::default()` is the donor sentinel for
+/// "auto-derive every knob"; [`Self::adjust_for`] performs that
+/// derivation.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct LdmParams {
+    /// Compression `windowLog` (mirrors `cParams->windowLog`). The
+    /// LDM window size in bytes is `1 << window_log`.
+    pub(crate) window_log: u32,
+    /// `log2` of the LDM hash-table size (in entries). Donor name:
+    /// `hashLog`. Clamped to `[LDM_HASHLOG_MIN, LDM_HASHLOG_MAX]`.
+    pub(crate) hash_log: u32,
+    /// `log2` of bytes between successive split-point checks (on
+    /// average). Donor name: `hashRateLog`. Defaults derived from
+    /// strategy.
+    pub(crate) hash_rate_log: u32,
+    /// Minimum accepted LDM match length in bytes. Donor name:
+    /// `minMatchLength`. Defaults to [`LDM_MIN_MATCH_LENGTH`], halved
+    /// for `>= btultra`.
+    pub(crate) min_match_length: u32,
+    /// `log2` of the per-bucket entry count. Donor name:
+    /// `bucketSizeLog`. Clamped to
+    /// `[LDM_BUCKET_SIZE_LOG, LDM_BUCKETSIZELOG_MAX]`.
+    pub(crate) bucket_size_log: u32,
+}
+
+impl LdmParams {
+    /// Derive a complete parameter set from caller-supplied
+    /// `window_log` + `strategy` using donor `ZSTD_ldm_adjustParameters`
+    /// (`zstd_ldm.c:135`). Strategy is the donor 1..=9 enum ordinal
+    /// (fast=1 .. btultra2=9).
+    ///
+    /// Returns a fully-initialised `LdmParams` with no zero fields.
+    pub(crate) fn adjust_for(window_log: u32, strategy: u32) -> Self {
+        debug_assert!(
+            (1..=9).contains(&strategy),
+            "strategy must be a donor 1..=9 ordinal (donor asserts at \
+             zstd_ldm.c:149 + zstd_ldm.c:167)"
+        );
+
+        let mut params = Self {
+            window_log,
+            ..Self::default()
+        };
+
+        // hash_rate_log: donor `zstd_ldm.c:141-153`. With `hash_log`
+        // still zero (the only path we expose), donor falls into the
+        // `7 - strategy/3` branch.
+        if params.hash_rate_log == 0 {
+            if params.hash_log > 0 && params.window_log > params.hash_log {
+                params.hash_rate_log = params.window_log - params.hash_log;
+            } else {
+                // Map [fast=1, rate 7] .. [btultra2=9, rate 4].
+                // Donor `zstd_ldm.c:151`.
+                params.hash_rate_log = LDM_HASH_RLOG - (strategy / 3);
+            }
+        }
+
+        // hash_log: donor `zstd_ldm.c:154-160`.
+        if params.hash_log == 0 {
+            params.hash_log = if params.window_log <= params.hash_rate_log {
+                LDM_HASHLOG_MIN
+            } else {
+                bounded(
+                    LDM_HASHLOG_MIN,
+                    params.window_log - params.hash_rate_log,
+                    LDM_HASHLOG_MAX,
+                )
+            };
+        }
+
+        // min_match_length: donor `zstd_ldm.c:161-165`.
+        if params.min_match_length == 0 {
+            let mut mml = LDM_MIN_MATCH_LENGTH as u32;
+            if strategy >= STRATEGY_BTULTRA {
+                mml /= 2;
+            }
+            params.min_match_length = mml;
+        }
+
+        // bucket_size_log: donor `zstd_ldm.c:166-169`.
+        if params.bucket_size_log == 0 {
+            params.bucket_size_log = bounded(LDM_BUCKET_SIZE_LOG, strategy, LDM_BUCKETSIZELOG_MAX);
+        }
+
+        params
+    }
+
+    /// Hash-table size in entries: `1 << hash_log`.
+    pub(crate) const fn hash_table_entries(&self) -> usize {
+        1usize << self.hash_log
+    }
+
+    /// Per-bucket slot count: `1 << bucket_size_log`.
+    pub(crate) const fn bucket_slots(&self) -> usize {
+        1usize << self.bucket_size_log
+    }
+}
+
+/// Donor `BOUNDED(lo, val, hi)` macro: clamp `val` into `[lo, hi]`.
+/// Equivalent to `val.clamp(lo, hi)` but kept as a free function so
+/// the donor-line citations read naturally.
+#[inline]
+const fn bounded(lo: u32, val: u32, hi: u32) -> u32 {
+    if val < lo {
+        lo
+    } else if val > hi {
+        hi
+    } else {
+        val
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Spot-check donor strategy → hash_rate_log mapping
+    /// (`zstd_ldm.c:151`): `7 - strategy/3`.
+    ///
+    ///   strategy 1 (fast)     → 7
+    ///   strategy 3 (greedy)   → 6
+    ///   strategy 6 (btlazy2)  → 5
+    ///   strategy 9 (btultra2) → 4
+    #[test]
+    fn adjust_strategy_to_hash_rate_log_matches_donor_table() {
+        assert_eq!(LdmParams::adjust_for(27, 1).hash_rate_log, 7);
+        assert_eq!(LdmParams::adjust_for(27, 3).hash_rate_log, 6);
+        assert_eq!(LdmParams::adjust_for(27, 6).hash_rate_log, 5);
+        assert_eq!(LdmParams::adjust_for(27, 9).hash_rate_log, 4);
+    }
+
+    /// `hash_log` clamping: `BOUNDED(6, window_log - hash_rate_log, 30)`.
+    ///
+    ///   window_log = 27, strategy = 1 → hash_rate_log = 7
+    ///     → window_log - hash_rate_log = 20, in range → hash_log = 20
+    ///   window_log = 10, strategy = 1 → hash_rate_log = 7
+    ///     → window_log - hash_rate_log = 3 < 6 → clamps to 6
+    ///   window_log = 7,  strategy = 1 → hash_rate_log = 7
+    ///     → window_log <= hash_rate_log → degenerate → hash_log = 6
+    #[test]
+    fn adjust_hash_log_clamps_within_donor_bounds() {
+        assert_eq!(LdmParams::adjust_for(27, 1).hash_log, 20);
+        assert_eq!(LdmParams::adjust_for(10, 1).hash_log, LDM_HASHLOG_MIN);
+        assert_eq!(LdmParams::adjust_for(7, 1).hash_log, LDM_HASHLOG_MIN);
+    }
+
+    /// `min_match_length` halving at btultra (strategy ≥ 8).
+    /// Donor `zstd_ldm.c:163-164`.
+    #[test]
+    fn adjust_min_match_halved_for_btultra_and_above() {
+        assert_eq!(
+            LdmParams::adjust_for(27, 7).min_match_length,
+            LDM_MIN_MATCH_LENGTH as u32
+        );
+        assert_eq!(
+            LdmParams::adjust_for(27, 8).min_match_length,
+            (LDM_MIN_MATCH_LENGTH / 2) as u32
+        );
+        assert_eq!(
+            LdmParams::adjust_for(27, 9).min_match_length,
+            (LDM_MIN_MATCH_LENGTH / 2) as u32
+        );
+    }
+
+    /// `bucket_size_log = BOUNDED(LDM_BUCKET_SIZE_LOG, strategy,
+    /// LDM_BUCKETSIZELOG_MAX)` — donor `zstd_ldm.c:168`.
+    /// `LDM_BUCKET_SIZE_LOG = 4`, `LDM_BUCKETSIZELOG_MAX = 8`.
+    #[test]
+    fn adjust_bucket_size_log_clamps_strategy_to_donor_bounds() {
+        // strategy 1 < lower bound 4 → clamps up
+        assert_eq!(LdmParams::adjust_for(27, 1).bucket_size_log, 4);
+        // strategy 4 == lower bound → identity
+        assert_eq!(LdmParams::adjust_for(27, 4).bucket_size_log, 4);
+        // strategy 7 in range → identity
+        assert_eq!(LdmParams::adjust_for(27, 7).bucket_size_log, 7);
+        // strategy 9 > upper bound 8 → clamps down
+        assert_eq!(LdmParams::adjust_for(27, 9).bucket_size_log, 8);
+    }
+
+    /// Derived hash-table size + bucket slots agree with the
+    /// `1 << log` definitions and with each other.
+    #[test]
+    fn derived_helpers_match_log_definitions() {
+        let p = LdmParams::adjust_for(27, 5);
+        assert_eq!(p.hash_table_entries(), 1usize << p.hash_log);
+        assert_eq!(p.bucket_slots(), 1usize << p.bucket_size_log);
+    }
+}

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -126,6 +126,15 @@ pub(crate) struct FindBestMatchInputs<'a> {
     /// Stored as `usize` so the comparison stays valid above the
     /// `u32` boundary (the table itself rebases internally).
     pub(crate) lowest_index_abs: usize,
+    /// Absolute stream position one past the last byte the
+    /// forward match is allowed to reach. Donor `iend` (the
+    /// caller-supplied `block_end_abs`); the forward count is
+    /// clamped to `iend_abs - split_abs` bytes so a match cannot
+    /// extend past the current block's scan boundary even if
+    /// `live_history` happens to contain matching bytes beyond
+    /// it. Must satisfy `iend_abs >= split_abs` and
+    /// `iend_abs <= history_abs_start + live_history.len()`.
+    pub(crate) iend_abs: usize,
     /// Donor `params->minMatchLength` — forward matches shorter
     /// than this floor are filtered out.
     pub(crate) min_match_length: usize,
@@ -155,19 +164,27 @@ pub(crate) fn find_best_match(
         split_abs,
         anchor_abs,
         lowest_index_abs,
+        iend_abs,
         min_match_length,
     } = inputs;
     debug_assert!(history_abs_start <= split_abs);
     debug_assert!(split_abs <= history_abs_start + live_history.len());
     debug_assert!(anchor_abs <= split_abs);
     debug_assert!(history_abs_start <= anchor_abs);
+    debug_assert!(split_abs <= iend_abs);
+    debug_assert!(iend_abs <= history_abs_start + live_history.len());
 
     let bucket = table.bucket(hash_id);
     let mut best: Option<LdmMatch> = None;
     let history_abs_end = history_abs_start + live_history.len();
-    // Translate split_abs to an index into `live_history` once;
-    // every forward comparison reuses it.
+    // Translate split_abs / iend_abs to indices into `live_history`
+    // once; every forward comparison reuses them. `split_idx_end`
+    // caps the forward slice so a match cannot extend past the
+    // current block's scan boundary even if matching bytes happen
+    // to live beyond it — donor `ZSTD_count(split, pMatch, iend)`
+    // is bounded by `iend`.
     let split_idx = split_abs - history_abs_start;
+    let split_idx_end = iend_abs - history_abs_start;
 
     for entry in bucket {
         // Donor `zstd_ldm.c:431`: skip stale or wrong-checksum
@@ -195,8 +212,16 @@ pub(crate) fn find_best_match(
 
         // Forward match: bytes that compare equal starting from
         // `split` vs `match_pos`. Donor `ZSTD_count(split, pMatch,
-        // iend)`.
-        let forward_len = common_prefix_len(&live_history[split_idx..], &live_history[match_idx..]);
+        // iend)` — bounded by `iend`, so we cap the `split` slice
+        // at `split_idx_end`. The match slice is bounded only by
+        // `live_history.len()` because back-references into the
+        // history before the current block are legitimate (donor
+        // `pMatch < iend` is automatically true when the entry's
+        // absolute offset is below `iend_abs`).
+        let forward_len = common_prefix_len(
+            &live_history[split_idx..split_idx_end],
+            &live_history[match_idx..],
+        );
         if forward_len < min_match_length {
             continue;
         }
@@ -287,6 +312,7 @@ mod tests {
                 split_abs: 8,
                 anchor_abs: 0,
                 lowest_index_abs: 0,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         );
@@ -312,6 +338,7 @@ mod tests {
                 split_abs: 8,
                 anchor_abs: 0,
                 lowest_index_abs: 4,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         );
@@ -342,6 +369,7 @@ mod tests {
                 split_abs: 12,
                 anchor_abs: 12,
                 lowest_index_abs: 0,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         )
@@ -374,6 +402,7 @@ mod tests {
                 split_abs: 12,
                 anchor_abs: 10,
                 lowest_index_abs: 0,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         )
@@ -410,12 +439,48 @@ mod tests {
                 split_abs: 16,
                 anchor_abs: 16,
                 lowest_index_abs: 0,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         )
         .expect("a valid candidate must be found");
         assert_eq!(m.match_pos, 8, "longer-forward winner must be picked");
         assert_eq!(m.forward_len, 8);
+    }
+
+    /// Forward count must respect `iend_abs` — even when matching
+    /// bytes continue past the block end inside `live_history`,
+    /// `forward_len` is capped at `iend_abs - split_abs`.
+    /// Regression for PR #139 round-7 review.
+    #[test]
+    fn find_best_match_forward_count_is_bounded_by_iend_abs() {
+        let mut table = fresh_table();
+        table.insert_absolute(1, 4, 0xCAFE);
+        // 4 preamble bytes + two 8-byte "abcdefgh" runs = 20 bytes.
+        // Without iend_abs cap the match at split=12 vs match=4
+        // would return forward_len = 8 ("abcdefgh"). With
+        // iend_abs = 16 (4 bytes past the split) the match must
+        // cap at 4.
+        let history = b"PPPPabcdefghabcdefgh";
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                live_history: history,
+                history_abs_start: 0,
+                split_abs: 12,
+                anchor_abs: 12,
+                lowest_index_abs: 0,
+                iend_abs: 16, // cap: only 4 forward bytes allowed
+                min_match_length: 4,
+            },
+        )
+        .expect("a 4-byte forward match still passes the min_match floor");
+        assert_eq!(
+            m.forward_len, 4,
+            "forward count must cap at iend_abs - split_abs"
+        );
     }
 
     /// Forward match below `min_match_length` is rejected even
@@ -437,6 +502,7 @@ mod tests {
                 split_abs: 12,
                 anchor_abs: 12,
                 lowest_index_abs: 0,
+                iend_abs: history.len(),
                 min_match_length: 4,
             },
         );

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -225,6 +225,23 @@ pub(crate) fn find_best_match(
         if match_abs < history_abs_start || match_abs >= history_abs_end {
             continue;
         }
+        // Back-reference ordering guard: a back-reference must
+        // point at bytes that already exist (`match_abs <
+        // split_abs`). In normal producer operation every entry
+        // in the bucket was inserted at a position strictly less
+        // than the current `split_abs` (the producer's `insert
+        // _absolute` runs AFTER `find_best_match`, and the outer
+        // loop's `split_abs` increases monotonically), so this
+        // check is structurally redundant. Keeping it explicit
+        // hardens against future direct callers (custom tables
+        // injected via test fixtures, an eventual `extDict`
+        // path) where `match_abs == split_abs` would emit
+        // `offset = 0` (invalid back-ref) and `match_abs >
+        // split_abs` would underflow the unsigned subtraction in
+        // the producer's `offset = split_abs − best.match_pos`.
+        if match_abs >= split_abs {
+            continue;
+        }
         let match_idx = match_abs - history_abs_start;
 
         // Forward match: bytes that compare equal starting from
@@ -467,6 +484,56 @@ mod tests {
         .expect("a valid candidate must be found");
         assert_eq!(m.match_pos, 8, "longer-forward winner must be picked");
         assert_eq!(m.forward_len, 8);
+    }
+
+    /// `find_best_match` must reject entries at or past
+    /// `split_abs` so the producer's `offset = split_abs −
+    /// match_pos` never underflows / emits a zero back-reference.
+    /// Regression for PR #139 round-9 review.
+    #[test]
+    fn find_best_match_rejects_entries_at_or_past_split() {
+        let mut table = fresh_table();
+        // Inject a stray entry at exactly `split_abs` — would be
+        // structurally impossible from `LdmProducer::generate_into`
+        // (inserts happen after the lookup) but possible from a
+        // direct caller / test fixture / future extDict variant.
+        table.insert_absolute(1, 12, 0xCAFE);
+        let history = b"PPPPabcdefghabcdefgh";
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                live_history: history,
+                history_abs_start: 0,
+                split_abs: 12,
+                anchor_abs: 12,
+                lowest_index_abs: 0,
+                iend_abs: history.len(),
+                min_match_length: 4,
+            },
+        );
+        assert!(m.is_none(), "entry at split_abs must be rejected");
+
+        // Same fixture but entry at strictly past split — also
+        // must be rejected.
+        let mut table_after = fresh_table();
+        table_after.insert_absolute(1, 16, 0xCAFE);
+        let m_after = find_best_match(
+            &table_after,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                live_history: history,
+                history_abs_start: 0,
+                split_abs: 12,
+                anchor_abs: 12,
+                lowest_index_abs: 0,
+                iend_abs: history.len(),
+                min_match_length: 4,
+            },
+        );
+        assert!(m_after.is_none(), "entry past split_abs must be rejected");
     }
 
     /// Forward count must respect `iend_abs` — even when matching

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -1,0 +1,443 @@
+//! Bucket lookup + forward / backward extension for the LDM
+//! producer.
+//!
+//! Implements the per-split candidate selection from donor
+//! `ZSTD_ldm_generateSequences_internal` (`zstd_ldm.c:405-466`)
+//! v1.5.7, **prefix-only path**. The two-segment `extDict`
+//! variant (donor `ZSTD_count_2segments` +
+//! `ZSTD_ldm_countBackwardsMatch_2segments`) is deferred — the
+//! current Rust encoder does not surface a separate `extDict`
+//! buffer, so every byte the producer can reach lives in a
+//! single contiguous `history` slice and the prefix-only path
+//! is bit-for-bit equivalent to donor on those inputs.
+//!
+//! Donor parity anchors:
+//! * `ZSTD_count`                        → [`super::super::match_table::helpers::common_prefix_len`]
+//! * `ZSTD_ldm_countBackwardsMatch`      → [`count_backwards_match`]
+//! * Per-bucket best-match selection     → [`find_best_match`]
+
+use super::super::match_table::helpers::common_prefix_len;
+use super::table::LdmHashTable;
+
+/// Result of [`find_best_match`]: a verified LDM candidate.
+///
+/// Holds the *resolved* forward and backward lengths separately
+/// because the caller needs both to derive the emitted raw-seq
+/// `lit_length` (`split - backward - anchor`) and the wire-format
+/// match length (`forward + backward`).
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub(crate) struct LdmMatch {
+    /// Absolute byte position of the matching window's start in
+    /// the back reference (donor `bestEntry->offset`).
+    pub(crate) match_pos: u32,
+    /// Bytes that matched forward from `split`.
+    pub(crate) forward_len: usize,
+    /// Bytes that matched backward from `split` (capped by
+    /// `split - anchor` and by `match_pos > lowest_index`).
+    pub(crate) backward_len: usize,
+}
+
+impl LdmMatch {
+    /// Total match length emitted on the wire. Donor
+    /// `mLength = forwardMatchLength + backwardMatchLength`
+    /// (`zstd_ldm.c:477`).
+    pub(crate) const fn total_len(&self) -> usize {
+        self.forward_len + self.backward_len
+    }
+}
+
+/// Donor `ZSTD_ldm_countBackwardsMatch` (`zstd_ldm.c:214-225`):
+/// walk left from `(p_in, p_match)` while bytes still match and
+/// both pointers stay above their respective lower bounds.
+///
+/// Bounds expressed as absolute byte positions into the same
+/// `history` slice the caller passed in: `p_in_abs` is the
+/// candidate's "split" position, `p_match_abs` is the back-ref
+/// position; the walk stops when either reaches its bound or the
+/// bytes diverge.
+///
+/// Returns the number of matched backward bytes (caps at the
+/// tighter of the two `min(p_in_abs - anchor, p_match_abs -
+/// match_base)` distances).
+pub(crate) fn count_backwards_match(
+    history: &[u8],
+    p_in_abs: usize,
+    anchor_abs: usize,
+    p_match_abs: usize,
+    match_base_abs: usize,
+) -> usize {
+    debug_assert!(p_in_abs <= history.len());
+    debug_assert!(p_match_abs <= history.len());
+    debug_assert!(anchor_abs <= p_in_abs);
+    debug_assert!(match_base_abs <= p_match_abs);
+
+    let mut p_in = p_in_abs;
+    let mut p_match = p_match_abs;
+    let mut len = 0usize;
+    while p_in > anchor_abs && p_match > match_base_abs && history[p_in - 1] == history[p_match - 1]
+    {
+        p_in -= 1;
+        p_match -= 1;
+        len += 1;
+    }
+    len
+}
+
+/// Per-call inputs to [`find_best_match`]. Bundled into a struct
+/// so the public function avoids the `clippy::too_many_arguments`
+/// trip-wire while keeping each input clearly named (every field
+/// has a distinct semantic role; merging would obscure the donor
+/// citations).
+pub(crate) struct FindBestMatchInputs<'a> {
+    /// Full per-frame byte slice the match is verified against.
+    pub(crate) history: &'a [u8],
+    /// Absolute byte position of the candidate window's start.
+    /// Donor `split`.
+    pub(crate) split_abs: usize,
+    /// Leftmost byte the producer is still allowed to emit as
+    /// literal — the previous emitted match's post-match
+    /// boundary or `block_start` at frame entry. Donor `anchor`.
+    pub(crate) anchor_abs: usize,
+    /// Donor `lowestIndex` — entries with
+    /// `offset <= lowest_index_abs` are stale and rejected.
+    pub(crate) lowest_index_abs: u32,
+    /// Donor `params->minMatchLength` — forward matches shorter
+    /// than this floor are filtered out.
+    pub(crate) min_match_length: usize,
+}
+
+/// Walk every slot of the bucket associated with `hash_id`, scoring
+/// each entry by `forward + backward` match length, and return the
+/// best candidate strictly above the donor's
+/// `forward >= min_match_length` floor. Returns `None` when no
+/// bucket entry survives the filter.
+///
+/// Mirrors the per-split inner loop in
+/// `ZSTD_ldm_generateSequences_internal` (`zstd_ldm.c:405-466`)
+/// prefix-only path. The caller must pre-resolve `hash_id` via
+/// [`LdmHashTable::bucket_mask`].
+pub(crate) fn find_best_match(
+    table: &LdmHashTable,
+    hash_id: u32,
+    checksum: u32,
+    inputs: FindBestMatchInputs<'_>,
+) -> Option<LdmMatch> {
+    let FindBestMatchInputs {
+        history,
+        split_abs,
+        anchor_abs,
+        lowest_index_abs,
+        min_match_length,
+    } = inputs;
+    debug_assert!(split_abs <= history.len());
+    debug_assert!(anchor_abs <= split_abs);
+
+    let bucket = table.bucket(hash_id);
+    let mut best: Option<LdmMatch> = None;
+    let iend = history.len();
+    // Prefix-only path: history starts at absolute 0 → both the
+    // `match_base` (donor `base`) and the low-prefix pointer
+    // (donor `lowPrefixPtr`) collapse to byte 0.
+    let match_base_abs = 0usize;
+    let low_prefix_abs = 0usize;
+
+    for entry in bucket {
+        // Donor `zstd_ldm.c:431`: skip stale or wrong-checksum
+        // entries.
+        if entry.checksum != checksum || entry.offset <= lowest_index_abs {
+            continue;
+        }
+        let match_pos = entry.offset as usize;
+        // Defensive: the producer should never insert an offset
+        // beyond `history.len()`, but if a caller injects a
+        // synthetic table this guard avoids panicking on the
+        // slice below.
+        if match_pos >= iend {
+            continue;
+        }
+
+        // Forward match: bytes that compare equal starting from
+        // `split` vs `match_pos`. Donor `ZSTD_count(split, pMatch,
+        // iend)`.
+        let forward_len = common_prefix_len(&history[split_abs..], &history[match_pos..]);
+        if forward_len < min_match_length {
+            continue;
+        }
+
+        // Backward match: walk left as far as both `anchor`-bound
+        // and `low_prefix`-bound permit. Donor `zstd_ldm.c:455-456`.
+        let backward_len = count_backwards_match(
+            history,
+            split_abs,
+            anchor_abs,
+            match_pos,
+            low_prefix_abs.max(match_base_abs),
+        );
+
+        let candidate = LdmMatch {
+            match_pos: match_pos as u32,
+            forward_len,
+            backward_len,
+        };
+        match best {
+            Some(b) if candidate.total_len() <= b.total_len() => {}
+            _ => best = Some(candidate),
+        }
+    }
+
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::ldm::table::{LdmEntry, LdmHashTable};
+
+    fn fresh_table() -> LdmHashTable {
+        // 4-bucket × 4-slot table — small enough that we can
+        // hand-place candidates in known slots.
+        LdmHashTable::new(4, 2)
+    }
+
+    /// `count_backwards_match` honours both lower bounds and
+    /// stops on the first mismatch. Fixture: "XXXabc" matches
+    /// "YYYabc" with 3 backward bytes from offset 3 in each.
+    #[test]
+    fn count_backwards_match_walks_until_mismatch_or_bound() {
+        // history = "abc__abc"  positions: 0..3 = "abc",
+        //                                  3..5 = "__",
+        //                                  5..8 = "abc".
+        // Backwards walk from p_in=8 (after "abc") and p_match=3
+        // (after the first "abc") should match the 3 bytes
+        // "abc".
+        let history = b"abc__abc";
+        let len = count_backwards_match(history, 8, 0, 3, 0);
+        assert_eq!(len, 3);
+
+        // Mismatch on the 4th byte back: '_' (history[4]) vs
+        // nothing in the first window — the walk hits the
+        // match_base_abs bound (0) earlier on the match side.
+        let len2 = count_backwards_match(history, 5, 0, 0, 0);
+        // p_match starts at 0 → match_base bound reached
+        // immediately → 0 bytes matched.
+        assert_eq!(len2, 0);
+    }
+
+    /// `anchor_abs` caps the backward walk on the in-stream side.
+    #[test]
+    fn count_backwards_match_respects_anchor_bound() {
+        let history = b"aaaaaaaa";
+        // anchor at position 5 → only 1 byte of leftward room.
+        let len = count_backwards_match(history, 6, 5, 4, 0);
+        assert_eq!(len, 1);
+    }
+
+    /// Bucket lookup returns `None` when every slot mismatches
+    /// the checksum.
+    #[test]
+    fn find_best_match_returns_none_on_checksum_mismatch() {
+        let mut table = fresh_table();
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 4,
+                checksum: 0x1111_1111,
+            },
+        );
+        let history = b"abcdefghabcdefgh";
+        let m = find_best_match(
+            &table,
+            1,
+            0xDEAD_BEEF,
+            FindBestMatchInputs {
+                history,
+                split_abs: 8,
+                anchor_abs: 0,
+                lowest_index_abs: 0,
+                min_match_length: 4,
+            },
+        );
+        assert!(m.is_none(), "wrong checksum must be filtered out");
+    }
+
+    /// Bucket lookup returns `None` when the offset is at or
+    /// below `lowest_index_abs` (donor staleness rejection).
+    #[test]
+    fn find_best_match_rejects_stale_entries() {
+        let mut table = fresh_table();
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 4,
+                checksum: 0xCAFE,
+            },
+        );
+        let history = b"abcdefghabcdefgh";
+        // lowest_index_abs = 4 → entry offset 4 is NOT strictly
+        // greater → rejected.
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                history,
+                split_abs: 8,
+                anchor_abs: 0,
+                lowest_index_abs: 4,
+                min_match_length: 4,
+            },
+        );
+        assert!(m.is_none(), "stale entry must be filtered out");
+    }
+
+    /// `find_best_match` returns the longest combined
+    /// forward+backward match across the bucket. Engineered
+    /// fixture: a 4-byte preamble (so the donor `offset > 0`
+    /// staleness floor is satisfied — entry.offset == 0 is the
+    /// reserved "empty slot" sentinel) followed by two
+    /// repetitions of "abcdefgh". The single candidate at
+    /// offset 4 should produce forward 8 + backward 0 = 8.
+    #[test]
+    fn find_best_match_picks_longest_combined_match() {
+        let mut table = fresh_table();
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 4,
+                checksum: 0xCAFE,
+            },
+        );
+        let history = b"PPPPabcdefghabcdefgh";
+        // split at position 12, anchor at 12 → no backward room.
+        // The forward count should match 8 bytes ("abcdefgh").
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                history,
+                split_abs: 12,
+                anchor_abs: 12,
+                lowest_index_abs: 0,
+                min_match_length: 4,
+            },
+        )
+        .expect("a valid candidate must be found");
+        assert_eq!(m.match_pos, 4);
+        assert_eq!(m.forward_len, 8);
+        assert_eq!(m.backward_len, 0);
+        assert_eq!(m.total_len(), 8);
+    }
+
+    /// Backward extension picks up the bytes BEFORE `split` when
+    /// `anchor` allows. Fixture: "XYabcdefghXYabcdefgh" — split
+    /// at position 12 ('a'), anchor at 10 ('X') gives 2 bytes of
+    /// backward room ("XY"). Forward 8 + backward 2 = total 10.
+    #[test]
+    fn find_best_match_extends_backwards_into_pre_split_bytes() {
+        let mut table = fresh_table();
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 2,
+                checksum: 0xCAFE,
+            },
+        );
+        let history = b"XYabcdefghXYabcdefgh";
+        // split at 12 (start of second "abcdefgh"), anchor at 10
+        // → backward up to 2 bytes ("XY" at positions 10..12 vs
+        // 0..2). Forward count: 8 bytes ("abcdefgh").
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                history,
+                split_abs: 12,
+                anchor_abs: 10,
+                lowest_index_abs: 0,
+                min_match_length: 4,
+            },
+        )
+        .expect("a valid candidate must be found");
+        assert_eq!(m.match_pos, 2);
+        assert_eq!(m.forward_len, 8);
+        assert_eq!(m.backward_len, 2);
+        assert_eq!(m.total_len(), 10);
+    }
+
+    /// When the bucket holds multiple valid candidates the longer
+    /// combined match wins, regardless of slot order. Preamble
+    /// bytes shift both candidate offsets above the donor `offset
+    /// > 0` floor.
+    #[test]
+    fn find_best_match_prefers_longer_total_across_slots() {
+        let mut table = fresh_table();
+        // Slot 0: offset 4 (short forward match — only 4 bytes).
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 4,
+                checksum: 0xCAFE,
+            },
+        );
+        // Slot 1: offset 8 (8-byte match — extends further forward).
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 8,
+                checksum: 0xCAFE,
+            },
+        );
+        let history = b"PPPPabcdabcdefghabcdefgh";
+        // split at position 16 ('a' of trailing block). Match at
+        // offset 8 ("abcdefgh") gives 8 bytes forward; match at
+        // offset 4 ("abcdabcd...") gives only 4 bytes forward
+        // because the 5th byte ('a' vs 'e') mismatches.
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                history,
+                split_abs: 16,
+                anchor_abs: 16,
+                lowest_index_abs: 0,
+                min_match_length: 4,
+            },
+        )
+        .expect("a valid candidate must be found");
+        assert_eq!(m.match_pos, 8, "longer-forward winner must be picked");
+        assert_eq!(m.forward_len, 8);
+    }
+
+    /// Forward match below `min_match_length` is rejected even
+    /// when the checksum agrees (donor `zstd_ldm.c:444/452`).
+    #[test]
+    fn find_best_match_filters_short_forward_matches() {
+        let mut table = fresh_table();
+        table.insert(
+            1,
+            LdmEntry {
+                offset: 4,
+                checksum: 0xCAFE,
+            },
+        );
+        let history = b"PPPPabXXXXXXab";
+        // 2-byte forward match from split=12 vs match=4, but
+        // min_match_length = 4 → rejected.
+        let m = find_best_match(
+            &table,
+            1,
+            0xCAFE,
+            FindBestMatchInputs {
+                history,
+                split_abs: 12,
+                anchor_abs: 12,
+                lowest_index_abs: 0,
+                min_match_length: 4,
+            },
+        );
+        assert!(m.is_none());
+    }
+}

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -119,12 +119,25 @@ pub(crate) struct FindBestMatchInputs<'a> {
     /// match's post-match boundary or the block start at frame
     /// entry. Donor `anchor`.
     pub(crate) anchor_abs: usize,
-    /// Donor `lowestIndex` — entries with absolute `offset <=
-    /// lowest_index_abs` are stale and rejected. Typically the
-    /// caller passes the current `history_abs_start` so any entry
-    /// inserted into a previous, now-evicted window is filtered.
-    /// Stored as `usize` so the comparison stays valid above the
-    /// `u32` boundary (the table itself rebases internally).
+    /// **Inclusive** lower bound: entries with absolute `offset <
+    /// lowest_index_abs` are stale and rejected, entries with
+    /// `offset >= lowest_index_abs` survive. Conceptually the
+    /// "lowest still-live absolute position" — the caller passes
+    /// `history_abs_start` so a candidate at the very left edge
+    /// of the live window (`live_history[0]`, absolute
+    /// `history_abs_start`) remains matchable. Stored as `usize`
+    /// so the comparison stays valid above the `u32` boundary
+    /// (the table itself rebases internally).
+    ///
+    /// Semantic deviation from donor `zstd_ldm.c:431` — donor's
+    /// `cur->offset <= lowestIndex` is an exclusive lower bound
+    /// where `lowestIndex` itself is rejected. We use the inclusive
+    /// form because our internal coordinate space (absolute
+    /// stream position, +1-biased relative offset in the
+    /// rebase-aware table) already differs from donor; flipping
+    /// the comparison removes the need for a
+    /// `history_abs_start.saturating_sub(1)` adjustment at every
+    /// callsite.
     pub(crate) lowest_index_abs: usize,
     /// Absolute stream position one past the last byte the
     /// forward match is allowed to reach. Donor `iend` (the
@@ -199,7 +212,11 @@ pub(crate) fn find_best_match(
         let Some(match_abs) = table.resolve(entry) else {
             continue;
         };
-        if match_abs <= lowest_index_abs {
+        // Inclusive lower bound (see `FindBestMatchInputs::
+        // lowest_index_abs` docs). `match_abs >=
+        // lowest_index_abs` survives; everything below the live
+        // window is filtered.
+        if match_abs < lowest_index_abs {
             continue;
         }
         // Out-of-window guard: an entry above `history_abs_end`
@@ -319,15 +336,19 @@ mod tests {
         assert!(m.is_none(), "wrong checksum must be filtered out");
     }
 
-    /// Bucket lookup returns `None` when the offset is at or
-    /// below `lowest_index_abs` (donor staleness rejection).
+    /// Bucket lookup returns `None` when the offset is strictly
+    /// below `lowest_index_abs` (inclusive lower bound — entries
+    /// at exactly `lowest_index_abs` survive, entries below are
+    /// stale).
     #[test]
     fn find_best_match_rejects_stale_entries() {
         let mut table = fresh_table();
         table.insert_absolute(1, 4, 0xCAFE);
         let history = b"abcdefghabcdefgh";
-        // lowest_index_abs = 4 → entry offset 4 is NOT strictly
-        // greater → rejected.
+        // lowest_index_abs = 5 → entry offset 4 is strictly below
+        // → rejected. (At lowest_index_abs = 4 the entry would
+        // exactly meet the floor and survive — that's the edge
+        // case the inclusive bound is designed to preserve.)
         let m = find_best_match(
             &table,
             1,
@@ -337,7 +358,7 @@ mod tests {
                 history_abs_start: 0,
                 split_abs: 8,
                 anchor_abs: 0,
-                lowest_index_abs: 4,
+                lowest_index_abs: 5,
                 iend_abs: history.len(),
                 min_match_length: 4,
             },

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -88,18 +88,35 @@ pub(crate) fn count_backwards_match(
 /// trip-wire while keeping each input clearly named (every field
 /// has a distinct semantic role; merging would obscure the donor
 /// citations).
+///
+/// All positional fields are **absolute stream coordinates** —
+/// stable across window evictions. `live_history` carries the
+/// concrete byte slice corresponding to the absolute range
+/// `[history_abs_start, history_abs_start + live_history.len())`;
+/// the function performs the abs→slice translation internally so
+/// the bucket entries (which `LdmProducer` stores in absolute
+/// coordinates by design) remain valid after a window slide.
 pub(crate) struct FindBestMatchInputs<'a> {
-    /// Full per-frame byte slice the match is verified against.
-    pub(crate) history: &'a [u8],
-    /// Absolute byte position of the candidate window's start.
-    /// Donor `split`.
+    /// Live history slice (donor: `base + dictLimit .. iend`).
+    /// `live_history[0]` is the byte at absolute position
+    /// `history_abs_start`.
+    pub(crate) live_history: &'a [u8],
+    /// Absolute stream position of `live_history[0]`. Subtracted
+    /// from every absolute position before indexing into the
+    /// slice.
+    pub(crate) history_abs_start: usize,
+    /// Absolute stream position of the candidate window's start.
+    /// Donor `split` (as an absolute index relative to `base`).
     pub(crate) split_abs: usize,
-    /// Leftmost byte the producer is still allowed to emit as
-    /// literal — the previous emitted match's post-match
-    /// boundary or `block_start` at frame entry. Donor `anchor`.
+    /// Absolute stream position of the leftmost byte the producer
+    /// is still allowed to emit as literal — the previous emitted
+    /// match's post-match boundary or the block start at frame
+    /// entry. Donor `anchor`.
     pub(crate) anchor_abs: usize,
-    /// Donor `lowestIndex` — entries with
-    /// `offset <= lowest_index_abs` are stale and rejected.
+    /// Donor `lowestIndex` — entries with absolute `offset <=
+    /// lowest_index_abs` are stale and rejected. Typically the
+    /// caller passes the current `history_abs_start` so any entry
+    /// inserted into a previous, now-evicted window is filtered.
     pub(crate) lowest_index_abs: u32,
     /// Donor `params->minMatchLength` — forward matches shorter
     /// than this floor are filtered out.
@@ -115,7 +132,9 @@ pub(crate) struct FindBestMatchInputs<'a> {
 /// Mirrors the per-split inner loop in
 /// `ZSTD_ldm_generateSequences_internal` (`zstd_ldm.c:405-466`)
 /// prefix-only path. The caller must pre-resolve `hash_id` via
-/// [`LdmHashTable::bucket_mask`].
+/// [`LdmHashTable::bucket_mask`]. All positions in
+/// [`FindBestMatchInputs`] are absolute stream coordinates; the
+/// returned [`LdmMatch::match_pos`] is also absolute.
 pub(crate) fn find_best_match(
     table: &LdmHashTable,
     hash_id: u32,
@@ -123,59 +142,64 @@ pub(crate) fn find_best_match(
     inputs: FindBestMatchInputs<'_>,
 ) -> Option<LdmMatch> {
     let FindBestMatchInputs {
-        history,
+        live_history,
+        history_abs_start,
         split_abs,
         anchor_abs,
         lowest_index_abs,
         min_match_length,
     } = inputs;
-    debug_assert!(split_abs <= history.len());
+    debug_assert!(history_abs_start <= split_abs);
+    debug_assert!(split_abs <= history_abs_start + live_history.len());
     debug_assert!(anchor_abs <= split_abs);
+    debug_assert!(history_abs_start <= anchor_abs);
 
     let bucket = table.bucket(hash_id);
     let mut best: Option<LdmMatch> = None;
-    let iend = history.len();
-    // Prefix-only path: history starts at absolute 0 → both the
-    // `match_base` (donor `base`) and the low-prefix pointer
-    // (donor `lowPrefixPtr`) collapse to byte 0.
-    let match_base_abs = 0usize;
-    let low_prefix_abs = 0usize;
+    let history_abs_end = history_abs_start + live_history.len();
+    // Translate split_abs to an index into `live_history` once;
+    // every forward comparison reuses it.
+    let split_idx = split_abs - history_abs_start;
 
     for entry in bucket {
         // Donor `zstd_ldm.c:431`: skip stale or wrong-checksum
-        // entries.
+        // entries. The staleness check uses absolute coordinates
+        // — entries inserted by previous, now-evicted windows
+        // have `entry.offset` below the current
+        // `history_abs_start` and are filtered here.
         if entry.checksum != checksum || entry.offset <= lowest_index_abs {
             continue;
         }
-        let match_pos = entry.offset as usize;
-        // Defensive: the producer should never insert an offset
-        // beyond `history.len()`, but if a caller injects a
-        // synthetic table this guard avoids panicking on the
-        // slice below.
-        if match_pos >= iend {
+        let match_abs = entry.offset as usize;
+        // Out-of-window guard: an entry above `history_abs_end`
+        // (caller misuse or a torn write race in a future
+        // concurrent caller) would index past `live_history`.
+        if match_abs < history_abs_start || match_abs >= history_abs_end {
             continue;
         }
+        let match_idx = match_abs - history_abs_start;
 
         // Forward match: bytes that compare equal starting from
         // `split` vs `match_pos`. Donor `ZSTD_count(split, pMatch,
         // iend)`.
-        let forward_len = common_prefix_len(&history[split_abs..], &history[match_pos..]);
+        let forward_len = common_prefix_len(&live_history[split_idx..], &live_history[match_idx..]);
         if forward_len < min_match_length {
             continue;
         }
 
         // Backward match: walk left as far as both `anchor`-bound
-        // and `low_prefix`-bound permit. Donor `zstd_ldm.c:455-456`.
+        // and `low_prefix`-bound (the absolute start of the live
+        // history) permit. Donor `zstd_ldm.c:455-456`.
         let backward_len = count_backwards_match(
-            history,
-            split_abs,
-            anchor_abs,
-            match_pos,
-            low_prefix_abs.max(match_base_abs),
+            live_history,
+            split_idx,
+            anchor_abs - history_abs_start,
+            match_idx,
+            0, // live_history[0] IS the low-prefix pointer in slice coords
         );
 
         let candidate = LdmMatch {
-            match_pos: match_pos as u32,
+            match_pos: match_abs as u32,
             forward_len,
             backward_len,
         };
@@ -250,7 +274,8 @@ mod tests {
             1,
             0xDEAD_BEEF,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 8,
                 anchor_abs: 0,
                 lowest_index_abs: 0,
@@ -280,7 +305,8 @@ mod tests {
             1,
             0xCAFE,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 8,
                 anchor_abs: 0,
                 lowest_index_abs: 4,
@@ -315,7 +341,8 @@ mod tests {
             1,
             0xCAFE,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 12,
                 anchor_abs: 12,
                 lowest_index_abs: 0,
@@ -352,7 +379,8 @@ mod tests {
             1,
             0xCAFE,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 12,
                 anchor_abs: 10,
                 lowest_index_abs: 0,
@@ -399,7 +427,8 @@ mod tests {
             1,
             0xCAFE,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 16,
                 anchor_abs: 16,
                 lowest_index_abs: 0,
@@ -431,7 +460,8 @@ mod tests {
             1,
             0xCAFE,
             FindBestMatchInputs {
-                history,
+                live_history: history,
+                history_abs_start: 0,
                 split_abs: 12,
                 anchor_abs: 12,
                 lowest_index_abs: 0,

--- a/zstd/src/encoding/ldm/search.rs
+++ b/zstd/src/encoding/ldm/search.rs
@@ -27,9 +27,13 @@ use super::table::LdmHashTable;
 /// match length (`forward + backward`).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) struct LdmMatch {
-    /// Absolute byte position of the matching window's start in
-    /// the back reference (donor `bestEntry->offset`).
-    pub(crate) match_pos: u32,
+    /// **Absolute** byte position of the matching window's start
+    /// in the back reference (donor `bestEntry->offset`). Stored
+    /// as `usize` so streams larger than `u32::MAX` (4 GiB) stay
+    /// representable end-to-end; the table rebases its internal
+    /// `u32` storage transparently via
+    /// [`LdmHashTable::ensure_room_for`].
+    pub(crate) match_pos: usize,
     /// Bytes that matched forward from `split`.
     pub(crate) forward_len: usize,
     /// Bytes that matched backward from `split` (capped by
@@ -50,31 +54,33 @@ impl LdmMatch {
 /// walk left from `(p_in, p_match)` while bytes still match and
 /// both pointers stay above their respective lower bounds.
 ///
-/// Bounds expressed as absolute byte positions into the same
-/// `history` slice the caller passed in: `p_in_abs` is the
-/// candidate's "split" position, `p_match_abs` is the back-ref
-/// position; the walk stops when either reaches its bound or the
-/// bytes diverge.
+/// Bounds expressed as **slice indices** into `history`: the
+/// caller is expected to translate absolute stream positions to
+/// slice indices via `abs - history_abs_start` before invoking.
+/// `p_in_idx` is the candidate's "split" index, `p_match_idx`
+/// is the back-ref index; `anchor_idx` / `match_base_idx` are
+/// the corresponding lower bounds. The walk stops when either
+/// pointer reaches its bound or the bytes diverge.
 ///
-/// Returns the number of matched backward bytes (caps at the
-/// tighter of the two `min(p_in_abs - anchor, p_match_abs -
-/// match_base)` distances).
+/// Returns the number of matched backward bytes (capped at the
+/// tighter of `min(p_in_idx - anchor_idx, p_match_idx -
+/// match_base_idx)`).
 pub(crate) fn count_backwards_match(
     history: &[u8],
-    p_in_abs: usize,
-    anchor_abs: usize,
-    p_match_abs: usize,
-    match_base_abs: usize,
+    p_in_idx: usize,
+    anchor_idx: usize,
+    p_match_idx: usize,
+    match_base_idx: usize,
 ) -> usize {
-    debug_assert!(p_in_abs <= history.len());
-    debug_assert!(p_match_abs <= history.len());
-    debug_assert!(anchor_abs <= p_in_abs);
-    debug_assert!(match_base_abs <= p_match_abs);
+    debug_assert!(p_in_idx <= history.len());
+    debug_assert!(p_match_idx <= history.len());
+    debug_assert!(anchor_idx <= p_in_idx);
+    debug_assert!(match_base_idx <= p_match_idx);
 
-    let mut p_in = p_in_abs;
-    let mut p_match = p_match_abs;
+    let mut p_in = p_in_idx;
+    let mut p_match = p_match_idx;
     let mut len = 0usize;
-    while p_in > anchor_abs && p_match > match_base_abs && history[p_in - 1] == history[p_match - 1]
+    while p_in > anchor_idx && p_match > match_base_idx && history[p_in - 1] == history[p_match - 1]
     {
         p_in -= 1;
         p_match -= 1;
@@ -117,7 +123,9 @@ pub(crate) struct FindBestMatchInputs<'a> {
     /// lowest_index_abs` are stale and rejected. Typically the
     /// caller passes the current `history_abs_start` so any entry
     /// inserted into a previous, now-evicted window is filtered.
-    pub(crate) lowest_index_abs: u32,
+    /// Stored as `usize` so the comparison stays valid above the
+    /// `u32` boundary (the table itself rebases internally).
+    pub(crate) lowest_index_abs: usize,
     /// Donor `params->minMatchLength` — forward matches shorter
     /// than this floor are filtered out.
     pub(crate) min_match_length: usize,
@@ -163,14 +171,20 @@ pub(crate) fn find_best_match(
 
     for entry in bucket {
         // Donor `zstd_ldm.c:431`: skip stale or wrong-checksum
-        // entries. The staleness check uses absolute coordinates
-        // — entries inserted by previous, now-evicted windows
-        // have `entry.offset` below the current
-        // `history_abs_start` and are filtered here.
-        if entry.checksum != checksum || entry.offset <= lowest_index_abs {
+        // entries. `table.resolve` filters the empty-slot
+        // sentinel (`entry.offset == 0`) and translates the
+        // stored relative offset back to an absolute stream
+        // position so the staleness threshold can be compared
+        // directly even past the `u32` rebase boundary.
+        if entry.checksum != checksum {
             continue;
         }
-        let match_abs = entry.offset as usize;
+        let Some(match_abs) = table.resolve(entry) else {
+            continue;
+        };
+        if match_abs <= lowest_index_abs {
+            continue;
+        }
         // Out-of-window guard: an entry above `history_abs_end`
         // (caller misuse or a torn write race in a future
         // concurrent caller) would index past `live_history`.
@@ -199,7 +213,7 @@ pub(crate) fn find_best_match(
         );
 
         let candidate = LdmMatch {
-            match_pos: match_abs as u32,
+            match_pos: match_abs,
             forward_len,
             backward_len,
         };
@@ -215,7 +229,7 @@ pub(crate) fn find_best_match(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encoding::ldm::table::{LdmEntry, LdmHashTable};
+    use crate::encoding::ldm::table::LdmHashTable;
 
     fn fresh_table() -> LdmHashTable {
         // 4-bucket × 4-slot table — small enough that we can
@@ -261,13 +275,7 @@ mod tests {
     #[test]
     fn find_best_match_returns_none_on_checksum_mismatch() {
         let mut table = fresh_table();
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 4,
-                checksum: 0x1111_1111,
-            },
-        );
+        table.insert_absolute(1, 4, 0x1111_1111);
         let history = b"abcdefghabcdefgh";
         let m = find_best_match(
             &table,
@@ -290,13 +298,7 @@ mod tests {
     #[test]
     fn find_best_match_rejects_stale_entries() {
         let mut table = fresh_table();
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 4,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 4, 0xCAFE);
         let history = b"abcdefghabcdefgh";
         // lowest_index_abs = 4 → entry offset 4 is NOT strictly
         // greater → rejected.
@@ -326,13 +328,7 @@ mod tests {
     #[test]
     fn find_best_match_picks_longest_combined_match() {
         let mut table = fresh_table();
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 4,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 4, 0xCAFE);
         let history = b"PPPPabcdefghabcdefgh";
         // split at position 12, anchor at 12 → no backward room.
         // The forward count should match 8 bytes ("abcdefgh").
@@ -363,13 +359,7 @@ mod tests {
     #[test]
     fn find_best_match_extends_backwards_into_pre_split_bytes() {
         let mut table = fresh_table();
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 2,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 2, 0xCAFE);
         let history = b"XYabcdefghXYabcdefgh";
         // split at 12 (start of second "abcdefgh"), anchor at 10
         // → backward up to 2 bytes ("XY" at positions 10..12 vs
@@ -402,21 +392,9 @@ mod tests {
     fn find_best_match_prefers_longer_total_across_slots() {
         let mut table = fresh_table();
         // Slot 0: offset 4 (short forward match — only 4 bytes).
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 4,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 4, 0xCAFE);
         // Slot 1: offset 8 (8-byte match — extends further forward).
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 8,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 8, 0xCAFE);
         let history = b"PPPPabcdabcdefghabcdefgh";
         // split at position 16 ('a' of trailing block). Match at
         // offset 8 ("abcdefgh") gives 8 bytes forward; match at
@@ -445,13 +423,7 @@ mod tests {
     #[test]
     fn find_best_match_filters_short_forward_matches() {
         let mut table = fresh_table();
-        table.insert(
-            1,
-            LdmEntry {
-                offset: 4,
-                checksum: 0xCAFE,
-            },
-        );
+        table.insert_absolute(1, 4, 0xCAFE);
         let history = b"PPPPabXXXXXXab";
         // 2-byte forward match from split=12 vs match=4, but
         // min_match_length = 4 → rejected.

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -211,11 +211,27 @@ impl LdmHashTable {
     ///
     /// # Panics
     ///
-    /// Panics in debug builds if `hash_id >= bucket_count()`. Release
-    /// builds rely on `bucket_offsets[]` indexing to panic the same
-    /// way (the `entries[]` write past the bucket would corrupt the
-    /// next bucket in release without the assertion).
+    /// Panics in all build modes if `entry.offset == 0` — that
+    /// value is reserved for the empty-slot sentinel and an
+    /// accepted insert would be silently dropped by
+    /// [`Self::resolve`]; callers must produce a +1-biased
+    /// relative offset (use [`Self::insert_absolute`] for the
+    /// common path).
+    ///
+    /// Out-of-range `hash_id` panics in both debug and release
+    /// (Vec bounds-check on `bucket_offsets[hash_id]`); the
+    /// `debug_assert!` exists purely to produce an earlier,
+    /// clearer error than the bare index-out-of-bounds.
     pub(crate) fn insert(&mut self, hash_id: u32, entry: LdmEntry) {
+        // Runtime check (not `debug_assert!`): storing offset 0
+        // would alias the empty-slot sentinel, so a buggy caller
+        // would silently lose candidates rather than fail fast.
+        assert!(
+            entry.offset != 0,
+            "offset 0 is reserved for the empty-slot sentinel; \
+             use `insert_absolute` (which applies the +1 bias) or \
+             store a +1-biased relative offset before calling insert"
+        );
         debug_assert!(
             hash_id <= self.bucket_mask,
             "hash_id {hash_id} out of range (bucket_count = {})",
@@ -394,10 +410,13 @@ mod tests {
     }
 
     /// Round-robin insertion fills the bucket then wraps.
+    /// Uses offsets `1..=6` (not `0..6`) so the test does not
+    /// rely on the sentinel value `0`, which
+    /// [`LdmHashTable::insert`] now rejects with a runtime assert.
     #[test]
     fn insert_round_robin_wraps_through_bucket_slots() {
         let mut t = LdmHashTable::new(4, 2); // 4 buckets × 4 slots
-        for k in 0..6u32 {
+        for k in 1..=6u32 {
             t.insert(
                 1,
                 LdmEntry {
@@ -407,13 +426,32 @@ mod tests {
             );
         }
         let b = t.bucket(1);
-        // After 6 inserts, slots hold: [k=4, k=5, k=2, k=3]
-        // (slot 0 overwritten by k=4, slot 1 by k=5; slots 2,3
-        // hold the pre-wrap inserts k=2,3).
-        assert_eq!(b[0].offset, 4);
-        assert_eq!(b[1].offset, 5);
-        assert_eq!(b[2].offset, 2);
-        assert_eq!(b[3].offset, 3);
+        // After 6 inserts in a 4-slot bucket the round-robin
+        // cursor cycles 0→1→2→3→0→1, so the last write to each
+        // slot is k=5 (slot 0), k=6 (slot 1), k=3 (slot 2),
+        // k=4 (slot 3).
+        assert_eq!(b[0].offset, 5);
+        assert_eq!(b[1].offset, 6);
+        assert_eq!(b[2].offset, 3);
+        assert_eq!(b[3].offset, 4);
+    }
+
+    /// `insert` must reject the empty-slot sentinel `offset == 0`
+    /// — otherwise the entry would survive in the bucket but be
+    /// invisible to [`LdmHashTable::resolve`] (which treats `0`
+    /// as the empty marker), silently dropping candidates.
+    /// Regression for PR #139 round-16 review (CodeRabbit Major).
+    #[test]
+    #[should_panic(expected = "offset 0 is reserved")]
+    fn insert_panics_on_sentinel_offset_zero() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.insert(
+            0,
+            LdmEntry {
+                offset: 0,
+                checksum: 0xDEAD,
+            },
+        );
     }
 
     /// Inserts to one bucket must not bleed into adjacent buckets.

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -1,0 +1,320 @@
+//! Bucket-based hash table for the LDM producer.
+//!
+//! Direct port of the table portion of `ldmState_t` and the
+//! `ZSTD_ldm_getBucket` / `ZSTD_ldm_insertEntry` helpers from
+//! `lib/compress/zstd_ldm.c` v1.5.7.
+//!
+//! Layout (donor `zstd_ldm.c:188-207`):
+//!
+//! ```text
+//! entries: [LdmEntry; 1 << hash_log]
+//!   = bucket_count buckets of `1 << bucket_size_log` slots each
+//!
+//! bucket_offsets: [u8; bucket_count]
+//!   = round-robin write cursor per bucket (donor uses one BYTE)
+//!
+//! bucket_count = 1 << (hash_log - bucket_size_log)
+//! ```
+//!
+//! Lookup is a bare slice into `entries`; insertion is a single
+//! 64-bit write plus a one-byte modular cursor bump. There is no
+//! eviction policy beyond the round-robin overwrite, which mirrors
+//! donor's behaviour and is correct because LDM tolerates dropped
+//! candidates (the verify step rejects stale entries via the
+//! checksum + window-distance check).
+//!
+//! Donor `bucket_size_log` is silently clamped to `hash_log`
+//! (`zstd_ldm.c:176`); the same clamp lives in [`LdmHashTable::new`].
+//!
+//! See [`super::params::LdmParams`] for how the logs are derived.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// One hash-table entry — `(absolute_position, checksum)`.
+///
+/// Mirrors donor `ldmEntry_t` from `zstd_compress_internal.h`. The
+/// 32-bit `checksum` is the high 32 bits of the per-window XXH64;
+/// the low 32 bits index into the bucket array and so do not need to
+/// be stored separately.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct LdmEntry {
+    /// Absolute byte position of the start of the matched window
+    /// (donor: `entry.offset = (U32)(split - base)`).
+    pub(crate) offset: u32,
+    /// High 32 bits of the XXH64 over the `min_match_length`-byte
+    /// window — donor `entry.checksum`. Used to filter false-positive
+    /// bucket collisions before invoking the byte-level verify.
+    pub(crate) checksum: u32,
+}
+
+/// Bucket-based hash table sized from an [`super::params::LdmParams`].
+///
+/// `entries.len() == 1 << hash_log`; `bucket_offsets.len() ==
+/// bucket_count`. Per-bucket slot count is `1 << effective_bucket_log`.
+pub(crate) struct LdmHashTable {
+    entries: Vec<LdmEntry>,
+    bucket_offsets: Vec<u8>,
+    /// Effective bucket-size log after the donor's
+    /// `MIN(bucketSizeLog, hashLog)` clamp (`zstd_ldm.c:176`).
+    effective_bucket_log: u32,
+    /// Hash-id mask: `bucket_count - 1`. The caller must hand in
+    /// hash ids in `[0, bucket_count)`; this mask is exposed so the
+    /// producer can clamp without re-deriving it.
+    bucket_mask: u32,
+}
+
+impl LdmHashTable {
+    /// Allocate a fresh table for the given parameters.
+    ///
+    /// Donor parity: matches `ZSTD_ldm_getTableSize` (`zstd_ldm.c:175-180`)
+    /// in shape — `hashTable + bucketOffsets`. `bucket_size_log` is
+    /// clamped to `hash_log` to mirror the donor's silent floor on
+    /// the per-bucket slot count.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash_log == 0` (no buckets) or `hash_log > 30`
+    /// (would allocate > 8 GiB of entries — far beyond donor's
+    /// `ZSTD_LDM_HASHLOG_MAX = 30`). Both bounds match donor.
+    pub(crate) fn new(hash_log: u32, bucket_size_log: u32) -> Self {
+        assert!(hash_log > 0, "hash_log must be > 0");
+        assert!(
+            hash_log <= 30,
+            "hash_log {hash_log} exceeds donor ZSTD_LDM_HASHLOG_MAX (30)"
+        );
+        // Donor `zstd_ldm.c:176`: effective bucket_size_log is the
+        // min of caller's request and hash_log. Without the clamp a
+        // bucket would span the whole table and bucket_count would
+        // be zero — undefined behaviour upstream and a div-by-zero
+        // here.
+        let effective_bucket_log = bucket_size_log.min(hash_log);
+        let bucket_count = 1u32 << (hash_log - effective_bucket_log);
+        let total_entries = 1usize << hash_log;
+
+        Self {
+            entries: vec![LdmEntry::default(); total_entries],
+            bucket_offsets: vec![0u8; bucket_count as usize],
+            effective_bucket_log,
+            bucket_mask: bucket_count - 1,
+        }
+    }
+
+    /// Reset every bucket to "empty" without reallocating. Donor
+    /// equivalent is the `ZSTD_cwksp` clear of the LDM region at
+    /// frame boundaries.
+    pub(crate) fn clear(&mut self) {
+        for e in &mut self.entries {
+            *e = LdmEntry::default();
+        }
+        self.bucket_offsets.fill(0);
+    }
+
+    /// Number of buckets (`1 << (hash_log - bucket_size_log)`).
+    pub(crate) const fn bucket_count(&self) -> usize {
+        // bucket_mask + 1 == bucket_count; computed at construction
+        // so this is a single load.
+        self.bucket_mask as usize + 1
+    }
+
+    /// Per-bucket slot count (`1 << effective_bucket_log`).
+    pub(crate) const fn bucket_slots(&self) -> usize {
+        1usize << self.effective_bucket_log
+    }
+
+    /// Slice of `bucket_slots()` entries for `hash_id`.
+    ///
+    /// `hash_id` MUST be in `[0, bucket_count())`. The caller is
+    /// responsible for masking via [`Self::bucket_mask`] before
+    /// calling — donor `ZSTD_ldm_getBucket` performs no clamping
+    /// either, leaving the responsibility to the producer.
+    pub(crate) fn bucket(&self, hash_id: u32) -> &[LdmEntry] {
+        let start = (hash_id as usize) << self.effective_bucket_log;
+        let len = self.bucket_slots();
+        &self.entries[start..start + len]
+    }
+
+    /// Insert `entry` into the bucket for `hash_id` at the bucket's
+    /// next round-robin slot.
+    ///
+    /// Donor `ZSTD_ldm_insertEntry` (`zstd_ldm.c:198-207`): the
+    /// per-bucket `bucket_offsets[hash_id]` byte is the next write
+    /// position, post-bump it modulo `1 << bucket_size_log`. The
+    /// modulo is implemented by masking with `slots - 1`.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `hash_id >= bucket_count()`. Release
+    /// builds rely on `bucket_offsets[]` indexing to panic the same
+    /// way (the `entries[]` write past the bucket would corrupt the
+    /// next bucket in release without the assertion).
+    pub(crate) fn insert(&mut self, hash_id: u32, entry: LdmEntry) {
+        debug_assert!(
+            hash_id <= self.bucket_mask,
+            "hash_id {hash_id} out of range (bucket_count = {})",
+            self.bucket_count()
+        );
+        // Read the cursor first (a copy out of the byte array) so the
+        // subsequent mutable accesses to `entries` and the write-back
+        // to `bucket_offsets` do not need to live simultaneously.
+        let slot_mask = self.bucket_slots() - 1;
+        let bucket_start = (hash_id as usize) << self.effective_bucket_log;
+        let offset = self.bucket_offsets[hash_id as usize] as usize;
+        self.entries[bucket_start + offset] = entry;
+        // Post-increment modulo bucket size. Donor stores the result
+        // in a BYTE (so the mask is implicit at bucket_size_log <= 8);
+        // we mirror the explicit mask so values above 8 (clamped by
+        // params, but defensive here) still wrap correctly.
+        let next = (offset + 1) & slot_mask;
+        self.bucket_offsets[hash_id as usize] = next as u8;
+    }
+
+    /// Mask to use on a raw hash to derive `hash_id`. Saves the
+    /// caller from re-deriving `bucket_count - 1`.
+    pub(crate) const fn bucket_mask(&self) -> u32 {
+        self.bucket_mask
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `hash_log = 8`, `bucket_size_log = 4` → 16 buckets ×
+    /// 16 slots = 256 entries, matches donor sizing math.
+    #[test]
+    fn new_table_sizes_match_donor_formulae() {
+        let t = LdmHashTable::new(8, 4);
+        assert_eq!(t.bucket_count(), 16);
+        assert_eq!(t.bucket_slots(), 16);
+        assert_eq!(t.entries.len(), 256);
+        assert_eq!(t.bucket_offsets.len(), 16);
+        assert_eq!(t.bucket_mask(), 15);
+    }
+
+    /// Donor `MIN(bucketSizeLog, hashLog)` clamp must apply: when
+    /// caller requests `bucket_size_log > hash_log` the bucket
+    /// collapses to a single bucket covering all entries.
+    #[test]
+    fn new_clamps_bucket_size_log_to_hash_log() {
+        let t = LdmHashTable::new(6, 12); // bucket > hash → clamp
+        assert_eq!(t.bucket_count(), 1, "clamp must yield a single bucket");
+        assert_eq!(t.bucket_slots(), 1usize << 6);
+        assert_eq!(t.entries.len(), 1usize << 6);
+    }
+
+    /// Round-robin insertion fills the bucket then wraps.
+    #[test]
+    fn insert_round_robin_wraps_through_bucket_slots() {
+        let mut t = LdmHashTable::new(4, 2); // 4 buckets × 4 slots
+        for k in 0..6u32 {
+            t.insert(
+                1,
+                LdmEntry {
+                    offset: k,
+                    checksum: k * 7,
+                },
+            );
+        }
+        let b = t.bucket(1);
+        // After 6 inserts, slots hold: [k=4, k=5, k=2, k=3]
+        // (slot 0 overwritten by k=4, slot 1 by k=5; slots 2,3
+        // hold the pre-wrap inserts k=2,3).
+        assert_eq!(b[0].offset, 4);
+        assert_eq!(b[1].offset, 5);
+        assert_eq!(b[2].offset, 2);
+        assert_eq!(b[3].offset, 3);
+    }
+
+    /// Inserts to one bucket must not bleed into adjacent buckets.
+    /// Guards against off-by-one in the `bucket_start` arithmetic.
+    #[test]
+    fn insert_does_not_contaminate_adjacent_bucket() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.insert(
+            2,
+            LdmEntry {
+                offset: 42,
+                checksum: 0xCAFE,
+            },
+        );
+        let b0 = t.bucket(0);
+        let b1 = t.bucket(1);
+        let b3 = t.bucket(3);
+        for e in b0.iter().chain(b1.iter()).chain(b3.iter()) {
+            assert_eq!(
+                *e,
+                LdmEntry::default(),
+                "neighbouring buckets must stay empty"
+            );
+        }
+        assert_eq!(t.bucket(2)[0].offset, 42);
+    }
+
+    /// `clear` rewinds bucket cursors and zeros entries.
+    #[test]
+    fn clear_zeros_entries_and_rewinds_cursors() {
+        let mut t = LdmHashTable::new(4, 2);
+        for k in 0..4u32 {
+            t.insert(
+                k % 4,
+                LdmEntry {
+                    offset: k + 1,
+                    checksum: k * 11,
+                },
+            );
+        }
+        t.clear();
+        for e in t.bucket(0).iter().chain(t.bucket(3).iter()) {
+            assert_eq!(*e, LdmEntry::default());
+        }
+        for c in &t.bucket_offsets {
+            assert_eq!(*c, 0);
+        }
+        // First insert after clear must land at slot 0.
+        t.insert(
+            2,
+            LdmEntry {
+                offset: 99,
+                checksum: 0,
+            },
+        );
+        assert_eq!(t.bucket(2)[0].offset, 99);
+    }
+
+    /// Boundary-arithmetic smoke test: a moderately large `hash_log`
+    /// must allocate without panic and produce a sane bucket count.
+    /// Doubles as a guard that the assertions don't accidentally
+    /// reject the donor-supported range.
+    ///
+    /// We deliberately do NOT use `hash_log = 30` (donor's max)
+    /// because that would allocate 8 GiB of entries; the bucket
+    /// arithmetic is the same at every log so 18 is sufficient.
+    /// Gated to 64-bit pointer widths to avoid the 32-bit CI shards
+    /// where the 2 MiB allocation would still succeed but the
+    /// `usize` × `u32` cast would over-restrict the integer types
+    /// we exercise elsewhere.
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn new_accepts_donor_max_hash_log() {
+        // Use a small bucket_size_log so the entry count is bounded
+        // and we don't actually allocate 8 GiB. Donor itself never
+        // allocates the max at runtime either (window_log caps
+        // hash_log to 27 or so in practice). Test just the boundary
+        // arithmetic — request hash_log = 18 with bucket_size_log =
+        // 4 → 16 buckets × 16384 slots = 262144 entries × 8 bytes
+        // = ~2 MiB allocation, safe on every CI runner.
+        let t = LdmHashTable::new(18, 4);
+        assert_eq!(t.bucket_count(), 1usize << (18 - 4));
+        assert_eq!(t.bucket_slots(), 1usize << 4);
+    }
+
+    /// `bucket_mask` returned by the table must agree with the
+    /// derived `bucket_count - 1`. Guard against drift if the
+    /// internal field is renamed.
+    #[test]
+    fn bucket_mask_matches_count_minus_one() {
+        let t = LdmHashTable::new(8, 3);
+        assert_eq!(t.bucket_mask() as usize + 1, t.bucket_count());
+    }
+}

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -266,10 +266,14 @@ impl LdmHashTable {
     ///
     /// # Panics
     ///
-    /// Panics in debug builds if `abs_pos < position_base` or if
-    /// `abs_pos - position_base + 1 > u32::MAX`. The producer
-    /// must call `ensure_room_for` before the first insert that
-    /// could exceed the window.
+    /// Panics in **all build modes** if `abs_pos < position_base`
+    /// (enforced by `checked_sub(...).unwrap_or_else(panic!)`) or
+    /// if `abs_pos - position_base + 1 > u32::MAX` (enforced by an
+    /// `assert!`). Both checks are runtime — never `debug_assert!`
+    /// — so a contract violation cannot silently wrap a relative
+    /// offset and corrupt the table in release. The producer must
+    /// call `ensure_room_for` before the first insert that could
+    /// exceed the window.
     pub(crate) fn insert_absolute(&mut self, hash_id: u32, abs_pos: usize, checksum: u32) {
         // Use runtime panics (rather than `debug_assert!`) for both
         // preconditions so a contract violation never silently

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -89,6 +89,22 @@ impl LdmHashTable {
         // be zero — undefined behaviour upstream and a div-by-zero
         // here.
         let effective_bucket_log = bucket_size_log.min(hash_log);
+        // Donor cap `ZSTD_LDM_BUCKETSIZELOG_MAX = 8` (`zstd.h:1300`).
+        // We store the per-bucket round-robin cursor in a `u8`
+        // (mirrors donor `BYTE bucketOffsets[]` in `zstd_ldm.c:202`),
+        // which silently truncates at 256 slots — i.e. above this
+        // cap the cursor would only cycle through the first 256
+        // entries of a larger bucket, dropping new inserts on the
+        // floor. The assertion enforces the donor pre-condition so
+        // callers that bypass `LdmParams::adjust_for` (which already
+        // clamps to `LDM_BUCKETSIZELOG_MAX`) still get a clear
+        // failure instead of silent data loss.
+        assert!(
+            effective_bucket_log <= 8,
+            "effective bucket_size_log {effective_bucket_log} exceeds donor \
+             ZSTD_LDM_BUCKETSIZELOG_MAX (8); a u8 cursor would silently \
+             truncate at 256 slots — widen the cursor or clamp the request"
+        );
         let bucket_count = 1u32 << (hash_log - effective_bucket_log);
         let total_entries = 1usize << hash_log;
 
@@ -307,6 +323,18 @@ mod tests {
         let t = LdmHashTable::new(18, 4);
         assert_eq!(t.bucket_count(), 1usize << (18 - 4));
         assert_eq!(t.bucket_slots(), 1usize << 4);
+    }
+
+    /// `effective_bucket_log > 8` (donor `LDM_BUCKETSIZELOG_MAX`)
+    /// must panic, not silently truncate the `u8` round-robin
+    /// cursor at 256 slots. Donor pre-condition mirrored from
+    /// `zstd_ldm.c:202` where `bucketOffsets` is a `BYTE`.
+    #[test]
+    #[should_panic(expected = "ZSTD_LDM_BUCKETSIZELOG_MAX")]
+    fn new_rejects_bucket_size_log_above_donor_cap() {
+        // hash_log = 12, bucket_size_log = 9 → effective = 9 > 8
+        // → assertion fires.
+        let _ = LdmHashTable::new(12, 9);
     }
 
     /// `bucket_mask` returned by the table must agree with the

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -476,7 +476,7 @@ mod tests {
     /// we exercise elsewhere.
     #[test]
     #[cfg(target_pointer_width = "64")]
-    fn new_accepts_donor_max_hash_log() {
+    fn new_accepts_large_hash_log_smoke() {
         // Use a small bucket_size_log so the entry count is bounded
         // and we don't actually allocate 8 GiB. Donor itself never
         // allocates the max at runtime either (window_log caps

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -291,8 +291,8 @@ impl LdmHashTable {
 
     /// Ensure that absolute position `abs_pos` can be stored as a
     /// `u32` offset relative to [`Self::position_base`] without
-    /// overflow. If the relative position would exceed `u32::MAX
-    /// - REBASE_GUARD_BAND`, advance `position_base` by
+    /// overflow. When the relative position would exceed
+    /// `u32::MAX − REBASE_GUARD_BAND`, advance `position_base` by
     /// [`REBASE_GUARD_BAND`] and run [`Self::reduce`] across all
     /// entries. In the common case (`rel <= max_rel`) the call is
     /// a single compare and returns immediately.

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -326,12 +326,18 @@ impl LdmHashTable {
             // not a rebase trigger.
             return;
         }
-        let rel = abs_pos - self.position_base;
         // Leave at least `REBASE_GUARD_BAND` of u32 headroom
         // above the current insert position so the next batch of
-        // inserts doesn't immediately re-rebase.
+        // inserts doesn't immediately re-rebase. The producer
+        // advances `abs_pos` in small strides today, so the loop
+        // typically runs at most once; the `while` is required by
+        // the doc guarantee — a caller that jumps the position by
+        // more than one guard band (e.g. a future hand-off path
+        // that skips frame regions) would otherwise leave `rel`
+        // above `u32::MAX` after a single shift and panic on the
+        // next insert.
         let max_rel = u32::MAX as usize - REBASE_GUARD_BAND as usize;
-        if rel > max_rel {
+        while abs_pos - self.position_base > max_rel {
             // Shift the base forward by `REBASE_GUARD_BAND` —
             // matches donor's "subtract the reducer value, clamp
             // anything below to 0" semantics.
@@ -589,6 +595,40 @@ mod tests {
         // round-trip.
         t.insert_absolute(2, trigger_pos, 0xCAFE);
         assert_eq!(t.resolve(&t.bucket(2)[0]), Some(trigger_pos));
+    }
+
+    /// `ensure_room_for` must loop until `rel <= max_rel` even if
+    /// the caller jumps the position past several guard bands in
+    /// a single call. With the old single-shot `if`, a jump
+    /// larger than `2 * REBASE_GUARD_BAND` left `rel` above
+    /// `u32::MAX - REBASE_GUARD_BAND`, so the next
+    /// `insert_absolute` would panic on the `(rel + 1) as u32`
+    /// cast. Regression for PR #139 round-14 review (CodeRabbit
+    /// Major).
+    #[test]
+    fn ensure_room_for_loops_across_multiple_guard_bands() {
+        let mut t = LdmHashTable::new(4, 2);
+        // Jump past two guard bands at once. With u32::MAX ≈
+        // 4 * REBASE_GUARD_BAND and max_rel = u32::MAX -
+        // REBASE_GUARD_BAND ≈ 3 * REBASE_GUARD_BAND, an abs_pos
+        // of 5 * REBASE_GUARD_BAND yields rel = 5 *
+        // REBASE_GUARD_BAND > max_rel even after one reduce
+        // (rel = 4 * REBASE_GUARD_BAND > 3 * REBASE_GUARD_BAND).
+        // A second reduce brings rel = 3 * REBASE_GUARD_BAND ≤
+        // max_rel and the loop exits.
+        let abs_pos = 5usize * (REBASE_GUARD_BAND as usize);
+        t.ensure_room_for(abs_pos);
+        let max_rel = u32::MAX as usize - REBASE_GUARD_BAND as usize;
+        assert!(
+            abs_pos - t.position_base() <= max_rel,
+            "ensure_room_for must rebase until rel ≤ max_rel \
+             (got rel = {}, max_rel = {})",
+            abs_pos - t.position_base(),
+            max_rel
+        );
+        // The subsequent insert must succeed (no u32 overflow).
+        t.insert_absolute(0, abs_pos, 0xFEED);
+        assert_eq!(t.resolve(&t.bucket(0)[0]), Some(abs_pos));
     }
 
     /// `insert_absolute` must panic in BOTH debug and release

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -482,7 +482,7 @@ mod tests {
         // allocates the max at runtime either (window_log caps
         // hash_log to 27 or so in practice). Test just the boundary
         // arithmetic — request hash_log = 18 with bucket_size_log =
-        // 4 → 16 buckets × 16384 slots = 262144 entries × 8 bytes
+        // 4 → 16384 buckets × 16 slots = 262144 entries × 8 bytes
         // = ~2 MiB allocation, safe on every CI runner.
         let t = LdmHashTable::new(18, 4);
         assert_eq!(t.bucket_count(), 1usize << (18 - 4));

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -609,7 +609,14 @@ mod tests {
     /// `insert_absolute` would panic on the `(rel + 1) as u32`
     /// cast. Regression for PR #139 round-14 review (CodeRabbit
     /// Major).
+    ///
+    /// Gated to 64-bit pointer widths: `5 * REBASE_GUARD_BAND`
+    /// (= 5 GiB) overflows `usize` on 32-bit targets, where the
+    /// scenario is unreachable anyway because `usize::MAX` < 4
+    /// GiB caps the addressable stream below the rebase
+    /// threshold.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn ensure_room_for_loops_across_multiple_guard_bands() {
         let mut t = LdmHashTable::new(4, 2);
         // Jump past two guard bands at once. With u32::MAX ≈

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -31,27 +31,66 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-/// One hash-table entry — `(absolute_position, checksum)`.
+/// One hash-table entry — `(offset_relative_to_position_base,
+/// checksum)`.
 ///
-/// Mirrors donor `ldmEntry_t` from `zstd_compress_internal.h`. The
-/// 32-bit `checksum` is the high 32 bits of the per-window XXH64;
-/// the low 32 bits index into the bucket array and so do not need to
-/// be stored separately.
+/// Mirrors donor `ldmEntry_t` from `zstd_compress_internal.h`.
+///
+/// **Offset semantics:** `offset` is **NOT an absolute stream
+/// position**. It is stored relative to the owning
+/// [`LdmHashTable::position_base`] so that streams larger than
+/// `u32::MAX` (4 GiB) can be encoded without truncation: the
+/// table calls [`LdmHashTable::resolve`] to translate
+/// `entry.offset` to an absolute position when the producer or
+/// search path needs it, and periodically rebases via
+/// [`LdmHashTable::reduce`] (donor `ZSTD_ldm_reduceTable`,
+/// `zstd_ldm.c:520`) to keep `position - position_base ≤
+/// u32::MAX`. Same scheme `MatchTable` uses for the BT/HC chain
+/// table.
+///
+/// The 32-bit `checksum` is the high 32 bits of the per-window
+/// XXH64; the low 32 bits index into the bucket array and so do
+/// not need to be stored separately.
+///
+/// `offset == 0` is the reserved **empty-slot sentinel** —
+/// callers must never produce a real relative offset of 0
+/// (every insert path adds 1 to the relative position before
+/// storing).
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct LdmEntry {
-    /// Absolute byte position of the start of the matched window
-    /// (donor: `entry.offset = (U32)(split - base)`).
+    /// Position relative to [`LdmHashTable::position_base`], with
+    /// a +1 bias so a fresh default-zeroed entry remains
+    /// distinguishable as "empty". A real absolute position
+    /// `P >= position_base` is stored as `(P - position_base + 1)
+    /// as u32`; the [`LdmHashTable::resolve`] helper handles the
+    /// inverse translation.
     pub(crate) offset: u32,
     /// High 32 bits of the XXH64 over the `min_match_length`-byte
-    /// window — donor `entry.checksum`. Used to filter false-positive
-    /// bucket collisions before invoking the byte-level verify.
+    /// window — donor `entry.checksum`. Used to filter
+    /// false-positive bucket collisions before invoking the
+    /// byte-level verify.
     pub(crate) checksum: u32,
 }
+
+/// Margin reserved above the high-water mark before triggering a
+/// rebase. Donor `ZSTD_ldm_reduceTable` is called at a coarser
+/// granularity (per-frame `ZSTD_window_update`); ours kicks in
+/// per-insert via [`LdmHashTable::ensure_room_for`] but uses a
+/// generous safety band so the rebase is amortised across many
+/// inserts.
+const REBASE_GUARD_BAND: u32 = 1u32 << 30;
 
 /// Bucket-based hash table sized from an [`super::params::LdmParams`].
 ///
 /// `entries.len() == 1 << hash_log`; `bucket_offsets.len() ==
 /// bucket_count`. Per-bucket slot count is `1 << effective_bucket_log`.
+///
+/// **Coordinate model:** entries store positions relative to
+/// `position_base` (see [`LdmEntry`] for the `+1` empty-slot
+/// convention). The producer interacts with the table via the
+/// [`LdmHashTable::insert_absolute`] / [`LdmHashTable::resolve`]
+/// helpers so absolute-position support extends past `u32::MAX`
+/// transparently — same pattern as `MatchTable`'s chain rebase.
 pub(crate) struct LdmHashTable {
     entries: Vec<LdmEntry>,
     bucket_offsets: Vec<u8>,
@@ -62,6 +101,12 @@ pub(crate) struct LdmHashTable {
     /// hash ids in `[0, bucket_count)`; this mask is exposed so the
     /// producer can clamp without re-deriving it.
     bucket_mask: u32,
+    /// Absolute stream position that corresponds to a stored
+    /// `entry.offset == 1` (offset 0 is the empty-slot sentinel).
+    /// Advanced by [`Self::reduce`] when the producer is about to
+    /// store a position beyond the `u32` window — donor
+    /// `ZSTD_ldm_reduceTable` (`zstd_ldm.c:520`).
+    position_base: usize,
 }
 
 impl LdmHashTable {
@@ -113,16 +158,17 @@ impl LdmHashTable {
             bucket_offsets: vec![0u8; bucket_count as usize],
             effective_bucket_log,
             bucket_mask: bucket_count - 1,
+            position_base: 0,
         }
     }
 
     /// Reset every bucket to "empty" without reallocating. Donor
     /// equivalent is the `ZSTD_cwksp` clear of the LDM region at
-    /// frame boundaries.
+    /// frame boundaries. `LdmEntry` is `Copy` so the slice
+    /// `fill` compiles down to a bulk memset — meaningful when
+    /// `hash_log` is large and this runs at every frame boundary.
     pub(crate) fn clear(&mut self) {
-        for e in &mut self.entries {
-            *e = LdmEntry::default();
-        }
+        self.entries.fill(LdmEntry::default());
         self.bucket_offsets.fill(0);
     }
 
@@ -189,6 +235,101 @@ impl LdmHashTable {
     /// caller from re-deriving `bucket_count - 1`.
     pub(crate) const fn bucket_mask(&self) -> u32 {
         self.bucket_mask
+    }
+
+    /// Absolute stream position that corresponds to the +1
+    /// relative-offset bias — i.e. an entry with `offset == 1`
+    /// refers to absolute byte `position_base`.
+    pub(crate) const fn position_base(&self) -> usize {
+        self.position_base
+    }
+
+    /// Translate an entry's stored `offset` (relative + 1-biased)
+    /// back to an absolute stream position. Returns `None` for
+    /// the empty-slot sentinel (`offset == 0`).
+    pub(crate) fn resolve(&self, entry: &LdmEntry) -> Option<usize> {
+        match entry.offset {
+            0 => None,
+            rel => Some(self.position_base + (rel as usize) - 1),
+        }
+    }
+
+    /// Insert a candidate at absolute position `abs_pos` into the
+    /// bucket for `hash_id`. The caller is responsible for
+    /// invoking [`Self::ensure_room_for`] beforehand so the
+    /// relative-offset arithmetic stays inside `u32`.
+    ///
+    /// # Panics
+    ///
+    /// Panics in debug builds if `abs_pos < position_base` or if
+    /// `abs_pos - position_base + 1 > u32::MAX`. The producer
+    /// must call `ensure_room_for` before the first insert that
+    /// could exceed the window.
+    pub(crate) fn insert_absolute(&mut self, hash_id: u32, abs_pos: usize, checksum: u32) {
+        debug_assert!(abs_pos >= self.position_base);
+        let rel = abs_pos - self.position_base;
+        debug_assert!(
+            rel < u32::MAX as usize,
+            "insert position {abs_pos} (rel {rel}) exceeds u32 window; \
+             producer must call `ensure_room_for` before insert"
+        );
+        // +1 bias so 0 stays reserved for the empty-slot sentinel.
+        let stored = (rel + 1) as u32;
+        self.insert(
+            hash_id,
+            LdmEntry {
+                offset: stored,
+                checksum,
+            },
+        );
+    }
+
+    /// Ensure that absolute position `abs_pos` (and the next
+    /// `LDM_INSERT_LOOKAHEAD` bytes, conservatively) can be
+    /// stored without `u32` overflow. If the relative position
+    /// is within [`REBASE_GUARD_BAND`] of `u32::MAX`, advance
+    /// `position_base` by `REBASE_GUARD_BAND` and run
+    /// [`Self::reduce`] across all entries.
+    ///
+    /// Returns the absolute position `abs_pos - shift_applied`
+    /// the caller should treat as "current" after the rebase
+    /// (zero shift in the common case). Donor:
+    /// `ZSTD_ldm_reduceTable` (`zstd_ldm.c:520`), invoked from
+    /// `ZSTD_window_update`.
+    pub(crate) fn ensure_room_for(&mut self, abs_pos: usize) {
+        if abs_pos < self.position_base {
+            // The caller asked about a position BEFORE the
+            // current base — that's the producer error case,
+            // not a rebase trigger.
+            return;
+        }
+        let rel = abs_pos - self.position_base;
+        // Leave at least `REBASE_GUARD_BAND` of u32 headroom
+        // above the current insert position so the next batch of
+        // inserts doesn't immediately re-rebase.
+        let max_rel = u32::MAX as usize - REBASE_GUARD_BAND as usize;
+        if rel > max_rel {
+            // Shift the base forward by `REBASE_GUARD_BAND` —
+            // matches donor's "subtract the reducer value, clamp
+            // anything below to 0" semantics.
+            self.reduce(REBASE_GUARD_BAND);
+        }
+    }
+
+    /// Donor `ZSTD_ldm_reduceTable` (`zstd_ldm.c:520`): subtract
+    /// `reducer` from every entry's relative offset, saturating
+    /// anything below at 0 (which becomes the empty-slot
+    /// sentinel); advance `position_base` by `reducer` so future
+    /// inserts continue from the shifted origin.
+    pub(crate) fn reduce(&mut self, reducer: u32) {
+        for entry in &mut self.entries {
+            if entry.offset <= reducer {
+                entry.offset = 0;
+            } else {
+                entry.offset -= reducer;
+            }
+        }
+        self.position_base = self.position_base.saturating_add(reducer as usize);
     }
 }
 
@@ -335,6 +476,96 @@ mod tests {
         // hash_log = 12, bucket_size_log = 9 → effective = 9 > 8
         // → assertion fires.
         let _ = LdmHashTable::new(12, 9);
+    }
+
+    /// `insert_absolute` + `resolve` round-trip preserves the
+    /// absolute position across the +1 empty-slot bias.
+    #[test]
+    fn insert_absolute_round_trips_through_resolve() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.insert_absolute(1, 42, 0xCAFE);
+        let entry = t.bucket(1)[0];
+        assert_eq!(entry.checksum, 0xCAFE);
+        assert_eq!(
+            t.resolve(&entry),
+            Some(42),
+            "stored relative offset must resolve back to the inserted absolute"
+        );
+    }
+
+    /// `resolve` returns `None` for the empty-slot sentinel
+    /// (`offset == 0`), distinguishing it from any real
+    /// inserted position.
+    #[test]
+    fn resolve_returns_none_for_empty_slot() {
+        let t = LdmHashTable::new(4, 2);
+        let empty = LdmEntry::default();
+        assert_eq!(empty.offset, 0);
+        assert_eq!(t.resolve(&empty), None);
+    }
+
+    /// `reduce` subtracts the reducer from every entry's relative
+    /// offset (saturating at 0 = empty sentinel) and advances
+    /// `position_base` so future `resolve` calls translate back
+    /// to the same absolute positions. Donor
+    /// `ZSTD_ldm_reduceTable` (`zstd_ldm.c:520`).
+    #[test]
+    fn reduce_preserves_resolved_absolute_positions() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.insert_absolute(0, 100, 0xAAAA);
+        t.insert_absolute(1, 200, 0xBBBB);
+        t.insert_absolute(2, 300, 0xCCCC);
+        assert_eq!(t.position_base(), 0);
+
+        // Shift the base forward by 150; positions 100 and 200
+        // should still resolve to 100 and 200 (the relative
+        // offsets shift but absolute stays).
+        t.reduce(150);
+        assert_eq!(t.position_base(), 150);
+        // pos 100 had relative offset 101 → after reduce: max(101−150, 0) = 0 (sentinel)
+        let entry0 = t.bucket(0)[0];
+        assert_eq!(
+            t.resolve(&entry0),
+            None,
+            "pos 100 < new_base 150 must be evicted"
+        );
+        // pos 200 had relative 201 → 201−150 = 51 → resolved 150 + 51 − 1 = 200
+        let entry1 = t.bucket(1)[0];
+        assert_eq!(t.resolve(&entry1), Some(200));
+        // pos 300 had relative 301 → 301−150 = 151 → resolved 150 + 151 − 1 = 300
+        let entry2 = t.bucket(2)[0];
+        assert_eq!(t.resolve(&entry2), Some(300));
+    }
+
+    /// `ensure_room_for` triggers a rebase when the relative
+    /// offset would exceed the guard band, keeping the `u32`
+    /// storage valid for streams past 4 GiB.
+    #[test]
+    fn ensure_room_for_rebases_above_guard_band() {
+        let mut t = LdmHashTable::new(4, 2);
+        // First insert at moderate offset — no rebase needed.
+        t.insert_absolute(0, 1024, 0xAAAA);
+        assert_eq!(t.position_base(), 0);
+
+        // Probe a position that would overflow the guard band:
+        // u32::MAX - REBASE_GUARD_BAND + 1 = the smallest abs
+        // that triggers a rebase.
+        let trigger_pos = (u32::MAX as usize) - (REBASE_GUARD_BAND as usize) + 1;
+        t.ensure_room_for(trigger_pos);
+        assert_eq!(
+            t.position_base(),
+            REBASE_GUARD_BAND as usize,
+            "rebase must advance position_base by REBASE_GUARD_BAND"
+        );
+        // The earlier insert at 1024 had relative offset 1025;
+        // after rebase by 2^30 it's clamped to 0 (empty) since
+        // 1025 < REBASE_GUARD_BAND.
+        assert_eq!(t.resolve(&t.bucket(0)[0]), None);
+
+        // A fresh insert past the rebase boundary must still
+        // round-trip.
+        t.insert_absolute(2, trigger_pos, 0xCAFE);
+        assert_eq!(t.resolve(&t.bucket(2)[0]), Some(trigger_pos));
     }
 
     /// `bucket_mask` returned by the table must agree with the

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -289,18 +289,20 @@ impl LdmHashTable {
         );
     }
 
-    /// Ensure that absolute position `abs_pos` (and the next
-    /// `LDM_INSERT_LOOKAHEAD` bytes, conservatively) can be
-    /// stored without `u32` overflow. If the relative position
-    /// is within [`REBASE_GUARD_BAND`] of `u32::MAX`, advance
-    /// `position_base` by `REBASE_GUARD_BAND` and run
-    /// [`Self::reduce`] across all entries.
+    /// Ensure that absolute position `abs_pos` can be stored as a
+    /// `u32` offset relative to [`Self::position_base`] without
+    /// overflow. If the relative position would exceed `u32::MAX
+    /// - REBASE_GUARD_BAND`, advance `position_base` by
+    /// [`REBASE_GUARD_BAND`] and run [`Self::reduce`] across all
+    /// entries. In the common case (`rel <= max_rel`) the call is
+    /// a single compare and returns immediately.
     ///
-    /// Returns the absolute position `abs_pos - shift_applied`
-    /// the caller should treat as "current" after the rebase
-    /// (zero shift in the common case). Donor:
-    /// `ZSTD_ldm_reduceTable` (`zstd_ldm.c:520`), invoked from
-    /// `ZSTD_window_update`.
+    /// The producer calls this before every insert so positions
+    /// past 4 GiB rebase transparently. Caller positions remain
+    /// absolute on both sides of the rebase — `Self::resolve` /
+    /// `Self::insert_absolute` handle the relative-coordinate
+    /// translation internally. Donor: `ZSTD_ldm_reduceTable`
+    /// (`zstd_ldm.c:520`), invoked from `ZSTD_window_update`.
     pub(crate) fn ensure_room_for(&mut self, abs_pos: usize) {
         if abs_pos < self.position_base {
             // The caller asked about a position BEFORE the

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -162,14 +162,19 @@ impl LdmHashTable {
         }
     }
 
-    /// Reset every bucket to "empty" without reallocating. Donor
-    /// equivalent is the `ZSTD_cwksp` clear of the LDM region at
-    /// frame boundaries. `LdmEntry` is `Copy` so the slice
-    /// `fill` compiles down to a bulk memset — meaningful when
-    /// `hash_log` is large and this runs at every frame boundary.
+    /// Reset every bucket to "empty" without reallocating, and
+    /// rewind the rebase base so a fresh frame can start its
+    /// absolute positions from any value (including 0) without
+    /// tripping the `abs_pos >= position_base` assertion in
+    /// [`Self::insert_absolute`]. Donor equivalent is the
+    /// `ZSTD_cwksp` clear of the LDM region at frame boundaries.
+    /// `LdmEntry` is `Copy` so the slice `fill` compiles down to
+    /// a bulk memset — meaningful when `hash_log` is large and
+    /// this runs at every frame boundary.
     pub(crate) fn clear(&mut self) {
         self.entries.fill(LdmEntry::default());
         self.bucket_offsets.fill(0);
+        self.position_base = 0;
     }
 
     /// Number of buckets (`1 << (hash_log - bucket_size_log)`).
@@ -566,6 +571,28 @@ mod tests {
         // round-trip.
         t.insert_absolute(2, trigger_pos, 0xCAFE);
         assert_eq!(t.resolve(&t.bucket(2)[0]), Some(trigger_pos));
+    }
+
+    /// `clear()` must reset `position_base` to 0 so a subsequent
+    /// frame can insert at any absolute position (including
+    /// values below the previous frame's `position_base`)
+    /// without tripping the `abs_pos >= position_base`
+    /// assertion. Regression for PR #139 round-4 CodeRabbit
+    /// nitpick.
+    #[test]
+    fn clear_resets_position_base() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.insert_absolute(0, 1024, 0xAAAA);
+        t.reduce(1 << 20); // shift base forward
+        assert!(t.position_base() > 0);
+        t.clear();
+        assert_eq!(t.position_base(), 0, "clear must rewind position_base to 0");
+        // Inserting at absolute 0 after clear must succeed —
+        // would panic on the assertion if position_base wasn't
+        // reset.
+        t.insert_absolute(0, 0, 0xCAFE);
+        let entry = t.bucket(0)[0];
+        assert_eq!(t.resolve(&entry), Some(0));
     }
 
     /// `bucket_mask` returned by the table must agree with the

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -271,15 +271,31 @@ impl LdmHashTable {
     /// must call `ensure_room_for` before the first insert that
     /// could exceed the window.
     pub(crate) fn insert_absolute(&mut self, hash_id: u32, abs_pos: usize, checksum: u32) {
-        debug_assert!(abs_pos >= self.position_base);
-        let rel = abs_pos - self.position_base;
-        debug_assert!(
+        // Use runtime panics (rather than `debug_assert!`) for both
+        // preconditions so a contract violation never silently
+        // wraps in release: an unchecked `abs_pos - position_base`
+        // would underflow and the subsequent `as u32` cast would
+        // corrupt the table, hiding the bug far from its source.
+        let rel = abs_pos.checked_sub(self.position_base).unwrap_or_else(|| {
+            panic!(
+                "insert position {abs_pos} is below position_base {}; \
+                 callers must rebase via `ensure_room_for` or clear before \
+                 reaching this state",
+                self.position_base
+            )
+        });
+        assert!(
             rel < u32::MAX as usize,
             "insert position {abs_pos} (rel {rel}) exceeds u32 window; \
              producer must call `ensure_room_for` before insert"
         );
         // +1 bias so 0 stays reserved for the empty-slot sentinel.
-        let stored = (rel + 1) as u32;
+        // The cast happens BEFORE the `+ 1` so the addition runs in
+        // `u32` arithmetic — guarded by the `rel < u32::MAX` assert
+        // above, the `+ 1` cannot overflow, and intermediate `usize`
+        // values stay bounded on 32-bit targets where
+        // `usize == u32`.
+        let stored = (rel as u32) + 1;
         self.insert(
             hash_id,
             LdmEntry {
@@ -573,6 +589,20 @@ mod tests {
         // round-trip.
         t.insert_absolute(2, trigger_pos, 0xCAFE);
         assert_eq!(t.resolve(&t.bucket(2)[0]), Some(trigger_pos));
+    }
+
+    /// `insert_absolute` must panic in BOTH debug and release
+    /// builds when called with an `abs_pos` below the current
+    /// `position_base` — silently underflowing the subtraction
+    /// would store a wraparound relative offset and corrupt the
+    /// table far from the bug's source. Regression for PR #139
+    /// round-6 review (Copilot + CodeRabbit, Major).
+    #[test]
+    #[should_panic(expected = "below position_base")]
+    fn insert_absolute_panics_below_position_base() {
+        let mut t = LdmHashTable::new(4, 2);
+        t.reduce(100); // shift position_base to 100
+        t.insert_absolute(0, 50, 0xCAFE); // 50 < 100 → panic
     }
 
     /// `clear()` must reset `position_base` to 0 so a subsequent

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2969,15 +2969,30 @@ impl HcMatchGenerator {
         self.table
             .backfill_boundary_positions(current_abs_start, current_abs_end);
         self.table.next_to_update3 = hash3_start_cursor;
-        // Borrow split: `prepare_ldm_candidates` (next-commit body)
-        // needs immutable access to `self.table.history` while it
-        // mutates the LDM bucket table owned by `self.backend.bt_mut()`.
-        // The two live in disjoint fields of `Self`, so we hand the
-        // history in by reference to keep the borrow checker happy.
+        // Borrow split: `prepare_ldm_candidates` needs immutable
+        // access to `self.table.history` while it mutates the LDM
+        // bucket table owned by `self.backend.bt_mut()`. The two
+        // live in disjoint fields of `Self`, so we hand the history
+        // in by reference to keep the borrow checker happy.
+        //
+        // `current_abs_start` is an *absolute* stream position
+        // (`history_abs_start + window_size - current_len`); the
+        // producer expects slice indices into the supplied
+        // `history` Vec. We pass both `history_abs_start` and the
+        // absolute cursor and let `prepare_ldm_candidates` perform
+        // the translation — keeps the abs→slice math in one place
+        // and matches every other matcher backend's coordinate
+        // convention (`idx = abs_pos - history_abs_start`,
+        // `concat = &history[history_start..]` — see
+        // `match_table/storage.rs:317-318`).
         let history = self.table.history.as_slice();
-        self.backend
-            .bt_mut()
-            .prepare_ldm_candidates(history, current_abs_start, current_len);
+        let history_abs_start = self.table.history_abs_start;
+        self.backend.bt_mut().prepare_ldm_candidates(
+            history,
+            history_abs_start,
+            current_abs_start,
+            current_len,
+        );
 
         if self.should_run_btultra2_seed_pass::<S>(current_len) {
             self.run_btultra2_seed_pass(current, current_abs_start, current_len);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2970,25 +2970,23 @@ impl HcMatchGenerator {
             .backfill_boundary_positions(current_abs_start, current_abs_end);
         self.table.next_to_update3 = hash3_start_cursor;
         // Borrow split: `prepare_ldm_candidates` needs immutable
-        // access to `self.table.history` while it mutates the LDM
-        // bucket table owned by `self.backend.bt_mut()`. The two
-        // live in disjoint fields of `Self`, so we hand the history
-        // in by reference to keep the borrow checker happy.
+        // access to the live history (the post-`history_start`
+        // slice of `self.table.history`) while it mutates the LDM
+        // bucket table owned by `self.backend.bt_mut()`. Both live
+        // in disjoint fields of `Self`, so we capture the slice +
+        // its base before reaching for `bt_mut()`.
         //
-        // `current_abs_start` is an *absolute* stream position
-        // (`history_abs_start + window_size - current_len`); the
-        // producer expects slice indices into the supplied
-        // `history` Vec. We pass both `history_abs_start` and the
-        // absolute cursor and let `prepare_ldm_candidates` perform
-        // the translation — keeps the abs→slice math in one place
-        // and matches every other matcher backend's coordinate
-        // convention (`idx = abs_pos - history_abs_start`,
-        // `concat = &history[history_start..]` — see
-        // `match_table/storage.rs:317-318`).
-        let history = self.table.history.as_slice();
+        // The producer operates in absolute stream coordinates
+        // throughout; `live_history[0]` corresponds to absolute
+        // `history_abs_start` (donor `base + dictLimit`), and the
+        // abs→slice translation happens inside the producer at
+        // each `live_history[..]` access. Passing the full
+        // `history` Vec would index into the dead prefix (the
+        // bytes already retired past `history_start`).
+        let live_history = self.table.live_history();
         let history_abs_start = self.table.history_abs_start;
         self.backend.bt_mut().prepare_ldm_candidates(
-            history,
+            live_history,
             history_abs_start,
             current_abs_start,
             current_len,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2969,9 +2969,15 @@ impl HcMatchGenerator {
         self.table
             .backfill_boundary_positions(current_abs_start, current_abs_end);
         self.table.next_to_update3 = hash3_start_cursor;
+        // Borrow split: `prepare_ldm_candidates` (next-commit body)
+        // needs immutable access to `self.table.history` while it
+        // mutates the LDM bucket table owned by `self.backend.bt_mut()`.
+        // The two live in disjoint fields of `Self`, so we hand the
+        // history in by reference to keep the borrow checker happy.
+        let history = self.table.history.as_slice();
         self.backend
             .bt_mut()
-            .prepare_ldm_candidates(current_abs_start, current_len);
+            .prepare_ldm_candidates(history, current_abs_start, current_len);
 
         if self.should_run_btultra2_seed_pass::<S>(current_len) {
             self.run_btultra2_seed_pass(current, current_abs_start, current_len);

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -49,10 +49,14 @@ pub(crate) mod hc;
 // `min_match_length` byte slice, donor `zstd_ldm.c:315`). The
 // `twox-hash` dependency is gated behind the `hash` feature so
 // `default-features = false` builds (no_std, embedded) don't pull
-// it in. The `BtMatcher::ldm_producer` field and every callsite
-// in `match_generator.rs` share the same `cfg(feature = "hash")`
-// gate so the codepath stays consistent across feature
-// combinations.
+// it in. `BtMatcher::ldm_producer` and the `cfg(feature = "hash")`
+// blocks inside `BtMatcher::prepare_ldm_candidates` /
+// `BtMatcher::reset` carry the same gate; the call site in
+// `match_generator.rs::start_matching_optimal` invokes
+// `prepare_ldm_candidates` unconditionally because the
+// gating is internal to the method body (under
+// `not(feature = "hash")` the method shrinks to the legacy
+// `ldm_sequences.clear()` stub).
 #[cfg(feature = "hash")]
 pub(crate) mod ldm;
 pub(crate) mod match_table;

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -45,6 +45,15 @@ pub(crate) mod bt;
 pub(crate) mod cost_model;
 pub(crate) mod dfast;
 pub(crate) mod hc;
+// LDM uses `twox_hash::XxHash64` (per-window XXH64 over the
+// `min_match_length` byte slice, donor `zstd_ldm.c:315`). The
+// `twox-hash` dependency is gated behind the `hash` feature so
+// `default-features = false` builds (no_std, embedded) don't pull
+// it in. The `BtMatcher::ldm_producer` field and every callsite
+// in `match_generator.rs` share the same `cfg(feature = "hash")`
+// gate so the codepath stays consistent across feature
+// combinations.
+#[cfg(feature = "hash")]
 pub(crate) mod ldm;
 pub(crate) mod match_table;
 pub(crate) mod opt;

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -2,10 +2,19 @@
 //!
 //! Three entry points cover the common use cases:
 //!
-//! * [`compress`] / [`compress_to_vec`] — one-shot helpers that build a
-//!   self-contained Zstandard frame from a `Read` source. They buffer the
-//!   entire input before compressing, so peak memory is ≈ `input + output`;
-//!   use [`StreamingEncoder`] for large or unbounded payloads.
+//! * [`compress`] — one-shot helper that builds a self-contained
+//!   Zstandard frame from a `Read` source to a `Write` sink. The
+//!   input is consumed incrementally from `Read`, so input buffering
+//!   stays bounded; however, the compressed output is buffered in
+//!   memory until the frame is complete so the Frame Content Size
+//!   field can be filled in the header — peak memory is ≈
+//!   `output_size`, independent of input length.
+//! * [`compress_to_vec`] — same one-shot path as [`compress`] but
+//!   the input is eagerly drained into an internal `Vec` first
+//!   (`read_to_end`) so the encoder can be handed a `&[u8]` and a
+//!   precise source-size hint. Peak memory is therefore ≈
+//!   `input_size + output_size`; prefer [`compress`] or
+//!   [`StreamingEncoder`] when the input is large or unbounded.
 //! * [`StreamingEncoder`] — implements [`std::io::Write`] (`std` feature),
 //!   accepting bytes incrementally and flushing compressed output as blocks
 //!   fill. Requires `set_pledged_content_size` before the first write if

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -1,4 +1,27 @@
-//! Structures and utilities used for compressing/encoding data into the Zstd format.
+//! Zstandard encoder — frame compression, streaming, dictionary support.
+//!
+//! Three entry points cover the common use cases:
+//!
+//! * [`compress`] / [`compress_to_vec`] — one-shot helpers that build a
+//!   self-contained Zstandard frame from a `Read` source. Compact when the
+//!   whole input is already in memory.
+//! * [`StreamingEncoder`] — implements [`std::io::Write`] (`std` feature),
+//!   accepting bytes incrementally and flushing compressed output as blocks
+//!   fill. Requires `set_pledged_content_size` before the first write if
+//!   the Frame Content Size field is to be populated.
+//! * [`FrameCompressor`] — lower-level builder that owns the matcher and
+//!   the per-frame configuration; the streaming and one-shot helpers are
+//!   thin wrappers over it. Reach for it when you need to swap in a custom
+//!   [`Matcher`] implementation or share the matcher across frames.
+//!
+//! Compression intensity is selected via [`CompressionLevel`], which
+//! provides both named presets (`Fastest`, `Default`, `Better`, `Best`) and
+//! numeric levels (`from_level(n)`) that mirror C zstd's level numbering
+//! (negative for ultra-fast, `0` = default, `1..=22` for the standard
+//! range).
+//!
+//! All produced frames are valid RFC 8878 Zstandard streams and decode
+//! through both this crate's [`crate::decoding`] module and upstream C zstd.
 
 pub(crate) mod block_header;
 pub(crate) mod blocks;

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -3,8 +3,9 @@
 //! Three entry points cover the common use cases:
 //!
 //! * [`compress`] / [`compress_to_vec`] — one-shot helpers that build a
-//!   self-contained Zstandard frame from a `Read` source. Compact when the
-//!   whole input is already in memory.
+//!   self-contained Zstandard frame from a `Read` source. They buffer the
+//!   entire input before compressing, so peak memory is ≈ `input + output`;
+//!   use [`StreamingEncoder`] for large or unbounded payloads.
 //! * [`StreamingEncoder`] — implements [`std::io::Write`] (`std` feature),
 //!   accepting bytes incrementally and flushing compressed output as blocks
 //!   fill. Requires `set_pledged_content_size` before the first write if

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -1,6 +1,6 @@
 //! Zstandard encoder — frame compression, streaming, dictionary support.
 //!
-//! Three entry points cover the common use cases:
+//! Four entry points cover the common use cases:
 //!
 //! * [`compress`] — one-shot helper that builds a self-contained
 //!   Zstandard frame from a `Read` source to a `Write` sink. The
@@ -15,9 +15,11 @@
 //!   precise source-size hint. Peak memory is therefore ≈
 //!   `input_size + output_size`; prefer [`compress`] or
 //!   [`StreamingEncoder`] when the input is large or unbounded.
-//! * [`StreamingEncoder`] — implements [`std::io::Write`] (`std` feature),
-//!   accepting bytes incrementally and flushing compressed output as blocks
-//!   fill. Requires `set_pledged_content_size` before the first write if
+//! * [`StreamingEncoder`] — implements [`crate::io::Write`], which
+//!   re-exports [`std::io::Write`] under the `std` feature and falls
+//!   back to a `no_std`-friendly trait otherwise. Accepts bytes
+//!   incrementally and flushes compressed output as blocks fill.
+//!   Requires `set_pledged_content_size` before the first write if
 //!   the Frame Content Size field is to be populated.
 //! * [`FrameCompressor`] — lower-level builder that owns the matcher and
 //!   the per-frame configuration; the streaming and one-shot helpers are

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -22,6 +22,7 @@ pub(crate) mod bt;
 pub(crate) mod cost_model;
 pub(crate) mod dfast;
 pub(crate) mod hc;
+pub(crate) mod ldm;
 pub(crate) mod match_table;
 pub(crate) mod opt;
 pub(crate) mod row;

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -7,8 +7,11 @@
 //!   input is consumed incrementally from `Read`, so input buffering
 //!   stays bounded; however, the compressed output is buffered in
 //!   memory until the frame is complete so the Frame Content Size
-//!   field can be filled in the header — peak memory is ≈
-//!   `output_size`, independent of input length.
+//!   field can be filled in the header — peak memory is
+//!   `O(compressed_size)` (worst-case `O(input_size)` for
+//!   incompressible payloads, plus a small frame overhead). The
+//!   savings vs [`compress_to_vec`] come from not materialising the
+//!   input alongside the output.
 //! * [`compress_to_vec`] — same one-shot path as [`compress`] but
 //!   the input is eagerly drained into an internal `Vec` first
 //!   (`read_to_end`) so the encoder can be handed a `&[u8]` and a

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -1,18 +1,28 @@
-//! A pure Rust implementation of the [Zstandard compression format](https://www.rfc-editor.org/rfc/rfc8878.pdf).
+//! Pure-Rust Zstandard codec with a production-grade decoder, dictionary
+//! handle reuse, and an actively-improved encoder.
 //!
-//! ## Decompression
-//! The [decoding] module contains the code for decompression.
-//! Decompression can be achieved by using the [`decoding::StreamingDecoder`]
-//! or the more low-level [`decoding::FrameDecoder`]
+//! The crate ships:
 //!
-//! ## Compression
-//! The [encoding] module contains the code for compression.
-//! Compression can be achieved by using the [`encoding::compress`]/[`encoding::compress_to_vec`]
-//! functions or [`encoding::FrameCompressor`]
+//! * [`decoding`] — [RFC 8878] decoder ([`decoding::StreamingDecoder`],
+//!   [`decoding::FrameDecoder`], dictionary-backed paths via
+//!   [`decoding::DictionaryHandle`]).
+//! * [`encoding`] — frame compressor, streaming encoder, named and numeric
+//!   compression levels ([`encoding::CompressionLevel`]).
+//! * [`dictionary`] (feature `dict_builder`) — COVER / FastCOVER training
+//!   plus raw-to-finalized dictionary helpers.
+//!
+//! No FFI, no cmake, no system zstd. `no_std` builds are supported by
+//! disabling the default `std` feature.
+//!
+//! The packaged README is included below for the docs.rs landing page; the
+//! API anchors above link straight into the per-module documentation.
+//!
+//! [RFC 8878]: https://www.rfc-editor.org/rfc/rfc8878
 // Keep crate docs aligned with the packaged README via the crate-local symlink in `zstd/README.md`.
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![deny(trivial_casts, trivial_numeric_casts, rust_2018_idioms)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "std")]
 extern crate std;


### PR DESCRIPTION
## Summary

Phase 5 of [#111](https://github.com/structured-world/structured-zstd/issues/111) — implements [#18](https://github.com/structured-world/structured-zstd/issues/18) (long-distance matching). Lands the full donor LDM producer (gear rolling hash + bucket-based hash table + verify/extend search + aggregate driver) under a new `encoding/ldm/` module. Two commits, ~2.1k LoC including 33 unit tests.

## Activation policy (distro-grade)

**`LdmProducer` is never activated automatically by any `CompressionLevel` preset.** This mirrors upstream `libzstd.so.1` behaviour: `ZSTD_compress(..., level)` keeps LDM off at every standard level (1..22). The opt-in surface lands separately:

| Surface | LDM activation | Status |
|---|---|---|
| `compress(level)` / `CompressionLevel::*` | **off**, every level | preserved by this PR |
| Rust parameter API (`set_parameter(EnableLdm, true)`) | **on** | tracked in [#27](https://github.com/structured-world/structured-zstd/issues/27) |
| C ABI (`ZSTD_c_enableLongDistanceMatching`) | **on** | tracked in #126 / #127 |
| `zstd --long[=N]` CLI flag | **on** | tracked in #128 |

`BtMatcher::ldm_producer: Option<LdmProducer>` stays `None` until those issues land — preserves byte-parity with upstream `ZSTD_compress(..., 22)` and keeps the `level22_sequences_match_donor_on_corpus_proxy` ratio gate green.

## Module structure

```
zstd/src/encoding/ldm/
├── mod.rs        — LdmProducer aggregator + generate_into pipeline
├── gear_hash.rs  — ZSTD_ldm_gear_init/reset/feed + verbatim 256-entry GEAR_TAB
├── params.rs     — LdmParams + ZSTD_ldm_adjustParameters port
├── table.rs      — LdmHashTable (round-robin bucket insert)
└── search.rs     — count_backwards_match + find_best_match (prefix-only path)
```

## Donor parity anchors

Every primitive cites \`lib/compress/zstd_ldm.c\` v1.5.7 by file:line:

* \`gear_hash::GEAR_TAB\` ← \`zstd_ldm_geartab.h\` (verbatim, 256-entry permutation table, cross-checked zero-mismatch against parsed donor header)
* \`gear_hash::GearHashState::new\` ← \`ZSTD_ldm_gear_init\` (zstd_ldm.c:32)
* \`gear_hash::reset\` ← \`ZSTD_ldm_gear_reset\` (zstd_ldm.c:65)
* \`gear_hash::feed\` ← \`ZSTD_ldm_gear_feed\` (zstd_ldm.c:96)
* \`params::LdmParams::adjust_for\` ← \`ZSTD_ldm_adjustParameters\` (zstd_ldm.c:135)
* \`table::LdmHashTable::insert\` ← \`ZSTD_ldm_insertEntry\` (zstd_ldm.c:198)
* \`search::count_backwards_match\` ← \`ZSTD_ldm_countBackwardsMatch\` (zstd_ldm.c:214)
* \`search::find_best_match\` ← per-split inner loop (zstd_ldm.c:405-466)
* \`LdmProducer::generate_into\` ← \`ZSTD_ldm_generateSequences_internal\` (zstd_ldm.c:346-515) prefix-only path

## Implementation status

* **Prefix-only path** — fully implemented. Equivalent to upstream on every input that fits in a single contiguous history slice (the only path the current Rust encoder exercises — no separate \`extDict\` buffer surface).
* **Two-segment (extDict) backward path** — documented and deferred. \`search.rs\` cites the donor functions (\`ZSTD_count_2segments\`, \`ZSTD_ldm_countBackwardsMatch_2segments\`) but does not yet implement them; lands together with the eventual dictionary-history support work.

## Test coverage

33 new LDM unit tests + 1 end-to-end producer test:

| Module | Tests | Coverage |
|---|---|---|
| \`gear_hash\` | 9 | GEAR_TAB anchor entries (donor cross-check), stop_mask derivation (3 paths), recurrence regression, reset/feed equivalence, zero-mask split-per-byte, concatenation invariant, batch-size pre-condition |
| \`params\` | 5 | strategy→hash_rate_log table, hash_log clamp, min_match halving at btultra, bucket clamp, derived helpers |
| \`table\` | 7 | sizing math, bucket clamp, round-robin wrap, adjacent-bucket isolation, clear+rewind, donor-max hash_log, bucket_mask |
| \`search\` | 9 | count_backwards_match (mismatch stop + anchor bound), find_best_match (stale rejection, checksum filter, longest-combined selection, backward extension, short-forward rejection) |
| \`mod\` (aggregate) | 3 | producer construction with btultra2 defaults, clear-resets-rolling-hash, empty-range no-op |
| \`mod\` (e2e) | 1 | 4 KiB payload + 64 KiB gap + 4 KiB repeat → producer emits at least one HcRawSeq crossing the gap |

## Build + suite

* **460 / 460** lib tests pass on the full suite (was 427 pre-Phase-5 → +33 LDM tests).
* \`cargo clippy --lib --tests\` clean (no warnings).
* \`level22_sequences_match_donor_on_corpus_proxy\` ratio gate **PASS**.
* No new dependencies; reuses existing \`twox-hash::XxHash64\` already pulled in for frame checksums.

## Commits

* \`8cd597b\` — Phase 5 foundations: gear hash + params + bucket table + LdmProducer construction + fill path (gear walk + XXH64 + bucket insert)
* \`7759eef\` — Phase 5 producer: search.rs (count_backwards_match + find_best_match) + generate_into rewritten end-to-end to emit HcRawSeq entries via verify/extend pipeline

## Test plan

- [x] \`cargo nextest run --lib\` — 460/460 green
- [x] \`cargo clippy --lib --tests\` — clean
- [x] \`level22_sequences_match_donor_on_corpus_proxy\` — PASS (byte-parity preserved, LDM stays None by default)
- [x] End-to-end producer test — long-range match emitted, offset crosses the engineered gap
- [ ] CI matrix (x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin, i686-linux) — pending GitHub Actions
- [ ] Codecov patch coverage — pending

## Related issues

* Closes [#18](https://github.com/structured-world/structured-zstd/issues/18) — long-distance matching
* Part of [#111](https://github.com/structured-world/structured-zstd/issues/111) Phase 5
* Unblocks [#27](https://github.com/structured-world/structured-zstd/issues/27) — configurable parameter API (LDM activation hook will plug into \`BtMatcher::ldm_producer\`)

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-gated long-distance-match (LDM) encoder: gear-hash split detection, bucketed LDM table, candidate search, and a producer pipeline; BT matcher now uses live-history context for LDM candidates.
* **Bug Fixes**
  * Prevented out-of-bounds panics by validating absolute-coordinate relationships and clearing producer state on reset.
* **Tests**
  * Extensive unit and regression tests covering hashing, parameter derivation, table behavior, candidate search, producer flow, and panic prevention.
* **Documentation**
  * Rewrote README and crate/module docs; enabled richer feature-gated docs for published builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->