### PR TITLE
ci(bench): bump bench shard timeout_minutes to 120 — fixes stuck publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,21 +293,21 @@ jobs:
               "target_triple": "x86_64-unknown-linux-gnu",
               "build_setup": "",
               "runtime_setup": "",
-              "timeout_minutes": 45
+              "timeout_minutes": 120
             },
             {
               "id": "i686-gnu",
               "target_triple": "i686-unknown-linux-gnu",
               "build_setup": "sudo apt-get update && sudo apt-get install -y gcc-multilib libc6-dev-i386",
               "runtime_setup": "sudo apt-get update && sudo apt-get install -y libc6-dev-i386",
-              "timeout_minutes": 60
+              "timeout_minutes": 120
             },
             {
               "id": "x86_64-musl",
               "target_triple": "x86_64-unknown-linux-musl",
               "build_setup": "sudo apt-get update && sudo apt-get install -y musl-tools",
               "runtime_setup": "",
-              "timeout_minutes": 45
+              "timeout_minutes": 120
             }
           ]
           EOF


### PR DESCRIPTION
## Summary

Raises bench shard `timeout_minutes` from 45/60/45 (per-target) to a uniform **120 min** in `.github/workflows/ci.yml` (`bench-matrix` job, inside `targets.json`).

## Why

PR #153 already bumped timeouts from 25/30 to 45/60/45, but slow shards (`lazy`, `fast`) STILL cancel at the cap. Latest example — run [26003106160](https://github.com/structured-world/structured-zstd/actions/runs/26003106160) (sha bbc9db42, PR #159 merge):

- `Bench x86_64-gnu / lazy`: started 21:54:12Z, completed 22:39:29Z → 45m17s ⇒ hit cap, cancelled
- `Bench x86_64-gnu / fast` and `Bench x86_64-musl / lazy` cancelled same way

Cancelled shards cascade: `benchmark-aggregate` needs all shards → `benchmark-pages` skipped → dashboard at `dev/bench/` stays stale.

## Tests aren't cycling — they're just slow

Verified from log of a previously cancelled shard (job 76419168123, sha f3a6dad3):
- Iterations make linear progress through `(level, scenario, codec_side, stream_variant)` combinations
- No gaps in timestamps — each criterion iteration ≈ 9s
- Worst-case suite math: 11 lazy levels × ~5 scenarios × 2 sides × 2 stream variants × 2 ops ≈ 440 iterations × 9s ≈ 66 min

So 45 min was structurally insufficient. 120 min gives ~50% headroom on the slowest shards. GH-hosted runner cap is 360 min, so we're well within limits.

## Acceptance

- All three target entries (`x86_64-gnu`, `i686-gnu`, `x86_64-musl`) carry `timeout_minutes: 120`
- Next main push completes all bench shards within the new cap
- `benchmark-aggregate` succeeds → `benchmark-pages` runs → dashboard publishes

## Test plan

- YAML syntax validated
- 5-min change; effect verified on next main run after merge

Closes #160

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD benchmark job timeout configurations to improve pipeline stability during extended benchmark runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->