### PR TITLE
perf(fse): replace next_state linear search with donor-parity flat tables + tune CI bench budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,8 +264,18 @@ jobs:
     # `runtime_setup` runs only on the bench shards (e.g. `i686-gnu`
     # needs gcc-multilib's 32-bit loader at runtime, while `x86_64-musl`
     # only needs `musl-tools` for the build).
+    #
+    # Release-plz PRs are version-bump-only (no source changes), so the
+    # entire bench pipeline (matrix → build → shards → aggregate →
+    # pages → regression) is gated out for them via this `if:` filter.
+    # The skip cascades through `needs:` so downstream bench jobs
+    # also stay green-skipped on those PRs. See #164.
     name: Resolve bench target matrix
     needs: lint
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.user.login != 'release-plz[bot]' &&
+       !startsWith(github.head_ref, 'release-plz-'))
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,11 +279,13 @@ jobs:
           # only the two canonical levels (`level_3_dfast` = donor
           # default, `level_22_btultra2` = max compression) bundled
           # into a single shard per target — three shards total, cheap
-          # PR feedback. On a `push: main` (post-merge), one shard
-          # per strategy group runs (fast / dfast / greedy / lazy /
-          # btopt / btultra / btultra2 — seven groups × three targets
-          # = 21 shards), so the published gh-pages snapshot keeps
-          # full coverage for the dashboard + tagged baselines.
+          # PR feedback. On a `push: main` (post-merge), one shard per
+          # strategy group runs — nine groups (fast split into
+          # `fast-neg` / `fast-pos`; lazy split into `lazy-lower` /
+          # `lazy-upper` to keep the worst-case per-shard wall under
+          # the 120-min CI cap) × three targets = 27 shards, so the
+          # published gh-pages snapshot keeps full coverage for the
+          # dashboard + tagged baselines (#164).
           EVENT_NAME: ${{ github.event_name }}
         run: |
           cat > targets.json <<'EOF'
@@ -343,8 +345,12 @@ jobs:
             cat > shards.json <<'EOF'
           [
             {
-              "id": "fast",
-              "levels": "level_-7_fast,level_-6_fast,level_-5_fast,level_-4_fast,level_-3_fast,level_-2_fast,level_-1_fast,level_1_fast"
+              "id": "fast-neg",
+              "levels": "level_-7_fast,level_-6_fast,level_-5_fast,level_-4_fast,level_-3_fast"
+            },
+            {
+              "id": "fast-pos",
+              "levels": "level_-2_fast,level_-1_fast,level_1_fast"
             },
             {
               "id": "dfast",
@@ -355,8 +361,12 @@ jobs:
               "levels": "level_4_greedy"
             },
             {
-              "id": "lazy",
-              "levels": "level_5_lazy,level_6_lazy,level_7_lazy,level_8_lazy,level_9_lazy,level_10_lazy,level_11_lazy,level_12_lazy,level_13_lazy,level_14_lazy,level_15_lazy"
+              "id": "lazy-lower",
+              "levels": "level_5_lazy,level_6_lazy,level_7_lazy,level_8_lazy,level_9_lazy"
+            },
+            {
+              "id": "lazy-upper",
+              "levels": "level_10_lazy,level_11_lazy,level_12_lazy,level_13_lazy,level_14_lazy,level_15_lazy"
             },
             {
               "id": "btopt",
@@ -454,9 +464,10 @@ jobs:
         # Shard plan is resolved in `bench-matrix.outputs.shards`.
         # Each shard owns one strategy-grouped level bundle (PR runs
         # a single `pr-canonical` shard with level_3 + level_22; main
-        # runs seven strategy groups). `shard.levels` is a CSV that
-        # we forward into `STRUCTURED_ZSTD_BENCH_LEVEL_FILTER` so the
-        # bench binary iterates the requested levels in one process.
+        # runs nine strategy groups — see #164 for the fast/lazy
+        # split rationale). `shard.levels` is a CSV that we forward
+        # into `STRUCTURED_ZSTD_BENCH_LEVEL_FILTER` so the bench
+        # binary iterates the requested levels in one process.
         shard: ${{ fromJSON(needs.bench-matrix.outputs.shards) }}
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ zstd/fuzz/artifacts/**
 .idea
 /=
 AGENTS.md
+CLAUDE.md
 .claude/
 .local/
 **/__pycache__/

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -505,33 +505,65 @@ fn configure_group<M: criterion::measurement::Measurement>(
     group: &mut criterion::BenchmarkGroup<'_, M>,
     scenario: &Scenario,
 ) {
+    // CI wall-time tuning (#164):
+    //
+    // criterion 0.8 hard-asserts `sample_size >= 10` (`benchmark_group.rs:97`
+    // / `lib.rs:519`). The floor is set in source and cannot be lowered
+    // without forking criterion, so we tune `measurement_time` and
+    // `warm_up_time` to cut per-bench wall-clock instead.
+    //
+    // Pre-tuning budget per `bench_function` (one side):
+    //   Small:    3s measurement + 3s default warm-up = 6s
+    //   Corpus/Entropy: 8s + 3s default warm-up      = 11s
+    //   Large/Silesia:  10s + 0.5s warm-up           = 10.5s
+    //
+    // Each `pure_rust` / `c_ffi` pair doubles that. Across the 21
+    // strategy shards × ~7 scenarios × 3 bench groups (compress,
+    // decompress rust_stream, decompress c_stream) × 2 sides, the
+    // worst shard (`lazy`, 11 levels) reached the 120-min CI cap.
+    //
+    // Post-tuning (criterion still gets >= 10 samples; only the
+    // wall-clock budget shrinks where the measured per-iter is faster
+    // than the budget — slow-per-iter benches are bound by
+    // `samples × per_iter` regardless of budget):
+    //   Small:    1s + 0.2s = 1.2s per side (×2 = 2.4s) — 60% cut
+    //   Corpus/Entropy: 3s + 0.5s = 3.5s per side (×2 = 7s) — 68% cut
+    //   Large/Silesia:  20s + 0.5s — bumped UP from 10s. The slowest
+    //     combos on i686 (level_22_btultra2 / 100 MiB) need ~2 s per
+    //     iter × 10 samples ≈ 20 s wall; the old 10 s budget produced
+    //     persistent criterion "increase target time" warnings and
+    //     occasional flaky measurements. Budget is dwarfed by the
+    //     actual per-iter cost on slow combos, so this only widens the
+    //     warning-free envelope — fast combos still finish under
+    //     budget.
+    //
+    // For very small inputs (1-10 KiB) Small still keeps `sample_size(30)` to
+    // amortise the per-sample fixed cost across more measurements — those
+    // benches finish their 30 samples well inside 1 s thanks to tight
+    // per-iter timings.
     match scenario.class {
         ScenarioClass::Small => {
             group.sample_size(30);
-            group.measurement_time(Duration::from_secs(3));
+            group.measurement_time(Duration::from_secs(1));
+            group.warm_up_time(Duration::from_millis(200));
             group.sampling_mode(SamplingMode::Flat);
         }
         ScenarioClass::Corpus | ScenarioClass::Entropy => {
-            // criterion 0.8 hard-asserts `sample_size >= 10` at runtime,
-            // so dropping below 10 is not an option (commit 73868b0
-            // tried `sample_size(3)` and every bench shard panicked at
-            // `benchmark_group.rs:97: assertion failed: n >= 10`).
-            // Instead, give criterion enough wall-clock budget — the
-            // earlier warning was "increase target time to 5.2s" on the
-            // slowest combo (level_22_btultra2 + 1 MiB decodecorpus).
-            // 8s covers that with headroom while keeping per-shard
-            // total runtime bounded (~11 min worst-case strategy shard).
             group.sample_size(10);
-            group.measurement_time(Duration::from_secs(8));
+            group.measurement_time(Duration::from_secs(3));
+            group.warm_up_time(Duration::from_millis(500));
             group.sampling_mode(SamplingMode::Flat);
         }
         ScenarioClass::Large | ScenarioClass::Silesia => {
-            // Same `sample_size >= 10` floor. Large/Silesia payloads
-            // (~16-100 MiB) take longer per iteration, so bump the
-            // measurement budget further — 10s covers level_22_btultra2
-            // on 16 MiB streams with margin.
+            // Large/Silesia payloads (16-100 MiB) on slow targets
+            // (i686 + level_22_btultra2) need ~2 s per iter ×
+            // 10 samples ≈ 20 s wall. Old 10 s budget caused
+            // "increase target time" warnings + occasional flakies;
+            // widening to 20 s covers the slowest combo without
+            // affecting wall on faster targets (criterion exits the
+            // budget early when samples complete).
             group.sample_size(10);
-            group.measurement_time(Duration::from_secs(10));
+            group.measurement_time(Duration::from_secs(20));
             group.warm_up_time(Duration::from_millis(500));
             group.sampling_mode(SamplingMode::Flat);
         }

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -123,26 +123,99 @@ impl<V: AsMut<Vec<u8>>> FSEEncoder<'_, V> {
     }
 }
 
+/// Donor-parity per-symbol coding transform, mirroring upstream
+/// `FSE_symbolCompressionTransform` in `lib/compress/fse_compress.c`.
+/// Together with [`FSETable::state_table_flat`] this gives an O(1)
+/// next-state lookup in [`FSETable::next_state`], replacing the prior
+/// linear scan over `SymbolStates::states`.
+///
+/// Donor formulas (`FSE_encodeSymbol`, `fse_compress.c`):
+///
+/// ```text
+/// value       = (1 << acc_log) + current_state.index
+/// nb_bits_out = (value + delta_nb_bits) >> 16
+/// baseline    = current_state.index & !((1 << nb_bits_out) - 1)
+/// next_index  = state_table_flat[(value >> nb_bits_out) + delta_find_state]
+/// ```
+///
+/// `delta_find_state` is intentionally signed (can be negative for
+/// low-probability symbols — see the `-1 | 1` arm in
+/// `build_table_from_probabilities`); the indexing arithmetic on
+/// `state_table_flat` is signed-correct via the construction above
+/// (`(value >> nb_bits_out)` is always large enough to cover any
+/// negative offset, because of how delta_find_state is derived).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct SymbolTT {
+    pub(crate) delta_nb_bits: usize,
+    pub(crate) delta_find_state: isize,
+}
+
 #[derive(Debug, Clone)]
 pub struct FSETable {
     /// Indexed by symbol
     pub(super) states: [SymbolStates; 256],
     /// Sum of all states.states.len()
     pub(crate) table_size: usize,
+    /// Donor-parity flat next-state table — `state_table_flat[i]` is the
+    /// FSE state index that the encoder transitions TO when the
+    /// transition arithmetic resolves to slot `i`. Length is exactly
+    /// `table_size` (= `1 << acc_log`). Mirror of upstream
+    /// `nextStateTable` (`fse_compress.c`).
+    pub(super) state_table_flat: alloc::boxed::Box<[u16]>,
+    /// Per-symbol donor-parity coding transform — see [`SymbolTT`].
+    pub(super) symbol_tt: [SymbolTT; 256],
 }
 
 impl FSETable {
-    pub(crate) fn next_state(&self, symbol: u8, idx: usize) -> &State {
-        let states = &self.states[symbol as usize];
-        states.get(idx, self.table_size)
+    /// O(1) next-state lookup mirroring upstream `FSE_encodeSymbol`
+    /// (`lib/compress/fse_compress.c`). Was a linear scan over a
+    /// `Vec<State>` per symbol; the flat tables that drive the donor
+    /// arithmetic were already built during table construction and
+    /// previously discarded — now they live on the FSETable
+    /// ([`SymbolTT`] + [`Self::state_table_flat`]) and `next_state` is
+    /// pure arithmetic + one array load. See #164.
+    #[inline]
+    pub(crate) fn next_state(&self, symbol: u8, idx: usize) -> State {
+        // Donor formulas, transliterated:
+        //   value       = (1 << acc_log) + idx
+        //   nb_bits     = (value + delta_nb_bits) >> 16
+        //   baseline    = idx & !((1 << nb_bits) - 1)
+        //   next_index  = state_table_flat[(value >> nb_bits) + delta_find_state]
+        //
+        // `delta_find_state` is signed (`isize`) — for low-probability
+        // symbols it is intentionally negative. The combined right-shift
+        // `(value >> nb_bits)` is always large enough to keep the final
+        // index non-negative; this is a construction invariant from
+        // `build_table_from_probabilities`.
+        let tt = self.symbol_tt[symbol as usize];
+        let value = self.table_size + idx;
+        let nb_bits = (value + tt.delta_nb_bits) >> 16;
+        let mask = (1usize << nb_bits) - 1;
+        let baseline = idx & !mask;
+        let slot = ((value >> nb_bits) as isize + tt.delta_find_state) as usize;
+        let next_index = self.state_table_flat[slot] as usize;
+        State {
+            num_bits: nb_bits as u8,
+            baseline,
+            last_index: baseline + mask,
+            index: next_index,
+        }
     }
 
-    pub(crate) fn start_state(&self, symbol: u8) -> &State {
+    /// First-state lookup for the encode-init of a new FSE stream.
+    /// Stays on the `Vec<State>` storage because (a) it is called once
+    /// per stream (not on the hot per-sequence path), and (b) the
+    /// donor flat-table arithmetic for the start state would require
+    /// an extra special-case for the `1 << acc_log` "virtual" current
+    /// state. Returning by value matches the new [`Self::next_state`]
+    /// return shape so callers can store `State` directly without
+    /// juggling lifetimes.
+    pub(crate) fn start_state(&self, symbol: u8) -> State {
         let states = &self.states[symbol as usize];
         let slot = states
             .start_state_slot
             .expect("symbol must be present in the FSE table");
-        &states.states[slot]
+        states.states[slot]
     }
 
     pub fn acc_log(&self) -> u8 {
@@ -280,32 +353,28 @@ pub(super) struct SymbolStates {
     start_state_slot: Option<usize>,
 }
 
-impl SymbolStates {
-    fn get(&self, idx: usize, max_idx: usize) -> &State {
-        let start_search_at = (idx * self.states.len()) / max_idx;
-        self.states[start_search_at..]
-            .iter()
-            .find(|state| state.contains(idx))
-            .unwrap()
-    }
-}
+// SymbolStates::get (the old linear-scan next-state lookup) was
+// replaced by [`FSETable::next_state`]'s O(1) donor arithmetic in
+// #164. The Vec<State> storage remains for `start_state`,
+// `symbol_probability`, `max_num_bits_for_symbol`, and `write_table`.
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct State {
     /// How many bits the range of this state needs to be encoded as
     pub(crate) num_bits: u8,
     /// The first index targeted by this state
     pub(crate) baseline: usize,
-    /// The last index targeted by this state (baseline + the maximum number with numbits bits allows)
+    /// The last index targeted by this state (baseline + the maximum
+    /// number with numbits bits allows). Computed by
+    /// [`FSETable::next_state`] for parity with the old
+    /// `Vec<State>` storage and consumed by the BTreeSet dedup in the
+    /// table builder (`build_table_from_probabilities`); not read on
+    /// the encode hot path (the linear-search consumer was retired in
+    /// #164).
+    #[allow(dead_code)]
     pub(crate) last_index: usize,
     /// Index of this state in the decoding table
     pub(crate) index: usize,
-}
-
-impl State {
-    fn contains(&self, idx: usize) -> bool {
-        self.baseline <= idx && self.last_index >= idx
-    }
 }
 
 #[cfg(any(test, feature = "fuzz_exports"))]
@@ -605,6 +674,26 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
         state_table.extend(positions.iter().copied());
     }
 
+    // Donor `FSE_encodeSymbol` driver tables (`fse_compress.c`). Built
+    // alongside the legacy `Vec<State>` storage. The flat
+    // `state_table_flat` is the donor `nextStateTable` (u16 entries
+    // for direct memory parity); `symbol_tt[s]` holds the per-symbol
+    // `{delta_nb_bits, delta_find_state}`. Once populated these drive
+    // the O(1) `FSETable::next_state` arithmetic; the `Vec<State>` per
+    // symbol stays alive for `start_state` / `symbol_probability` /
+    // `max_num_bits_for_symbol` / `write_table` and the existing test
+    // suite, but is no longer touched on the encode hot path. See #164.
+    let mut state_table_flat: alloc::vec::Vec<u16> = alloc::vec::Vec::with_capacity(1 << acc_log);
+    for &slot in &state_table {
+        // `slot` originates from `idx` values bounded by
+        // `(1 << acc_log) - 1` (see the negative_idx / next_position
+        // distribution loops above), so `u16` is wide enough for
+        // every supported `acc_log` (max 12 → table_size 4096).
+        state_table_flat.push(slot as u16);
+    }
+    let state_table_flat: alloc::boxed::Box<[u16]> = state_table_flat.into_boxed_slice();
+    let mut symbol_tt = [SymbolTT::default(); 256];
+
     // Build encoder transitions directly from C `FSE_encodeSymbol()` formulas.
     let mut symbol_transform_total = 0usize;
     for (symbol, probability) in probs.iter().copied().enumerate() {
@@ -627,6 +716,10 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
                 )
             }
             _ => unreachable!(),
+        };
+        symbol_tt[symbol] = SymbolTT {
+            delta_nb_bits,
+            delta_find_state,
         };
         let state = &mut states[symbol];
         let init_nb_bits_out = (delta_nb_bits + (1 << 15)) >> 16;
@@ -674,6 +767,8 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
     FSETable {
         table_size: 1 << acc_log,
         states,
+        state_table_flat,
+        symbol_tt,
     }
 }
 

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -146,7 +146,13 @@ impl<V: AsMut<Vec<u8>>> FSEEncoder<'_, V> {
 /// negative offset, because of how delta_find_state is derived).
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct SymbolTT {
-    pub(crate) delta_nb_bits: usize,
+    /// Donor 16.16 fixed-point value. **`u32`, not `usize`** — on 16-bit
+    /// targets (AVR / MSP430 / Cortex-M0 in the no-atomic profile this
+    /// crate documents) `usize` is 16 bits, and `<<16` / `>>16` on a
+    /// `usize` would silently overflow to zero, breaking the
+    /// fixed-point math. Donor `fse_compress.c` uses `U32` throughout
+    /// the same arithmetic for the same reason.
+    pub(crate) delta_nb_bits: u32,
     pub(crate) delta_find_state: isize,
 }
 
@@ -187,9 +193,17 @@ impl FSETable {
         // `(value >> nb_bits)` is always large enough to keep the final
         // index non-negative; this is a construction invariant from
         // `build_table_from_probabilities`.
+        // Fixed-point arithmetic uses `u32` (donor parity, 16-bit-target
+        // safe — see `SymbolTT::delta_nb_bits` doc). `table_size` is
+        // `1 << acc_log` with `acc_log <= 12`, so `value <= 4096 + 4095`
+        // fits comfortably; the `<<16` half of the math lives entirely
+        // inside `delta_nb_bits` which was already computed in u32 by
+        // the builder. Result `nb_bits` is small (<= 8 for typical
+        // FSE tables) — cast to `usize` only at the final indexing
+        // sites (`(1usize << nb_bits)`, `value >> nb_bits` as slot).
         let tt = self.symbol_tt[symbol as usize];
-        let value = self.table_size + idx;
-        let nb_bits = (value + tt.delta_nb_bits) >> 16;
+        let value = (self.table_size + idx) as u32;
+        let nb_bits = ((value + tt.delta_nb_bits) >> 16) as usize;
         let mask = (1usize << nb_bits) - 1;
         let baseline = idx & !mask;
         let slot = ((value >> nb_bits) as isize + tt.delta_find_state) as usize;
@@ -701,14 +715,18 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
             continue;
         }
         let probability_abs = probability.unsigned_abs() as usize;
-        let (delta_nb_bits, delta_find_state) = match probability {
+        // Donor 16.16 fixed-point arithmetic — performed in `u32` so a
+        // 16-bit `usize` target (AVR / MSP430 / no-atomic Cortex-M0)
+        // can't silently overflow the `<<16` shift. Donor
+        // `fse_compress.c` keeps the same width.
+        let (delta_nb_bits, delta_find_state): (u32, isize) = match probability {
             -1 | 1 => (
-                ((acc_log as usize) << 16).saturating_sub(1usize << acc_log),
+                ((acc_log as u32) << 16).saturating_sub(1u32 << acc_log),
                 symbol_transform_total as isize - 1,
             ),
             probability if probability > 1 => {
-                let probability = probability as usize;
-                let max_bits_out = acc_log as usize - (probability - 1).ilog2() as usize;
+                let probability = probability as u32;
+                let max_bits_out = (acc_log as u32) - (probability - 1).ilog2();
                 let min_state_plus = probability << max_bits_out;
                 (
                     (max_bits_out << 16).saturating_sub(min_state_plus),
@@ -738,8 +756,11 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
         // lookup depends on which duplicate-keyed entry shows up first.
         let mut seen: BTreeSet<(usize, usize, usize, u8)> = BTreeSet::new();
         for current_index in 0..(1usize << acc_log) {
-            let current_value = (1usize << acc_log) + current_index;
-            let num_bits = (current_value + delta_nb_bits) >> 16;
+            // Same 16.16 fixed-point arithmetic as `next_state` —
+            // keep in `u32` for 16-bit-target safety, then cast back
+            // to `usize` at indexing sites.
+            let current_value = (1u32 << acc_log) + (current_index as u32);
+            let num_bits = ((current_value + delta_nb_bits) >> 16) as usize;
             let next_state_idx = (current_value >> num_bits) as isize + delta_find_state;
             let next_index = state_table[next_state_idx as usize];
             let mask = (1usize << num_bits) - 1;


### PR DESCRIPTION
## Summary

Two changes in one PR (per scope expansion request).

### 1. FSE encode hot path: replace linear search with donor-parity flat tables — perf

`FSETable::next_state` previously linear-scanned a `Vec<State>` per symbol to find the entry whose `[baseline, last_index]` range contained the current state index. For each emitted sequence: 3 such scans (LL, ML, OF). The donor (`fse_compress.c::FSE_encodeSymbol`) does the same lookup in O(1) via flat `nextStateTable` + per-symbol `FSE_symbolCompressionTransform`.

The flat tables were **already computed** in our `build_table_from_probabilities` to seed the per-symbol `Vec<State>`, then discarded. This PR stores them on `FSETable` (`state_table_flat: Box<[u16]>` + `symbol_tt: [SymbolTT; 256]`) and switches `next_state` to donor arithmetic:

```rust
let value = (1 << acc_log) + idx;
let nb_bits = (value + tt.delta_nb_bits) >> 16;
let baseline = idx & !((1 << nb_bits) - 1);
let next_index = state_table_flat[(value >> nb_bits) + tt.delta_find_state];
```

`State` becomes `Copy`; `next_state` / `start_state` now return `State` by value; `SymbolStates::get` retired. Dead `State.last_index` kept (used by the builder's BTreeSet dedup key) with `#[allow(dead_code)]`.

**Standalone A/B (200 iters, level 3, same session):**

| Fixture | Baseline | After | Δ |
|---------|---------:|------:|--:|
| **z000033 (target, compressible)** | 20543 µs | 18286 µs | **−11.0%** |
| 1 MiB pseudo-random | 699 µs | 712 µs | +2% (noise) |
| 1 MiB repeating pattern | 1179 µs | 1183 µs | neutral |

Random / repeating-pattern inputs barely touch `encode_sequences` (raw fast-path / single short block) so the change is correctly neutral there.

### 2. CI bench tuning — wall-time

criterion 0.8 hard-asserts `sample_size >= 10`, so `sample_size(3)` is off the table without forking criterion. Two complementary tweaks bring the worst-case shard (`lazy`) under the 120-min cap:

**`configure_group` budgets:**

| Class | Old | New |
|-------|-----|-----|
| Small (1–10 KiB) | 3 s + ~3 s warmup | 1 s + 0.2 s |
| Corpus/Entropy (1 MiB) | 8 s + ~3 s warmup | 3 s + 0.5 s |
| Large/Silesia (16–100 MiB) | 10 s + 0.5 s | **20 s** + 0.5 s |

Small/Corpus/Entropy were budget-bound — the wall budget exceeded what samples actually needed. Large/Silesia was the opposite — 10 s was too tight on i686 / level_22_btultra2 / 100 MiB (~2 s × 10 samples ≈ 20 s wall), producing persistent "increase target time" warnings. The 20 s bump matches the realistic floor without affecting fast combos (criterion exits the budget early once samples complete).

**Shard split (`.github/workflows/ci.yml`):**

- `fast` (8 levels) → `fast-neg` (-7..=-3) + `fast-pos` (-2..=-1, 1)
- `lazy` (11 levels) → `lazy-lower` (5..=9) + `lazy-upper` (10..=15)

Other shards unchanged. Total strategy groups go from 7 to 9 → main-push matrix expands from 21 to 27 jobs, each smaller.

### 3. Bonus: add `CLAUDE.md` to `.gitignore`

Project-local Claude rules file, mirrors the already-ignored `.claude/` and `AGENTS.md`. Stops untracked file from showing up in `git status`.

## Test plan

- `cargo nextest run -p structured-zstd --features "dict_builder bench_internals"` 526/526 ✅
- `cargo test --doc --features "dict_builder bench_internals"` 12/12 ✅
- `cargo clippy --features "dict_builder bench_internals" --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- `level22_sequences_match_donor_on_corpus_proxy` (ratio gate) PASS ✅
- `python3 -c "yaml.safe_load(open('.github/workflows/ci.yml'))"` ✅
- Standalone A/B numbers above

Closes #164


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compression encoder internals to reduce overhead and speed up encoding hot paths.

* **Chores**
  * Increased CI benchmark sharding on main to broaden coverage across workload types.
  * Adjusted benchmark measurement budgets and warm-up timing to better fit CI runtime constraints.
  * Added a development file pattern to .gitignore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->