### PR TITLE
fix(bench): restore criterion sample_size to 10

### DIFF
--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -510,23 +510,26 @@ fn configure_group<M: criterion::measurement::Measurement>(
             group.sampling_mode(SamplingMode::Flat);
         }
         ScenarioClass::Corpus | ScenarioClass::Entropy => {
-            // 3 samples (was 10) — at level_22_btultra2 a single encode
-            // pass on `decodecorpus-z000033` (~1 MiB) takes well over
-            // 1s, so criterion would otherwise warn "Unable to complete
-            // 10 samples in 4s, increase target time to 5.2s". Three
-            // samples are enough for the dashboard's regression-band
-            // ±5% sensitivity while keeping per-shard wall time bounded.
-            group.sample_size(3);
-            group.measurement_time(Duration::from_secs(4));
+            // criterion 0.8 hard-asserts `sample_size >= 10` at runtime,
+            // so dropping below 10 is not an option (commit 73868b0
+            // tried `sample_size(3)` and every bench shard panicked at
+            // `benchmark_group.rs:97: assertion failed: n >= 10`).
+            // Instead, give criterion enough wall-clock budget — the
+            // earlier warning was "increase target time to 5.2s" on the
+            // slowest combo (level_22_btultra2 + 1 MiB decodecorpus).
+            // 8s covers that with headroom while keeping per-shard
+            // total runtime bounded (~11 min worst-case strategy shard).
+            group.sample_size(10);
+            group.measurement_time(Duration::from_secs(8));
             group.sampling_mode(SamplingMode::Flat);
         }
         ScenarioClass::Large | ScenarioClass::Silesia => {
-            // 3 samples (was 10) — Large/Silesia payloads (~16-100 MiB)
-            // dominate per-shard runtime at higher levels. Three
-            // samples + 2s measurement is sufficient for regression
-            // detection on the canonical alert levels.
-            group.sample_size(3);
-            group.measurement_time(Duration::from_secs(2));
+            // Same `sample_size >= 10` floor. Large/Silesia payloads
+            // (~16-100 MiB) take longer per iteration, so bump the
+            // measurement budget further — 10s covers level_22_btultra2
+            // on 16 MiB streams with margin.
+            group.sample_size(10);
+            group.measurement_time(Duration::from_secs(10));
             group.warm_up_time(Duration::from_millis(500));
             group.sampling_mode(SamplingMode::Flat);
         }


### PR DESCRIPTION
## Summary

Every Bench matrix shard on main has been panicking with
`assertion failed: n >= 10` since PR #143 merged as 3fc499ae. Run
25966753761 shows every strategy shard (fast / dfast / greedy / lazy
/ btopt / btultra / btultra2) on every target hitting the same panic
the first time a non-Small scenario is configured.

## Root cause

Commit 73868b0 (last in PR #143) dropped `sample_size` from 10 to 3
for Corpus / Entropy / Large / Silesia scenarios to silence criterion's
"Unable to complete 10 samples in 4s" advisory. criterion 0.8 hard-asserts
`n >= 10` at `benchmark_group.rs:97`; the advisory the original commit
was trying to address is the suggested remediation path.

Locally this surfaced only after `level_3_dfast` / `small-*` benches
(which use `sample_size(30)`). The first Corpus/Entropy scenario in
CI hits the assertion immediately.

## Fix

Restore `sample_size(10)` and raise `measurement_time` to give criterion
the wall-clock budget it was already hinting at:

- Corpus / Entropy: 4s to 8s
- Large / Silesia: 2s to 10s
- Small unchanged (`sample_size(30) + 3s`)

Per the failing CI log the criterion advisory quoted "increase target
time to 5.2s" for `level_22_btultra2` on 1 MiB, so 8s gives ~60% headroom
on the slowest observed case.

## Test plan
- [x] cargo clippy bench clean
- [x] cargo fmt check clean
- [ ] CI bench shards green after merge

Regression from PR #143.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark configuration parameters to improve measurement accuracy and consistency across different test scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->