### PR TITLE
ci(bench): cover full -7..=-1, 1..=22 level range with strategy-tag labels

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -311,6 +311,75 @@
         select.replaceChildren(fragment);
       }
 
+      // Match `level_<N>_<strategy>` (e.g. `level_-7_fast`, `level_3_dfast`,
+      // `level_22_btultra2`) — the canonical bench ID format set by
+      // `supported_levels()` in `zstd/benches/support/mod.rs`. Anything that
+      // doesn't match keeps its raw label and sorts to the bottom so legacy
+      // / ad-hoc bench names don't disappear from the dropdown.
+      const LEVEL_ID_PATTERN = /^level_(-?\d+)_([a-z][a-z0-9]*)$/i;
+
+      function parseLevelId(raw) {
+        const text = String(raw);
+        const match = text.match(LEVEL_ID_PATTERN);
+        if (!match) return null;
+        const numeric = Number.parseInt(match[1], 10);
+        if (!Number.isFinite(numeric)) return null;
+        const tag = match[2].toLowerCase();
+        // Fixed mapping so the dropdown label matches the
+        // `StrategyTag` enum spelling (`BtOpt`, `BtUltra`,
+        // `BtUltra2`) on the Rust side. Unknown / future tags fall
+        // back to a capitalised version of the raw suffix so a new
+        // strategy still gets a readable label without a dashboard
+        // patch.
+        const STRATEGY_LABELS = {
+          fast: "Fast",
+          dfast: "Dfast",
+          greedy: "Greedy",
+          lazy: "Lazy",
+          btopt: "BtOpt",
+          btultra: "BtUltra",
+          btultra2: "BtUltra2",
+        };
+        const pretty = STRATEGY_LABELS[tag]
+          || tag.charAt(0).toUpperCase() + tag.slice(1);
+        return { numeric, tag, label: `${numeric} :: ${pretty}` };
+      }
+
+      function renderLevelOptions(select, values) {
+        const fragment = document.createDocumentFragment();
+        const allOption = document.createElement("option");
+        allOption.value = ALWAYS;
+        allOption.textContent = "all";
+        fragment.appendChild(allOption);
+        // Sort numerically when the raw ID parses (`level_-7_fast` →
+        // numeric -7, sorts before `level_1_fast`). Non-matching IDs
+        // (legacy `level22` / `fastest` from old bench JSON, or a
+        // future variant we haven't taught the parser about) fall to
+        // the bottom in their original lexicographic order so they
+        // stay visible and selectable.
+        const decorated = values.map((value) => ({
+          value: String(value),
+          parsed: parseLevelId(value),
+        }));
+        decorated.sort((a, b) => {
+          if (a.parsed && b.parsed) return a.parsed.numeric - b.parsed.numeric;
+          if (a.parsed) return -1;
+          if (b.parsed) return 1;
+          return a.value.localeCompare(b.value);
+        });
+        for (const entry of decorated) {
+          const option = document.createElement("option");
+          option.value = entry.value;
+          // Filter logic compares against `option.value` (the raw
+          // bench ID), so the human-readable form lives purely in
+          // `textContent` and never leaks into the URL or filter
+          // record matching.
+          option.textContent = entry.parsed ? entry.parsed.label : entry.value;
+          fragment.appendChild(option);
+        }
+        select.replaceChildren(fragment);
+      }
+
       function renderPointOptions(select, values) {
         const fragment = document.createDocumentFragment();
         for (const value of values) {
@@ -652,7 +721,7 @@
         renderOptions(selectors.metric, metricValues);
         renderOptions(selectors.stage, uniq(state.records.map((r) => r.stage)));
         renderOptions(selectors.scenario, uniq(state.records.map((r) => r.scenario)));
-        renderOptions(selectors.level, uniq(state.records.map((r) => r.level)));
+        renderLevelOptions(selectors.level, uniq(state.records.map((r) => r.level)));
         renderOptions(selectors.source, uniq(state.records.map((r) => r.source || "none")));
 
         const defaultMetric = "throughput_bytes_per_sec";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,13 +319,46 @@ jobs:
       fail-fast: false
       matrix:
         bench: ${{ fromJSON(needs.bench-matrix.outputs.targets) }}
+        # Canonical level inventory: `-7..=-1` (ultra-fast, donor
+        # Fast strategy) plus `1..=22` (donor advertised range with
+        # strategies fast/dfast/greedy/lazy/btopt/btultra/btultra2).
+        # Level 0 is intentionally omitted — donor treats it as a
+        # sentinel for "use default" (= 3) so a dedicated shard
+        # would just duplicate level_3_dfast's numbers. 29 entries ×
+        # 3 targets = 87 shards. Names mirror `supported_levels()`
+        # in `zstd/benches/support/mod.rs`; `level_filter_from_env`
+        # panics on drift so a typo here surfaces in the first
+        # affected shard instead of silently skipping the level.
         level:
-          - fastest
-          - default
-          - better
-          - level4-row
-          - best
-          - level22
+          - level_-7_fast
+          - level_-6_fast
+          - level_-5_fast
+          - level_-4_fast
+          - level_-3_fast
+          - level_-2_fast
+          - level_-1_fast
+          - level_1_fast
+          - level_2_dfast
+          - level_3_dfast
+          - level_4_greedy
+          - level_5_lazy
+          - level_6_lazy
+          - level_7_lazy
+          - level_8_lazy
+          - level_9_lazy
+          - level_10_lazy
+          - level_11_lazy
+          - level_12_lazy
+          - level_13_lazy
+          - level_14_lazy
+          - level_15_lazy
+          - level_16_btopt
+          - level_17_btopt
+          - level_18_btultra
+          - level_19_btultra
+          - level_20_btultra2
+          - level_21_btultra2
+          - level_22_btultra2
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,6 +386,14 @@ jobs:
           STRUCTURED_ZSTD_BENCH_LEVEL_FILTER: ${{ matrix.level }}
           # run-benchmarks.sh: re-exec this binary instead of `cargo bench`.
           STRUCTURED_ZSTD_BENCH_BIN: ${{ github.workspace }}/bench-binary/compare_ffi
+          # The prebuilt bench binary is launched directly (not via cargo),
+          # so `env::var("CARGO_MANIFEST_DIR")` returns None inside it.
+          # Without this override, `load_decode_corpus_scenario()` falls
+          # back to the synthetic 1 MiB corpus and the bench label silently
+          # flips from `decodecorpus-z000033` to `decodecorpus-synthetic-1m`,
+          # making dashboards diverge from a baseline produced via
+          # `cargo bench`. Point the binary at the checkout's real fixture.
+          STRUCTURED_ZSTD_BENCH_CORPUS_PATH: ${{ github.workspace }}/zstd/decodecorpus_files/z000033
         run: bash .github/scripts/run-benchmarks.sh
 
       - name: Rename benchmark outputs for matrix artifact

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -132,7 +132,21 @@ pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
 /// `clevels.h` and `StrategyTag::for_level` exactly.
 fn strategy_suffix(level: i32) -> &'static str {
     match level {
-        ..=0 => "fast",
+        // Negative levels uniformly map to the ultra-fast `Fast`
+        // strategy (donor `cParams.strategy = ZSTD_fast` for any
+        // `cLevel <= 1`). Level 0 is intentionally NOT classified
+        // here — donor treats it as a sentinel for "use default"
+        // (= 3, `Dfast`), and `supported_levels()` omits it to keep
+        // bench labels unambiguous. A future caller that does pass
+        // `0` should pre-resolve it to `3` before reaching this
+        // helper rather than have it silently aliased to `fast`.
+        i32::MIN..=-1 => "fast",
+        0 => unreachable!(
+            "strategy_suffix(0) called; level 0 is the donor sentinel for \
+             'use default' (= 3). `supported_levels()` skips it so it never \
+             reaches this helper. Resolve to the canonical numeric level \
+             before calling."
+        ),
         1 => "fast",
         2 | 3 => "dfast",
         4 => "greedy",
@@ -157,7 +171,19 @@ fn strategy_suffix(level: i32) -> &'static str {
 /// Renaming an entry requires synchronising all three call sites. The
 /// `level_filter_from_env()` panic on unknown names is the safety net
 /// that catches the drift in CI before any silent skips.
+///
+/// The inventory is built once per process via [`LazyLock`] so the
+/// `Box::leak` that backs each `&'static str` `name` happens exactly
+/// 29 times total — the criterion bench loops call this helper many
+/// times per scenario, and a naive per-call rebuild would compound
+/// the leak proportionally.
 pub(crate) fn supported_levels() -> Vec<LevelConfig> {
+    static INVENTORY: std::sync::LazyLock<Vec<LevelConfig>> =
+        std::sync::LazyLock::new(build_supported_levels);
+    INVENTORY.clone()
+}
+
+fn build_supported_levels() -> Vec<LevelConfig> {
     let mut levels = Vec::with_capacity(29);
     // Ultra-fast tier: `-7..=-1`. Donor strategy = Fast.
     for n in -7..=-1i32 {
@@ -189,11 +215,12 @@ pub(crate) fn supported_levels() -> Vec<LevelConfig> {
 }
 
 /// Convert a one-shot owned `String` (built by `format!`) into a
-/// `&'static str`. The leak is deliberate and bounded: `supported_levels()`
-/// is called a handful of times per bench process at most, the leaked
-/// data lives for the rest of the run, and the process exits within
-/// minutes. Keeps `LevelConfig::name: &'static str` simple so bench
-/// IDs can stay `&'static`-friendly inside criterion's helpers.
+/// `&'static str`. Called exactly once per level inside
+/// [`build_supported_levels`], whose result is cached in a
+/// `LazyLock` so the total leak is bounded to the 29 strings the
+/// bench inventory needs — no proportional growth even when
+/// `supported_levels()` is called inside criterion's per-scenario
+/// loops.
 fn leak_owned(name: String) -> &'static str {
     Box::leak(name.into_boxed_str())
 }

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -167,11 +167,21 @@ pub(crate) fn supported_levels() -> Vec<LevelConfig> {
             ffi_level: n,
         });
     }
-    // Standard tier: `1..=22`. Strategy mirrors `clevels.h`.
+    // Standard tier: `1..=22`. Strategy mirrors `clevels.h`. Use
+    // `CompressionLevel::Level(n)` directly — NOT
+    // `CompressionLevel::from_level(n)` — so the bench label
+    // `level_<N>_<strategy>` matches the variant exercised by the
+    // encoder. `from_level(11)` collapses to `Best`, and the named
+    // `Best` variant bypasses `donor_pre_split_level`'s
+    // `Level(11..=15) -> Some(0)` arm (the borders pre-splitter
+    // landed in #140), so the numbers would silently diverge from
+    // what a user calling `compress_to_vec(input, Level(11))` sees.
+    // Same divergence applies to 1 (`Fastest`), 3 (`Default`),
+    // 7 (`Better`) on any future preset-only branch.
     for n in 1..=22i32 {
         levels.push(LevelConfig {
             name: leak_owned(format!("level_{n}_{}", strategy_suffix(n))),
-            rust_level: CompressionLevel::from_level(n),
+            rust_level: CompressionLevel::Level(n),
             ffi_level: n,
         });
     }

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -102,7 +102,7 @@ pub(crate) fn level_filter_from_env() -> Option<Vec<String>> {
 pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
     let all = supported_levels();
     let Some(keep) = level_filter_from_env() else {
-        return all.to_vec();
+        return all;
     };
     let known: Vec<&'static str> = all.iter().map(|cfg| cfg.name).collect();
     let unknown: Vec<String> = keep
@@ -121,39 +121,71 @@ pub(crate) fn supported_levels_filtered() -> Vec<LevelConfig> {
         .collect()
 }
 
-pub(crate) fn supported_levels() -> [LevelConfig; 6] {
-    [
-        LevelConfig {
-            name: "fastest",
-            rust_level: CompressionLevel::Fastest,
-            ffi_level: 1,
-        },
-        LevelConfig {
-            name: "default",
-            rust_level: CompressionLevel::Default,
-            ffi_level: 3,
-        },
-        LevelConfig {
-            name: "better",
-            rust_level: CompressionLevel::Better,
-            ffi_level: 7,
-        },
-        LevelConfig {
-            name: "level4-row",
-            rust_level: CompressionLevel::Level(4),
-            ffi_level: 4,
-        },
-        LevelConfig {
-            name: "best",
-            rust_level: CompressionLevel::Best,
-            ffi_level: 11,
-        },
-        LevelConfig {
-            name: "level22",
-            rust_level: CompressionLevel::Level(22),
-            ffi_level: 22,
-        },
-    ]
+/// Bench-side mirror of `StrategyTag::for_compression_level`. Returns
+/// the lowercase tag suffix used in bench IDs and CI shard labels so
+/// the dashboard can render `level -7 :: Fast`, `level 3 :: Dfast`,
+/// `level 22 :: BtUltra2`, etc. without re-deriving the strategy from
+/// the numeric level on the consumer side.
+///
+/// Negative levels share the `fast` ultra-fast strategy (donor maps
+/// any `cParams.cLevel <= 1` to `ZSTD_fast`). The 1..=22 split mirrors
+/// `clevels.h` and `StrategyTag::for_level` exactly.
+fn strategy_suffix(level: i32) -> &'static str {
+    match level {
+        ..=0 => "fast",
+        1 => "fast",
+        2 | 3 => "dfast",
+        4 => "greedy",
+        5..=15 => "lazy",
+        16 | 17 => "btopt",
+        18 | 19 => "btultra",
+        _ => "btultra2",
+    }
+}
+
+/// Canonical bench level inventory: `-7..=-1` (ultra-fast) plus
+/// `1..=22` (the donor advertised range). Level 0 is omitted because
+/// the donor treats it as a sentinel for "use default" (= 3) — a
+/// distinct bench entry would just duplicate level 3's numbers.
+///
+/// Each entry's `name` field is the canonical `level_<N>_<strategy>`
+/// label consumed by:
+///   - bench IDs in criterion output (`compress/level_3_dfast/...`)
+///   - the CI matrix `level:` keys in `.github/workflows/ci.yml`
+///   - the `STRUCTURED_ZSTD_BENCH_LEVEL_FILTER` env var
+///
+/// Renaming an entry requires synchronising all three call sites. The
+/// `level_filter_from_env()` panic on unknown names is the safety net
+/// that catches the drift in CI before any silent skips.
+pub(crate) fn supported_levels() -> Vec<LevelConfig> {
+    let mut levels = Vec::with_capacity(29);
+    // Ultra-fast tier: `-7..=-1`. Donor strategy = Fast.
+    for n in -7..=-1i32 {
+        levels.push(LevelConfig {
+            name: leak_owned(format!("level_{n}_{}", strategy_suffix(n))),
+            rust_level: CompressionLevel::Level(n),
+            ffi_level: n,
+        });
+    }
+    // Standard tier: `1..=22`. Strategy mirrors `clevels.h`.
+    for n in 1..=22i32 {
+        levels.push(LevelConfig {
+            name: leak_owned(format!("level_{n}_{}", strategy_suffix(n))),
+            rust_level: CompressionLevel::from_level(n),
+            ffi_level: n,
+        });
+    }
+    levels
+}
+
+/// Convert a one-shot owned `String` (built by `format!`) into a
+/// `&'static str`. The leak is deliberate and bounded: `supported_levels()`
+/// is called a handful of times per bench process at most, the leaked
+/// data lives for the rest of the run, and the process exits within
+/// minutes. Keeps `LevelConfig::name: &'static str` simple so bench
+/// IDs can stay `&'static`-friendly inside criterion's helpers.
+fn leak_owned(name: String) -> &'static str {
+    Box::leak(name.into_boxed_str())
 }
 
 impl Scenario {

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -367,35 +367,55 @@ fn load_decode_corpus_scenario() -> Scenario {
     const FALLBACK_ID: &str = "decodecorpus-synthetic-1m";
     const FALLBACK_LABEL: &str = "Synthetic decode corpus fallback (1 MiB)";
 
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").ok();
-    let fixture_path = manifest_dir
-        .as_deref()
-        .map(Path::new)
-        .map(|dir| dir.join("decodecorpus_files/z000033"));
+    // Resolution order:
+    //   1. `STRUCTURED_ZSTD_BENCH_CORPUS_PATH` — explicit absolute path
+    //      to the corpus file. CI sets this so the prebuilt bench
+    //      binary (invoked directly via `STRUCTURED_ZSTD_BENCH_BIN`,
+    //      bypassing cargo) can still locate the fixture even though
+    //      `CARGO_MANIFEST_DIR` is not in its environment.
+    //   2. `CARGO_MANIFEST_DIR/decodecorpus_files/z000033` — local
+    //      `cargo bench` runs, where cargo injects the manifest dir.
+    //   3. Synthetic 1 MiB fallback — packaged sources / hand-run
+    //      binaries with no fixture access.
+    let candidate_paths: Vec<std::path::PathBuf> = {
+        let mut paths = Vec::new();
+        if let Ok(explicit) = env::var("STRUCTURED_ZSTD_BENCH_CORPUS_PATH") {
+            let trimmed = explicit.trim();
+            if !trimmed.is_empty() {
+                paths.push(std::path::PathBuf::from(trimmed));
+            }
+        }
+        if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
+            paths.push(Path::new(&manifest_dir).join("decodecorpus_files/z000033"));
+        }
+        paths
+    };
 
-    if let Some(path) = fixture_path {
-        match fs::read(&path) {
+    if candidate_paths.is_empty() {
+        eprintln!(
+            "BENCH_WARN neither STRUCTURED_ZSTD_BENCH_CORPUS_PATH nor \
+             CARGO_MANIFEST_DIR is set; using synthetic decode corpus fallback"
+        );
+    }
+    for path in &candidate_paths {
+        match fs::read(path) {
             Ok(bytes) if !bytes.is_empty() => {
                 return Scenario::new(REAL_ID, REAL_LABEL, bytes, ScenarioClass::Corpus);
             }
             Ok(_) => {
                 eprintln!(
-                    "BENCH_WARN decode corpus fixture is empty at {}, using synthetic fallback",
+                    "BENCH_WARN decode corpus fixture is empty at {}, trying next candidate",
                     path.display()
                 );
             }
             Err(err) => {
                 eprintln!(
-                    "BENCH_WARN failed to read decode corpus fixture at {}: {}. Using synthetic fallback",
+                    "BENCH_WARN failed to read decode corpus fixture at {}: {}. Trying next candidate",
                     path.display(),
                     err
                 );
             }
         }
-    } else {
-        eprintln!(
-            "BENCH_WARN CARGO_MANIFEST_DIR is not set, using synthetic decode corpus fallback"
-        );
     }
 
     // Keep the benchmark matrix runnable from packaged sources where fixture files may be omitted.


### PR DESCRIPTION
## Summary

Replace the 6 hand-picked bench presets with a 29-entry canonical level inventory so every advertised donor level (`-7..=-1` and `1..=22`) gets its own bench shard. Bench IDs and CI matrix keys converge on a single form: `level_<N>_<strategy_lowercase>` (e.g. `level_-7_fast`, `level_3_dfast`, `level_22_btultra2`), letting the gh-pages dashboard render `level 3 :: Dfast` directly from the bench label.

## Why now

- #111 phases run cross-strategy work but our regression dashboard only sees 6 of 28 unique advertised levels.
- Strategy tag in the label removes a fragile re-derivation step on the dashboard side.
- Donor-parity comparisons need symmetric FFI vs Rust at every level — currently we compare only at preset boundaries.

## What changed

- `zstd/benches/support/mod.rs::supported_levels()` returns `Vec<LevelConfig>` with 29 entries: `-7..=-1` (ultra-fast, Fast strategy) plus `1..=22`. Names follow `level_<N>_<strategy>`. Local `strategy_suffix(level: i32) -> &'static str` mirrors `StrategyTag::for_compression_level` so bench labels stay in sync with the public API mapping.
- Level 0 omitted — donor treats `0` as a sentinel for "use default" (= 3); a dedicated shard would just duplicate level 3's numbers.
- `.github/workflows/ci.yml` `level:` matrix enumerates all 29 names. The `level_filter_from_env()` panic on unknown names catches drift between the Rust inventory and the YAML matrix on the first affected shard.

## Cost

CI bench-matrix grows from 18 (3 targets × 6 levels) to **87 shards** (3 × 29). Wall-clock stays bounded by `level_22_btultra2` on i686 (~20 min); the other 86 shards run in parallel.

## Verification

- `cargo clippy -p structured-zstd --features hash,std,dict_builder,bench_internals --benches -- -D warnings` — clean
- `cargo clippy -p structured-zstd --features hash,std,dict_builder -- -D warnings` — clean
- `cargo nextest run --lib` — 478/478 PASS
- `STRUCTURED_ZSTD_BENCH_LEVEL_FILTER=level_-1_fast cargo bench --bench compare_ffi -- --quick` — single-level shard runs locally with the new ID format
- Bench check `cargo check --benches` — clean

Closes #141. Part of #28 (roadmap visibility) and #111 (per-strategy regression coverage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard level selector recognizes canonical level IDs, shows human-friendly labels, and sorts levels numerically while preserving legacy entries.

* **Chores**
  * CI benchmark coverage expanded to an explicit, broader set of levels with updated canonical level names.
  * Bench tooling now prefers a repo fixture for the decode corpus to avoid fallback to synthetic data, stabilizing benchmark labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->