### PR TITLE
ci(bench): decouple regression alert from publish — fixes stuck baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,21 +577,26 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-      - name: Store benchmark results (x86_64-gnu only)
-        if: steps.bot-token.outputs.token != ''
+      # Save baseline (main push only). Intentionally NO `fail-on-alert`
+      # and NO `comment-on-alert` here — regression alerts are handled
+      # exclusively by the `benchmark-regression-check` job below, which
+      # runs only on regular developer PRs. Mixing the alert/fail path
+      # with the save path here would re-create the stuck-baseline
+      # cascade from #158: a regression on main push would fail the step
+      # before `save-data-file` ran, freezing the baseline indefinitely.
+      - name: Save benchmark baseline (main push only)
+        if: steps.bot-token.outputs.token != '' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: "structured-zstd vs C FFI (x86_64-gnu)"
           tool: customSmallerIsBetter
           output-file-path: benchmark-results.x86_64-gnu.json
           github-token: ${{ steps.bot-token.outputs.token }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          comment-on-alert: true
-          alert-comment-cc-users: "@polaz"
+          auto-push: true
+          save-data-file: true
+          comment-on-alert: false
+          fail-on-alert: false
           alert-threshold: "130%"
-          fail-threshold: "160%"
-          fail-on-alert: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-          save-data-file: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           benchmark-data-dir-path: dev/bench
 
   benchmark-pages:
@@ -650,3 +655,60 @@ jobs:
           git add dev/bench/index.html dev/bench/benchmark-report.md dev/bench/benchmark-delta.json dev/bench/benchmark-delta.md dev/bench/benchmark-relative.json dev/bench/benchmark-summary.md dev/bench/benchmark-delta-summary.md
           git diff --cached --quiet || git commit -m "chore(bench): publish benchmark reports"
           git push origin gh-pages
+
+  # Regression alert gate — runs ONLY on regular developer PRs from
+  # this repo. Intentionally NOT on:
+  #   * push events (main is the immutable historical record; the
+  #     dev/bench dashboard surfaces regressions visually, no need to
+  #     fail CI red and freeze the publish chain)
+  #   * release-plz PRs (version-bump only, no source changes → perf
+  #     deltas are noise)
+  #   * fork PRs (no access to gh-pages baseline anyway, would just
+  #     emit a confusing comparison-failed line)
+  #
+  # Decoupled from `benchmark-aggregate` / `benchmark-pages` so that a
+  # red alert here does NOT block publish or baseline save (see #158
+  # for the stuck-baseline cascade this avoids).
+  benchmark-regression-check:
+    name: Bench regression alert (developer PR only)
+    needs: benchmark-aggregate
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'release-plz[bot]' &&
+      !startsWith(github.head_ref, 'release-plz-')
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # The aggregated artifact carries `benchmark-results.<target>.json`
+      # at its root; download into workspace root so the action's
+      # `output-file-path` resolves without extra path plumbing.
+      - uses: actions/download-artifact@v8
+        with:
+          name: benchmark-aggregated
+
+      - name: Compare against baseline + alert (no save, no push)
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: "structured-zstd vs C FFI (x86_64-gnu)"
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.x86_64-gnu.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Read-only comparison: no baseline write, no gh-pages push.
+          # The save path lives in `benchmark-aggregate` and runs on
+          # main push only.
+          auto-push: false
+          save-data-file: false
+          # Surface regressions to the PR author + reviewer. Comment is
+          # posted on the head commit so it shows in the PR conversation.
+          comment-on-alert: true
+          alert-comment-cc-users: "@polaz"
+          alert-threshold: "130%"
+          fail-threshold: "160%"
+          # Red CI on >60% regression so a reviewer can't merge by
+          # accident without acknowledging the delta. Failing here does
+          # NOT block publish / baseline save (separate job).
+          fail-on-alert: true
+          benchmark-data-dir-path: dev/bench


### PR DESCRIPTION
## Summary

Splits the bench regression alert out of the `benchmark-aggregate` save path into its own `benchmark-regression-check` job that runs only on regular developer PRs.

Before: `Store benchmark results` step had `fail-on-alert: true` (on main push) and `save-data-file: true` in the same action call. Alert → step exits 1 → save never runs → baseline freezes → next main push hits the same alert vs the same stale baseline → freeze forever.

After:
- `benchmark-aggregate` keeps a save-only step (`auto-push` + `save-data-file` for main push, no alert/fail). Baseline always advances when bench shards pass.
- New `benchmark-regression-check` job runs read-only comparison + comment + fail-on-alert. Triggers ONLY when ALL of:
  - event is `pull_request`
  - head repo == base repo (excludes fork PRs that have no token access)
  - author is not `release-plz[bot]`
  - head branch does not start with `release-plz-`

## Why this design

- Main push is the immutable historical record. Regressions are visible on the dashboard at `dev/bench` over time — no need to red-CI them on main.
- release-plz PRs are version-bump only, perf comparison is pure noise — no gate.
- Fork PRs have no gh-pages token access so the alert step would emit a confusing comparison-failed line anyway.
- A red alert on a regular developer PR posts a comment on the head commit + pings `@polaz` so the regression is acknowledged before merge.

## Currently broken since

SHA `1e0f6954` (16 May 02:28 KYIV) — `compress/level_9_lazy/decodecorpus-z000033/matrix/pure_rust` ratio 1.67 vs baseline `fa2e9ff6`. Every main push since either failed at the same alert or got cancelled by concurrency. Bench dashboard at `dev/bench` has been stale for two days.

After this lands, the next main push that completes will advance the baseline regardless of regression magnitude. The `level_9_lazy` regression itself still needs investigation as a separate issue.

## Test plan

- YAML syntax validated (`python3 -c yaml.safe_load`)
- New job's `if:` evaluates correctly:
  - This PR: `pull_request` event, same-repo head, `polaz` author, branch `fix/#158-...` → runs gate
  - release-plz PRs: author check excludes → skipped
  - main push: event check excludes → skipped
- `benchmark-aggregate` save step now strictly gated on `push && main` so PR runs don't try to call it (the save action only runs once main merge happens)

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated benchmark regression testing on pull requests to detect performance regressions, with alerts posted to PR comments and CI failure when thresholds are exceeded.
  * Enhanced benchmark baseline saving on main branch pushes with improved alert management, now separating baseline storage from regression detection workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->