### PR TITLE
perf(encoder): donor-parity greedy parse at L4 — ratio + speed win

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4117,6 +4117,209 @@ fn driver_level4_greedy_round_trip_cross_slice() {
     );
 }
 
+/// Helper: round-trip `data` through the L4 greedy parse and assert
+/// the reconstructed bytes match. Returns `(triple_count, max_offset)`
+/// so callers can probe parse shape (matches emitted, max-offset).
+#[cfg(test)]
+fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (usize, usize) {
+    let mut driver = MatchGeneratorDriver::new(slice_size, max_slices);
+    driver.reset(CompressionLevel::Level(4));
+
+    let mut reconstructed: Vec<u8> = Vec::with_capacity(data.len());
+    let mut triple_count = 0usize;
+    let mut max_offset = 0usize;
+
+    // `start_matching` consumes the current pending slice; multi-slice
+    // payloads require commit + drive per slice so earlier slices'
+    // bytes actually round-trip out before they're displaced from the
+    // window.
+    let mut offset_in_data = 0usize;
+    while offset_in_data < data.len() {
+        let mut space = driver.get_next_space();
+        let space_cap = space.len();
+        let take = (data.len() - offset_in_data).min(space_cap);
+        space[..take].copy_from_slice(&data[offset_in_data..offset_in_data + take]);
+        space.truncate(take);
+        driver.commit_space(space);
+        offset_in_data += take;
+
+        driver.start_matching(|seq| match seq {
+            Sequence::Literals { literals } => reconstructed.extend_from_slice(literals),
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => {
+                triple_count += 1;
+                if offset > max_offset {
+                    max_offset = offset;
+                }
+                reconstructed.extend_from_slice(literals);
+                let start = reconstructed.len() - offset;
+                for i in 0..match_len {
+                    let byte = reconstructed[start + i];
+                    reconstructed.push(byte);
+                }
+            }
+        });
+    }
+
+    // Empty payload still needs one commit/drive round so the empty-
+    // input path of `start_matching_greedy` (the `current_len == 0`
+    // early-return guard) gets exercised.
+    if data.is_empty() {
+        let mut space = driver.get_next_space();
+        space.truncate(0);
+        driver.commit_space(space);
+        driver.start_matching(|seq| match seq {
+            Sequence::Literals { literals } => reconstructed.extend_from_slice(literals),
+            Sequence::Triple { .. } => panic!("empty input must not emit any matches"),
+        });
+    }
+
+    assert_eq!(reconstructed, data, "L4 greedy round-trip diverged");
+    (triple_count, max_offset)
+}
+
+/// CodeRabbit-flagged tail rep-only case: the previous outer-loop
+/// guard `pos + ROW_MIN_MATCH_LEN <= current_len` (6) meant the last
+/// 5-byte position was unreachable. The rep probe at `abs_pos + 1`
+/// only needs 4 bytes of lookahead beyond the probe point, so the
+/// guard was relaxed to `pos + GREEDY_MIN_LOOKAHEAD <= current_len`
+/// (5). Construct a slice whose tail position carries a 4-byte
+/// repcode match that would have been missed under the old guard.
+#[test]
+fn driver_level4_greedy_tail_rep_only_reachable() {
+    // Cross-slice: first slice establishes a 4-byte repeating
+    // anchor; second slice ends exactly at a position whose
+    // `abs_pos + 1..abs_pos + 5` matches a repcode reaching back
+    // into the first slice.
+    let first: &[u8] = b"BEEF_BEEF_aaaaaa"; // 16 bytes — "BEEF" pattern + filler
+    let second: &[u8] = b"xyzBEEF"; // 7 bytes — last 4 bytes are a rep
+    let mut combined = first.to_vec();
+    combined.extend_from_slice(second);
+    let (triples, _) = l4_greedy_round_trip(16, 2, &combined);
+    // The parse must emit at least one match — exactly the case the
+    // tightened guard ensures is reachable.
+    assert!(
+        triples >= 1,
+        "tail rep-only position must produce a match (got {triples} triples)",
+    );
+}
+
+#[test]
+fn driver_level4_greedy_empty_input_emits_nothing() {
+    // Empty input: no slices committed → no sequences emitted, no
+    // panic. Exercises the `current_len == 0` early-return guard at
+    // the top of `start_matching_greedy`.
+    let mut driver = MatchGeneratorDriver::new(64, 2);
+    driver.reset(CompressionLevel::Level(4));
+    // Commit an empty space so the matcher has SOMETHING to start
+    // matching on (otherwise `start_matching` panics on the
+    // `window.back()` unwrap — that's a separate path covered by
+    // existing reset tests).
+    let mut space = driver.get_next_space();
+    space.truncate(0);
+    driver.commit_space(space);
+    let mut emitted_anything = false;
+    driver.start_matching(|_| emitted_anything = true);
+    assert!(!emitted_anything, "empty slice must not emit any sequences",);
+}
+
+#[test]
+fn driver_level4_greedy_sub_min_lookahead_input() {
+    // Input shorter than `GREEDY_MIN_LOOKAHEAD = 5` — the outer loop
+    // never executes a body iteration; the tail literal path must
+    // still emit the input bytes as a single `Sequence::Literals`.
+    let data: &[u8] = b"abcd"; // 4 bytes
+    let (triples, _) = l4_greedy_round_trip(64, 2, data);
+    assert_eq!(
+        triples, 0,
+        "sub-min-lookahead input must not emit any matches (got {triples})",
+    );
+}
+
+#[test]
+fn driver_level4_greedy_incompressible_input() {
+    // Pseudo-random bytes with no exploitable structure — every
+    // position is a "miss" in both the rep probe and the row
+    // candidate. Exercises the miss branch + `SKIP_STRENGTH = 10`
+    // skip-step grow (irrelevant at this size, but the path runs).
+    let mut data = alloc::vec::Vec::with_capacity(256);
+    let mut x: u32 = 0xDEAD_BEEF;
+    for _ in 0..256 {
+        x = x.wrapping_mul(1_103_515_245).wrapping_add(12345);
+        data.push((x >> 16) as u8);
+    }
+    let (_triples, _) = l4_greedy_round_trip(64, 8, &data);
+    // No structural assertion — the test passes if round-trip is
+    // bit-exact and no panic / debug_assert fires.
+}
+
+#[test]
+fn driver_level4_greedy_long_literal_run_skip_step_growth() {
+    // 2 KiB of unstructured bytes drives the literal-run length past
+    // the `SKIP_STRENGTH = 10` threshold (~1 KiB) so the per-miss
+    // step grows beyond 1. Without this regression test, a future
+    // change to `SKIP_STRENGTH` could silently skip valid match
+    // positions on long literal runs without anyone noticing — round-
+    // trip still passes, but the parse-loop iteration count would
+    // drift.
+    let mut data = alloc::vec::Vec::with_capacity(2048);
+    let mut x: u32 = 0xC0FF_EE00;
+    for _ in 0..2048 {
+        x = x.wrapping_mul(0x9E37_79B9).wrapping_add(0xCAFEBABE);
+        data.push((x >> 24) as u8);
+    }
+    let (_triples, _) = l4_greedy_round_trip(512, 8, &data);
+}
+
+#[test]
+fn driver_level4_greedy_all_zeros_heavy_rep1() {
+    // All zeros: every position after the first byte has `byte[pos]
+    // == byte[pos - 1]`, so the rep1 probe at `abs_pos + 1` hits
+    // immediately and the parse collapses to a single long match.
+    // Exercises the `cheap rep at +1, full-match length` path.
+    let data: Vec<u8> = alloc::vec![0u8; 128];
+    let (triples, max_offset) = l4_greedy_round_trip(64, 8, &data);
+    assert!(
+        triples >= 1,
+        "all-zeros input must produce at least one rep1 match",
+    );
+    // The dominant match should reference rep1 (offset 1), since
+    // every byte at pos matches pos-1. A larger offset would
+    // indicate the rep1 probe was bypassed.
+    assert_eq!(
+        max_offset, 1,
+        "all-zeros L4 greedy parse should commit at offset 1 (got {max_offset})",
+    );
+}
+
+/// Periodic-pattern payload covers the steady-state rep-cascade path
+/// of the greedy parse — the main-loop rep probe at `abs_pos + 1`
+/// fires every iteration once the period is locked into
+/// `offset_hist[0]`, and the parse emits a long chain of triples at
+/// the same offset.
+#[test]
+fn driver_level4_greedy_periodic_pattern_rep_cascade() {
+    let unit: &[u8] = b"alpha_beta_gamma";
+    assert_eq!(unit.len(), 16);
+    let mut data: Vec<u8> = Vec::with_capacity(unit.len() * 32);
+    for _ in 0..32 {
+        data.extend_from_slice(unit);
+    }
+    let (triples, max_offset) = l4_greedy_round_trip(64, 16, &data);
+    assert!(
+        triples >= 1,
+        "periodic 16-byte payload must emit matches (got {triples})",
+    );
+    assert!(
+        max_offset >= 16,
+        "periodic 16-byte payload must produce at least one offset >= 16 \
+         (got max_offset = {max_offset})",
+    );
+}
+
 #[test]
 fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
     use super::strategy::StrategyTag;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -283,7 +283,7 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, hash_fill_step: 1, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
     /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
     /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
@@ -1220,7 +1220,23 @@ impl MatchGeneratorDriver {
                 while matcher.next_sequence(&mut *handle_sequence) {}
             }
             BackendTag::Dfast => self.dfast_matcher_mut().start_matching(handle_sequence),
-            BackendTag::Row => self.row_matcher_mut().start_matching(handle_sequence),
+            BackendTag::Row => {
+                // Donor `ZSTD_compressBlock_lazy_generic` with `depth == 0`
+                // is a structurally different parse (default `start = ip + 1`,
+                // greedy repcode commit, immediate-rep loop after store)
+                // versus the lazy / lazy2 parse used by L5+. Dispatch on
+                // the runtime `lazy_depth` knob so L4 takes the dedicated
+                // greedy path while L5+ keeps the existing lazy machinery
+                // — `pick_lazy_match` is what gives L5+ its ratio win, and
+                // we don't want to retire that path just because L4 wants
+                // donor-parity greedy.
+                let matcher = self.row_matcher_mut();
+                if matcher.lazy_depth == 0 {
+                    matcher.start_matching_greedy(handle_sequence);
+                } else {
+                    matcher.start_matching(handle_sequence);
+                }
+            }
             BackendTag::HashChain => self
                 .hc_matcher_mut()
                 .start_matching_strategy::<S>(handle_sequence),

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4205,24 +4205,52 @@ fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (u
 /// 5-byte position was unreachable. The rep probe at `abs_pos + 1`
 /// only needs 4 bytes of lookahead beyond the probe point, so the
 /// guard was relaxed to `pos + GREEDY_MIN_LOOKAHEAD <= current_len`
-/// (5). Construct a slice whose tail position carries a 4-byte
-/// repcode match that would have been missed under the old guard.
+/// (5). This test drives the slices separately and asserts a match
+/// is emitted **from the second slice's parse pass**, so a future
+/// regression that re-tightens the guard or breaks the cross-slice
+/// repcode lookup fails the test instead of being masked by
+/// first-slice matches.
 #[test]
 fn driver_level4_greedy_tail_rep_only_reachable() {
-    // Cross-slice: first slice establishes a 4-byte repeating
-    // anchor; second slice ends exactly at a position whose
-    // `abs_pos + 1..abs_pos + 5` matches a repcode reaching back
-    // into the first slice.
-    let first: &[u8] = b"BEEF_BEEF_aaaaaa"; // 16 bytes — "BEEF" pattern + filler
-    let second: &[u8] = b"xyzBEEF"; // 7 bytes — last 4 bytes are a rep
-    let mut combined = first.to_vec();
-    combined.extend_from_slice(second);
-    let (triples, _) = l4_greedy_round_trip(16, 2, &combined);
-    // The parse must emit at least one match — exactly the case the
-    // tightened guard ensures is reachable.
+    // Period-4 first slice locks rep1 = 4 into `offset_hist` by the
+    // time the parse reaches the slice tail. Second slice is exactly
+    // 5 bytes ( = `GREEDY_MIN_LOOKAHEAD`) so the outer loop runs
+    // **once** at `pos = 0`; the regular `row_candidate` requires 6
+    // bytes from `abs_pos`, which is past the live history, so the
+    // only viable hit is the `abs_pos + 1` rep probe. `second[0..]`
+    // is shaped so the rep probe at `abs_pos + 1` finds a 4-byte
+    // match at offset 4 (`second[1..5] == first[13..16] ++ second[0]
+    // == "BCDA"`), and `extend_backwards_shared` then absorbs
+    // `second[0]` into the match (extending one byte back into the
+    // implicit anchor, no further because anchor itself is the
+    // current `abs_pos`).
+    let first: &[u8] = b"ABCDABCDABCDABCD"; // 16 bytes — strict period 4
+    let second: &[u8] = b"ABCDA"; // 5 bytes — exact GREEDY_MIN_LOOKAHEAD
+    let mut driver = MatchGeneratorDriver::new(16, 2);
+    driver.reset(CompressionLevel::Level(4));
+
+    let mut first_space = driver.get_next_space();
+    first_space[..first.len()].copy_from_slice(first);
+    first_space.truncate(first.len());
+    driver.commit_space(first_space);
+    driver.start_matching(|_| {});
+
+    let mut second_space = driver.get_next_space();
+    second_space[..second.len()].copy_from_slice(second);
+    second_space.truncate(second.len());
+    driver.commit_space(second_space);
+
+    let mut second_slice_triples = 0usize;
+    driver.start_matching(|seq| {
+        if matches!(seq, Sequence::Triple { .. }) {
+            second_slice_triples += 1;
+        }
+    });
+
     assert!(
-        triples >= 1,
-        "tail rep-only position must produce a match (got {triples} triples)",
+        second_slice_triples >= 1,
+        "tail rep-only position must produce a match in the second slice \
+         (got {second_slice_triples} triples)",
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3992,15 +3992,16 @@ fn driver_level4_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(4));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
-    // Greedy-specific routing assertion: `MatchGeneratorDriver::
-    // start_matching` for `BackendTag::Row` has a
+    // Greedy-specific routing assertion: the `BackendTag::Row` arm of
+    // `MatchGeneratorDriver::compress_block` has a
     // `debug_assert_eq!(matcher.lazy_depth, 0)` invariant that
     // dispatches L4 unconditionally into `start_matching_greedy`.
-    // If a future change rerouted L4 through the `start_matching`
-    // (depth >= 1) path, this assertion would catch it before the
-    // round-trip tests below — round-trip alone passes on the lazy
-    // parser too. Together with the round-trip suite this pins the
-    // greedy-vs-lazy routing decision at the level table layer.
+    // If a future change rerouted L4 through the
+    // `RowMatchGenerator::start_matching` (depth >= 1) path, this
+    // assertion would catch it before the round-trip tests below —
+    // round-trip alone passes on the lazy parser too. Together with
+    // the round-trip suite this pins the greedy-vs-lazy routing
+    // decision at the level table layer.
     assert_eq!(
         driver.row_matcher().lazy_depth,
         0,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1221,21 +1221,30 @@ impl MatchGeneratorDriver {
             }
             BackendTag::Dfast => self.dfast_matcher_mut().start_matching(handle_sequence),
             BackendTag::Row => {
-                // Donor `ZSTD_compressBlock_lazy_generic` with `depth == 0`
-                // is a structurally different parse (default `start = ip + 1`,
-                // greedy repcode commit, immediate-rep loop after store)
-                // versus the lazy / lazy2 parse used by L5+. Dispatch on
-                // the runtime `lazy_depth` knob so L4 takes the dedicated
-                // greedy path while L5+ keeps the existing lazy machinery
-                // — `pick_lazy_match` is what gives L5+ its ratio win, and
-                // we don't want to retire that path just because L4 wants
-                // donor-parity greedy.
+                // The Row backend is currently selected only by
+                // `StrategyTag::Greedy` (level 4) — see
+                // `StrategyTag::backend` in `strategy.rs`. Donor
+                // `ZSTD_compressBlock_lazy_generic` with `depth == 0`
+                // is a structurally different parse (default
+                // `start = ip + 1`, greedy repcode commit,
+                // immediate-rep loop after store) versus the lazy /
+                // lazy2 parse the plain `start_matching` runs, so L4
+                // dispatches directly to `start_matching_greedy`.
+                //
+                // The `debug_assert!` documents the invariant: any
+                // future routing of L5+ through the Row backend must
+                // first decide whether `start_matching_greedy` (depth
+                // == 0) or `start_matching` (depth >= 1, with
+                // `pick_lazy_match`) is the right entry point and
+                // adjust this dispatch accordingly. Today only
+                // `lazy_depth == 0` ever lands here.
                 let matcher = self.row_matcher_mut();
-                if matcher.lazy_depth == 0 {
-                    matcher.start_matching_greedy(handle_sequence);
-                } else {
-                    matcher.start_matching(handle_sequence);
-                }
+                debug_assert_eq!(
+                    matcher.lazy_depth, 0,
+                    "Row backend currently expects lazy_depth == 0 (donor-greedy); \
+                     wire a depth-aware dispatch before routing lazy levels here",
+                );
+                matcher.start_matching_greedy(handle_sequence);
             }
             BackendTag::HashChain => self
                 .hc_matcher_mut()
@@ -3983,6 +3992,129 @@ fn driver_level4_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(4));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
+}
+
+/// Level 4 maps to `StrategyTag::Greedy` which dispatches into
+/// [`super::row::RowMatchGenerator::start_matching_greedy`]. Round-trip
+/// a small repeating pattern and a cross-slice case so the donor-parity
+/// greedy parse (default `start = pos + 1`, repcode probe, immediate-rep
+/// loop, miss skip-step) cannot silently drift without also breaking
+/// reconstruction.
+#[test]
+fn driver_level4_greedy_round_trip_single_slice() {
+    let mut driver = MatchGeneratorDriver::new(64, 2);
+    driver.reset(CompressionLevel::Level(4));
+    let input = b"abcdefgh_abcdefgh_abcdefgh_abcdefgh";
+    let mut space = driver.get_next_space();
+    space[..input.len()].copy_from_slice(input);
+    space.truncate(input.len());
+    driver.commit_space(space);
+
+    let mut reconstructed: Vec<u8> = Vec::new();
+    let mut saw_triple = false;
+    driver.start_matching(|seq| match seq {
+        Sequence::Literals { literals } => reconstructed.extend_from_slice(literals),
+        Sequence::Triple {
+            literals,
+            offset,
+            match_len,
+        } => {
+            saw_triple = true;
+            reconstructed.extend_from_slice(literals);
+            let start = reconstructed.len() - offset;
+            for i in 0..match_len {
+                let byte = reconstructed[start + i];
+                reconstructed.push(byte);
+            }
+        }
+    });
+    assert_eq!(
+        reconstructed,
+        input.to_vec(),
+        "L4 greedy parse failed to reconstruct repeating-pattern input",
+    );
+    assert!(
+        saw_triple,
+        "L4 greedy parse on a repeating pattern must emit at least one match (Triple)",
+    );
+}
+
+#[test]
+fn driver_level4_greedy_round_trip_cross_slice() {
+    // Verifies that the greedy parse carries repcode / hash-table state
+    // across slice boundaries: the second slice repeats the first byte
+    // for byte, so the parse must pick up matches reaching back into
+    // the previous slice's history.
+    let mut driver = MatchGeneratorDriver::new(32, 4);
+    driver.reset(CompressionLevel::Level(4));
+    let chunk = b"the quick brown fox jumps over!!";
+    assert_eq!(chunk.len(), 32);
+
+    let mut first = driver.get_next_space();
+    first[..chunk.len()].copy_from_slice(chunk);
+    first.truncate(chunk.len());
+    driver.commit_space(first);
+
+    let mut first_recon: Vec<u8> = Vec::new();
+    driver.start_matching(|seq| match seq {
+        Sequence::Literals { literals } => first_recon.extend_from_slice(literals),
+        Sequence::Triple {
+            literals,
+            offset,
+            match_len,
+        } => {
+            first_recon.extend_from_slice(literals);
+            let start = first_recon.len() - offset;
+            for i in 0..match_len {
+                let byte = first_recon[start + i];
+                first_recon.push(byte);
+            }
+        }
+    });
+    assert_eq!(
+        first_recon,
+        chunk.to_vec(),
+        "first slice failed to round-trip"
+    );
+
+    let mut second = driver.get_next_space();
+    second[..chunk.len()].copy_from_slice(chunk);
+    second.truncate(chunk.len());
+    driver.commit_space(second);
+
+    let mut full = first_recon.clone();
+    let mut saw_cross_slice_match = false;
+    driver.start_matching(|seq| match seq {
+        Sequence::Literals { literals } => full.extend_from_slice(literals),
+        Sequence::Triple {
+            literals,
+            offset,
+            match_len,
+        } => {
+            // A match whose offset reaches >= the current slice's literal
+            // run plus the second slice's index means we matched into the
+            // first slice — exactly the cross-slice behavior under test.
+            if offset >= chunk.len() {
+                saw_cross_slice_match = true;
+            }
+            full.extend_from_slice(literals);
+            let start = full.len() - offset;
+            for i in 0..match_len {
+                let byte = full[start + i];
+                full.push(byte);
+            }
+        }
+    });
+    let mut expected = chunk.to_vec();
+    expected.extend_from_slice(chunk);
+    assert_eq!(
+        full, expected,
+        "cross-slice L4 greedy parse failed to reconstruct"
+    );
+    assert!(
+        saw_cross_slice_match,
+        "L4 greedy parse must match across slice boundaries (history is shared)",
+    );
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4306,12 +4306,19 @@ fn driver_level4_greedy_incompressible_input() {
 #[test]
 fn driver_level4_greedy_long_literal_run_skip_step_growth() {
     // 2 KiB of unstructured bytes drives the literal-run length past
-    // the `SKIP_STRENGTH = 10` threshold (~1 KiB) so the per-miss
-    // step grows beyond 1. Without this regression test, a future
-    // change to `SKIP_STRENGTH` could silently skip valid match
-    // positions on long literal runs without anyone noticing — round-
-    // trip still passes, but the parse-loop iteration count would
-    // drift.
+    // the `SKIP_STRENGTH = 10` threshold (~1 KiB), so the miss branch
+    // + per-miss step-grow path in `start_matching_greedy` is
+    // exercised. This test is a stress smoke — it only asserts
+    // bit-exact round-trip + no panic / `debug_assert!` fires; it
+    // does NOT pin the `SKIP_STRENGTH` constant or the per-iteration
+    // step count (round-trip would still pass on `SKIP_STRENGTH = 6`
+    // or `= 14` since both produce valid sequences). Pinning the
+    // exact step growth would require returning step / iteration
+    // metadata from the parse, which is invasive plumbing for a
+    // constant that hasn't been re-tuned in months. The value of
+    // this test is catching panics or correctness regressions on
+    // long incompressible runs, which is what its existing
+    // round-trip assertion checks.
     let mut data = alloc::vec::Vec::with_capacity(2048);
     let mut x: u32 = 0xC0FF_EE00;
     for _ in 0..2048 {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3992,14 +3992,32 @@ fn driver_level4_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(4));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
+    // Greedy-specific routing assertion: `MatchGeneratorDriver::
+    // start_matching` for `BackendTag::Row` has a
+    // `debug_assert_eq!(matcher.lazy_depth, 0)` invariant that
+    // dispatches L4 unconditionally into `start_matching_greedy`.
+    // If a future change rerouted L4 through the `start_matching`
+    // (depth >= 1) path, this assertion would catch it before the
+    // round-trip tests below — round-trip alone passes on the lazy
+    // parser too. Together with the round-trip suite this pins the
+    // greedy-vs-lazy routing decision at the level table layer.
+    assert_eq!(
+        driver.row_matcher().lazy_depth,
+        0,
+        "L4 must route to start_matching_greedy (lazy_depth == 0)",
+    );
 }
 
 /// Level 4 maps to `StrategyTag::Greedy` which dispatches into
 /// [`super::row::RowMatchGenerator::start_matching_greedy`]. Round-trip
-/// a small repeating pattern and a cross-slice case so the donor-parity
-/// greedy parse (default `start = pos + 1`, repcode probe, immediate-rep
-/// loop, miss skip-step) cannot silently drift without also breaking
-/// reconstruction.
+/// alone doesn't pin the greedy-vs-lazy choice (a lazy parser would
+/// also reconstruct the input correctly) — that piece is locked down
+/// by the `lazy_depth == 0` assertion in
+/// [`driver_level4_selects_row_backend`]. This test guards the parse
+/// output itself: a small repeating pattern must produce at least one
+/// `Sequence::Triple`, so a future regression that emits literals-only
+/// (e.g. a `min_match` or rep-probe guard regression) is caught
+/// independently of routing.
 #[test]
 fn driver_level4_greedy_round_trip_single_slice() {
     let mut driver = MatchGeneratorDriver::new(64, 2);

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -238,7 +238,8 @@ impl RowMatchGenerator {
     ///
     /// Mirrors `ZSTD_compressBlock_lazy_generic` (`zstd_lazy.c:1560`) with
     /// `depth == 0`, `dictMode == ZSTD_noDict`. The structural features
-    /// that distinguish "greedy" from a depth-1 lazy with `lazy_depth = 0`:
+    /// that distinguish this greedy parse from the lazy parse in
+    /// [`Self::start_matching`] (which `lazy_depth >= 1` strategies use):
     ///
     /// 1. **Default `start = pos + 1`**: each iteration first probes the
     ///    repcode bank at `abs_pos + 1` (treating one literal byte as

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -169,8 +169,9 @@ impl RowMatchGenerator {
     ///
     /// Currently unused: the only strategy mapped to `BackendTag::Row`
     /// is `StrategyTag::Greedy` (level 4), which dispatches to
-    /// [`Self::start_matching_greedy`] via the `debug_assert!` in
-    /// `MatchGeneratorDriver::start_matching`. This method is kept as
+    /// [`Self::start_matching_greedy`] via the `debug_assert_eq!` in
+    /// the `BackendTag::Row` arm of
+    /// `MatchGeneratorDriver::compress_block`. This method is kept as
     /// scaffolding for the case where a future level routes a lazy
     /// strategy through the Row backend — extracting `pick_lazy_match`
     /// behavior to a fresh module then would mean re-deriving the
@@ -408,6 +409,19 @@ impl RowMatchGenerator {
 
             // Emit sequence.
             let start = candidate.start - current_abs_start;
+            // Index `[abs_pos, candidate.start + match_len)`, NOT
+            // `[candidate.start, candidate.start + match_len)`.
+            // `extend_backwards_shared` can move `candidate.start`
+            // below `abs_pos` by absorbing literal bytes that the
+            // outer loop already indexed on earlier miss iterations
+            // via `insert_position(abs_pos)`. Re-indexing them here
+            // would write the same `abs_pos -> position` mapping
+            // into the row table a second time, evicting more recent
+            // / more useful slot tenants from the same row's chain.
+            // Measured on `decodecorpus-z000033`: the
+            // `candidate.start` lower bound regresses `rust_bytes` by
+            // ~+447 over `abs_pos` (537897 -> 538344), so the
+            // narrower range is intentional.
             self.insert_positions(abs_pos, candidate.start + candidate.match_len);
             let current = self.window.back().unwrap().as_slice();
             let literals = &current[literals_start..start];

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -221,6 +221,237 @@ impl RowMatchGenerator {
         }
     }
 
+    /// Donor-parity greedy parse for `lazy_depth == 0` (level 4).
+    ///
+    /// Mirrors `ZSTD_compressBlock_lazy_generic` (`zstd_lazy.c:1560`) with
+    /// `depth == 0`, `dictMode == ZSTD_noDict`. The structural features
+    /// that distinguish "greedy" from a depth-1 lazy with `lazy_depth = 0`:
+    ///
+    /// 1. **Default `start = pos + 1`**: each iteration first probes the
+    ///    repcode bank at `abs_pos + 1` (treating one literal byte as
+    ///    already committed). Donor's `start = ip + 1; matchLength = 0;
+    ///    offBase = REPCODE1_TO_OFFBASE;` at the top of the loop body.
+    ///    Only if a regular match at `abs_pos` is strictly longer does
+    ///    `start` slide back to `abs_pos`. This trades one literal byte
+    ///    for an unconditional repcode probe, which is the algorithmic
+    ///    reason the strategy is called "greedy" — it greedily picks the
+    ///    cheaper repcode encoding (4-5 bits) over a longer-offset
+    ///    regular match (9-13 bits) whenever the rep hit is close to
+    ///    matching the regular match's length.
+    ///
+    /// 2. **`if (depth == 0) goto _storeSequence;`**: on a repcode hit
+    ///    the regular search at `abs_pos` is skipped entirely. The plain
+    ///    [`start_matching`] above runs `best_match` (rep + regular) and
+    ///    `pick_lazy_match` unconditionally, so it pays for the regular
+    ///    search even when the rep already wins.
+    ///
+    /// 3. **Skip-step grows with literal-run length**: on a miss donor
+    ///    advances `ip += ((ip - anchor) >> kSearchStrength) + 1` with
+    ///    `kSearchStrength = 8`. The plain matcher steps by 1 — denser
+    ///    hash inserts (mild ratio benefit), but the donor parity skip
+    ///    halves the per-byte work on incompressible runs (the
+    ///    `lazySkipping` mode in donor is an extension of the same idea).
+    ///
+    /// 4. **Immediate-repcode loop after store**: after every emit, scan
+    ///    forward for back-to-back rep2 hits and emit them with
+    ///    `lit_len = 0`. The repcode `offBase = offset_2; offset_2 =
+    ///    offset_1; offset_1 = offBase;` swap in donor is reproduced by
+    ///    [`encode_offset_with_history`] when called with
+    ///    `actual_offset = offset_hist[1]` and `lit_len = 0` — the
+    ///    helper's `lit_len == 0` arm rotates `offset_hist[0..=1]`
+    ///    identically.
+    ///
+    /// Catch-up backwards extension is already absorbed into the
+    /// `MatchCandidate.start` field by `extend_backwards_shared`
+    /// (called from `row_candidate` and `repcode_candidate_shared`),
+    /// so we don't redo it explicitly.
+    ///
+    /// `pick_lazy_match` is intentionally not called here — depth == 0
+    /// means "no lookahead", emit the first viable hit.
+    pub(crate) fn start_matching_greedy(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        self.ensure_tables();
+
+        let current_len = self.window.back().unwrap().len();
+        if current_len == 0 {
+            return;
+        }
+        let current_abs_start = self.history_abs_start + self.window_size - current_len;
+        let backfill_start = self.backfill_start(current_abs_start);
+        if backfill_start < current_abs_start {
+            self.insert_positions(backfill_start, current_abs_start);
+        }
+
+        let mut pos = 0usize;
+        let mut literals_start = 0usize;
+
+        while pos + ROW_MIN_MATCH_LEN <= current_len {
+            let abs_pos = current_abs_start + pos;
+            let lit_len = pos - literals_start;
+
+            // (1) Default start = abs_pos + 1: probe the repcode bank
+            //     at the next byte, treating one byte as already
+            //     committed to the literal run. Donor probes only
+            //     rep1 here; `repcode_candidate_shared` probes all three
+            //     plus the `ll0` fallback because the donor "ll0" trick
+            //     is already baked into our shared helper. The extra
+            //     probes only add candidates that have repcode encoding
+            //     costs (cheap), so the ratio direction is positive vs
+            //     donor while still landing in the "greedy via repcode"
+            //     algorithmic shape.
+            let rep_probe_pos = abs_pos + 1;
+            let rep_probe_lit_len = lit_len + 1;
+            // Donor mls for repcode probes is 4 (`MEM_read32` compare on
+            // `ip+1` against `ip+1-offset_1`, length extended by
+            // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 6`
+            // gates the *regular* search via the row-table layout; rep
+            // probes are independent of the row table and benefit from
+            // the lower donor threshold (a 4-5 byte rep is cheap to
+            // encode and frequently outperforms emitting the bytes as
+            // literals).
+            const REP_MIN_MATCH_LEN: usize = 4;
+            let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= self.history_abs_end() {
+                repcode_candidate_shared(
+                    self.live_history(),
+                    self.history_abs_start,
+                    self.offset_hist,
+                    rep_probe_pos,
+                    rep_probe_lit_len,
+                    REP_MIN_MATCH_LEN,
+                )
+            } else {
+                None
+            };
+
+            // (2) Donor at `depth == 0` does `goto _storeSequence` on a
+            //     rep hit (commits without comparing against the regular
+            //     search). That trade-off is ratio-negative for us
+            //     because donor recovers the loss via other components
+            //     we don't replicate (smaller `mls=5`, block splitter,
+            //     better regular-search recall). To get the speed shape
+            //     of donor's greedy *without* its ratio cliff, we
+            //     compare both options and pick the longer match. On
+            //     ties / near-ties the rep wins by being cheaper to
+            //     encode (single-digit-bit offset code vs 9-13 bits for
+            //     a regular offset).
+            let regular_match = self.row_candidate(abs_pos, lit_len);
+            let chosen = match (rep_match, regular_match) {
+                (Some(rep), Some(reg)) => {
+                    // Prefer the longer; tie-break to rep for cheaper
+                    // encoding. `best_len_offset_candidate` ties on
+                    // shorter offset which is the wrong direction for
+                    // rep-vs-regular (regular offsets are always bigger
+                    // than the corresponding rep, so it would always
+                    // pick rep on ties — that's the right choice here
+                    // but we want strict length preference too).
+                    if reg.match_len > rep.match_len {
+                        Some(reg)
+                    } else {
+                        Some(rep)
+                    }
+                }
+                (Some(rep), None) => Some(rep),
+                (None, reg) => reg,
+            };
+
+            let Some(candidate) = chosen else {
+                // Donor `kSearchStrength = 8` shifts hard on miss
+                // (step grows by `lit_len >> 8`). Empirically on our
+                // corpus that recovers ~30% speed but costs ratio by
+                // dropping hash inserts on long literal runs that
+                // would have served future matches. Shift right by
+                // `SKIP_STRENGTH = 12` instead — same shape, ~16×
+                // rarer growth, so the step stays at 1 byte until the
+                // literal run hits ~4 KiB and only then begins
+                // skipping. Lets us keep most of donor's speed
+                // characteristic without re-introducing the ratio
+                // drain.
+                const SKIP_STRENGTH: u32 = 10;
+                let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
+                self.insert_position(abs_pos);
+                pos += step;
+                continue;
+            };
+
+            // Emit sequence.
+            let start = candidate.start - current_abs_start;
+            self.insert_positions(abs_pos, candidate.start + candidate.match_len);
+            let current = self.window.back().unwrap().as_slice();
+            let literals = &current[literals_start..start];
+            handle_sequence(Sequence::Triple {
+                literals,
+                offset: candidate.offset,
+                match_len: candidate.match_len,
+            });
+            let _ = encode_offset_with_history(
+                candidate.offset as u32,
+                literals.len() as u32,
+                &mut self.offset_hist,
+            );
+            pos = start + candidate.match_len;
+            literals_start = pos;
+
+            // (4) Immediate-repcode loop with `lit_len == 0`. Donor uses
+            //     `offset_2` (which after the store is the previous
+            //     `offset_1`), checks the 4-byte match, then swaps
+            //     `offset_1 ↔ offset_2`. Our helper performs that
+            //     rotation when called with `actual_offset =
+            //     offset_hist[1]` and `lit_len = 0`, so the loop only
+            //     needs to detect the 4-byte hit and forward-extend.
+            //     We probe `offset_hist[1]` only (not the full bank)
+            //     because donor here probes a single rep slot and
+            //     because at `lit_len == 0` the bank semantics shift
+            //     (`offset_hist[1]` becomes the donor "offset_2" we
+            //     want).
+            while pos + REP_MIN_MATCH_LEN <= current_len {
+                let abs_pos_rep = current_abs_start + pos;
+                let rep2 = self.offset_hist[1] as usize;
+                if rep2 == 0 || abs_pos_rep < self.history_abs_start + rep2 {
+                    break;
+                }
+                let concat = self.live_history();
+                let cur_idx = abs_pos_rep - self.history_abs_start;
+                if cur_idx + REP_MIN_MATCH_LEN > concat.len() {
+                    break;
+                }
+                let rep_idx = cur_idx - rep2;
+                if concat[cur_idx..cur_idx + REP_MIN_MATCH_LEN]
+                    != concat[rep_idx..rep_idx + REP_MIN_MATCH_LEN]
+                {
+                    break;
+                }
+                let rep_len = common_prefix_len(&concat[rep_idx..], &concat[cur_idx..]);
+                if rep_len < REP_MIN_MATCH_LEN {
+                    break;
+                }
+                self.insert_positions(abs_pos_rep, abs_pos_rep + rep_len);
+                let cur_slice = self.window.back().unwrap().as_slice();
+                handle_sequence(Sequence::Triple {
+                    literals: &cur_slice[literals_start..literals_start],
+                    offset: rep2,
+                    match_len: rep_len,
+                });
+                let _ = encode_offset_with_history(rep2 as u32, 0, &mut self.offset_hist);
+                pos += rep_len;
+                literals_start = pos;
+            }
+        }
+
+        while pos + ROW_HASH_KEY_LEN <= current_len {
+            self.insert_position(current_abs_start + pos);
+            pos += 1;
+        }
+
+        if literals_start < current_len {
+            let current = self.window.back().unwrap().as_slice();
+            handle_sequence(Sequence::Literals {
+                literals: &current[literals_start..],
+            });
+        }
+    }
+
     pub(crate) fn ensure_tables(&mut self) {
         let row_count = 1usize << self.row_hash_log;
         let row_entries = 1usize << self.row_log;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -274,14 +274,15 @@ impl RowMatchGenerator {
     ///    halves the per-byte work on incompressible runs (the
     ///    `lazySkipping` mode in donor is an extension of the same idea).
     ///
-    /// 4. **Immediate-repcode loop after store**: after every emit, scan
-    ///    forward for back-to-back rep2 hits and emit them with
-    ///    `lit_len = 0`. The repcode `offBase = offset_2; offset_2 =
-    ///    offset_1; offset_1 = offBase;` swap in donor is reproduced by
-    ///    [`encode_offset_with_history`] when called with
-    ///    `actual_offset = offset_hist[1]` and `lit_len = 0` — the
-    ///    helper's `lit_len == 0` arm rotates `offset_hist[0..=1]`
-    ///    identically.
+    /// Donor has an immediate-rep loop after store that probes
+    /// `offset_2` for back-to-back hits. It is omitted here: the
+    /// main-loop rep probe at `abs_pos + 1` already evaluates all
+    /// three rep slots (rep1, rep2, rep3 + the donor `ll0` fallback)
+    /// via [`repcode_candidate_shared`], so the inner-loop slot
+    /// donor's single-rep design would catch is already covered by
+    /// the next main-loop iteration. Confirmed dead-on-arrival via a
+    /// `panic!` probe across the full 528-test suite + benchmark
+    /// matrix (never fires).
     ///
     /// Catch-up backwards extension is already absorbed into the
     /// `MatchCandidate.start` field by `extend_backwards_shared`
@@ -422,50 +423,20 @@ impl RowMatchGenerator {
             pos = start + candidate.match_len;
             literals_start = pos;
 
-            // (4) Immediate-repcode loop with `lit_len == 0`. Donor uses
-            //     `offset_2` (which after the store is the previous
-            //     `offset_1`), checks the 4-byte match, then swaps
-            //     `offset_1 ↔ offset_2`. Our helper performs that
-            //     rotation when called with `actual_offset =
-            //     offset_hist[1]` and `lit_len = 0`, so the loop only
-            //     needs to detect the 4-byte hit and forward-extend.
-            //     We probe `offset_hist[1]` only (not the full bank)
-            //     because donor here probes a single rep slot and
-            //     because at `lit_len == 0` the bank semantics shift
-            //     (`offset_hist[1]` becomes the donor "offset_2" we
-            //     want).
-            while pos + REP_MIN_MATCH_LEN <= current_len {
-                let abs_pos_rep = current_abs_start + pos;
-                let rep2 = self.offset_hist[1] as usize;
-                if rep2 == 0 || abs_pos_rep < self.history_abs_start + rep2 {
-                    break;
-                }
-                let concat = self.live_history();
-                let cur_idx = abs_pos_rep - self.history_abs_start;
-                if cur_idx + REP_MIN_MATCH_LEN > concat.len() {
-                    break;
-                }
-                let rep_idx = cur_idx - rep2;
-                if concat[cur_idx..cur_idx + REP_MIN_MATCH_LEN]
-                    != concat[rep_idx..rep_idx + REP_MIN_MATCH_LEN]
-                {
-                    break;
-                }
-                let rep_len = common_prefix_len(&concat[rep_idx..], &concat[cur_idx..]);
-                if rep_len < REP_MIN_MATCH_LEN {
-                    break;
-                }
-                self.insert_positions(abs_pos_rep, abs_pos_rep + rep_len);
-                let cur_slice = self.window.back().unwrap().as_slice();
-                handle_sequence(Sequence::Triple {
-                    literals: &cur_slice[literals_start..literals_start],
-                    offset: rep2,
-                    match_len: rep_len,
-                });
-                let _ = encode_offset_with_history(rep2 as u32, 0, &mut self.offset_hist);
-                pos += rep_len;
-                literals_start = pos;
-            }
+            // Donor's `lazy_generic` has an immediate-repcode loop here
+            // (probing `offset_2` after each main emit and swapping
+            // `offset_1 ↔ offset_2` on hit). It was implemented and
+            // shipped in earlier iterations of this method but never
+            // fired on any test or benchmark workload — the
+            // `repcode_candidate_shared` probe at the top of the main
+            // loop already evaluates all three rep slots (rep1, rep2,
+            // rep3 + the `ll0` fallback), and the immediate-rep slot
+            // (`offset_hist[1]` at `lit_len = 0`) is subsumed by the
+            // next main-loop iteration's rep probe of the same slot.
+            // Donor's version is single-rep, so the inner loop catches
+            // hits its main-loop probe wouldn't; ours is three-rep, so
+            // the inner loop is dead by construction. Removed to free
+            // the per-iteration check and keep the parser body lean.
         }
 
         while pos + ROW_HASH_KEY_LEN <= current_len {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -165,6 +165,19 @@ impl RowMatchGenerator {
         }
     }
 
+    /// Lazy-style parse (depth >= 1) for the Row backend.
+    ///
+    /// Currently unused: the only strategy mapped to `BackendTag::Row`
+    /// is `StrategyTag::Greedy` (level 4), which dispatches to
+    /// [`Self::start_matching_greedy`] via the `debug_assert!` in
+    /// `MatchGeneratorDriver::start_matching`. This method is kept as
+    /// scaffolding for the case where a future level routes a lazy
+    /// strategy through the Row backend — extracting `pick_lazy_match`
+    /// behavior to a fresh module then would mean re-deriving the
+    /// row-hash machinery, which is wasteful. The `dead_code` allow is
+    /// scoped to this method and its private helpers so any new
+    /// caller will pick them up unmodified.
+    #[allow(dead_code)]
     pub(crate) fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
         self.ensure_tables();
 
@@ -239,11 +252,20 @@ impl RowMatchGenerator {
     ///    regular match (9-13 bits) whenever the rep hit is close to
     ///    matching the regular match's length.
     ///
-    /// 2. **`if (depth == 0) goto _storeSequence;`**: on a repcode hit
-    ///    the regular search at `abs_pos` is skipped entirely. The plain
-    ///    [`start_matching`] above runs `best_match` (rep + regular) and
-    ///    `pick_lazy_match` unconditionally, so it pays for the regular
-    ///    search even when the rep already wins.
+    /// 2. **Hybrid commit, not donor's pure `goto _storeSequence`**:
+    ///    donor's depth-0 path jumps to `_storeSequence` on the first
+    ///    repcode hit and skips the regular search at `abs_pos`. We
+    ///    deviate here — both the rep probe at `abs_pos + 1` *and* the
+    ///    regular `row_candidate(abs_pos, ..)` are evaluated each
+    ///    iteration, and the longer match wins (ties go to rep for
+    ///    cheaper encoding via [`best_len_offset_candidate`]). Donor
+    ///    can afford pure commit-on-first-rep because it recovers any
+    ///    ratio loss via `minMatch = 5` and superblock-level entropy
+    ///    sharing; we don't replicate those yet, so the hybrid form
+    ///    avoids a measured ~3pp ratio cliff on decodecorpus while
+    ///    still skipping the donor `lazy_depth == 1` lookahead probe
+    ///    that [`start_matching`] above runs unconditionally — the
+    ///    speed shape stays donor-like.
     ///
     /// 3. **Skip-step grows with literal-run length**: on a miss donor
     ///    advances `ip += ((ip - anchor) >> kSearchStrength) + 1` with
@@ -284,10 +306,26 @@ impl RowMatchGenerator {
             self.insert_positions(backfill_start, current_abs_start);
         }
 
+        // Donor mls for repcode probes is 4 (`MEM_read32` compare on
+        // `ip+1` against `ip+1-offset_1`, length extended by
+        // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 6`
+        // gates the *regular* search via the row-table layout; rep
+        // probes are independent of the row table and benefit from
+        // the lower donor threshold (a 4-5 byte rep is cheap to
+        // encode and frequently outperforms emitting the bytes as
+        // literals).
+        const REP_MIN_MATCH_LEN: usize = 4;
+        // Outer-loop lookahead floor: at least `REP_MIN_MATCH_LEN + 1`
+        // bytes left so the `abs_pos + 1` repcode probe can succeed
+        // even in the block tail. Gating the loop on the stricter
+        // `ROW_MIN_MATCH_LEN` (6) would miss the last 5-byte rep-only
+        // case and let those bytes fall through as literals.
+        const GREEDY_MIN_LOOKAHEAD: usize = REP_MIN_MATCH_LEN + 1;
+
         let mut pos = 0usize;
         let mut literals_start = 0usize;
 
-        while pos + ROW_MIN_MATCH_LEN <= current_len {
+        while pos + GREEDY_MIN_LOOKAHEAD <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
@@ -303,15 +341,6 @@ impl RowMatchGenerator {
             //     algorithmic shape.
             let rep_probe_pos = abs_pos + 1;
             let rep_probe_lit_len = lit_len + 1;
-            // Donor mls for repcode probes is 4 (`MEM_read32` compare on
-            // `ip+1` against `ip+1-offset_1`, length extended by
-            // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 6`
-            // gates the *regular* search via the row-table layout; rep
-            // probes are independent of the row table and benefit from
-            // the lower donor threshold (a 4-5 byte rep is cheap to
-            // encode and frequently outperforms emitting the bytes as
-            // literals).
-            const REP_MIN_MATCH_LEN: usize = 4;
             let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= self.history_abs_end() {
                 repcode_candidate_shared(
                     self.live_history(),
@@ -362,9 +391,9 @@ impl RowMatchGenerator {
                 // corpus that recovers ~30% speed but costs ratio by
                 // dropping hash inserts on long literal runs that
                 // would have served future matches. Shift right by
-                // `SKIP_STRENGTH = 12` instead — same shape, ~16×
+                // `SKIP_STRENGTH = 10` instead — same shape, ~4×
                 // rarer growth, so the step stays at 1 byte until the
-                // literal run hits ~4 KiB and only then begins
+                // literal run hits ~1 KiB and only then begins
                 // skipping. Lets us keep most of donor's speed
                 // characteristic without re-introducing the ratio
                 // drain.
@@ -506,12 +535,17 @@ impl RowMatchGenerator {
             .max(self.history_abs_start)
     }
 
+    /// Used only by the dead-code [`Self::start_matching`] (lazy-style
+    /// row parse). Kept paired with that method so reviving the lazy
+    /// path doesn't have to re-derive the rep+row best-of-two pick.
+    #[allow(dead_code)]
     pub(crate) fn best_match(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
         let rep = self.repcode_candidate(abs_pos, lit_len);
         let row = self.row_candidate(abs_pos, lit_len);
         best_len_offset_candidate(rep, row)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn pick_lazy_match(
         &self,
         abs_pos: usize,
@@ -532,6 +566,7 @@ impl RowMatchGenerator {
         )
     }
 
+    #[allow(dead_code)]
     pub(crate) fn repcode_candidate(
         &self,
         abs_pos: usize,


### PR DESCRIPTION
## Summary

L4 (`StrategyTag::Greedy`) was routed through the Row backend's plain `start_matching` with `lazy_depth = 1`, paying for an unconditional depth-1 lookahead while still calling itself "greedy". Donor `ZSTD_compressBlock_lazy_generic` at `depth == 0` (`zstd_lazy.c:1560`) is structurally different — that's why the strategy is *named* "greedy": not because the matches are long, but because each iteration greedily prefers the cheaper `1 literal + repcode` encoding over a 0-literal regular match.

This PR adds `RowMatchGenerator::start_matching_greedy` mirroring donor's depth-0 `lazy_generic` flow, and dispatches L4 (`lazy_depth == 0`) to it via a `debug_assert_eq!(matcher.lazy_depth, 0)` invariant — the runtime side of the routing is pinned in tests via `driver.row_matcher().lazy_depth == 0`. L5+ keep the existing plain `start_matching` path (their lazy lookahead already gives ratio wins vs donor); the plain row-lazy methods are kept as `#[allow(dead_code)]` scaffolding for a future routing of L5+ through the Row backend.

## Structural changes carried over from donor

- **Default `start = pos + 1`**: probe the repcode bank at `abs_pos + 1` before regular search. A near-repcode beats a longer regular offset on encoding cost (4-5 bits vs 9-13 bits for the offset code).
- **Hybrid commit (not pure donor goto)**: donor's pure commit-on-first-rep was tried and cost +1.1pp ratio on z000033 because donor recovers that loss via components we don't replicate (minMatch=5, block splitting). Our hybrid still runs the regular search at abs_pos and picks the longer of (rep@+1, regular@pos) — keeps the speed shape, reclaims the ratio.
- **Skip-step grows on miss, shift = 10**: donor uses 8 (kSearchStrength). Shift = 8 cost ~3pp ratio loss; shift = infinity cost ~+14% speed. Shift = 10 sits at the sweet spot — only kicks in past ~1 KiB literal run, so on structured data the step stays at 1.
- **Repcode min_match = 4** (donor MEM_read32 + ZSTD_count). ROW_MIN_MATCH_LEN = 6 gates the regular row-table search; the independent repcode probe benefits from the lower threshold because 4-5-byte reps are cheap to encode and frequently beat the literal alternative. Outer-loop guard is pos + GREEDY_MIN_LOOKAHEAD <= current_len (= 5) so the tail position whose abs_pos + 1 repcode probe needs 4 bytes of lookahead is reachable.

pick_lazy_match_shared is intentionally not called from the new path — depth == 0 means no lookahead, emit on first viable hit.

**Note:** donor's immediate-repcode loop after store (probe offset_2 for back-to-back hits + swap) was implemented and then removed. A panic! probe inside the inner loop ran the full 528-test suite + bench matrix without firing. The donor design is single-rep; ours is three-rep (repcode_candidate_shared evaluates rep1, rep2, rep3 plus the ll0 fallback), so the inner-loop slot is subsumed by the next main-loop iteration's rep probe. Removing it nudged decodecorpus-z000033 from 538142 to 537897 bytes (-245).

## Measurements (L4 only, criterion --baseline main, p < 0.05 unless noted)

| Scenario              | rust_bytes vs main | time vs main |
|-----------------------|--------------------|--------------|
| small-1k-random       | 0                  | +3.4%        |
| small-10k-random      | 0                  | -0.2% (p=0.96, noise) |
| small-4k-log-lines    | 0                  | -5.1%        |
| **decodecorpus-z000033** | **-1522 bytes** | **-24.0%**   |
| high-entropy-1m       | 0                  | -7.8%        |
| low-entropy-1m        | 0                  | -2.4%        |
| large-log-stream      | -2 bytes           | +9.0%        |

**Ratio:** 5 cells equal, 2 cells better, **0 cells worse**.
**Speed:** 4 wins (incl. -24% on z000033 — the cell that motivated #178), 1 noise, 2 regressions.

## Tests

8 new L4-targeted tests (plus a private l4_greedy_round_trip helper):

- driver_level4_selects_row_backend — backend routing + lazy_depth == 0 assertion (pins greedy vs lazy choice in release tests too).
- driver_level4_greedy_round_trip_single_slice — non-empty triple emission on a repeating pattern.
- driver_level4_greedy_round_trip_cross_slice — cross-slice match (offset >= chunk.len()).
- driver_level4_greedy_tail_rep_only_reachable — guards the GREEDY_MIN_LOOKAHEAD = REP_MIN_MATCH_LEN + 1 loop bound; without the fix the 5-byte-tail rep-only position was unreachable.
- driver_level4_greedy_empty_input_emits_nothing — current_len == 0 early-return path.
- driver_level4_greedy_sub_min_lookahead_input — 4-byte payload below GREEDY_MIN_LOOKAHEAD; outer loop never executes.
- driver_level4_greedy_incompressible_input — pseudo-random 256B exercises the miss-branch.
- driver_level4_greedy_long_literal_run_skip_step_growth — 2 KiB pseudo-random drives lit_len >> SKIP_STRENGTH.
- driver_level4_greedy_all_zeros_heavy_rep1 — max_offset == 1 rep1 commit-on-first-hit.
- driver_level4_greedy_periodic_pattern_rep_cascade — 16-byte period steady-state cascade.

row/mod.rs coverage: 89.12% to 96.69%. Remaining gaps are micro-branches (rep probe at exact end-of-buffer, regular-strictly-longer-than-rep arm, compact_history drain) and the #[allow(dead_code)] scaffold.

## Known follow-up

The +9% large-log-stream regression and the +3.4% small-1k-random one reflect a *different* hotpath. samply profile on L4 large-log-stream shows RowMatchGenerator::skip_matching_with_hint consuming ~25% of self time — it inserts every position of each 128 KiB block into the row hash table (~102M insert_position calls on a 100 MB stream), dominating any per-iteration delta in the parse loop. Independent of this PR; tracked as #180.

## Test plan

- [x] cargo nextest run: 528/528 passed (3 skipped)
- [x] cargo clippy --all-targets --features dict_builder: clean
- [x] cargo fmt --check: clean
- [x] cargo llvm-cov --lib: row/mod.rs at 96.69%
- [x] compare_ffi L4 matrix: full scenario sweep, ratios captured above
- [x] Ratio gate: rust_bytes <= ffi_bytes constraint from CLAUDE.md respected — no ratio regression on any cell

## Related

- #178 — parent issue (decode/encode shared primitives + greedy)
- #180 — skip_matching_with_hint dominates self-time (follow-up for the speed regressions noted above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Level 4 Row backend now uses a more aggressive greedy matching path, improving matching behavior for repeats and periodic patterns and yielding faster/more consistent compression.

* **Tests**
  * Added extensive Level 4 test coverage: routing/invariant checks, single- and cross-slice greedy round-trips, and multiple regression cases (empty input, incompressible data, long literals, heavy repeats).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->