### PR TITLE
ci(bench): bump per-target timeout_minutes to 45/60/45 (fixes #152)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,21 +293,21 @@ jobs:
               "target_triple": "x86_64-unknown-linux-gnu",
               "build_setup": "",
               "runtime_setup": "",
-              "timeout_minutes": 25
+              "timeout_minutes": 45
             },
             {
               "id": "i686-gnu",
               "target_triple": "i686-unknown-linux-gnu",
               "build_setup": "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386",
               "runtime_setup": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386",
-              "timeout_minutes": 30
+              "timeout_minutes": 60
             },
             {
               "id": "x86_64-musl",
               "target_triple": "x86_64-unknown-linux-musl",
               "build_setup": "sudo apt-get update && sudo apt-get install -y musl-tools",
               "runtime_setup": "",
-              "timeout_minutes": 25
+              "timeout_minutes": 45
             }
           ]
           EOF


### PR DESCRIPTION
## Summary

Today's main pushes (#148, #151, #138 → v0.0.21) all failed to publish bench data to https://structured-world.github.io/structured-zstd/dev/bench/ because 7 of the 21 bench shards hit the per-target `timeout_minutes` cap. When any shard fails, `benchmark-aggregate` and `benchmark-pages` never run, so no points land on the dashboard.

## Which shards timed out

The bench-matrix runs 7 strategy shards on 3 targets in parallel. Of the 21 shards:

- **14 passed** in 8-25 minutes
- **7 hit their cap exactly:**
  - `lazy` on all 3 targets (11 levels: 5..15)
  - `fast` on all 3 targets (8 levels: -7..-1, 1)
  - `btultra2` on i686-gnu (3 levels but slow 32-bit target)

Each level takes ~2-3 minutes through the bench binary; 11 levels exceed the 25-30 min caps.

## Fix

Bump per-target `timeout_minutes`:

- `x86_64-gnu`: 25 → **45**
- `i686-gnu`: 30 → **60** (slower 32-bit target)
- `x86_64-musl`: 25 → **45**

This was user's explicit choice over splitting heavy shards (which would parallelize better but increase the CI surface). The bumped caps leave ~50% headroom over observed worst cases:

- Observed worst: i686-gnu/btultra2 at 30m16s, i686-gnu/fast/lazy at ~30m
- New i686 cap: 60m — fits with margin

## Test plan
- [ ] CI green on this PR (lint, tests, all 21 bench shards complete)
- [ ] After merge, `benchmark-pages` job publishes a new data point on the dashboard

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI benchmark timeout configurations to allow extended test execution times on multiple target platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->