### PR TITLE
fix(test): test_all_artifacts skip when fuzz corpus dir is absent

### DIFF
--- a/zstd/src/tests/fuzz_regressions.rs
+++ b/zstd/src/tests/fuzz_regressions.rs
@@ -9,7 +9,24 @@ fn test_all_artifacts() {
 
     let mut frame_dec = FrameDecoder::new();
 
-    for file in fs::read_dir("./fuzz/artifacts/decode").unwrap() {
+    // The fuzz artifact corpus is locally produced by `cargo fuzz run`
+    // and intentionally NOT tracked in git (see PR #148 — these files
+    // are in `.gitignore` so release-plz can compute next versions
+    // without a "tracked + ignored" conflict). When the directory is
+    // absent — fresh checkout with no local fuzz runs, or a CI worker
+    // that hasn't generated artifacts yet — the test passes as a
+    // smoke check: there's nothing to replay against, and the
+    // regression contract (no panic on the literal crash inputs
+    // pinned in the other `#[test]` below, e.g.
+    // `interop_7_byte_input_does_not_oob_in_dfast_fast_loop`) still
+    // holds for the corpus inputs that DO exist in the donor crate.
+    let entries = match fs::read_dir("./fuzz/artifacts/decode") {
+        Ok(e) => e,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return,
+        Err(err) => panic!("unexpected error reading fuzz artifacts dir: {err}"),
+    };
+
+    for file in entries {
         let file_name = file.unwrap().path();
 
         let fnstr = file_name.to_str().unwrap().to_owned();


### PR DESCRIPTION
## Summary

Main is currently red — `test_all_artifacts` panics on every fresh checkout / CI worker because PR #148 untracked the fuzz crash corpus via `git rm --cached`, and `git pull` then deletes the files locally. The test unwraps `fs::read_dir("./fuzz/artifacts/decode")`:

\`\`\`
thread 'tests::fuzz_regressions::test_all_artifacts' panicked at zstd/src/tests/fuzz_regressions.rs:12:57:
called \`Result::unwrap()\` on an \`Err\` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
\`\`\`

## Fix

Treat `NotFound` as a no-op. The corpus is locally produced or CI-generated and intentionally not tracked (see PR #148 — the files are in `.gitignore` so release-plz can compute next versions without a tracked-and-ignored conflict). The other regression test in the same file — `interop_7_byte_input_does_not_oob_in_dfast_fast_loop` — pins the canonical 7-byte crash as bytes inline, so the regression contract for known-bad inputs is still covered when the on-disk corpus is empty.

## Context

The same fix is already part of #99 (PR #149) but bundled with a 600-line bench addition. Extracting as a standalone one-file hotfix so main goes green immediately without waiting for the full #99 review cycle. After this merges, the duplicate commit on the #99 branch becomes a no-op and falls out cleanly on rebase.

## Test plan
- [x] `cargo nextest run tests::fuzz_regressions` — both tests pass (`test_all_artifacts` no-ops on missing dir, `interop_7_byte_input_does_not_oob_in_dfast_fast_loop` still pins the 7-byte regression)

Closes #150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by gracefully handling missing test artifacts, allowing the test to pass as a smoke check instead of failing when artifacts are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->