### PR TITLE
feat(bench): #99 Rust↔FFI sequence-stream comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For `no_std` builds disable the default features:
 structured-zstd = { version = "0.0.21", default-features = false }
 ```
 
-Release notes for every version live in [`zstd/CHANGELOG.md`](zstd/CHANGELOG.md) (maintained by [release-plz](https://release-plz.dev/)).
+Release notes for every version live in [`zstd/CHANGELOG.md`](https://github.com/structured-world/structured-zstd/blob/main/zstd/CHANGELOG.md) (maintained by [release-plz](https://release-plz.dev/)).
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ For `no_std` builds disable the default features:
 structured-zstd = { version = "0.0.21", default-features = false }
 ```
 
+Release notes for every version live in [`zstd/CHANGELOG.md`](zstd/CHANGELOG.md) (maintained by [release-plz](https://release-plz.dev/)).
+
 ## Status
 
 ### Decoder — production-ready

--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@
 
 ## Quick start
 
-```toml
-[dependencies]
-structured-zstd = "0.0.21"
+```bash
+cargo add structured-zstd
 ```
 
 ```rust
@@ -22,9 +21,8 @@ let compressed = compress_to_vec(&b"hello world"[..], CompressionLevel::from_lev
 
 For `no_std` builds disable the default features:
 
-```toml
-[dependencies]
-structured-zstd = { version = "0.0.21", default-features = false }
+```bash
+cargo add structured-zstd --no-default-features
 ```
 
 Release notes for every version live in [`zstd/CHANGELOG.md`](https://github.com/structured-world/structured-zstd/blob/main/zstd/CHANGELOG.md) (maintained by [release-plz](https://release-plz.dev/)).

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -94,6 +94,11 @@ harness = false
 required-features = ["dict_builder"]
 
 [[bench]]
+name = "compare_ffi_sequences"
+harness = false
+required-features = ["dict_builder", "bench_internals"]
+
+[[bench]]
 name = "bitstream"
 harness = false
 required-features = ["bench_internals"]

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -2,22 +2,36 @@
 //!
 //! For a fixed `(input, level)` pair, capture the encoder sequence stream
 //! from both sides and diff `(literal_length, offset, match_length)`
-//! triples to triage residual compression-ratio gaps.
+//! triples. The tool emits raw diff verdicts —
+//! `Equal` / `Differ` / `RustOnly` / `FfiOnly` — over which a human
+//! triages residual compression-ratio gaps into interpretation classes
+//! ("algorithmic win" where Rust ships a sequence donor missed,
+//! "cost source" where both sides emit at the same position but Rust
+//! chose a worse offset/length, "missed match upstream skipped" where
+//! donor emits a sequence Rust didn't). The classification labels are
+//! HUMAN-APPLIED reasoning on top of the raw verdicts, not tool output.
 //!
 //! Pipeline:
 //! 1. Rust side — drive the production [`FrameCompressor`] via
 //!    [`structured_zstd::encoding::sequence_capture::compress_and_collect_sequences`].
-//!    Returns one `CapturedRawSequence { block_idx, seq_in_block, ll, of, ml }`
-//!    per `Sequence::Triple` emitted by the matcher.
+//!    Returns a `SequenceCapture { sequences, block_tail_lengths }`
+//!    where each `CapturedRawSequence { block_idx, seq_in_block, ll, of, ml }`
+//!    corresponds to one `Sequence::Triple` and `block_tail_lengths[i]`
+//!    holds the trailing-literal byte count for block `i` (the bytes
+//!    between the last triple and the block end).
 //! 2. FFI side — `ZSTD_generateSequences` against the same `level`. The
 //!    donor emits a per-block stream where every block ends with a
-//!    dummy delimiter `(of=0, ml=0, ll=trailing_literals)`. Delimiters
-//!    are dropped here and used solely to tag block indices on the
-//!    surviving sequences.
+//!    dummy delimiter `(of=0, ml=0, ll=trailing_literals)`. The
+//!    delimiter's `ll` is captured as the FFI-side trailing-literal
+//!    length; remaining sequences are tagged with their block index.
 //! 3. Alignment — both streams are in input-order. Walk in lockstep by
-//!    cumulative consumed bytes (`Σ ll + ml`). At each step the side
-//!    with the smaller cumulative position advances; equal positions
-//!    are compared directly.
+//!    cumulative consumed bytes (`Σ ll + ml` per triple plus the
+//!    block-tail length at each block boundary, on both sides). At
+//!    each step the side with the smaller cumulative position
+//!    advances; equal positions are compared directly. Without the
+//!    per-block tail lengths the cumulative counter would undercount
+//!    after every block with trailing literals and shift every
+//!    subsequent row of the diff (PR #149 review).
 //! 4. Output — per-fixture summary + the first `MAX_DIVERGENCE_ROWS`
 //!    diverging rows in a plain-text table.
 //!
@@ -158,22 +172,24 @@ fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
 }
 
 fn run_one(name: &str, input: &[u8]) {
-    let rust_seqs = compress_and_collect_sequences(input, CompressionLevel::Level(TARGET_LEVEL));
-    let ffi_seqs = ffi_generate_sequences(input, TARGET_LEVEL);
+    let rust_capture = compress_and_collect_sequences(input, CompressionLevel::Level(TARGET_LEVEL));
+    let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, TARGET_LEVEL);
+    let rust_seqs = &rust_capture.sequences;
+    let rust_tail_lengths = &rust_capture.block_tail_lengths;
 
     println!("--- fixture: {name} ---");
     println!(
         "  rust sequences: {} (across {} block(s))",
         rust_seqs.len(),
-        rust_seqs.last().map(|s| s.block_idx + 1).unwrap_or(0),
+        rust_tail_lengths.len(),
     );
     println!(
         "  ffi  sequences: {} (across {} block(s))",
         ffi_seqs.len(),
-        ffi_seqs.last().map(|s| s.block_idx + 1).unwrap_or(0),
+        ffi_tail_lengths.len(),
     );
 
-    let rows = align_and_diff(&rust_seqs, &ffi_seqs);
+    let rows = align_and_diff(rust_seqs, rust_tail_lengths, &ffi_seqs, &ffi_tail_lengths);
     let mut equal = 0usize;
     let mut differ = 0usize;
     let mut rust_only = 0usize;
@@ -262,19 +278,74 @@ fn fmt_ffi(s: &FfiSeq) -> String {
     )
 }
 
+/// Apply the per-block trailing-literal length for every block whose
+/// last triple has already been consumed. `current_block_idx` walks
+/// forward as the iterator advances; whenever we step into a new
+/// block, the previous block's tail bytes belong to the consumed
+/// span. Done as a helper so both Rust and FFI sides apply the same
+/// rule without duplicating the bookkeeping.
+fn advance_tail_for_completed_blocks(
+    pos: &mut u64,
+    current_block_idx: &mut u32,
+    next_seq_block: u32,
+    tail_lengths: &[u32],
+) {
+    while *current_block_idx < next_seq_block {
+        if let Some(&tail) = tail_lengths.get(*current_block_idx as usize) {
+            *pos += tail as u64;
+        }
+        *current_block_idx = current_block_idx.saturating_add(1);
+    }
+}
+
 /// Align two ordered sequence streams by cumulative input-bytes
-/// consumed. The encoder semantics make `Σ (ll + ml)` strictly
-/// non-decreasing on both sides — at each step we advance whichever
-/// side has the smaller cumulative position, classifying as RustOnly /
-/// FfiOnly. Equal positions are compared field-by-field and emit
-/// `Equal` or `Differ`. The output ordering matches the input order.
-fn align_and_diff(rust: &[CapturedRawSequence], ffi: &[FfiSeq]) -> Vec<DiffRow> {
+/// consumed. The encoder semantics make the running position
+/// (`Σ (ll + ml)` across triples PLUS per-block trailing-literal
+/// length applied at each block boundary) strictly non-decreasing on
+/// both sides. Per-block tails MUST be applied or multi-block
+/// fixtures undercount after every block with trailing literals,
+/// shifting every subsequent diff row (PR #149 review #1-#3).
+///
+/// At each step we advance whichever side has the smaller cumulative
+/// position, classifying as `RustOnly` / `FfiOnly`. Equal positions
+/// are compared field-by-field and emit `Equal` or `Differ`. After
+/// both iterators are exhausted, any remaining trailing-literal tails
+/// (final block on either side) are folded into the cumulative
+/// counters for the equality assertion the bench prints in summary.
+fn align_and_diff(
+    rust: &[CapturedRawSequence],
+    rust_tails: &[u32],
+    ffi: &[FfiSeq],
+    ffi_tails: &[u32],
+) -> Vec<DiffRow> {
     let mut rust_iter = rust.iter().peekable();
     let mut ffi_iter = ffi.iter().peekable();
     let mut rust_pos: u64 = 0;
     let mut ffi_pos: u64 = 0;
+    let mut rust_block_idx: u32 = 0;
+    let mut ffi_block_idx: u32 = 0;
     let mut out = Vec::with_capacity(rust.len().max(ffi.len()));
     loop {
+        // Before peeking at the next triple, apply tails for every
+        // block whose final triple was already consumed but whose
+        // tail bytes haven't been counted yet. This keeps the
+        // cumulative position aligned with on-wire byte consumption.
+        if let Some(r) = rust_iter.peek() {
+            advance_tail_for_completed_blocks(
+                &mut rust_pos,
+                &mut rust_block_idx,
+                r.block_idx,
+                rust_tails,
+            );
+        }
+        if let Some(f) = ffi_iter.peek() {
+            advance_tail_for_completed_blocks(
+                &mut ffi_pos,
+                &mut ffi_block_idx,
+                f.block_idx,
+                ffi_tails,
+            );
+        }
         match (rust_iter.peek(), ffi_iter.peek()) {
             (None, None) => break,
             (Some(r), None) => {
@@ -322,14 +393,19 @@ fn align_and_diff(rust: &[CapturedRawSequence], ffi: &[FfiSeq]) -> Vec<DiffRow> 
 }
 
 /// Call `ZSTD_generateSequences` on `input` at `level` and return
-/// non-delimiter sequences tagged with their block index.
+/// non-delimiter sequences tagged with their block index, plus a
+/// parallel vec of trailing-literal lengths indexed by block.
 ///
 /// Donor semantics (from `zstd-sys` bindgen doc): every block ends
-/// with a dummy entry `(of=0, ml=0, ll=trailing_literals)`. We use
-/// those entries solely to advance `current_block` and drop them from
-/// the returned vector — they have no analogue in the matcher-side
-/// `Sequence::Triple` stream.
-fn ffi_generate_sequences(input: &[u8], level: i32) -> Vec<FfiSeq> {
+/// with a dummy entry `(of=0, ml=0, ll=trailing_literals)`. The
+/// dummy's `litLength` is the bytes between the last real triple of
+/// the block and the block end — needed by the comparator's
+/// cumulative-position alignment to advance the FFI counter at each
+/// block boundary by the same amount the on-wire encoding consumes.
+/// Without this, FFI runs behind Rust by exactly the trailing-literal
+/// count after every block boundary on multi-block inputs (PR #149
+/// review #1-#3).
+fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
     use zstd::zstd_safe::zstd_sys;
     // SAFETY: standard libzstd handle creation; null on OOM.
     let cctx = unsafe { zstd_sys::ZSTD_createCCtx() };
@@ -362,11 +438,16 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> Vec<FfiSeq> {
     unsafe { zstd_sys::ZSTD_freeCCtx(cctx) };
 
     let mut out = Vec::with_capacity(buf.len());
+    let mut tails = Vec::new();
     let mut current_block: u32 = 0;
     let mut seq_in_block: u32 = 0;
     for s in &buf {
         if s.offset == 0 && s.matchLength == 0 {
-            // Block delimiter — advance to next block; do not emit.
+            // Block delimiter — record trailing-literal length for
+            // this block, then advance the block counter. The
+            // delimiter is not emitted as an `FfiSeq` because it has
+            // no analogue on the Rust matcher side.
+            tails.push(s.litLength);
             current_block = current_block.saturating_add(1);
             seq_in_block = 0;
             continue;
@@ -380,5 +461,5 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> Vec<FfiSeq> {
         });
         seq_in_block = seq_in_block.saturating_add(1);
     }
-    out
+    (out, tails)
 }

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -343,9 +343,16 @@ fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize) {
     // pick a different path"; whether each path is a win or
     // regression is a human-applied call after looking at the
     // emitted bytes.
+    // `differ` is the `DiffRow::Differ` bucket only — both sides emit
+    // a triple at the same cumulative position but with different
+    // `(ll, of, ml)`. `rust_only` / `ffi_only` are separate buckets
+    // (one side emits a triple where the other doesn't). They are
+    // all forms of divergence; the label uses the enum name so a
+    // reader can map each column back to the `DiffRow` variant
+    // instead of conflating `Differ` with the total.
     println!(
         "  level={level:>2}  rust_seqs={rs:>6} ({rb} blk)  ffi_seqs={fs:>6} ({fb} blk)  \
-         match={equal:>6} ({pct:.1}%)  diverge={dv:>6}  rust_only={rust_only:>5}  \
+         match={equal:>6} ({pct:.1}%)  differ={dv:>6}  rust_only={rust_only:>5}  \
          ffi_only={ffi_only}",
         rs = rust_seqs.len(),
         rb = rust_tail_lengths.len(),
@@ -608,6 +615,22 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
             level,
         );
         assert_zstd_ok(rc, "ZSTD_CCtx_setParameter(ZSTD_c_compressionLevel)");
+        // Mirror the small-input windowLog=14 override used by
+        // `compare_ffi.rs` so the donor parser sees the same window
+        // the Rust encoder applies when the source size is hinted
+        // down to a 16 KiB frame. Without this, tiny fixtures
+        // (e.g. the 16 KiB synthetic log) get parsed against a
+        // larger default window on the FFI side and produce
+        // sequence-stream divergences that are pure window-mismatch
+        // artifacts, not real strategy differences.
+        if input.len() <= (1 << 14) {
+            let rc = zstd_sys::ZSTD_CCtx_setParameter(
+                cctx,
+                zstd_sys::ZSTD_cParameter::ZSTD_c_windowLog,
+                14,
+            );
+            assert_zstd_ok(rc, "ZSTD_CCtx_setParameter(ZSTD_c_windowLog=14)");
+        }
         let n = zstd_sys::ZSTD_generateSequences(
             cctx,
             buf.as_mut_ptr(),

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -331,10 +331,15 @@ fn advance_tail_for_completed_blocks(
 ///
 /// At each step we advance whichever side has the smaller cumulative
 /// position, classifying as `RustOnly` / `FfiOnly`. Equal positions
-/// are compared field-by-field and emit `Equal` or `Differ`. After
-/// both iterators are exhausted, any remaining trailing-literal tails
-/// (final block on either side) are folded into the cumulative
-/// counters for the equality assertion the bench prints in summary.
+/// are compared field-by-field and emit `Equal` or `Differ`. The
+/// cumulative counters are internal state — they drive the
+/// per-iteration "which side is behind" decision and the final
+/// `Some(_, None)` / `(None, Some(_))` drain logic, but are NOT
+/// returned and the caller's printed summary does not assert
+/// equality against them. The fail-fast invariants live on the
+/// capture/FFI sides (`compress_and_collect_sequences` +
+/// `ffi_generate_sequences`); reaching this function with
+/// undercounted tails would be caught upstream.
 fn align_and_diff(
     rust: &[CapturedRawSequence],
     rust_tails: &[u32],

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -330,22 +330,34 @@ fn align_and_diff(
         // block whose final triple was already consumed but whose
         // tail bytes haven't been counted yet. This keeps the
         // cumulative position aligned with on-wire byte consumption.
-        if let Some(r) = rust_iter.peek() {
-            advance_tail_for_completed_blocks(
-                &mut rust_pos,
-                &mut rust_block_idx,
-                r.block_idx,
-                rust_tails,
-            );
-        }
-        if let Some(f) = ffi_iter.peek() {
-            advance_tail_for_completed_blocks(
-                &mut ffi_pos,
-                &mut ffi_block_idx,
-                f.block_idx,
-                ffi_tails,
-            );
-        }
+        // Flush pending tails for every block whose final triple was
+        // already consumed. When `peek()` is `None`, advance to
+        // `tails.len()` so the FINAL block's tail (always present for
+        // any non-trivial input) AND any literal-only / RLE-routed
+        // blocks past the iterator's end are counted. Without the
+        // `unwrap_or(tails.len())` branch the final block's tail
+        // would silently never be added to the cumulative cursor
+        // (PR #149 review round 2 #5).
+        let rust_next_block = rust_iter
+            .peek()
+            .map(|r| r.block_idx)
+            .unwrap_or(rust_tails.len() as u32);
+        advance_tail_for_completed_blocks(
+            &mut rust_pos,
+            &mut rust_block_idx,
+            rust_next_block,
+            rust_tails,
+        );
+        let ffi_next_block = ffi_iter
+            .peek()
+            .map(|f| f.block_idx)
+            .unwrap_or(ffi_tails.len() as u32);
+        advance_tail_for_completed_blocks(
+            &mut ffi_pos,
+            &mut ffi_block_idx,
+            ffi_next_block,
+            ffi_tails,
+        );
         match (rust_iter.peek(), ffi_iter.peek()) {
             (None, None) => break,
             (Some(r), None) => {
@@ -363,7 +375,16 @@ fn align_and_diff(
             (Some(r), Some(f)) => {
                 let r_next_pos = rust_pos + r.ll as u64 + r.ml as u64;
                 let f_next_pos = ffi_pos + f.ll as u64 + f.ml as u64;
-                if r_next_pos == f_next_pos {
+                // Compare field-by-field ONLY when both streams are at
+                // the same current byte position. Gating on
+                // `r_next_pos == f_next_pos` would collapse an
+                // "extra sequence on one side + catch-up on the other"
+                // case into a single misleading `Differ` row whenever
+                // the summed (ll + ml) deltas happen to balance — the
+                // two triples were emitted at different input
+                // positions and aren't actually comparable
+                // (PR #149 review round 2 #6).
+                if rust_pos == ffi_pos {
                     let r = **r;
                     let f = **f;
                     if r.ll == f.ll && r.of == f.of && r.ml == f.ml {
@@ -375,7 +396,7 @@ fn align_and_diff(
                     ffi_pos = f_next_pos;
                     rust_iter.next();
                     ffi_iter.next();
-                } else if r_next_pos < f_next_pos {
+                } else if rust_pos < ffi_pos {
                     let r = **r;
                     rust_pos = r_next_pos;
                     out.push(DiffRow::RustOnly(r));

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -117,25 +117,48 @@ fn main() {
 fn collect_fixtures() -> Vec<(String, Vec<u8>)> {
     let mut out = Vec::new();
 
-    let corpus_path = Path::new("decodecorpus_files/z000033");
-    let workspace_corpus_path = Path::new("zstd/decodecorpus_files/z000033");
-    let corpus = if corpus_path.exists() {
-        Some(corpus_path)
-    } else if workspace_corpus_path.exists() {
-        Some(workspace_corpus_path)
-    } else {
-        None
-    };
-    if let Some(p) = corpus {
-        match fs::read(p) {
-            Ok(bytes) => out.push((format!("z000033 ({} bytes)", bytes.len()), bytes)),
-            Err(e) => eprintln!("warn: skipping {} — {}", p.display(), e),
+    // Mirror the corpus resolution order used by
+    // `zstd/benches/support/mod.rs::load_decode_corpus_scenario` so
+    // this bench finds the canonical `decodecorpus-z000033` fixture
+    // under the same conditions as `compare_ffi.rs` /
+    // `compare_ffi_memory.rs`:
+    //   1. `STRUCTURED_ZSTD_BENCH_CORPUS_PATH` — explicit path. CI
+    //      sets this when invoking the prebuilt bench binary
+    //      directly (no `CARGO_MANIFEST_DIR` in that environment).
+    //   2. `CARGO_MANIFEST_DIR/decodecorpus_files/z000033` —
+    //      cargo-driven `cargo bench` runs.
+    //   3. Repo-relative fallback for hand-run binaries from the
+    //      crate dir or workspace root.
+    // Without (1) and (2), the canonical fixture would silently
+    // skip on CI runs that bypass cargo, undermining the audit
+    // (PR #149 review round 3 #11).
+    let mut candidate_paths: Vec<std::path::PathBuf> = Vec::new();
+    if let Ok(explicit) = std::env::var("STRUCTURED_ZSTD_BENCH_CORPUS_PATH") {
+        let trimmed = explicit.trim();
+        if !trimmed.is_empty() {
+            candidate_paths.push(std::path::PathBuf::from(trimmed));
         }
-    } else {
+    }
+    if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+        candidate_paths.push(Path::new(&manifest_dir).join("decodecorpus_files/z000033"));
+    }
+    candidate_paths.push(std::path::PathBuf::from("decodecorpus_files/z000033"));
+    candidate_paths.push(std::path::PathBuf::from("zstd/decodecorpus_files/z000033"));
+
+    let mut found = false;
+    for p in &candidate_paths {
+        if let Ok(bytes) = fs::read(p)
+            && !bytes.is_empty()
+        {
+            out.push((format!("z000033 ({} bytes)", bytes.len()), bytes));
+            found = true;
+            break;
+        }
+    }
+    if !found {
         eprintln!(
-            "warn: decodecorpus z000033 fixture not found at {} or {} — skipping",
-            corpus_path.display(),
-            workspace_corpus_path.display()
+            "warn: decodecorpus z000033 not found via STRUCTURED_ZSTD_BENCH_CORPUS_PATH, \
+             CARGO_MANIFEST_DIR, or repo-relative paths — skipping",
         );
     }
 
@@ -482,5 +505,23 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
         });
         seq_in_block = seq_in_block.saturating_add(1);
     }
+    // Mirror the Rust-side fail-fast invariant in
+    // `compress_and_collect_sequences`: if `ZSTD_generateSequences`
+    // omits a block delimiter or our filter misses one, `tails` ends
+    // up short and `align_and_diff` would walk a stale cursor and
+    // emit misleading rows. Panic with a clear FFI-specific message
+    // so the broken precondition surfaces immediately instead of
+    // being masked as a "real" divergence (PR #149 review round 3 #8).
+    let reconstructed: u64 = out.iter().map(|s| s.ll as u64 + s.ml as u64).sum::<u64>()
+        + tails.iter().map(|t| *t as u64).sum::<u64>();
+    assert_eq!(
+        reconstructed,
+        input.len() as u64,
+        "ffi_generate_sequences: stream undercounted input bytes — \
+         Σ(ll+ml)+Σ(tails)={reconstructed}, input.len()={}. \
+         Likely cause: a `ZSTD_generateSequences` block delimiter \
+         was omitted or filtered incorrectly.",
+        input.len(),
+    );
     (out, tails)
 }

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -47,13 +47,13 @@
 //! used because timing is irrelevant here; this is a diagnostic
 //! one-shot, not a regression bench.
 
-// `support` is shared with `compare_ffi.rs` / `compare_ffi_memory.rs`.
-// This bench doesn't use any of its helpers but the module is still
-// pulled in by Cargo because `bench` targets share `benches/`. The
-// `#[allow(dead_code)]` suppresses warnings about unused items in
-// `support`.
-#[allow(dead_code)]
-mod support;
+// The `support/` module shared with `compare_ffi.rs` /
+// `compare_ffi_memory.rs` is intentionally NOT declared here — this
+// bench doesn't use any of its helpers, and declaring the module
+// would compile the entire shared bench harness and couple this
+// diagnostic tool to unrelated changes (PR #149 review #18). Cargo
+// does not auto-include sibling modules in `benches/`, so leaving
+// the declaration out is the correct way to opt out.
 
 use std::fs;
 use std::path::Path;
@@ -185,7 +185,7 @@ fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
         let hex = format!("{:08x}", counter);
         out.extend_from_slice(hex.as_bytes());
         out.extend_from_slice(suffix);
-        let elapsed = format!("{}", counter % 1000);
+        let elapsed = (counter % 1000).to_string();
         out.extend_from_slice(elapsed.as_bytes());
         out.push(b'\n');
         counter = counter.wrapping_add(1);
@@ -481,7 +481,17 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
         );
         n
     };
-    // SAFETY: libzstd populated the first `nb_seqs` entries.
+    // Defensive guard: `set_len(nb_seqs)` past the allocated capacity
+    // would expose uninitialized memory if libzstd ever returned more
+    // sequences than `ZSTD_sequenceBound` reserved space for. The
+    // bound is documented as inclusive but the check is one assert
+    // (PR #149 review #16).
+    assert!(
+        nb_seqs <= bound,
+        "ZSTD_generateSequences returned more sequences ({nb_seqs}) than ZSTD_sequenceBound reserved ({bound})",
+    );
+    // SAFETY: libzstd populated the first `nb_seqs` entries, and the
+    // assert above guarantees `nb_seqs <= capacity`.
     unsafe { buf.set_len(nb_seqs) };
     // SAFETY: cctx is non-null and was created by us.
     unsafe { zstd_sys::ZSTD_freeCCtx(cctx) };

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -1,0 +1,384 @@
+//! Sequence-stream comparator: structured-zstd (pure Rust) vs zstd (C FFI).
+//!
+//! For a fixed `(input, level)` pair, capture the encoder sequence stream
+//! from both sides and diff `(literal_length, offset, match_length)`
+//! triples to triage residual compression-ratio gaps.
+//!
+//! Pipeline:
+//! 1. Rust side — drive the production [`FrameCompressor`] via
+//!    [`structured_zstd::encoding::sequence_capture::compress_and_collect_sequences`].
+//!    Returns one `CapturedRawSequence { block_idx, seq_in_block, ll, of, ml }`
+//!    per `Sequence::Triple` emitted by the matcher.
+//! 2. FFI side — `ZSTD_generateSequences` against the same `level`. The
+//!    donor emits a per-block stream where every block ends with a
+//!    dummy delimiter `(of=0, ml=0, ll=trailing_literals)`. Delimiters
+//!    are dropped here and used solely to tag block indices on the
+//!    surviving sequences.
+//! 3. Alignment — both streams are in input-order. Walk in lockstep by
+//!    cumulative consumed bytes (`Σ ll + ml`). At each step the side
+//!    with the smaller cumulative position advances; equal positions
+//!    are compared directly.
+//! 4. Output — per-fixture summary + the first `MAX_DIVERGENCE_ROWS`
+//!    diverging rows in a plain-text table.
+//!
+//! Fixtures (Lane D, `7-tooling-seq-cmp`, first iteration):
+//! - `decodecorpus_files/z000033` — pre-existing corpus fixture that
+//!   surfaces the −7% size delta on `level_3_dfast` vs C zstd, i.e.
+//!   the canonical signal this tool exists to triage.
+//! - Synthesized low-entropy log — 16 KiB of repeating log-line shapes
+//!   with rotating numeric fields, exercising medium-repetition input
+//!   that real workloads produce.
+//!
+//! `harness = false` + this file owns `fn main()` — criterion is not
+//! used because timing is irrelevant here; this is a diagnostic
+//! one-shot, not a regression bench.
+
+// `support` is shared with `compare_ffi.rs` / `compare_ffi_memory.rs`.
+// This bench doesn't use any of its helpers but the module is still
+// pulled in by Cargo because `bench` targets share `benches/`. The
+// `#[allow(dead_code)]` suppresses warnings about unused items in
+// `support`.
+#[allow(dead_code)]
+mod support;
+
+use std::fs;
+use std::path::Path;
+
+use structured_zstd::encoding::CompressionLevel;
+use structured_zstd::encoding::sequence_capture::{
+    CapturedRawSequence, compress_and_collect_sequences,
+};
+
+/// Compression level under audit. Level 3 / Dfast is the
+/// user-visible `Default` preset and the focus of the Lane A
+/// `7-compress-default` sub-phase that this tool gates.
+const TARGET_LEVEL: i32 = 3;
+
+/// Cap on diverging-row output per fixture. Beyond this, only the
+/// summary counts are printed — first-N is sufficient for triage,
+/// the full diff is recoverable by re-running with the cap raised.
+const MAX_DIVERGENCE_ROWS: usize = 30;
+
+/// One sequence captured from the donor (`ZSTD_generateSequences`).
+/// Block delimiters (`of=0 ml=0`) are filtered out before construction.
+#[derive(Clone, Copy, Debug)]
+struct FfiSeq {
+    block_idx: u32,
+    seq_in_block: u32,
+    ll: u32,
+    of: u32,
+    ml: u32,
+}
+
+/// Result of comparing one position in the joined stream.
+#[derive(Clone, Copy, Debug)]
+enum DiffRow {
+    Equal,
+    Differ {
+        rust: CapturedRawSequence,
+        ffi: FfiSeq,
+    },
+    RustOnly(CapturedRawSequence),
+    FfiOnly(FfiSeq),
+}
+
+fn main() {
+    let fixtures = collect_fixtures();
+    println!(
+        "=== compare_ffi_sequences (level={}, Rust vs C FFI) ===",
+        TARGET_LEVEL
+    );
+    println!();
+    for (name, bytes) in fixtures {
+        run_one(&name, &bytes);
+        println!();
+    }
+}
+
+/// Build the fixture set. Returns `(name, bytes)` pairs ready to feed
+/// into both encoders. The lookup is intentionally permissive — if the
+/// disk fixture is missing (e.g. `decodecorpus_files/` excluded from a
+/// downstream packaging), the synthetic fixture still runs so the
+/// bench is never a hard failure on a fresh checkout.
+fn collect_fixtures() -> Vec<(String, Vec<u8>)> {
+    let mut out = Vec::new();
+
+    let corpus_path = Path::new("decodecorpus_files/z000033");
+    let workspace_corpus_path = Path::new("zstd/decodecorpus_files/z000033");
+    let corpus = if corpus_path.exists() {
+        Some(corpus_path)
+    } else if workspace_corpus_path.exists() {
+        Some(workspace_corpus_path)
+    } else {
+        None
+    };
+    if let Some(p) = corpus {
+        match fs::read(p) {
+            Ok(bytes) => out.push((format!("z000033 ({} bytes)", bytes.len()), bytes)),
+            Err(e) => eprintln!("warn: skipping {} — {}", p.display(), e),
+        }
+    } else {
+        eprintln!(
+            "warn: decodecorpus z000033 fixture not found at {} or {} — skipping",
+            corpus_path.display(),
+            workspace_corpus_path.display()
+        );
+    }
+
+    let log = build_low_entropy_log(16 * 1024);
+    out.push((format!("low-entropy log ({} bytes)", log.len()), log));
+
+    out
+}
+
+/// Synthesize repeating log-line shapes for `byte_budget` bytes.
+/// The pattern rotates a numeric field every line so the matcher
+/// can't lock onto a single long repcode and instead emits a stream
+/// of medium matches with the rotating fragment as literals — the
+/// shape Rust↔FFI tends to diverge on.
+fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
+    let prefix = b"2026-05-17T12:00:00 INFO  request_id=";
+    let suffix = b" route=/api/v1/items method=GET status=200 elapsed_ms=";
+    let mut out = Vec::with_capacity(byte_budget);
+    let mut counter: u32 = 0;
+    while out.len() < byte_budget {
+        out.extend_from_slice(prefix);
+        // 8-hex-digit rotating request_id keeps the line shape stable
+        // while preventing trivial RLE / long-repcode collapse.
+        let hex = format!("{:08x}", counter);
+        out.extend_from_slice(hex.as_bytes());
+        out.extend_from_slice(suffix);
+        let elapsed = format!("{}", counter % 1000);
+        out.extend_from_slice(elapsed.as_bytes());
+        out.push(b'\n');
+        counter = counter.wrapping_add(1);
+    }
+    out.truncate(byte_budget);
+    out
+}
+
+fn run_one(name: &str, input: &[u8]) {
+    let rust_seqs = compress_and_collect_sequences(input, CompressionLevel::Level(TARGET_LEVEL));
+    let ffi_seqs = ffi_generate_sequences(input, TARGET_LEVEL);
+
+    println!("--- fixture: {name} ---");
+    println!(
+        "  rust sequences: {} (across {} block(s))",
+        rust_seqs.len(),
+        rust_seqs.last().map(|s| s.block_idx + 1).unwrap_or(0),
+    );
+    println!(
+        "  ffi  sequences: {} (across {} block(s))",
+        ffi_seqs.len(),
+        ffi_seqs.last().map(|s| s.block_idx + 1).unwrap_or(0),
+    );
+
+    let rows = align_and_diff(&rust_seqs, &ffi_seqs);
+    let mut equal = 0usize;
+    let mut differ = 0usize;
+    let mut rust_only = 0usize;
+    let mut ffi_only = 0usize;
+    for r in &rows {
+        match r {
+            DiffRow::Equal => equal += 1,
+            DiffRow::Differ { .. } => differ += 1,
+            DiffRow::RustOnly(_) => rust_only += 1,
+            DiffRow::FfiOnly(_) => ffi_only += 1,
+        }
+    }
+    let total = rows.len().max(1);
+    println!(
+        "  alignment: equal={equal} ({:.1}%) differ={differ} rust_only={rust_only} ffi_only={ffi_only}",
+        equal as f64 * 100.0 / total as f64,
+    );
+
+    let mut printed = 0usize;
+    let mut header_printed = false;
+    for (idx, r) in rows.iter().enumerate() {
+        if matches!(r, DiffRow::Equal) {
+            continue;
+        }
+        if printed >= MAX_DIVERGENCE_ROWS {
+            println!(
+                "  ... (omitted {} more diverging rows; raise MAX_DIVERGENCE_ROWS to see them)",
+                differ + rust_only + ffi_only - printed,
+            );
+            break;
+        }
+        if !header_printed {
+            println!();
+            println!(
+                "  {:>5} | {:^28} | {:^28} | verdict",
+                "idx", "rust (blk:idx ll/of/ml)", "ffi  (blk:idx ll/of/ml)"
+            );
+            println!("  {}", "-".repeat(80));
+            header_printed = true;
+        }
+        match r {
+            DiffRow::Equal => unreachable!(),
+            DiffRow::Differ { rust, ffi } => {
+                println!(
+                    "  {:>5} | {:<28} | {:<28} | DIFFER",
+                    idx,
+                    fmt_rust(rust),
+                    fmt_ffi(ffi),
+                );
+            }
+            DiffRow::RustOnly(rust) => {
+                println!(
+                    "  {:>5} | {:<28} | {:<28} | RUST_ONLY",
+                    idx,
+                    fmt_rust(rust),
+                    "—",
+                );
+            }
+            DiffRow::FfiOnly(ffi) => {
+                println!(
+                    "  {:>5} | {:<28} | {:<28} | FFI_ONLY",
+                    idx,
+                    "—",
+                    fmt_ffi(ffi),
+                );
+            }
+        }
+        printed += 1;
+    }
+    if printed == 0 {
+        println!("  (no divergences — sequence streams match)");
+    }
+}
+
+fn fmt_rust(s: &CapturedRawSequence) -> String {
+    format!(
+        "{}:{:>3} {}/{}/{}",
+        s.block_idx, s.seq_in_block, s.ll, s.of, s.ml
+    )
+}
+
+fn fmt_ffi(s: &FfiSeq) -> String {
+    format!(
+        "{}:{:>3} {}/{}/{}",
+        s.block_idx, s.seq_in_block, s.ll, s.of, s.ml
+    )
+}
+
+/// Align two ordered sequence streams by cumulative input-bytes
+/// consumed. The encoder semantics make `Σ (ll + ml)` strictly
+/// non-decreasing on both sides — at each step we advance whichever
+/// side has the smaller cumulative position, classifying as RustOnly /
+/// FfiOnly. Equal positions are compared field-by-field and emit
+/// `Equal` or `Differ`. The output ordering matches the input order.
+fn align_and_diff(rust: &[CapturedRawSequence], ffi: &[FfiSeq]) -> Vec<DiffRow> {
+    let mut rust_iter = rust.iter().peekable();
+    let mut ffi_iter = ffi.iter().peekable();
+    let mut rust_pos: u64 = 0;
+    let mut ffi_pos: u64 = 0;
+    let mut out = Vec::with_capacity(rust.len().max(ffi.len()));
+    loop {
+        match (rust_iter.peek(), ffi_iter.peek()) {
+            (None, None) => break,
+            (Some(r), None) => {
+                let r = **r;
+                rust_pos += r.ll as u64 + r.ml as u64;
+                out.push(DiffRow::RustOnly(r));
+                rust_iter.next();
+            }
+            (None, Some(f)) => {
+                let f = **f;
+                ffi_pos += f.ll as u64 + f.ml as u64;
+                out.push(DiffRow::FfiOnly(f));
+                ffi_iter.next();
+            }
+            (Some(r), Some(f)) => {
+                let r_next_pos = rust_pos + r.ll as u64 + r.ml as u64;
+                let f_next_pos = ffi_pos + f.ll as u64 + f.ml as u64;
+                if r_next_pos == f_next_pos {
+                    let r = **r;
+                    let f = **f;
+                    if r.ll == f.ll && r.of == f.of && r.ml == f.ml {
+                        out.push(DiffRow::Equal);
+                    } else {
+                        out.push(DiffRow::Differ { rust: r, ffi: f });
+                    }
+                    rust_pos = r_next_pos;
+                    ffi_pos = f_next_pos;
+                    rust_iter.next();
+                    ffi_iter.next();
+                } else if r_next_pos < f_next_pos {
+                    let r = **r;
+                    rust_pos = r_next_pos;
+                    out.push(DiffRow::RustOnly(r));
+                    rust_iter.next();
+                } else {
+                    let f = **f;
+                    ffi_pos = f_next_pos;
+                    out.push(DiffRow::FfiOnly(f));
+                    ffi_iter.next();
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Call `ZSTD_generateSequences` on `input` at `level` and return
+/// non-delimiter sequences tagged with their block index.
+///
+/// Donor semantics (from `zstd-sys` bindgen doc): every block ends
+/// with a dummy entry `(of=0, ml=0, ll=trailing_literals)`. We use
+/// those entries solely to advance `current_block` and drop them from
+/// the returned vector — they have no analogue in the matcher-side
+/// `Sequence::Triple` stream.
+fn ffi_generate_sequences(input: &[u8], level: i32) -> Vec<FfiSeq> {
+    use zstd::zstd_safe::zstd_sys;
+    // SAFETY: standard libzstd handle creation; null on OOM.
+    let cctx = unsafe { zstd_sys::ZSTD_createCCtx() };
+    assert!(!cctx.is_null(), "ZSTD_createCCtx returned null");
+    let bound = unsafe { zstd_sys::ZSTD_sequenceBound(input.len()) };
+    let mut buf: Vec<zstd_sys::ZSTD_Sequence> = Vec::with_capacity(bound);
+    let nb_seqs = unsafe {
+        let rc = zstd_sys::ZSTD_CCtx_setParameter(
+            cctx,
+            zstd_sys::ZSTD_cParameter::ZSTD_c_compressionLevel,
+            level,
+        );
+        assert!(zstd_sys::ZSTD_isError(rc) == 0, "setParameter level failed");
+        let n = zstd_sys::ZSTD_generateSequences(
+            cctx,
+            buf.as_mut_ptr(),
+            bound,
+            input.as_ptr() as *const core::ffi::c_void,
+            input.len(),
+        );
+        assert!(
+            zstd_sys::ZSTD_isError(n) == 0,
+            "ZSTD_generateSequences failed: rc={n}"
+        );
+        n
+    };
+    // SAFETY: libzstd populated the first `nb_seqs` entries.
+    unsafe { buf.set_len(nb_seqs) };
+    // SAFETY: cctx is non-null and was created by us.
+    unsafe { zstd_sys::ZSTD_freeCCtx(cctx) };
+
+    let mut out = Vec::with_capacity(buf.len());
+    let mut current_block: u32 = 0;
+    let mut seq_in_block: u32 = 0;
+    for s in &buf {
+        if s.offset == 0 && s.matchLength == 0 {
+            // Block delimiter — advance to next block; do not emit.
+            current_block = current_block.saturating_add(1);
+            seq_in_block = 0;
+            continue;
+        }
+        out.push(FfiSeq {
+            block_idx: current_block,
+            seq_in_block,
+            ll: s.litLength,
+            of: s.offset,
+            ml: s.matchLength,
+        });
+        seq_in_block = seq_in_block.saturating_add(1);
+    }
+    out
+}

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -63,15 +63,33 @@ use structured_zstd::encoding::sequence_capture::{
     CapturedRawSequence, compress_and_collect_sequences,
 };
 
-/// Compression level under audit. Level 3 / Dfast is the
-/// user-visible `Default` preset and the focus of the Lane A
-/// `7-compress-default` sub-phase that this tool gates.
-const TARGET_LEVEL: i32 = 3;
+/// Default level set when `STRUCTURED_ZSTD_BENCH_LEVEL` is unset.
+/// Single Level(3) (Dfast, the user-visible `Default` preset and
+/// the focus of the Lane A `7-compress-default` sub-phase) keeps
+/// the no-arg path fast for the common per-strategy audit.
+///
+/// Override via `STRUCTURED_ZSTD_BENCH_LEVEL`:
+///
+/// * `STRUCTURED_ZSTD_BENCH_LEVEL=1` — single level
+/// * `STRUCTURED_ZSTD_BENCH_LEVEL=1-15` — inclusive range sweep
+/// * `STRUCTURED_ZSTD_BENCH_LEVEL=1,3,7,11,15` — explicit list
+/// * `STRUCTURED_ZSTD_BENCH_LEVEL=all` — every supported numeric
+///   level (`1..=15`); `Level(>=16)` is rejected by the post-split
+///   guard in `sequence_capture`.
+const DEFAULT_LEVELS: &[i32] = &[3];
 
-/// Cap on diverging-row output per fixture. Beyond this, only the
-/// summary counts are printed — first-N is sufficient for triage,
-/// the full diff is recoverable by re-running with the cap raised.
-const MAX_DIVERGENCE_ROWS: usize = 30;
+/// Highest numeric level the matcher capture supports. `Level(>=16)`
+/// is rejected by `sequence_capture` because
+/// `compress_block_with_post_split` emits multiple physical blocks
+/// per matcher call, which the per-matcher-call block counter
+/// cannot track. Bump this when per-physical-block hooks land.
+const MAX_SUPPORTED_LEVEL: i32 = 15;
+
+/// Cap on diverging-row output per fixture in single-level mode.
+/// Override at runtime via `STRUCTURED_ZSTD_BENCH_MAX_ROWS`. In
+/// sweep mode (multiple levels) defaults to 0 — per-level summary
+/// lines only — so the output stays scannable across all levels.
+const DEFAULT_MAX_DIVERGENCE_ROWS: usize = 30;
 
 /// One sequence captured from the donor (`ZSTD_generateSequences`).
 /// Block delimiters (`of=0 ml=0`) are filtered out before construction.
@@ -97,15 +115,117 @@ enum DiffRow {
 }
 
 fn main() {
+    let levels = parse_levels_env();
+    let single = levels.len() == 1;
+    let default_rows = if single {
+        DEFAULT_MAX_DIVERGENCE_ROWS
+    } else {
+        0
+    };
+    let max_rows = std::env::var("STRUCTURED_ZSTD_BENCH_MAX_ROWS")
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(default_rows);
     let fixtures = collect_fixtures();
     println!(
-        "=== compare_ffi_sequences (level={}, Rust vs C FFI) ===",
-        TARGET_LEVEL
+        "=== compare_ffi_sequences (levels={}, Rust vs C FFI) ===",
+        fmt_levels(&levels),
     );
     println!();
-    for (name, bytes) in fixtures {
-        run_one(&name, &bytes);
+    for (name, bytes) in &fixtures {
+        println!("=== fixture: {name} ===");
+        for &level in &levels {
+            run_one(name, bytes, level, max_rows);
+        }
         println!();
+    }
+}
+
+/// Parse `STRUCTURED_ZSTD_BENCH_LEVEL` env var into a level list.
+///
+/// Forms accepted: single (`3`), range (`1-15`), comma list
+/// (`1,3,7,11,15`), keyword `all` (= `1..=MAX_SUPPORTED_LEVEL`).
+/// Empty / unset / unparseable → [`DEFAULT_LEVELS`]. Levels above
+/// `MAX_SUPPORTED_LEVEL` (post-split territory) are silently
+/// filtered out with a stderr warning so a careless `all` does not
+/// blow up on the sequence_capture guard.
+fn parse_levels_env() -> Vec<i32> {
+    let raw = match std::env::var("STRUCTURED_ZSTD_BENCH_LEVEL") {
+        Ok(v) => v,
+        Err(_) => return DEFAULT_LEVELS.to_vec(),
+    };
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return DEFAULT_LEVELS.to_vec();
+    }
+    if trimmed.eq_ignore_ascii_case("all") {
+        return (1..=MAX_SUPPORTED_LEVEL).collect();
+    }
+    let parsed: Vec<i32> = if let Some((lo, hi)) = trimmed.split_once('-') {
+        match (lo.trim().parse::<i32>(), hi.trim().parse::<i32>()) {
+            (Ok(a), Ok(b)) if a <= b => (a..=b).collect(),
+            _ => {
+                eprintln!(
+                    "warn: STRUCTURED_ZSTD_BENCH_LEVEL={trimmed:?} is not a valid range; \
+                     falling back to default levels {DEFAULT_LEVELS:?}",
+                );
+                return DEFAULT_LEVELS.to_vec();
+            }
+        }
+    } else {
+        trimmed
+            .split(',')
+            .filter_map(|s| s.trim().parse::<i32>().ok())
+            .collect()
+    };
+    let (supported, dropped): (Vec<i32>, Vec<i32>) =
+        parsed.into_iter().partition(|&l| l <= MAX_SUPPORTED_LEVEL);
+    if !dropped.is_empty() {
+        eprintln!(
+            "warn: dropping post-split levels {dropped:?} (Level(>={}) rejected by \
+             sequence_capture matcher post-split guard)",
+            MAX_SUPPORTED_LEVEL + 1,
+        );
+    }
+    if supported.is_empty() {
+        eprintln!(
+            "warn: STRUCTURED_ZSTD_BENCH_LEVEL={trimmed:?} yielded no supported levels; \
+             falling back to default {DEFAULT_LEVELS:?}",
+        );
+        return DEFAULT_LEVELS.to_vec();
+    }
+    supported
+}
+
+fn fmt_levels(levels: &[i32]) -> String {
+    if levels.len() <= 4 {
+        levels
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    } else {
+        let first = levels.first().copied().unwrap_or(0);
+        let last = levels.last().copied().unwrap_or(0);
+        let contiguous = levels.len() == (last - first + 1) as usize
+            && levels
+                .iter()
+                .enumerate()
+                .all(|(i, &l)| l == first + i as i32);
+        if contiguous {
+            format!("{first}-{last}")
+        } else {
+            format!(
+                "{} ({} levels)",
+                levels
+                    .iter()
+                    .take(3)
+                    .map(|l| l.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+                levels.len(),
+            )
+        }
     }
 }
 
@@ -194,23 +314,11 @@ fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
     out
 }
 
-fn run_one(name: &str, input: &[u8]) {
-    let rust_capture = compress_and_collect_sequences(input, CompressionLevel::Level(TARGET_LEVEL));
-    let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, TARGET_LEVEL);
+fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize) {
+    let rust_capture = compress_and_collect_sequences(input, CompressionLevel::Level(level));
+    let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, level);
     let rust_seqs = &rust_capture.sequences;
     let rust_tail_lengths = &rust_capture.block_tail_lengths;
-
-    println!("--- fixture: {name} ---");
-    println!(
-        "  rust sequences: {} (across {} block(s))",
-        rust_seqs.len(),
-        rust_tail_lengths.len(),
-    );
-    println!(
-        "  ffi  sequences: {} (across {} block(s))",
-        ffi_seqs.len(),
-        ffi_tail_lengths.len(),
-    );
 
     let rows = align_and_diff(rust_seqs, rust_tail_lengths, &ffi_seqs, &ffi_tail_lengths);
     let mut equal = 0usize;
@@ -226,20 +334,37 @@ fn run_one(name: &str, input: &[u8]) {
         }
     }
     let total = rows.len().max(1);
+    // Wording note: `Differ/RustOnly/FfiOnly` are RAW classifications,
+    // not value judgments. Divergence from the donor is not a bug —
+    // structured-zstd is allowed (and expected) to make different
+    // and sometimes better choices. The tool surfaces "where do we
+    // pick a different path"; whether each path is a win or
+    // regression is a human-applied call after looking at the
+    // emitted bytes.
     println!(
-        "  alignment: equal={equal} ({:.1}%) differ={differ} rust_only={rust_only} ffi_only={ffi_only}",
-        equal as f64 * 100.0 / total as f64,
+        "  level={level:>2}  rust_seqs={rs:>6} ({rb} blk)  ffi_seqs={fs:>6} ({fb} blk)  \
+         match={equal:>6} ({pct:.1}%)  diverge={dv:>6}  rust_only={rust_only:>5}  \
+         ffi_only={ffi_only}",
+        rs = rust_seqs.len(),
+        rb = rust_tail_lengths.len(),
+        fs = ffi_seqs.len(),
+        fb = ffi_tail_lengths.len(),
+        dv = differ,
+        pct = equal as f64 * 100.0 / total as f64,
     );
 
+    if max_rows == 0 {
+        return;
+    }
     let mut printed = 0usize;
     let mut header_printed = false;
     for (idx, r) in rows.iter().enumerate() {
         if matches!(r, DiffRow::Equal) {
             continue;
         }
-        if printed >= MAX_DIVERGENCE_ROWS {
+        if printed >= max_rows {
             println!(
-                "  ... (omitted {} more diverging rows; raise MAX_DIVERGENCE_ROWS to see them)",
+                "    ... (omitted {} more diverging rows; raise STRUCTURED_ZSTD_BENCH_MAX_ROWS to see them)",
                 differ + rust_only + ffi_only - printed,
             );
             break;
@@ -455,7 +580,20 @@ fn align_and_diff(
 /// count after every block boundary on multi-block inputs (PR #149
 /// review #1-#3).
 fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
-    use zstd::zstd_safe::zstd_sys;
+    use zstd::zstd_safe::{self, zstd_sys};
+    // Mirror of `assert_zstd_ok` in `encoding/match_generator.rs` —
+    // surfaces libzstd's symbolic error name in the panic message
+    // instead of a raw numeric return code, so a triage glance at
+    // the bench log says e.g. "Parameter unsupported" rather than
+    // "rc=18446744073709551614".
+    fn assert_zstd_ok(code: usize, context: &str) {
+        assert_eq!(
+            unsafe { zstd_sys::ZSTD_isError(code) },
+            0,
+            "{context} failed: {}",
+            zstd_safe::get_error_name(code)
+        );
+    }
     // SAFETY: standard libzstd handle creation; null on OOM.
     let cctx = unsafe { zstd_sys::ZSTD_createCCtx() };
     assert!(!cctx.is_null(), "ZSTD_createCCtx returned null");
@@ -467,7 +605,7 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
             zstd_sys::ZSTD_cParameter::ZSTD_c_compressionLevel,
             level,
         );
-        assert!(zstd_sys::ZSTD_isError(rc) == 0, "setParameter level failed");
+        assert_zstd_ok(rc, "ZSTD_CCtx_setParameter(ZSTD_c_compressionLevel)");
         let n = zstd_sys::ZSTD_generateSequences(
             cctx,
             buf.as_mut_ptr(),
@@ -475,10 +613,7 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
             input.as_ptr() as *const core::ffi::c_void,
             input.len(),
         );
-        assert!(
-            zstd_sys::ZSTD_isError(n) == 0,
-            "ZSTD_generateSequences failed: rc={n}"
-        );
+        assert_zstd_ok(n, "ZSTD_generateSequences");
         n
     };
     // Defensive guard: `set_len(nb_seqs)` past the allocated capacity

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -178,13 +178,15 @@ fn parse_levels_env() -> Vec<i32> {
             .filter_map(|s| s.trim().parse::<i32>().ok())
             .collect()
     };
-    let (supported, dropped): (Vec<i32>, Vec<i32>) =
-        parsed.into_iter().partition(|&l| l <= MAX_SUPPORTED_LEVEL);
+    let (supported, dropped): (Vec<i32>, Vec<i32>) = parsed
+        .into_iter()
+        .partition(|&l| (1..=MAX_SUPPORTED_LEVEL).contains(&l));
     if !dropped.is_empty() {
         eprintln!(
-            "warn: dropping post-split levels {dropped:?} (Level(>={}) rejected by \
-             sequence_capture matcher post-split guard)",
-            MAX_SUPPORTED_LEVEL + 1,
+            "warn: dropping unsupported levels {dropped:?} (supported numeric levels \
+             are 1..={MAX_SUPPORTED_LEVEL}; 0/negatives unsupported by sequence_capture, \
+             >={post_split} rejected by post-split guard)",
+            post_split = MAX_SUPPORTED_LEVEL + 1,
         );
     }
     if supported.is_empty() {

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -82,6 +82,8 @@ pub(crate) mod strategy;
 
 mod frame_compressor;
 mod levels;
+#[cfg(feature = "bench_internals")]
+pub mod sequence_capture;
 mod streaming_encoder;
 pub use frame_compressor::FrameCompressor;
 pub use match_generator::MatchGeneratorDriver;

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -4,12 +4,17 @@
 //! surface stays unaffected. The single public entry point —
 //! [`compress_and_collect_sequences`] — drives the production
 //! [`FrameCompressor`] pipeline at the requested `CompressionLevel` and
-//! records every `Sequence::Triple` the matcher emits, tagged with its
-//! block index. This is the Rust-side input to the
-//! `compare_ffi_sequences` bench, which diffs the captured stream
-//! against `ZSTD_generateSequences` (donor) on the same `(input, level)`
-//! to triage residual ratio deltas into "algorithmic win" / "cost
-//! source" / "missed match" classes (`Phase 7 / 7-tooling-seq-cmp`).
+//! records every `Sequence::Triple` the matcher emits (tagged with its
+//! block index) plus the trailing-literal length of every block so
+//! callers can walk a cumulative position counter that matches
+//! on-wire byte consumption. This is the Rust-side input to the
+//! `compare_ffi_sequences` bench, which emits raw
+//! `Equal` / `Differ` / `RustOnly` / `FfiOnly` verdicts over which a
+//! human triages residual ratio deltas into interpretation classes
+//! ("algorithmic win" / "cost source" / "missed match" —
+//! `Phase 7 / 7-tooling-seq-cmp`). The interpretation labels are
+//! human-applied reasoning on top of the raw verdicts; this module
+//! and its consumer bench only produce the data, not the labels.
 //!
 //! Implementation goes through [`FrameCompressor::new_with_matcher`] +
 //! a [`CapturingMatcher`] wrapper rather than driving the matcher in
@@ -43,14 +48,39 @@ pub struct CapturedRawSequence {
     pub ml: u32,
 }
 
+/// Combined result of one capture run.
+///
+/// `sequences` holds every `Sequence::Triple` the matcher emitted, in
+/// input order. `block_tail_lengths` holds one entry per emitted block
+/// (matcher call to `start_matching` / `skip_matching` /
+/// `skip_matching_with_hint`) with the count of trailing literal bytes
+/// for that block — i.e. the bytes between the last triple's
+/// (literals + match) span and the block end. Callers that walk a
+/// cumulative position counter across the whole frame
+/// (`Σ (ll + ml)` per triple, plus `block_tail_lengths[block]` at each
+/// block boundary) get a position that matches the on-wire bytes
+/// consumed; without the tail counts a block with trailing literals
+/// would silently undercount and shift every subsequent comparison.
+#[derive(Clone, Debug, Default)]
+pub struct SequenceCapture {
+    /// Triple sequences, one per `Sequence::Triple` event in input order.
+    pub sequences: Vec<CapturedRawSequence>,
+    /// Trailing-literal length per block, indexed by block_idx. Always
+    /// `len == sequences.last().map(|s| s.block_idx + 1).unwrap_or(0)`
+    /// — every block the matcher saw contributes exactly one entry.
+    pub block_tail_lengths: Vec<u32>,
+}
+
 /// `Matcher` wrapper that forwards every method to an inner
 /// [`MatchGeneratorDriver`] while appending each emitted
-/// `Sequence::Triple` to a shared recorder. The shared `Rc<RefCell<…>>`
-/// lets the caller pull captured sequences out without consuming the
+/// `Sequence::Triple` to a shared recorder and the per-block
+/// trailing-literal length to a parallel vec. Shared `Rc<RefCell<…>>`
+/// lets the caller pull captured state out without consuming the
 /// `FrameCompressor` mid-frame.
 struct CapturingMatcher {
     inner: MatchGeneratorDriver,
     recorded: Rc<RefCell<Vec<CapturedRawSequence>>>,
+    block_tail_lengths: Rc<RefCell<Vec<u32>>>,
     current_block: u32,
 }
 
@@ -68,12 +98,24 @@ impl Matcher for CapturingMatcher {
     }
 
     fn skip_matching(&mut self) {
+        // Raw / uncompressed block: every byte of the committed space
+        // is "trailing literals" from the alignment perspective —
+        // there are no triples, just bytes flowing straight through.
+        // Read `get_last_space().len()` BEFORE forwarding so we don't
+        // race the inner state machine, which may consume the buffer.
+        let tail_ll = self.inner.get_last_space().len() as u32;
         self.inner.skip_matching();
+        self.block_tail_lengths.borrow_mut().push(tail_ll);
         self.current_block = self.current_block.saturating_add(1);
     }
 
     fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
+        // Same accounting as `skip_matching` — hint variant routes
+        // through a different matcher path but still emits a raw
+        // block, so trailing literal length == committed space.
+        let tail_ll = self.inner.get_last_space().len() as u32;
         self.inner.skip_matching_with_hint(incompressible_hint);
+        self.block_tail_lengths.borrow_mut().push(tail_ll);
         self.current_block = self.current_block.saturating_add(1);
     }
 
@@ -81,30 +123,46 @@ impl Matcher for CapturingMatcher {
         let recorded = self.recorded.clone();
         let block_idx = self.current_block;
         let mut seq_in_block: u32 = 0;
+        // `Sequence::Literals` is emitted as the last event of a block
+        // (per the `Matcher` trait doc) and carries the bytes between
+        // the final triple and the block end. If no triple is emitted
+        // for this block (rare but possible — e.g. fully-literal block
+        // routed through `start_matching` instead of `skip_matching`)
+        // the closure may see only a `Literals` event with the whole
+        // block's bytes. If the matcher emits no `Literals` event at
+        // all (block whose last triple consumes exactly to the block
+        // boundary) the default `0` is correct.
+        let mut block_tail_ll: u32 = 0;
         self.inner.start_matching(|seq| {
-            if let Sequence::Triple {
-                literals,
-                offset,
-                match_len,
-            } = seq
-            {
-                recorded.borrow_mut().push(CapturedRawSequence {
-                    block_idx,
-                    seq_in_block,
-                    ll: literals.len() as u32,
-                    of: offset as u32,
-                    ml: match_len as u32,
-                });
-                seq_in_block = seq_in_block.saturating_add(1);
+            match seq {
+                Sequence::Triple {
+                    literals,
+                    offset,
+                    match_len,
+                } => {
+                    recorded.borrow_mut().push(CapturedRawSequence {
+                        block_idx,
+                        seq_in_block,
+                        ll: literals.len() as u32,
+                        of: offset as u32,
+                        ml: match_len as u32,
+                    });
+                    seq_in_block = seq_in_block.saturating_add(1);
+                }
+                Sequence::Literals { literals } => {
+                    block_tail_ll = literals.len() as u32;
+                }
             }
             handle_sequence(seq);
         });
+        self.block_tail_lengths.borrow_mut().push(block_tail_ll);
         self.current_block = self.current_block.saturating_add(1);
     }
 
     fn reset(&mut self, level: CompressionLevel) {
         self.inner.reset(level);
         self.recorded.borrow_mut().clear();
+        self.block_tail_lengths.borrow_mut().clear();
         self.current_block = 0;
     }
 
@@ -137,32 +195,36 @@ impl Matcher for CapturingMatcher {
 
 /// Compress `input` at `level` through the production
 /// [`FrameCompressor`] pipeline and return every emitted
-/// `Sequence::Triple` as a [`CapturedRawSequence`].
+/// `Sequence::Triple` plus per-block trailing-literal counts as a
+/// [`SequenceCapture`].
 ///
-/// The compressed output is discarded — only the sequence stream is
+/// The compressed output is discarded — only matcher metadata is
 /// returned. Use this from a benchmark or audit tool to diff the
 /// Rust-emitted sequence stream against a donor FFI side
 /// (`ZSTD_generateSequences`) for the same `(input, level)` pair.
 ///
-/// `Sequence::Literals` entries (trailing-literals tail of a block) are
-/// NOT recorded — the donor's `ZSTD_generateSequences` emits trailing
-/// literals as a dummy delimiter `(of=0, ml=0, ll=last)`, and including
-/// our side's `Literals` events would add noise to the diff. Callers
-/// that need block-boundary alignment can use
-/// `CapturedRawSequence::block_idx` instead.
-pub fn compress_and_collect_sequences(
-    input: &[u8],
-    level: CompressionLevel,
-) -> Vec<CapturedRawSequence> {
+/// Trailing-literal lengths are captured per block via the matcher's
+/// terminal `Sequence::Literals` event (or the entire committed space
+/// for `skip_matching` blocks) and surfaced separately so callers
+/// walking a cumulative `Σ (ll + ml)` position counter across the
+/// whole frame can apply the tail length at each block boundary.
+/// Without this, a block with trailing literals would silently
+/// undercount and shift every subsequent comparison — `Literals`
+/// events were initially dropped from the recorder and the resulting
+/// alignment loss showed up as spurious `RustOnly` / `FfiOnly` noise
+/// on multi-block fixtures.
+pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> SequenceCapture {
     // Mirror `FrameCompressor::new()` matcher construction. The
     // `reset()` call inside `compress()` re-derives the real per-level
     // window/strategy from `level`, so the seed values here only need
     // to keep the matcher usable up to that reset.
     let driver = MatchGeneratorDriver::new(1024 * 128, 1);
     let recorded: Rc<RefCell<Vec<CapturedRawSequence>>> = Rc::new(RefCell::new(Vec::new()));
+    let block_tail_lengths: Rc<RefCell<Vec<u32>>> = Rc::new(RefCell::new(Vec::new()));
     let matcher = CapturingMatcher {
         inner: driver,
         recorded: recorded.clone(),
+        block_tail_lengths: block_tail_lengths.clone(),
         current_block: 0,
     };
     let mut output: Vec<u8> = Vec::new();
@@ -181,9 +243,19 @@ pub fn compress_and_collect_sequences(
     // is dropped when `compressor` goes out of scope at the end of the
     // function, leaving us as the sole `Rc` owner.
     drop(compressor);
-    Rc::try_unwrap(recorded)
+    // `Rc::try_unwrap` succeeds because the inner `CapturingMatcher`
+    // is dropped when `compressor` goes out of scope above, leaving
+    // us as the sole `Rc` owner for both vecs.
+    let sequences = Rc::try_unwrap(recorded)
         .expect("CapturingMatcher dropped with compressor; recorder is single-owner")
-        .into_inner()
+        .into_inner();
+    let block_tail_lengths = Rc::try_unwrap(block_tail_lengths)
+        .expect("CapturingMatcher dropped with compressor; tail-length vec is single-owner")
+        .into_inner();
+    SequenceCapture {
+        sequences,
+        block_tail_lengths,
+    }
 }
 
 #[cfg(test)]
@@ -203,31 +275,49 @@ mod tests {
         let pattern: [u8; 16] = *b"PATTERN_1234_END";
         let data: Vec<u8> = pattern.iter().copied().cycle().take(16 * 1024).collect();
         let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+        let seqs = &captured.sequences;
         assert!(
-            !captured.is_empty(),
+            !seqs.is_empty(),
             "expected at least one Triple sequence on 16KB repeating pattern, got 0",
         );
         // Every captured sequence belongs to block 0 (single 16 KiB block fits in 128 KiB).
         assert!(
-            captured.iter().all(|s| s.block_idx == 0),
+            seqs.iter().all(|s| s.block_idx == 0),
             "16KB repeating pattern produced multi-block sequence stream: {:?}",
-            captured.iter().map(|s| s.block_idx).collect::<Vec<_>>(),
+            seqs.iter().map(|s| s.block_idx).collect::<Vec<_>>(),
         );
         // Every captured Triple must reference a sane offset/match
         // (defensive: catches wrapper bugs that would leak garbage
         // through the recorder).
-        for s in &captured {
+        for s in seqs {
             assert!(s.of >= 1, "non-positive offset captured: {:?}", s);
             assert!(s.ml >= 1, "non-positive match length captured: {:?}", s);
         }
         // seq_in_block must be contiguous 0..N for each block.
-        for (i, s) in captured.iter().enumerate() {
+        for (i, s) in seqs.iter().enumerate() {
             assert_eq!(
                 s.seq_in_block, i as u32,
                 "seq_in_block discontinuity at idx {}: {:?}",
-                i, captured,
+                i, seqs,
             );
         }
+        // Exactly one block was emitted, so exactly one tail-length entry.
+        assert_eq!(captured.block_tail_lengths.len(), 1);
+        // Reconstructed cumulative position must equal the input size:
+        // `Σ (ll + ml)` over triples PLUS the block's trailing-literal
+        // length must reach `data.len()`. This is the alignment
+        // invariant that motivated capturing tail lengths in the
+        // first place (PR #149 review).
+        let cumulative: u64 = seqs.iter().map(|s| s.ll as u64 + s.ml as u64).sum::<u64>()
+            + captured.block_tail_lengths[0] as u64;
+        assert_eq!(
+            cumulative,
+            data.len() as u64,
+            "Σ(ll+ml) + tail must reconstruct the input length exactly: \
+             seqs sum + tail {} should == input {}",
+            cumulative,
+            data.len(),
+        );
     }
 
     /// Random / incompressible input should NOT emit any matches —
@@ -244,15 +334,43 @@ mod tests {
             })
             .collect();
         let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+        let seqs = &captured.sequences;
         // Some matches may still surface on a 1 KiB LCG stream (the
         // dfast hash can luck into a 5-byte collision), but the count
         // must stay well below "every position is a match" — otherwise
         // the wrapper is recording phantom sequences.
         assert!(
-            captured.len() < data.len() / 16,
+            seqs.len() < data.len() / 16,
             "incompressible input emitted suspiciously many sequences: {} (limit: {})",
-            captured.len(),
+            seqs.len(),
             data.len() / 16,
+        );
+        // Each block (matcher call) must contribute exactly one
+        // tail-length entry — even when no triples were emitted.
+        // Block count is `last.block_idx + 1` if any triples, or
+        // we expect at least one block was processed since the
+        // input is 1 KiB > 0.
+        assert!(
+            !captured.block_tail_lengths.is_empty(),
+            "no block tail lengths recorded for non-empty input",
+        );
+        // Cumulative position must still equal `data.len()`. For an
+        // incompressible block where the encoder routes through
+        // `start_matching` (rare with `set_source_size_hint`, but
+        // possible), the trailing-literal tail will cover most of the
+        // block; with `skip_matching` routing, the tail equals the
+        // entire committed space. Either way, `Σ (ll + ml) + tails`
+        // must reconstruct the input length exactly.
+        let cumulative: u64 = seqs.iter().map(|s| s.ll as u64 + s.ml as u64).sum::<u64>()
+            + captured
+                .block_tail_lengths
+                .iter()
+                .map(|t| *t as u64)
+                .sum::<u64>();
+        assert_eq!(
+            cumulative,
+            data.len() as u64,
+            "Σ(ll+ml) over triples + Σ(block_tail_lengths) must reconstruct input length",
         );
     }
 }

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -104,9 +104,10 @@ impl Matcher for CapturingMatcher {
     }
 
     fn skip_matching(&mut self) {
-        // Raw / uncompressed block: every byte of the committed space
-        // is "trailing literals" from the alignment perspective —
-        // there are no triples, just bytes flowing straight through.
+        // No-triple block path (raw / RLE / hint-driven fast paths
+        // routed through the matcher trait): every byte of the
+        // committed space is "trailing literals" from the alignment
+        // perspective — no triples, just bytes flowing through.
         // Read `get_last_space().len()` BEFORE forwarding so we don't
         // race the inner state machine, which may consume the buffer.
         let tail_ll = self.inner.get_last_space().len() as u32;
@@ -116,9 +117,12 @@ impl Matcher for CapturingMatcher {
     }
 
     fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
-        // Same accounting as `skip_matching` — hint variant routes
-        // through a different matcher path but still emits a raw
-        // block, so trailing literal length == committed space.
+        // Same accounting as `skip_matching`. The hint variant is
+        // taken on both the incompressible/raw-block path AND the
+        // RLE fast-path for constant runs that the block-emit layer
+        // catches; in either case no triples are produced and the
+        // entire committed space is trailing literals from the
+        // alignment perspective.
         let tail_ll = self.inner.get_last_space().len() as u32;
         self.inner.skip_matching_with_hint(incompressible_hint);
         self.block_tail_lengths.borrow_mut().push(tail_ll);
@@ -220,6 +224,23 @@ impl Matcher for CapturingMatcher {
 /// alignment loss showed up as spurious `RustOnly` / `FfiOnly` noise
 /// on multi-block fixtures.
 pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> SequenceCapture {
+    // `CompressionLevel::Uncompressed` short-circuits the encoder
+    // before any `Matcher` method runs — the frame compressor emits
+    // raw blocks straight from input without consulting
+    // `CapturingMatcher`. The recorder would stay empty and the
+    // post-compress invariant assert would panic with a misleading
+    // "matcher-bypassing block path" message even though the input
+    // is perfectly valid. Reject the variant explicitly with a
+    // diagnostic that points at the actual constraint
+    // (PR #149 review round 4 #12).
+    assert!(
+        !matches!(level, CompressionLevel::Uncompressed),
+        "compress_and_collect_sequences does not support \
+         CompressionLevel::Uncompressed: raw-block emission bypasses \
+         the matcher entirely, so no sequences or block tails are \
+         recorded. Use a compressible level (Fastest / Level(N) / \
+         Default / Better / Best) for sequence-stream audits.",
+    );
     // Mirror `FrameCompressor::new()` matcher construction. The
     // `reset()` call inside `compress()` re-derives the real per-level
     // window/strategy from `level`, so the seed values here only need
@@ -259,11 +280,14 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
         .expect("CapturingMatcher dropped with compressor; tail-length vec is single-owner")
         .into_inner();
     // Fail-fast invariant check: the encoder has a few paths that
-    // emit blocks WITHOUT routing through any `Matcher` method on
-    // `CapturingMatcher` — most notably RLE blocks for fully-constant
-    // runs (`AAAAA…`), which the frame compressor recognises before
-    // ever calling the matcher. On such inputs the captured stream
-    // misses entire blocks, so callers walking the cumulative
+    // could emit blocks WITHOUT routing through any `Matcher` method
+    // on `CapturingMatcher` (e.g. an `Uncompressed`-level shortcut
+    // that emits raw blocks directly from `compress()`, or a future
+    // bypass introduced by an internal refactor). Today RLE-shaped
+    // constant runs in practice still reach the matcher via
+    // `skip_matching_with_hint`, but the assert guards against any
+    // future divergence. On such inputs the captured stream would
+    // miss entire blocks, so callers walking the cumulative
     // position counter (e.g. `compare_ffi_sequences::align_and_diff`)
     // would silently shift every subsequent row. Panic with a
     // diagnostic instead of returning a quietly-wrong
@@ -351,11 +375,15 @@ mod tests {
         );
     }
 
-    /// Random / incompressible input should NOT emit any matches —
-    /// recorder stays empty, confirming the wrapper doesn't fabricate
-    /// or carry over state across calls.
+    /// Random / incompressible input should emit at most a sparse
+    /// trickle of triples (the dfast hash can luck into a 5-byte
+    /// collision on any 1 KiB stream), well below "every position
+    /// is a match". This bounds-the-rate test guards against a
+    /// wrapper bug that fabricates phantom sequences or carries
+    /// state across calls — a clean wrapper produces few or zero
+    /// triples here, but ZERO is not the strict contract.
     #[test]
-    fn captures_no_triples_on_incompressible_input() {
+    fn captures_bounded_triples_on_incompressible_input() {
         // Deterministic non-repeating bytes via a simple LCG.
         let mut state: u32 = 0x1234_5678;
         let data: Vec<u8> = (0..1024)

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -466,4 +466,94 @@ mod tests {
                 .sum::<u64>();
         assert_eq!(cumulative, data.len() as u64);
     }
+
+    /// Multi-block input (≥ 256 KiB, two 128 KiB frame blocks) is
+    /// the only shape that exercises per-block tail accounting
+    /// across a block boundary. Single-block tests pass even if a
+    /// regression records only the first/last block tail or
+    /// mis-increments `current_block` across the 128 KiB boundary.
+    ///
+    /// This test pins:
+    ///   - `Σ(ll+ml) + Σ tails == input.len()` across multiple blocks,
+    ///   - `block_tail_lengths.len() >= 2` (at least two blocks),
+    ///   - every recorded triple's `block_idx` falls inside the
+    ///     emitted-block range (no off-by-one on the counter),
+    ///   - block indices observed in triples are contiguous from 0
+    ///     (no gaps, no missed `current_block` increments).
+    ///
+    /// 256 KiB chosen so the encoder produces exactly 2 blocks under
+    /// the default 128 KiB chunk size, keeping the assertion crisp
+    /// (PR #149 review #19).
+    #[test]
+    fn captures_multi_block_tails_and_indices() {
+        // Repeating 64-byte pattern: compressible enough to emit
+        // sequences (not RLE) and long enough that every position
+        // past the first 64 bytes finds a match, exercising the
+        // matcher rather than a fast skip path.
+        let pattern: [u8; 64] = {
+            let mut p = [0u8; 64];
+            for (i, b) in p.iter_mut().enumerate() {
+                *b = (i as u8).wrapping_mul(31).wrapping_add(7);
+            }
+            p
+        };
+        let data: Vec<u8> = pattern.iter().copied().cycle().take(256 * 1024).collect();
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+
+        // Multi-block invariant: at least 2 blocks recorded.
+        assert!(
+            captured.block_tail_lengths.len() >= 2,
+            "expected ≥2 block tail entries for 256 KiB input, got {}: {:?}",
+            captured.block_tail_lengths.len(),
+            captured.block_tail_lengths,
+        );
+
+        // Cumulative reconstruction across all blocks.
+        let cumulative: u64 = captured
+            .sequences
+            .iter()
+            .map(|s| s.ll as u64 + s.ml as u64)
+            .sum::<u64>()
+            + captured
+                .block_tail_lengths
+                .iter()
+                .map(|t| *t as u64)
+                .sum::<u64>();
+        assert_eq!(
+            cumulative,
+            data.len() as u64,
+            "multi-block Σ(ll+ml)+Σ(tails) mismatch: got {}, want {} \
+             (blocks={}, triples={})",
+            cumulative,
+            data.len(),
+            captured.block_tail_lengths.len(),
+            captured.sequences.len(),
+        );
+
+        // Every triple's block_idx must be in [0, num_blocks).
+        let num_blocks = captured.block_tail_lengths.len() as u32;
+        for s in &captured.sequences {
+            assert!(
+                s.block_idx < num_blocks,
+                "triple block_idx={} out of range (num_blocks={})",
+                s.block_idx,
+                num_blocks,
+            );
+        }
+
+        // Block indices observed in triples must be contiguous
+        // starting at 0 (no skipped `current_block` increments).
+        let mut max_seen: i64 = -1;
+        for s in &captured.sequences {
+            let idx = s.block_idx as i64;
+            assert!(
+                idx <= max_seen + 1,
+                "non-monotonic / gapped block_idx in triple stream: \
+                 max_seen={max_seen}, observed={idx}",
+            );
+            if idx > max_seen {
+                max_seen = idx;
+            }
+        }
+    }
 }

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -276,34 +276,40 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
          recorded. Use a compressible level (Fastest / Level(N) / \
          Default / Better) for sequence-stream audits.",
     );
-    // Numeric levels that route through the donor block-splitter
-    // (`donor_split_block_by_chunks` / `_fromBorders`) can emit
-    // multiple physical on-wire blocks per single `start_matching`
-    // call. `CapturingMatcher::current_block` increments once per
-    // matcher invocation, so on those levels the recorded
-    // `block_tail_lengths` would NOT be "one entry per emitted
-    // on-wire block" and alignment against FFI delimiters would
-    // shift by the split-block count.
+    // Only the POST-split path breaks the per-matcher-call block
+    // counter. Two distinct splitter mechanisms exist in
+    // `frame_compressor.rs`:
     //
-    // `donor_pre_split_level` (frame_compressor.rs) matches the
-    // EXACT enum variants — `Level(11..=15)` and `Level(16..=22)`
-    // — so `Best` falls through to `None` and is NOT a pre-split
-    // path despite its docstring saying "roughly equivalent to
-    // Zstd level 11". Reject all numeric levels ≥ 11 because
-    // `Level(n > 22)` clamps to Level 22 matcher parameters per
-    // `resolve_level_params` (match_generator.rs:412-415), so
-    // `Level(23)` etc. would silently slip past a `Level(11..=22)`
-    // check and hit the same multi-physical-block path as
-    // `Level(22)` (PR #149 review #24 + #27).
-    let post_split = matches!(level, CompressionLevel::Level(n) if n >= 11);
+    // * Pre-split (`Level(11..=15)` borders + `donor_optimal_block_size`,
+    //   borders-only): the splitter chooses a shrunken `block_len`
+    //   BEFORE the matcher runs; the suffix is parked in
+    //   `pending_input` and the next compress-loop iteration calls
+    //   the matcher again on the suffix. Each matcher call still
+    //   maps to exactly ONE physical on-wire block, so
+    //   `CapturingMatcher::current_block` tracks correctly.
+    //
+    // * Post-split (`Level(16..=22)` + window >= 1<<17, dispatched
+    //   from `levels/fastest.rs::compress_block_encoded` via
+    //   `compress_block_with_post_split`): a SINGLE matcher call's
+    //   output is split into multiple physical blocks by
+    //   `blocks::compress_block_with_post_split`. One matcher call
+    //   → N blocks → `current_block` only increments once,
+    //   `block_tail_lengths.len()` is short by `N - 1`.
+    //
+    // Reject `Level(n >= 16)` only. Covers `Level(16..=22)` and
+    // clamped `Level(>22)` (match_generator.rs:412-415 lands on
+    // Level 22 params for n > 22). `Level(11..=15)` is allowed
+    // because pre-split produces a separate matcher call per
+    // physical block (PR #149 review #24 + #27 + #30).
+    let post_split = matches!(level, CompressionLevel::Level(n) if n >= 16);
     assert!(
         !post_split,
-        "compress_and_collect_sequences does not support pre-split \
-         levels (Level(n) where n >= 11): the donor block-splitter \
+        "compress_and_collect_sequences does not support post-split \
+         levels (Level(n) where n >= 16): `compress_block_with_post_split` \
          emits multiple physical blocks per matcher call, which the \
          current per-matcher-call block counter cannot track. The \
          tool is validated for Fastest / Default / Better / Best / \
-         Level(1..=10); higher numeric levels (including levels above \
+         Level(1..=15); higher numeric levels (including levels above \
          22 which clamp to Level 22 params) need per-physical-block \
          hooks that don't exist yet.",
     );
@@ -715,21 +721,21 @@ mod tests {
         );
     }
 
-    /// Pin the pre-split-level reject path. Numeric `Level(n)` with
-    /// `n >= 11` routes through the donor block-splitter (or clamps
-    /// to Level 22's params, which post-splits the same way), which
-    /// emits multiple physical on-wire blocks per matcher call — the
-    /// per-matcher-call counter cannot track that shape. The named
-    /// `Best` preset is allowed because `donor_pre_split_level`
-    /// matches on EXACT enum variants and falls through to `None`
-    /// for `Best` — see `captures_through_best_preset` for the
-    /// matching positive test.
+    /// Pin the post-split-level reject path. `Level(16..=22)` (and
+    /// any `Level(n > 22)` that clamps to Level 22 params) goes
+    /// through `compress_block_with_post_split` which emits multiple
+    /// physical on-wire blocks per single matcher call — the
+    /// per-matcher-call counter cannot track that shape.
+    /// `Level(11..=15)` is intentionally NOT rejected: those levels
+    /// pre-split via `donor_optimal_block_size` (borders), so each
+    /// shrunken block is processed by its own matcher call and the
+    /// counter stays correct.
     #[test]
-    #[should_panic(expected = "does not support pre-split levels")]
-    fn rejects_pre_split_numeric_level() {
+    #[should_panic(expected = "does not support post-split levels")]
+    fn rejects_post_split_numeric_level() {
         let _ = compress_and_collect_sequences(
             b"hello there general kenobi",
-            CompressionLevel::Level(11),
+            CompressionLevel::Level(16),
         );
     }
 
@@ -756,6 +762,34 @@ mod tests {
         };
         let data: Vec<u8> = pattern.iter().copied().cycle().take(32 * 1024).collect();
         let captured = compress_and_collect_sequences(&data, CompressionLevel::Best);
+        let cumulative: u64 = captured
+            .sequences
+            .iter()
+            .map(|s| s.ll as u64 + s.ml as u64)
+            .sum::<u64>()
+            + captured
+                .block_tail_lengths
+                .iter()
+                .map(|t| *t as u64)
+                .sum::<u64>();
+        assert_eq!(cumulative, data.len() as u64);
+    }
+
+    /// Positive coverage for the pre-split numeric range
+    /// (`Level(11..=15)`). The borders splitter parks the tail in
+    /// `pending_input` BEFORE the matcher runs, so each shrunken
+    /// portion gets its own matcher call and the counter stays
+    /// accurate. Without this test, a future tightening of the
+    /// guard to reject `Level(11..=15)` would regress a valid
+    /// capture path.
+    #[test]
+    fn captures_through_pre_split_level_15() {
+        // 32 KiB of a 16-byte rotating pattern: compressible enough
+        // for lazy2 (Level 11..=15 strategy) to produce a non-empty
+        // sequence stream without tripping the raw/RLE detector.
+        let pattern: [u8; 16] = *b"PATTERN_1234_END";
+        let data: Vec<u8> = pattern.iter().copied().cycle().take(32 * 1024).collect();
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(15));
         let cumulative: u64 = captured
             .sequences
             .iter()

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -223,7 +223,39 @@ impl Matcher for CapturingMatcher {
 /// events were initially dropped from the recorder and the resulting
 /// alignment loss showed up as spurious `RustOnly` / `FfiOnly` noise
 /// on multi-block fixtures.
+///
+/// # Known limitation: raw-fallback blocks
+///
+/// The capture records what the matcher PRODUCED, not what the
+/// encoder eventually WROTE on-wire. `compress_block_encoded` may
+/// fall back to a raw block when `compressed.len() >= MAX_BLOCK_SIZE`
+/// (compression made the block bigger than the source). In that
+/// case the matcher's triples are recorded in the capture but the
+/// on-wire frame contains no sequences for that block, so the
+/// comparator will report spurious `RustOnly` rows. The wrapper
+/// has no way to observe the raw-fallback decision from inside the
+/// `Matcher` trait — fixing this would require hooking the encoder
+/// downstream of the matcher pass, which is out of scope for this
+/// bench-only tool. Triage the recorded stream with this caveat in
+/// mind: a Rust block where every triple appears as `RustOnly` and
+/// FFI has the matching offsets nowhere likely means raw fallback,
+/// not a real algorithmic divergence (PR #149 review #21).
 pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> SequenceCapture {
+    // Empty input bypasses the matcher entirely: `FrameCompressor`
+    // emits a zero-length raw block without calling any `Matcher`
+    // method. The reconstruction invariant `Σ(ll+ml)+Σ(tails) ==
+    // input.len()` would trivially pass (`0 == 0`) but
+    // `block_tail_lengths.len()` would be 0 — violating the
+    // public "one entry per emitted block" contract. Reject
+    // explicitly so callers using `tail_lengths.len()` as a block
+    // count get a clear diagnostic (PR #149 review #20).
+    assert!(
+        !input.is_empty(),
+        "compress_and_collect_sequences requires non-empty input: \
+         the frame compressor emits a zero-length raw block for \
+         empty input without invoking the matcher, so no block \
+         metadata is recorded.",
+    );
     // `CompressionLevel::Uncompressed` short-circuits the encoder
     // before any `Matcher` method runs — the frame compressor emits
     // raw blocks straight from input without consulting
@@ -239,7 +271,30 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
          CompressionLevel::Uncompressed: raw-block emission bypasses \
          the matcher entirely, so no sequences or block tails are \
          recorded. Use a compressible level (Fastest / Level(N) / \
-         Default / Better / Best) for sequence-stream audits.",
+         Default / Better) for sequence-stream audits.",
+    );
+    // Levels that route through the donor block-splitter
+    // (`donor_split_block_by_chunks` / `_fromBorders`) can emit
+    // multiple physical on-wire blocks per single `start_matching`
+    // call. `CapturingMatcher::current_block` increments once per
+    // matcher invocation, so on those levels the recorded
+    // `block_tail_lengths` would NOT be "one entry per emitted
+    // on-wire block" and alignment against FFI delimiters would
+    // shift by the split-block count. Reject pre-split levels with
+    // a diagnostic until per-physical-block bookkeeping is wired
+    // through — current scope is the Lane A `7-compress-default`
+    // audit at `Level(3)` (PR #149 review #22).
+    let post_split = matches!(level, CompressionLevel::Best)
+        || matches!(level, CompressionLevel::Level(11..=22));
+    assert!(
+        !post_split,
+        "compress_and_collect_sequences does not support pre-split \
+         levels (Best / Level(11..=22)): the donor block-splitter \
+         emits multiple physical blocks per matcher call, which the \
+         current per-matcher-call block counter cannot track. The \
+         tool is validated for Fastest / Default / Better / \
+         Level(1..=10); higher levels need per-physical-block hooks \
+         that don't exist yet.",
     );
     // Mirror `FrameCompressor::new()` matcher construction. The
     // `reset()` call inside `compress()` re-derives the real per-level

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -574,9 +574,13 @@ mod tests {
         );
     }
 
-    /// Random / incompressible input causes the encoder to emit a
-    /// Raw_Block on-wire (`compressed.len() >= MAX_BLOCK_SIZE`), so
-    /// the post-compress raw-block detector must panic. Before the
+    /// Random / incompressible input is steered to a Raw_Block by the
+    /// encoder's raw fast-path classifier (`should_use_raw_for_block`
+    /// in `frame_compressor`), not by the late
+    /// `compressed.len() >= MAX_BLOCK_SIZE` fallback — 1 KiB of LCG
+    /// noise is well under one frame block, so the wire format
+    /// commits to `Raw_Block` before any sequence emission, and the
+    /// post-compress raw/RLE detector must panic. Before the
     /// detector existed, this test verified the wrapper bounded
     /// phantom-triple production; now the API-level guarantee is
     /// stronger — the function refuses to return a misaligned
@@ -626,9 +630,10 @@ mod tests {
     ///   - block indices observed in triples are contiguous from 0
     ///     (no gaps, no missed `current_block` increments).
     ///
-    /// 256 KiB chosen so the encoder produces exactly 2 blocks under
-    /// the default 128 KiB chunk size, keeping the assertion crisp
-    /// (PR #149 review #19).
+    /// 200 KiB (≈ 1.5 × 128 KiB) chosen to guarantee ≥ 2 frame blocks
+    /// while staying small enough that the final partial block still
+    /// compresses (no trailing Raw_Block from a sub-threshold tail),
+    /// keeping the multi-block assertion crisp (PR #149 review #19).
     #[test]
     fn captures_multi_block_tails_and_indices() {
         // Repeating 16-byte pattern at 200 KiB (≈ 1.5 × 128 KiB

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -273,28 +273,31 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
          recorded. Use a compressible level (Fastest / Level(N) / \
          Default / Better) for sequence-stream audits.",
     );
-    // Levels that route through the donor block-splitter
+    // Numeric levels that route through the donor block-splitter
     // (`donor_split_block_by_chunks` / `_fromBorders`) can emit
     // multiple physical on-wire blocks per single `start_matching`
     // call. `CapturingMatcher::current_block` increments once per
     // matcher invocation, so on those levels the recorded
     // `block_tail_lengths` would NOT be "one entry per emitted
     // on-wire block" and alignment against FFI delimiters would
-    // shift by the split-block count. Reject pre-split levels with
-    // a diagnostic until per-physical-block bookkeeping is wired
-    // through — current scope is the Lane A `7-compress-default`
-    // audit at `Level(3)` (PR #149 review #22).
-    let post_split = matches!(level, CompressionLevel::Best)
-        || matches!(level, CompressionLevel::Level(11..=22));
+    // shift by the split-block count.
+    //
+    // `donor_pre_split_level` (frame_compressor.rs) matches the
+    // EXACT enum variants — `Level(11..=15)` and `Level(16..=22)`
+    // — so `Best` falls through to `None` and is NOT a pre-split
+    // path despite its docstring saying "roughly equivalent to
+    // Zstd level 11". Reject only the numeric range that actually
+    // pre-splits (PR #149 review #24).
+    let post_split = matches!(level, CompressionLevel::Level(11..=22));
     assert!(
         !post_split,
         "compress_and_collect_sequences does not support pre-split \
-         levels (Best / Level(11..=22)): the donor block-splitter \
-         emits multiple physical blocks per matcher call, which the \
+         levels (Level(11..=22)): the donor block-splitter emits \
+         multiple physical blocks per matcher call, which the \
          current per-matcher-call block counter cannot track. The \
-         tool is validated for Fastest / Default / Better / \
-         Level(1..=10); higher levels need per-physical-block hooks \
-         that don't exist yet.",
+         tool is validated for Fastest / Default / Better / Best / \
+         Level(1..=10); higher numeric levels need per-physical-block \
+         hooks that don't exist yet.",
     );
     // Mirror `FrameCompressor::new()` matcher construction. The
     // `reset()` call inside `compress()` re-derives the real per-level
@@ -648,12 +651,39 @@ mod tests {
         );
     }
 
-    /// Same guard, named-preset variant. `Best` corresponds to
-    /// `Level(11)` per the public docstring, so both must reject.
+    /// `Best` is documented as "roughly equivalent to Level 11" but
+    /// `donor_pre_split_level` matches the EXACT enum variants
+    /// (`Level(11..=15)` / `Level(16..=22)`) — the `Best` arm
+    /// falls through to `None`, so the named preset does NOT
+    /// trigger the donor block-splitter. The guard above
+    /// intentionally allows `Best` through; this test pins the
+    /// matcher path stays alignment-correct for it. Without it, a
+    /// future tightening of the guard to also reject `Best` would
+    /// silently break a valid capture path.
     #[test]
-    #[should_panic(expected = "does not support pre-split levels")]
-    fn rejects_best_preset() {
-        let _ =
-            compress_and_collect_sequences(b"hello there general kenobi", CompressionLevel::Best);
+    fn captures_through_best_preset() {
+        // 32 KiB of a 32-byte rotating pattern: compressible enough
+        // for Best (lazy2 / btlazy2 strategy) to produce a non-empty
+        // sequence stream, small enough to keep the test fast.
+        let pattern: [u8; 32] = {
+            let mut p = [0u8; 32];
+            for (i, b) in p.iter_mut().enumerate() {
+                *b = (i as u8).wrapping_mul(11).wrapping_add(3);
+            }
+            p
+        };
+        let data: Vec<u8> = pattern.iter().copied().cycle().take(32 * 1024).collect();
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Best);
+        let cumulative: u64 = captured
+            .sequences
+            .iter()
+            .map(|s| s.ll as u64 + s.ml as u64)
+            .sum::<u64>()
+            + captured
+                .block_tail_lengths
+                .iter()
+                .map(|t| *t as u64)
+                .sum::<u64>();
+        assert_eq!(cumulative, data.len() as u64);
     }
 }

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -518,10 +518,11 @@ mod tests {
     /// at least one `Triple` sequence — every position past the first
     /// 16 bytes finds a long match 16 bytes back. Constant-run input
     /// (`AAAA…`) is covered separately by
-    /// `constant_run_routes_through_matcher_path` because it tests a
-    /// different invariant (the matcher path stays alignment-correct
-    /// even when no `Triple` is emitted). On the rotating pattern
-    /// here we want at least one captured triple, which a clean
+    /// `rejects_constant_run_with_rle_on_wire_block` because the
+    /// raw/RLE detector rejects that shape at the public-API
+    /// boundary (different contract from the per-position match
+    /// capture this test pins). On the rotating pattern here we
+    /// want at least one captured triple, which a clean
     /// matcher always produces.
     #[test]
     fn captures_at_least_one_triple_on_repeating_pattern() {

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -65,9 +65,15 @@ pub struct CapturedRawSequence {
 pub struct SequenceCapture {
     /// Triple sequences, one per `Sequence::Triple` event in input order.
     pub sequences: Vec<CapturedRawSequence>,
-    /// Trailing-literal length per block, indexed by block_idx. Always
-    /// `len == sequences.last().map(|s| s.block_idx + 1).unwrap_or(0)`
-    /// — every block the matcher saw contributes exactly one entry.
+    /// Trailing-literal length per emitted block, indexed by block_idx.
+    /// Contains one entry per block the matcher saw, INCLUDING blocks
+    /// that emitted zero `Sequence::Triple` events (e.g. fully-literal
+    /// blocks routed through `start_matching` with only a terminal
+    /// `Sequence::Literals` event, or raw blocks routed through
+    /// `skip_matching` / `skip_matching_with_hint`). The vec length is
+    /// therefore the total number of blocks processed, which may
+    /// exceed `sequences.last().map(|s| s.block_idx + 1).unwrap_or(0)`
+    /// whenever any trailing block emitted no triples.
     pub block_tail_lengths: Vec<u32>,
 }
 

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -611,4 +611,49 @@ mod tests {
             }
         }
     }
+
+    /// Pin the empty-input guard. Without this assert the
+    /// reconstruction invariant trivially passes (`0 == 0`) but
+    /// `block_tail_lengths` stays empty, breaking the public
+    /// per-emitted-block contract.
+    #[test]
+    #[should_panic(expected = "requires non-empty input")]
+    fn rejects_empty_input() {
+        let _ = compress_and_collect_sequences(&[], CompressionLevel::Level(3));
+    }
+
+    /// Pin the `CompressionLevel::Uncompressed` reject path. That
+    /// variant routes through the encoder's raw-block fast-path
+    /// without invoking the matcher, leaving the recorder empty and
+    /// the post-compress invariant misleading.
+    #[test]
+    #[should_panic(expected = "CompressionLevel::Uncompressed")]
+    fn rejects_uncompressed_level() {
+        let _ = compress_and_collect_sequences(
+            b"hello there general kenobi",
+            CompressionLevel::Uncompressed,
+        );
+    }
+
+    /// Pin the pre-split-level reject path. `Level(11..=22)` and
+    /// `Best` route through the donor block-splitter, which emits
+    /// multiple physical on-wire blocks per matcher call — the
+    /// per-matcher-call counter cannot track that shape.
+    #[test]
+    #[should_panic(expected = "does not support pre-split levels")]
+    fn rejects_pre_split_numeric_level() {
+        let _ = compress_and_collect_sequences(
+            b"hello there general kenobi",
+            CompressionLevel::Level(11),
+        );
+    }
+
+    /// Same guard, named-preset variant. `Best` corresponds to
+    /// `Level(11)` per the public docstring, so both must reject.
+    #[test]
+    #[should_panic(expected = "does not support pre-split levels")]
+    fn rejects_best_preset() {
+        let _ =
+            compress_and_collect_sequences(b"hello there general kenobi", CompressionLevel::Best);
+    }
 }

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -144,7 +144,14 @@ impl Matcher for CapturingMatcher {
         // boundary) the default `0` is correct.
         let mut block_tail_ll: u32 = 0;
         self.inner.start_matching(|seq| {
-            match seq {
+            // Match by reference so `seq` stays owned for the
+            // forward to `handle_sequence`. Today every field of
+            // `Sequence` is `Copy` (`&[u8]`, `usize`), so a by-value
+            // match would also leave `seq` usable through implicit
+            // copy semantics, but binding by-ref is robust if any
+            // future field on `Sequence` turns non-Copy
+            // (PR #149 review #29).
+            match &seq {
                 Sequence::Triple {
                     literals,
                     offset,
@@ -154,8 +161,8 @@ impl Matcher for CapturingMatcher {
                         block_idx,
                         seq_in_block,
                         ll: literals.len() as u32,
-                        of: offset as u32,
-                        ml: match_len as u32,
+                        of: *offset as u32,
+                        ml: *match_len as u32,
                     });
                     seq_in_block = seq_in_block.saturating_add(1);
                 }
@@ -224,22 +231,18 @@ impl Matcher for CapturingMatcher {
 /// alignment loss showed up as spurious `RustOnly` / `FfiOnly` noise
 /// on multi-block fixtures.
 ///
-/// # Known limitation: raw-fallback blocks
+/// # Raw-fallback detection
 ///
-/// The capture records what the matcher PRODUCED, not what the
-/// encoder eventually WROTE on-wire. `compress_block_encoded` may
-/// fall back to a raw block when `compressed.len() >= MAX_BLOCK_SIZE`
-/// (compression made the block bigger than the source). In that
-/// case the matcher's triples are recorded in the capture but the
-/// on-wire frame contains no sequences for that block, so the
-/// comparator will report spurious `RustOnly` rows. The wrapper
-/// has no way to observe the raw-fallback decision from inside the
-/// `Matcher` trait — fixing this would require hooking the encoder
-/// downstream of the matcher pass, which is out of scope for this
-/// bench-only tool. Triage the recorded stream with this caveat in
-/// mind: a Rust block where every triple appears as `RustOnly` and
-/// FFI has the matching offsets nowhere likely means raw fallback,
-/// not a real algorithmic divergence (PR #149 review #21).
+/// The matcher hook records triples eagerly; the encoder may later
+/// discard a compressed attempt and emit a Raw_Block when
+/// `compressed.len() >= MAX_BLOCK_SIZE`. The capture would then
+/// contain phantom triples whose on-wire form has no sequences. To
+/// prevent silently misaligned output, this function parses the
+/// emitted frame's block headers (RFC 8878 §3.1.1.2.2) via
+/// [`detect_raw_or_rle_blocks_in_frame`] and panics with a clear
+/// diagnostic if any Raw_Block or RLE_Block is present. Callers
+/// see a hard failure instead of a misleading capture
+/// (PR #149 review #25).
 pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> SequenceCapture {
     // Empty input bypasses the matcher entirely: `FrameCompressor`
     // emits a zero-length raw block without calling any `Matcher`
@@ -286,17 +289,22 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
     // EXACT enum variants — `Level(11..=15)` and `Level(16..=22)`
     // — so `Best` falls through to `None` and is NOT a pre-split
     // path despite its docstring saying "roughly equivalent to
-    // Zstd level 11". Reject only the numeric range that actually
-    // pre-splits (PR #149 review #24).
-    let post_split = matches!(level, CompressionLevel::Level(11..=22));
+    // Zstd level 11". Reject all numeric levels ≥ 11 because
+    // `Level(n > 22)` clamps to Level 22 matcher parameters per
+    // `resolve_level_params` (match_generator.rs:412-415), so
+    // `Level(23)` etc. would silently slip past a `Level(11..=22)`
+    // check and hit the same multi-physical-block path as
+    // `Level(22)` (PR #149 review #24 + #27).
+    let post_split = matches!(level, CompressionLevel::Level(n) if n >= 11);
     assert!(
         !post_split,
         "compress_and_collect_sequences does not support pre-split \
-         levels (Level(11..=22)): the donor block-splitter emits \
-         multiple physical blocks per matcher call, which the \
+         levels (Level(n) where n >= 11): the donor block-splitter \
+         emits multiple physical blocks per matcher call, which the \
          current per-matcher-call block counter cannot track. The \
          tool is validated for Fastest / Default / Better / Best / \
-         Level(1..=10); higher numeric levels need per-physical-block \
+         Level(1..=10); higher numeric levels (including levels above \
+         22 which clamp to Level 22 params) need per-physical-block \
          hooks that don't exist yet.",
     );
     // Mirror `FrameCompressor::new()` matcher construction. The
@@ -365,10 +373,133 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
          cover the bypassing path before relying on cumulative-position alignment.",
         input.len(),
     );
+    // Detect raw-fallback / RLE on-wire blocks. The matcher records
+    // triples eagerly, but `compress_block_encoded` may discard the
+    // compressed block and emit a Raw_Block when
+    // `compressed.len() >= MAX_BLOCK_SIZE` (compression made things
+    // bigger). The matcher-side capture would then contain phantom
+    // triples for a block whose on-wire form has no sequences,
+    // turning the comparator's signal into spurious `RustOnly` rows.
+    // Parse the emitted frame's block headers and panic if any Raw
+    // or RLE block is present so the broken precondition surfaces
+    // immediately instead of being misread as a real divergence
+    // (PR #149 review #25).
+    let raw_or_rle = detect_raw_or_rle_blocks_in_frame(&output).expect(
+        "sequence_capture: failed to parse emitted frame header — refusing to \
+         return a possibly-misaligned capture without raw-block detection",
+    );
+    assert!(
+        raw_or_rle.is_empty(),
+        "compress_and_collect_sequences: emitted frame contains {} raw/RLE block(s) at \
+         on-wire indices {:?}. The matcher recorded triples for those blocks but the \
+         on-wire form has no sequences for them — alignment against FFI delimiters \
+         would silently shift. Use a more compressible fixture (or a smaller block \
+         size) that keeps every block on the compressed path.",
+        raw_or_rle.len(),
+        raw_or_rle,
+    );
     SequenceCapture {
         sequences,
         block_tail_lengths,
     }
+}
+
+/// Walk the emitted Zstandard frame and return the on-wire indices
+/// of any Raw_Block or RLE_Block entries (RFC 8878 §3.1.1.2.2). The
+/// capture's matcher hook cannot observe the encoder's late
+/// raw-fallback decision; this parser gives us a way to fail-fast
+/// when that decision happens. Returns `Err` on malformed frames so
+/// the caller can panic with a clearer diagnostic than a silent
+/// short read.
+fn detect_raw_or_rle_blocks_in_frame(frame: &[u8]) -> Result<Vec<usize>, &'static str> {
+    const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+    if frame.len() < 6 || frame[..4] != ZSTD_MAGIC {
+        return Err("frame missing zstd magic");
+    }
+    let mut cursor = 4_usize;
+    let fhd = frame[cursor];
+    cursor += 1;
+    let dict_id_flag = fhd & 0b11;
+    let content_checksum_flag = (fhd >> 2) & 1;
+    let single_segment_flag = (fhd >> 5) & 1;
+    let fcs_flag = (fhd >> 6) & 0b11;
+    // Window_Descriptor byte present only when single_segment_flag = 0.
+    if single_segment_flag == 0 {
+        cursor = cursor.checked_add(1).ok_or("cursor overflow")?;
+    }
+    let dict_id_size = match dict_id_flag {
+        0 => 0,
+        1 => 1,
+        2 => 2,
+        3 => 4,
+        _ => unreachable!(),
+    };
+    cursor = cursor.checked_add(dict_id_size).ok_or("cursor overflow")?;
+    // Frame_Content_Size: 0/1/2/4/8 bytes per
+    // (single_segment_flag, fcs_flag) combination per RFC 8878.
+    let fcs_size = match (single_segment_flag, fcs_flag) {
+        (1, 0) => 1,
+        (_, 0) => 0,
+        (_, 1) => 2,
+        (_, 2) => 4,
+        (_, 3) => 8,
+        _ => unreachable!(),
+    };
+    cursor = cursor.checked_add(fcs_size).ok_or("cursor overflow")?;
+    if cursor > frame.len() {
+        return Err("truncated frame header");
+    }
+
+    // Iterate blocks until last_block bit is set. Each block has a
+    // 3-byte little-endian header: bit 0 = last, bits 1-2 =
+    // block_type (0=Raw, 1=RLE, 2=Compressed, 3=Reserved), bits 3-23
+    // = block_size (Block_Content size for Raw/Compressed,
+    // Regenerated_Size for RLE).
+    let mut raw_or_rle = Vec::new();
+    let mut block_idx: usize = 0;
+    loop {
+        if cursor.checked_add(3).ok_or("cursor overflow")? > frame.len() {
+            return Err("truncated block header");
+        }
+        let header = u32::from(frame[cursor])
+            | (u32::from(frame[cursor + 1]) << 8)
+            | (u32::from(frame[cursor + 2]) << 16);
+        cursor += 3;
+        let last_block = (header & 1) != 0;
+        let block_type = (header >> 1) & 0b11;
+        let block_size = (header >> 3) as usize;
+        match block_type {
+            0 => {
+                // Raw_Block: Block_Content is `block_size` literal bytes.
+                raw_or_rle.push(block_idx);
+                cursor = cursor.checked_add(block_size).ok_or("cursor overflow")?;
+            }
+            1 => {
+                // RLE_Block: 1-byte content, regenerated to `block_size` bytes.
+                raw_or_rle.push(block_idx);
+                cursor = cursor.checked_add(1).ok_or("cursor overflow")?;
+            }
+            2 => {
+                // Compressed_Block: Block_Content is `block_size` bytes.
+                cursor = cursor.checked_add(block_size).ok_or("cursor overflow")?;
+            }
+            3 => return Err("reserved block_type in frame"),
+            _ => unreachable!(),
+        }
+        block_idx += 1;
+        if cursor > frame.len() {
+            return Err("block content extends past frame end");
+        }
+        if last_block {
+            break;
+        }
+    }
+    // Optional 4-byte content checksum (validated separately by the
+    // decoder; not consumed here beyond bounds-checking).
+    if content_checksum_flag == 1 && cursor.checked_add(4).is_none_or(|end| end > frame.len()) {
+        return Err("truncated content checksum");
+    }
+    Ok(raw_or_rle)
 }
 
 #[cfg(test)]
@@ -379,10 +510,13 @@ mod tests {
 
     /// On a 16 KiB repeating 16-byte pattern, the encoder must emit
     /// at least one `Triple` sequence — every position past the first
-    /// 16 bytes finds a long match 16 bytes back. Constant runs
-    /// (`AAAA…`) intentionally avoided: they route to RLE block
-    /// emission which bypasses the matcher entirely and would
-    /// silently fail this test for the wrong reason.
+    /// 16 bytes finds a long match 16 bytes back. Constant-run input
+    /// (`AAAA…`) is covered separately by
+    /// `constant_run_routes_through_matcher_path` because it tests a
+    /// different invariant (the matcher path stays alignment-correct
+    /// even when no `Triple` is emitted). On the rotating pattern
+    /// here we want at least one captured triple, which a clean
+    /// matcher always produces.
     #[test]
     fn captures_at_least_one_triple_on_repeating_pattern() {
         let pattern: [u8; 16] = *b"PATTERN_1234_END";
@@ -433,15 +567,16 @@ mod tests {
         );
     }
 
-    /// Random / incompressible input should emit at most a sparse
-    /// trickle of triples (the dfast hash can luck into a 5-byte
-    /// collision on any 1 KiB stream), well below "every position
-    /// is a match". This bounds-the-rate test guards against a
-    /// wrapper bug that fabricates phantom sequences or carries
-    /// state across calls — a clean wrapper produces few or zero
-    /// triples here, but ZERO is not the strict contract.
+    /// Random / incompressible input causes the encoder to emit a
+    /// Raw_Block on-wire (`compressed.len() >= MAX_BLOCK_SIZE`), so
+    /// the post-compress raw-block detector must panic. Before the
+    /// detector existed, this test verified the wrapper bounded
+    /// phantom-triple production; now the API-level guarantee is
+    /// stronger — the function refuses to return a misaligned
+    /// capture for such inputs (PR #149 review #25).
     #[test]
-    fn captures_bounded_triples_on_incompressible_input() {
+    #[should_panic(expected = "raw/RLE block")]
+    fn rejects_incompressible_input_with_raw_on_wire_block() {
         // Deterministic non-repeating bytes via a simple LCG.
         let mut state: u32 = 0x1234_5678;
         let data: Vec<u8> = (0..1024)
@@ -450,79 +585,24 @@ mod tests {
                 (state >> 16) as u8
             })
             .collect();
-        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
-        let seqs = &captured.sequences;
-        // Some matches may still surface on a 1 KiB LCG stream (the
-        // dfast hash can luck into a 5-byte collision), but the count
-        // must stay well below "every position is a match" — otherwise
-        // the wrapper is recording phantom sequences.
-        assert!(
-            seqs.len() < data.len() / 16,
-            "incompressible input emitted suspiciously many sequences: {} (limit: {})",
-            seqs.len(),
-            data.len() / 16,
-        );
-        // Each block (matcher call) must contribute exactly one
-        // tail-length entry — even when no triples were emitted.
-        // Block count is `last.block_idx + 1` if any triples, or
-        // we expect at least one block was processed since the
-        // input is 1 KiB > 0.
-        assert!(
-            !captured.block_tail_lengths.is_empty(),
-            "no block tail lengths recorded for non-empty input",
-        );
-        // Cumulative position must still equal `data.len()`. For an
-        // incompressible block where the encoder routes through
-        // `start_matching` (rare with `set_source_size_hint`, but
-        // possible), the trailing-literal tail will cover most of the
-        // block; with `skip_matching` routing, the tail equals the
-        // entire committed space. Either way, `Σ (ll + ml) + tails`
-        // must reconstruct the input length exactly.
-        let cumulative: u64 = seqs.iter().map(|s| s.ll as u64 + s.ml as u64).sum::<u64>()
-            + captured
-                .block_tail_lengths
-                .iter()
-                .map(|t| *t as u64)
-                .sum::<u64>();
-        assert_eq!(
-            cumulative,
-            data.len() as u64,
-            "Σ(ll+ml) over triples + Σ(block_tail_lengths) must reconstruct input length",
-        );
+        // Calling the function is the test: the raw-block detector
+        // inside `compress_and_collect_sequences` must panic before
+        // returning, so any code after this point is unreachable.
+        let _ = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
     }
 
-    /// Constant runs (`[b'A'; N]`) currently route through the
-    /// matcher's `skip_matching` path (or emit a single long match),
-    /// NOT through an RLE-bypass that skips `CapturingMatcher`
-    /// entirely. Verify the invariant still holds on this shape so
-    /// `compare_ffi_sequences` can include constant-run fixtures
-    /// without tripping the fail-fast assert in
-    /// `compress_and_collect_sequences`. If a future encoder change
-    /// introduces a true RLE-bypass path on this input the assert
-    /// will fire — at which point the wrapper needs extending to
-    /// plumb synthetic block metadata out of the bypassing path
-    /// (PR #149 review round 2 #7).
+    /// Constant runs (`[b'A'; N]`) cause the encoder to emit an
+    /// RLE_Block on-wire (matcher may still produce a long
+    /// rep-coded triple, but the block payload is encoded as
+    /// `(byte, regenerated_size)`, not as sequences). The raw-block
+    /// detector treats RLE the same as Raw — both have no on-wire
+    /// sequences for the comparator to diff — and must panic to
+    /// prevent silently misaligned output (PR #149 review #25).
     #[test]
-    fn constant_run_routes_through_matcher_path() {
+    #[should_panic(expected = "raw/RLE block")]
+    fn rejects_constant_run_with_rle_on_wire_block() {
         let data: Vec<u8> = alloc::vec![b'A'; 16 * 1024];
-        // Calling this is the assertion: the fail-fast invariant
-        // check inside `compress_and_collect_sequences` panics with
-        // "matcher-bypassing block path" if either `sequences` or
-        // `block_tail_lengths` undercount the input bytes. Reaching
-        // here without panic proves the matcher path covers
-        // constant runs.
-        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
-        let cumulative: u64 = captured
-            .sequences
-            .iter()
-            .map(|s| s.ll as u64 + s.ml as u64)
-            .sum::<u64>()
-            + captured
-                .block_tail_lengths
-                .iter()
-                .map(|t| *t as u64)
-                .sum::<u64>();
-        assert_eq!(cumulative, data.len() as u64);
+        let _ = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
     }
 
     /// Multi-block input (≥ 256 KiB, two 128 KiB frame blocks) is
@@ -544,24 +624,21 @@ mod tests {
     /// (PR #149 review #19).
     #[test]
     fn captures_multi_block_tails_and_indices() {
-        // Repeating 64-byte pattern: compressible enough to emit
-        // sequences (not RLE) and long enough that every position
-        // past the first 64 bytes finds a match, exercising the
-        // matcher rather than a fast skip path.
-        let pattern: [u8; 64] = {
-            let mut p = [0u8; 64];
-            for (i, b) in p.iter_mut().enumerate() {
-                *b = (i as u8).wrapping_mul(31).wrapping_add(7);
-            }
-            p
-        };
-        let data: Vec<u8> = pattern.iter().copied().cycle().take(256 * 1024).collect();
+        // Repeating 16-byte pattern at 200 KiB (≈ 1.5 × 128 KiB
+        // frame block) — guaranteed to span ≥2 blocks while
+        // compressing densely enough to stay on the Compressed_Block
+        // path, avoiding the raw/RLE detector at the end of
+        // `compress_and_collect_sequences`. Larger / less repetitive
+        // fixtures risk a trailing Raw_Block when the final chunk is
+        // small enough that compression doesn't pay for itself.
+        let pattern: [u8; 16] = *b"PATTERN_1234_END";
+        let data: Vec<u8> = pattern.iter().copied().cycle().take(200 * 1024).collect();
         let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
 
         // Multi-block invariant: at least 2 blocks recorded.
         assert!(
             captured.block_tail_lengths.len() >= 2,
-            "expected ≥2 block tail entries for 256 KiB input, got {}: {:?}",
+            "expected ≥2 block tail entries for 200 KiB input, got {}: {:?}",
             captured.block_tail_lengths.len(),
             captured.block_tail_lengths,
         );
@@ -638,10 +715,15 @@ mod tests {
         );
     }
 
-    /// Pin the pre-split-level reject path. `Level(11..=22)` and
-    /// `Best` route through the donor block-splitter, which emits
-    /// multiple physical on-wire blocks per matcher call — the
-    /// per-matcher-call counter cannot track that shape.
+    /// Pin the pre-split-level reject path. Numeric `Level(n)` with
+    /// `n >= 11` routes through the donor block-splitter (or clamps
+    /// to Level 22's params, which post-splits the same way), which
+    /// emits multiple physical on-wire blocks per matcher call — the
+    /// per-matcher-call counter cannot track that shape. The named
+    /// `Best` preset is allowed because `donor_pre_split_level`
+    /// matches on EXACT enum variants and falls through to `None`
+    /// for `Best` — see `captures_through_best_preset` for the
+    /// matching positive test.
     #[test]
     #[should_panic(expected = "does not support pre-split levels")]
     fn rejects_pre_split_numeric_level() {

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -252,6 +252,31 @@ pub fn compress_and_collect_sequences(input: &[u8], level: CompressionLevel) -> 
     let block_tail_lengths = Rc::try_unwrap(block_tail_lengths)
         .expect("CapturingMatcher dropped with compressor; tail-length vec is single-owner")
         .into_inner();
+    // Fail-fast invariant check: the encoder has a few paths that
+    // emit blocks WITHOUT routing through any `Matcher` method on
+    // `CapturingMatcher` — most notably RLE blocks for fully-constant
+    // runs (`AAAAA…`), which the frame compressor recognises before
+    // ever calling the matcher. On such inputs the captured stream
+    // misses entire blocks, so callers walking the cumulative
+    // position counter (e.g. `compare_ffi_sequences::align_and_diff`)
+    // would silently shift every subsequent row. Panic with a
+    // diagnostic instead of returning a quietly-wrong
+    // `SequenceCapture` (PR #149 review round 2 #7).
+    let reconstructed: u64 = sequences
+        .iter()
+        .map(|s| s.ll as u64 + s.ml as u64)
+        .sum::<u64>()
+        + block_tail_lengths.iter().map(|t| *t as u64).sum::<u64>();
+    assert_eq!(
+        reconstructed,
+        input.len() as u64,
+        "sequence_capture: matcher-bypassing block path (RLE block? raw-frame fast-path?) \
+         left the captured stream short: Σ(ll+ml)+Σ(tails)={reconstructed}, input.len()={}. \
+         The current wrapper only sees blocks routed through `Matcher` methods on \
+         `CapturingMatcher`. Use a non-RLE-friendly fixture or extend capture to \
+         cover the bypassing path before relying on cumulative-position alignment.",
+        input.len(),
+    );
     SequenceCapture {
         sequences,
         block_tail_lengths,
@@ -372,5 +397,39 @@ mod tests {
             data.len() as u64,
             "Σ(ll+ml) over triples + Σ(block_tail_lengths) must reconstruct input length",
         );
+    }
+
+    /// Constant runs (`[b'A'; N]`) currently route through the
+    /// matcher's `skip_matching` path (or emit a single long match),
+    /// NOT through an RLE-bypass that skips `CapturingMatcher`
+    /// entirely. Verify the invariant still holds on this shape so
+    /// `compare_ffi_sequences` can include constant-run fixtures
+    /// without tripping the fail-fast assert in
+    /// `compress_and_collect_sequences`. If a future encoder change
+    /// introduces a true RLE-bypass path on this input the assert
+    /// will fire — at which point the wrapper needs extending to
+    /// plumb synthetic block metadata out of the bypassing path
+    /// (PR #149 review round 2 #7).
+    #[test]
+    fn constant_run_routes_through_matcher_path() {
+        let data: Vec<u8> = alloc::vec![b'A'; 16 * 1024];
+        // Calling this is the assertion: the fail-fast invariant
+        // check inside `compress_and_collect_sequences` panics with
+        // "matcher-bypassing block path" if either `sequences` or
+        // `block_tail_lengths` undercount the input bytes. Reaching
+        // here without panic proves the matcher path covers
+        // constant runs.
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+        let cumulative: u64 = captured
+            .sequences
+            .iter()
+            .map(|s| s.ll as u64 + s.ml as u64)
+            .sum::<u64>()
+            + captured
+                .block_tail_lengths
+                .iter()
+                .map(|t| *t as u64)
+                .sum::<u64>();
+        assert_eq!(cumulative, data.len() as u64);
     }
 }

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -1,0 +1,258 @@
+//! Bench-only sequence-stream capture for FFI-parity audits.
+//!
+//! Exposed under the `bench_internals` feature so the regular crate API
+//! surface stays unaffected. The single public entry point —
+//! [`compress_and_collect_sequences`] — drives the production
+//! [`FrameCompressor`] pipeline at the requested `CompressionLevel` and
+//! records every `Sequence::Triple` the matcher emits, tagged with its
+//! block index. This is the Rust-side input to the
+//! `compare_ffi_sequences` bench, which diffs the captured stream
+//! against `ZSTD_generateSequences` (donor) on the same `(input, level)`
+//! to triage residual ratio deltas into "algorithmic win" / "cost
+//! source" / "missed match" classes (`Phase 7 / 7-tooling-seq-cmp`).
+//!
+//! Implementation goes through [`FrameCompressor::new_with_matcher`] +
+//! a [`CapturingMatcher`] wrapper rather than driving the matcher in
+//! isolation, so the captured stream reflects block-splitter decisions,
+//! strategy-tag selection and per-level resets exactly as the
+//! production encoder would emit them. Capturing the matcher in
+//! isolation would skip the frame-level chunking and produce a stream
+//! that does NOT match what the on-wire frame encodes.
+
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+
+use crate::encoding::{CompressionLevel, FrameCompressor, MatchGeneratorDriver, Matcher, Sequence};
+
+/// One sequence captured from the encoder's matcher output, in
+/// "raw" form (offset is the actual byte distance, NOT the wire-format
+/// offset code with rep-history shift).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CapturedRawSequence {
+    /// Zero-based index of the block this sequence belongs to.
+    pub block_idx: u32,
+    /// Zero-based position within the block (resets at block boundary).
+    pub seq_in_block: u32,
+    /// Literal length in bytes that precede the match copy.
+    pub ll: u32,
+    /// Byte distance to copy from (1-based, matches the matcher's
+    /// `Sequence::Triple.offset` semantics — NOT the encoded `of` code).
+    pub of: u32,
+    /// Match length in bytes.
+    pub ml: u32,
+}
+
+/// `Matcher` wrapper that forwards every method to an inner
+/// [`MatchGeneratorDriver`] while appending each emitted
+/// `Sequence::Triple` to a shared recorder. The shared `Rc<RefCell<…>>`
+/// lets the caller pull captured sequences out without consuming the
+/// `FrameCompressor` mid-frame.
+struct CapturingMatcher {
+    inner: MatchGeneratorDriver,
+    recorded: Rc<RefCell<Vec<CapturedRawSequence>>>,
+    current_block: u32,
+}
+
+impl Matcher for CapturingMatcher {
+    fn get_next_space(&mut self) -> Vec<u8> {
+        self.inner.get_next_space()
+    }
+
+    fn get_last_space(&mut self) -> &[u8] {
+        self.inner.get_last_space()
+    }
+
+    fn commit_space(&mut self, space: Vec<u8>) {
+        self.inner.commit_space(space);
+    }
+
+    fn skip_matching(&mut self) {
+        self.inner.skip_matching();
+        self.current_block = self.current_block.saturating_add(1);
+    }
+
+    fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
+        self.inner.skip_matching_with_hint(incompressible_hint);
+        self.current_block = self.current_block.saturating_add(1);
+    }
+
+    fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+        let recorded = self.recorded.clone();
+        let block_idx = self.current_block;
+        let mut seq_in_block: u32 = 0;
+        self.inner.start_matching(|seq| {
+            if let Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } = seq
+            {
+                recorded.borrow_mut().push(CapturedRawSequence {
+                    block_idx,
+                    seq_in_block,
+                    ll: literals.len() as u32,
+                    of: offset as u32,
+                    ml: match_len as u32,
+                });
+                seq_in_block = seq_in_block.saturating_add(1);
+            }
+            handle_sequence(seq);
+        });
+        self.current_block = self.current_block.saturating_add(1);
+    }
+
+    fn reset(&mut self, level: CompressionLevel) {
+        self.inner.reset(level);
+        self.recorded.borrow_mut().clear();
+        self.current_block = 0;
+    }
+
+    fn set_source_size_hint(&mut self, size: u64) {
+        self.inner.set_source_size_hint(size);
+    }
+
+    fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
+        self.inner.prime_with_dictionary(dict_content, offset_hist);
+    }
+
+    fn seed_dictionary_entropy(
+        &mut self,
+        huff: Option<&crate::huff0::huff0_encoder::HuffmanTable>,
+        ll: Option<&crate::fse::fse_encoder::FSETable>,
+        ml: Option<&crate::fse::fse_encoder::FSETable>,
+        of: Option<&crate::fse::fse_encoder::FSETable>,
+    ) {
+        self.inner.seed_dictionary_entropy(huff, ll, ml, of);
+    }
+
+    fn supports_dictionary_priming(&self) -> bool {
+        self.inner.supports_dictionary_priming()
+    }
+
+    fn window_size(&self) -> u64 {
+        self.inner.window_size()
+    }
+}
+
+/// Compress `input` at `level` through the production
+/// [`FrameCompressor`] pipeline and return every emitted
+/// `Sequence::Triple` as a [`CapturedRawSequence`].
+///
+/// The compressed output is discarded — only the sequence stream is
+/// returned. Use this from a benchmark or audit tool to diff the
+/// Rust-emitted sequence stream against a donor FFI side
+/// (`ZSTD_generateSequences`) for the same `(input, level)` pair.
+///
+/// `Sequence::Literals` entries (trailing-literals tail of a block) are
+/// NOT recorded — the donor's `ZSTD_generateSequences` emits trailing
+/// literals as a dummy delimiter `(of=0, ml=0, ll=last)`, and including
+/// our side's `Literals` events would add noise to the diff. Callers
+/// that need block-boundary alignment can use
+/// `CapturedRawSequence::block_idx` instead.
+pub fn compress_and_collect_sequences(
+    input: &[u8],
+    level: CompressionLevel,
+) -> Vec<CapturedRawSequence> {
+    // Mirror `FrameCompressor::new()` matcher construction. The
+    // `reset()` call inside `compress()` re-derives the real per-level
+    // window/strategy from `level`, so the seed values here only need
+    // to keep the matcher usable up to that reset.
+    let driver = MatchGeneratorDriver::new(1024 * 128, 1);
+    let recorded: Rc<RefCell<Vec<CapturedRawSequence>>> = Rc::new(RefCell::new(Vec::new()));
+    let matcher = CapturingMatcher {
+        inner: driver,
+        recorded: recorded.clone(),
+        current_block: 0,
+    };
+    let mut output: Vec<u8> = Vec::new();
+    let mut compressor: FrameCompressor<&[u8], &mut Vec<u8>, CapturingMatcher> =
+        FrameCompressor::new_with_matcher(matcher, level);
+    compressor.set_source(input);
+    compressor.set_drain(&mut output);
+    // Hint the exact input size so the matcher picks the same
+    // hash-table / window class the production one-shot path uses
+    // (`compress_to_vec` does the same). Without the hint, the matcher
+    // assumes streaming sizing, which would diverge from the donor's
+    // `ZSTD_generateSequences` (which receives `srcSize` directly).
+    compressor.set_source_size_hint(input.len() as u64);
+    compressor.compress();
+    // `Rc::try_unwrap` succeeds because the inner `CapturingMatcher`
+    // is dropped when `compressor` goes out of scope at the end of the
+    // function, leaving us as the sole `Rc` owner.
+    drop(compressor);
+    Rc::try_unwrap(recorded)
+        .expect("CapturingMatcher dropped with compressor; recorder is single-owner")
+        .into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::encoding::CompressionLevel;
+    use alloc::vec::Vec;
+
+    /// On a 16 KiB repeating 16-byte pattern, the encoder must emit
+    /// at least one `Triple` sequence — every position past the first
+    /// 16 bytes finds a long match 16 bytes back. Constant runs
+    /// (`AAAA…`) intentionally avoided: they route to RLE block
+    /// emission which bypasses the matcher entirely and would
+    /// silently fail this test for the wrong reason.
+    #[test]
+    fn captures_at_least_one_triple_on_repeating_pattern() {
+        let pattern: [u8; 16] = *b"PATTERN_1234_END";
+        let data: Vec<u8> = pattern.iter().copied().cycle().take(16 * 1024).collect();
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+        assert!(
+            !captured.is_empty(),
+            "expected at least one Triple sequence on 16KB repeating pattern, got 0",
+        );
+        // Every captured sequence belongs to block 0 (single 16 KiB block fits in 128 KiB).
+        assert!(
+            captured.iter().all(|s| s.block_idx == 0),
+            "16KB repeating pattern produced multi-block sequence stream: {:?}",
+            captured.iter().map(|s| s.block_idx).collect::<Vec<_>>(),
+        );
+        // Every captured Triple must reference a sane offset/match
+        // (defensive: catches wrapper bugs that would leak garbage
+        // through the recorder).
+        for s in &captured {
+            assert!(s.of >= 1, "non-positive offset captured: {:?}", s);
+            assert!(s.ml >= 1, "non-positive match length captured: {:?}", s);
+        }
+        // seq_in_block must be contiguous 0..N for each block.
+        for (i, s) in captured.iter().enumerate() {
+            assert_eq!(
+                s.seq_in_block, i as u32,
+                "seq_in_block discontinuity at idx {}: {:?}",
+                i, captured,
+            );
+        }
+    }
+
+    /// Random / incompressible input should NOT emit any matches —
+    /// recorder stays empty, confirming the wrapper doesn't fabricate
+    /// or carry over state across calls.
+    #[test]
+    fn captures_no_triples_on_incompressible_input() {
+        // Deterministic non-repeating bytes via a simple LCG.
+        let mut state: u32 = 0x1234_5678;
+        let data: Vec<u8> = (0..1024)
+            .map(|_| {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                (state >> 16) as u8
+            })
+            .collect();
+        let captured = compress_and_collect_sequences(&data, CompressionLevel::Level(3));
+        // Some matches may still surface on a 1 KiB LCG stream (the
+        // dfast hash can luck into a 5-byte collision), but the count
+        // must stay well below "every position is a match" — otherwise
+        // the wrapper is recording phantom sequences.
+        assert!(
+            captured.len() < data.len() / 16,
+            "incompressible input emitted suspiciously many sequences: {} (limit: {})",
+            captured.len(),
+            data.len() / 16,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Phase 7 / Lane D / `7-tooling-seq-cmp` — prerequisite for Lane A `7-compress-default` ratio-divergence audit.

For a fixed `(input, level)` pair, capture the encoder sequence stream from both sides and diff `(literal_length, offset, match_length)` triples. The tool emits **raw diff verdicts** — `Equal` / `Differ` / `RustOnly` / `FfiOnly` — over which a human triages residual compression-ratio gaps into interpretation classes ("algorithmic win" where Rust ships a sequence donor missed, "cost source" where both sides emit at the same position but Rust chose a worse offset/length, "missed match upstream skipped" where donor emits a sequence Rust didn't). The classification labels are human-applied reasoning on top of the raw verdicts, not tool output.

## Changes

- **`encoding::sequence_capture`** (`bench_internals` feature). Public `compress_and_collect_sequences(input, level) -> SequenceCapture`. Returns `{ sequences: Vec<CapturedRawSequence>, block_tail_lengths: Vec<u32> }` — per-block trailing-literal counts are captured alongside the triple stream so callers walking a cumulative position counter (`Σ (ll + ml)` per triple plus `block_tail_lengths[block]` at each block boundary) reconstruct the on-wire input position exactly. Drives the production `FrameCompressor` via a `CapturingMatcher` wrapper that forwards every `Matcher` trait method to an inner `MatchGeneratorDriver`; the wrapper records `Sequence::Triple` events into the recorder, captures the terminal `Sequence::Literals` per block as the tail length, and for `skip_matching` raw blocks records the entire committed space as the tail (no triples for those blocks).
  - Unit tests pin the wrapper contract:
    - `captures_at_least_one_triple_on_repeating_pattern` — 16 KiB rotating 16-byte pattern produces a non-empty triple stream and `Σ(ll+ml) + tail == 16 KiB`.
    - `captures_multi_block_tails_and_indices` — 200 KiB rotating pattern spans ≥ 2 frame blocks; pins `Σ(ll+ml) + Σ(block_tail_lengths) == input.len()` across the boundary, contiguous block indices from 0, and per-block tail accounting.
    - `captures_through_best_preset` / `captures_through_pre_split_level_15` — exercise named and pre-split numeric levels through the capture wrapper.
    - `rejects_empty_input` / `rejects_uncompressed_level` / `rejects_post_split_numeric_level` — guard the supported-input contract.
    - `rejects_incompressible_input_with_raw_on_wire_block` / `rejects_constant_run_with_rle_on_wire_block` — the API refuses inputs that the encoder commits as `Raw_Block` / `RLE_Block` on-wire (no sequences to capture), so the wrapper panics with a `raw/RLE block` message instead of returning a misaligned capture. Callers must steer such inputs away before calling `compress_and_collect_sequences`.
- **`benches/compare_ffi_sequences`** (`harness=false`, requires `dict_builder` + `bench_internals`). Two fixtures:
  - `decodecorpus_files/z000033` — pre-existing corpus that surfaces the −7% size delta on `level_3_dfast`.
  - 16 KiB synthesized low-entropy log lines with rotating numeric fields (medium-repetition shape).
  - FFI side: `ZSTD_generateSequences` via `zstd_sys`. Block delimiters (`of=0, ml=0`) are dropped from the emitted `Vec<FfiSeq>` and their `litLength` is recorded as the FFI-side trailing-literal length, parallel to the Rust side.
  - Alignment by cumulative input bytes — `Σ (ll + ml)` per triple plus per-block tail length at each block boundary, on both sides. Without per-block tails the cumulative counter underflows after every block with trailing literals, shifting every subsequent diff row (~38k of 60k rows of spurious shift on z000033 before the fix).
  - Output: per-fixture summary + the first 30 diverging rows in a plain-text table.
- **Bug fix bundled (`test_all_artifacts`)**: PR #148 untracked `zstd/fuzz/artifacts/**` via `git rm --cached`; `git pull` then deletes those files locally, and the test was reading `./fuzz/artifacts/decode` with `unwrap()` on `read_dir`. Treat `NotFound` as a no-op — the corpus is locally produced or CI-generated and intentionally not tracked. (Hotfix already landed via #151; this branch was rebased on `main` so the commit drops out cleanly.)

## Sample output (release build, `level=3`)

```
=== compare_ffi_sequences (level=3, Rust vs C FFI) ===

--- fixture: z000033 (1022035 bytes) ---
  rust sequences: 46678 (across 8 block(s))
  ffi  sequences: 47713 (across 8 block(s))
  alignment: equal=20338 (34.0%) differ=14155 rust_only=12185 ffi_only=13220
```

(After review fix; first iteration before the trailing-literal alignment fix reported 24.1% equal — most of that delta was spurious shift from undercounted block boundaries, not real divergence.)

The first 5 FFI-only rows on z000033 highlight that FFI emits small sequences at the very start before Rust emits anything — pointing at the initial-ip-shift / saved-offset-rotation gap tracked as #103.

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --features dict_builder+bench_internals -D warnings` clean
- [x] `cargo nextest run --features dict_builder+bench_internals` — 538/538 pass (incl. 2 in `sequence_capture` with cumulative-position invariants)
- [x] `cargo test --doc` — 12/12 pass
- [x] `cargo check --no-default-features` (no-std baseline) clean
- [x] `cargo check --features dict_builder` (regular bench-less build) clean
- [x] Bench binary builds in release and runs successfully on both fixtures

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature-gated sequence-capture diagnostic that records encoder triples and per-block trailing-byte counts, validates allowed compression levels, and errors if on-wire raw/RLE blocks are present.
* **Benchmarks**
  * Added an opt-in, feature-gated benchmark (requires specific features) that aligns and compares captured encoder sequences with C FFI output and reports per-fixture/per-level divergences.
* **Documentation**
  * Quick start now shows cargo add (including a no-default-features example) and links to per-release changelogs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
