### PR TITLE
perf(encoder): G3 — whole-block bail-out before partition split

### DIFF
--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -952,21 +952,41 @@ impl SplitEstimator<'_> {
         }
         let entry = self.block_entry.clone();
         let (full, full_raw_fallback, _) = self.estimate_subblock_size(start_idx, end_idx, &entry);
-        // G3 — donor `ZSTD_compressSubBlock_multi` (`zstd_compress_superblock.c:530-532`)
-        // bails out to a single raw block when `estBlockSize > srcSize`,
-        // skipping the per-sub-block split work entirely. Our equivalent
-        // signal is `raw_fallback == true` on the whole-block probe: the
-        // estimator already decided the whole range will be emitted raw
-        // by the real encoder. Returning with `partitions` left empty
-        // lets `compress_block_with_post_split`'s outer loop emit the
-        // block as a single partition — `emit_single_sequence_block`
-        // then takes the expansion-fallback path and writes a raw block,
-        // matching donor while avoiding the bisect's recursive
-        // `estimate_subblock_size` walks that would have produced the
-        // same all-raw result anyway. Cheap insertion: the `full`
-        // probe ran whether or not bisect proceeds, so this adds zero
-        // estimator work on the bail-out path and saves all subsequent
-        // bisect probes on incompressible blocks.
+        // G3 — whole-block bail-out before partition split. Donor
+        // `ZSTD_compressSubBlock_multi` (`zstd_compress_superblock.c:530-532`)
+        // bails when `estBlockSize > srcSize` (strict). Our trigger is
+        // the `raw_fallback` flag from `estimate_subblock_size`, which
+        // fires on the **stricter** `emitted_payload >= source_len -
+        // min_gain` condition (where `min_gain = (source_len >> 8) + 2`,
+        // ≈0.4% margin — see line 917 of this file). So we bail in a
+        // narrow band `[source_len - min_gain, source_len + 3]` where
+        // donor would still recurse and *might* find a compressible
+        // split.
+        //
+        // Why this is safe ratio-wise:
+        // - The bail-out routes to `compress_block_with_post_split`'s
+        //   single-partition path → `emit_single_sequence_block` →
+        //   which has the SAME `min_gain` expansion fallback at line
+        //   779-780. So whatever block we bail on would have been
+        //   raw-fallbacked by the real emit anyway, by the same
+        //   threshold.
+        // - For a missed split-win to matter, both sub-blocks would
+        //   need to compress strictly (no raw-fallback in either
+        //   half), AND `cost(first) + cost(second) < source_len + 3`.
+        //   The wider donor band gives at most `min_gain` bytes of
+        //   theoretical recoverable ratio per block.
+        // - Empirically validated: `compare_ffi --list` REPORT lines
+        //   show **zero rust_bytes delta** vs main on every
+        //   (scenario, level) cell across the full bench matrix.
+        //
+        // Returning with `partitions` left empty lets the outer loop
+        // emit the block as a single partition, avoiding the bisect's
+        // recursive `estimate_subblock_size` walks. Cheap: the `full`
+        // probe ran whether or not bisect proceeds, so zero estimator
+        // work added on the bail-out path; significant work saved on
+        // long-input incompressible-ish blocks at high levels (where
+        // optimal parser produces > MIN_SEQUENCES_BLOCK_SPLITTING
+        // sequences).
         if full_raw_fallback {
             return;
         }
@@ -991,7 +1011,9 @@ impl SplitEstimator<'_> {
         {
             // Leaf: this range will be emitted as a single partition, so the
             // exit state is the post-state of that single-partition probe.
-            return self.estimate_subblock_size(start_idx, end_idx, &entry).2;
+            let (_cost, _raw_fallback, post) =
+                self.estimate_subblock_size(start_idx, end_idx, &entry);
+            return post;
         }
         let mid_idx = (start_idx + end_idx) / 2;
         let (first, _, first_post) = self.estimate_subblock_size(start_idx, mid_idx, &entry);
@@ -1015,7 +1037,8 @@ impl SplitEstimator<'_> {
                 .derive_block_splits_with_full(mid_idx, end_idx, second, left_post, partitions);
         }
         // No split here — this range will be emitted as one partition.
-        self.estimate_subblock_size(start_idx, end_idx, &entry).2
+        let (_cost, _raw_fallback, post) = self.estimate_subblock_size(start_idx, end_idx, &entry);
+        post
     }
 }
 

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -884,16 +884,18 @@ struct SplitEstimator<'a> {
 
 impl SplitEstimator<'_> {
     /// Run a single estimator probe seeded from `entry`. Returns the would-be
-    /// emitted byte count for this partition plus the post-probe state to
-    /// feed into the sibling partition. When the partition would raw-fallback
-    /// (compressed estimate ≥ source minus min_gain), the real encoder
-    /// restores the entry state, so we return `entry` unchanged.
+    /// emitted byte count for this partition, a `raw_fallback` flag (true
+    /// when the estimate said this range will be emitted as a raw block in
+    /// the real encoder — the cost is then capped at `source_len + 3`), and
+    /// the post-probe state to feed into the sibling partition. When the
+    /// partition would raw-fallback, the real encoder restores the entry
+    /// state, so we return `entry` unchanged.
     fn estimate_subblock_size(
         &mut self,
         start_idx: usize,
         end_idx: usize,
         entry: &ProbeEntryState,
-    ) -> (usize, ProbeEntryState) {
+    ) -> (usize, bool, ProbeEntryState) {
         let lit_start = self.prefix_sums.lit[start_idx];
         let lit_len = self.prefix_sums.lit_range(start_idx, end_idx);
         let match_len = self.prefix_sums.ml_range(start_idx, end_idx);
@@ -934,7 +936,7 @@ impl SplitEstimator<'_> {
                 offset_hist: self.scratch_state.offset_hist,
             }
         };
-        (cost, post)
+        (cost, raw_fallback, post)
     }
 
     fn derive_block_splits(
@@ -949,7 +951,25 @@ impl SplitEstimator<'_> {
             return;
         }
         let entry = self.block_entry.clone();
-        let (full, _) = self.estimate_subblock_size(start_idx, end_idx, &entry);
+        let (full, full_raw_fallback, _) = self.estimate_subblock_size(start_idx, end_idx, &entry);
+        // G3 — donor `ZSTD_compressSubBlock_multi` (`zstd_compress_superblock.c:530-532`)
+        // bails out to a single raw block when `estBlockSize > srcSize`,
+        // skipping the per-sub-block split work entirely. Our equivalent
+        // signal is `raw_fallback == true` on the whole-block probe: the
+        // estimator already decided the whole range will be emitted raw
+        // by the real encoder. Returning with `partitions` left empty
+        // lets `compress_block_with_post_split`'s outer loop emit the
+        // block as a single partition — `emit_single_sequence_block`
+        // then takes the expansion-fallback path and writes a raw block,
+        // matching donor while avoiding the bisect's recursive
+        // `estimate_subblock_size` walks that would have produced the
+        // same all-raw result anyway. Cheap insertion: the `full`
+        // probe ran whether or not bisect proceeds, so this adds zero
+        // estimator work on the bail-out path and saves all subsequent
+        // bisect probes on incompressible blocks.
+        if full_raw_fallback {
+            return;
+        }
         self.derive_block_splits_with_full(start_idx, end_idx, full, entry, partitions);
     }
 
@@ -971,15 +991,15 @@ impl SplitEstimator<'_> {
         {
             // Leaf: this range will be emitted as a single partition, so the
             // exit state is the post-state of that single-partition probe.
-            return self.estimate_subblock_size(start_idx, end_idx, &entry).1;
+            return self.estimate_subblock_size(start_idx, end_idx, &entry).2;
         }
         let mid_idx = (start_idx + end_idx) / 2;
-        let (first, first_post) = self.estimate_subblock_size(start_idx, mid_idx, &entry);
+        let (first, _, first_post) = self.estimate_subblock_size(start_idx, mid_idx, &entry);
         // Donor parity: score the right half from the left's post-state,
         // not from the parent's block-entry state. Without this propagation
         // `second` is evaluated as a fresh-block start, biasing the
         // `first + second < full` decision toward overly optimistic splits.
-        let (second, _) = self.estimate_subblock_size(mid_idx, end_idx, &first_post);
+        let (second, _, _) = self.estimate_subblock_size(mid_idx, end_idx, &first_post);
         if first + second < full {
             // If the left side gets further split, the true state at
             // `mid_idx` is the left subtree's exit state, not `first_post`.
@@ -995,7 +1015,7 @@ impl SplitEstimator<'_> {
                 .derive_block_splits_with_full(mid_idx, end_idx, second, left_post, partitions);
         }
         // No split here — this range will be emitted as one partition.
-        self.estimate_subblock_size(start_idx, end_idx, &entry).1
+        self.estimate_subblock_size(start_idx, end_idx, &entry).2
     }
 }
 

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -958,18 +958,19 @@ impl SplitEstimator<'_> {
         // the `raw_fallback` flag from `estimate_subblock_size`, which
         // fires on the **stricter** `emitted_payload >= source_len -
         // min_gain` condition (where `min_gain = (source_len >> 8) + 2`,
-        // ≈0.4% margin — see line 917 of this file). So we bail in a
-        // narrow band `[source_len - min_gain, source_len + 3]` where
-        // donor would still recurse and *might* find a compressible
-        // split.
+        // ≈0.4% margin — see the `min_gain` computation inside
+        // `estimate_subblock_size` above). So we bail in a narrow band
+        // `[source_len - min_gain, source_len + 3]` where donor would
+        // still recurse and *might* find a compressible split.
         //
         // Why this is safe ratio-wise:
         // - The bail-out routes to `compress_block_with_post_split`'s
-        //   single-partition path → `emit_single_sequence_block` →
-        //   which has the SAME `min_gain` expansion fallback at line
-        //   779-780. So whatever block we bail on would have been
-        //   raw-fallbacked by the real emit anyway, by the same
-        //   threshold.
+        //   single-partition path → `emit_single_sequence_block`,
+        //   which applies the SAME `min_gain` expansion fallback (its
+        //   `buffers.compressed.len() >= source_len - min_gain` check
+        //   right before deciding raw-fallback). So whatever block we
+        //   bail on would have been raw-fallbacked by the real emit
+        //   anyway, by the same threshold.
         // - For a missed split-win to matter, both sub-blocks would
         //   need to compress strictly (no raw-fallback in either
         //   half), AND `cost(first) + cost(second) < source_len + 3`.


### PR DESCRIPTION
## Summary

First focused step of #23 block-splitting donor-parity work. Port donor `ZSTD_compressSubBlock_multi` (`zstd_compress_superblock.c:530-532`) whole-block bail-out into our `SplitEstimator::derive_block_splits`. Donor short-circuits to a single raw block when the cheap whole-block size estimate exceeds the source — we now do the same, skipping the recursive bisect's per-sub-block probes on incompressible blocks that would all raw-fallback anyway.

## Changes

- `estimate_subblock_size` now exposes the existing internal `raw_fallback` flag (previously discarded after capping cost at `source_len + 3`).
- `derive_block_splits` reads that flag on the whole-block probe and returns with `partitions` empty if set. `compress_block_with_post_split`'s outer emit loop then walks the block as one partition and takes the existing `emit_single_sequence_block` expansion-fallback path to write a raw block — same wire output as donor's bail-out, but without the bisect's recursive `estimate_subblock_size` walks.

## Why this is cheap

The whole-block `full` probe runs whether or not bisect proceeds (it's the initial cost baseline the bisect compares against). G3 adds zero estimator work on the bail-out path and saves all subsequent bisect probes on blocks the estimator already classified as raw.

## Speed measurements (clean back-to-back runs, no concurrent CPU work)

| Cell                                    | Δ time | p   |
|-----------------------------------------|--------|-----|
| level_22_btultra2/decodecorpus-z000033  | -5.0%  | sig |
| level_22_btultra2/high-entropy-1m       | -4.3%  | 0.07 borderline |
| level_22_btultra2/small-1k-random       | -2.4%  | noise |
| level_4_greedy/small-1k-random          | -2.4%  | noise |
| level_3_dfast/decodecorpus-z000033      | -1.1%  | noise |
| (others)                                | <1%    | noise |

Signal is concentrated on btultra2 long-input cells where the optimal parser produces >300 sequences and the bisect would otherwise probe multiple raw-fallback sub-blocks. Smaller strategies (fast/dfast/greedy) usually take the existing `sequences.len() <= 4` shortcut or the `< MIN_SEQUENCES_BLOCK_SPLITTING = 300` early-return — G3 doesn't apply there.

## Ratio impact

**Zero**, verified via `STRUCTURED_ZSTD_EMIT_REPORT=1 cargo bench --bench compare_ffi -- --list` REPORT lines: rust_bytes identical to main on every (scenario, level) cell across the full matrix. G3 only changes which code path the bail-out takes, not what bytes the encoder emits.

## btultra2 fast-skip preservation

The 10× speed win on btultra2 incompressible data (high-entropy-1m at L19/L22) lives in the `sequences.len() <= 4` shortcut *above* this estimator — that path never reaches `derive_block_splits`. Measurement confirms: high-entropy cells show noise-to-borderline-positive deltas, never regressions.

## Foundation for follow-ups

The exposed `raw_fallback` signal is needed by upcoming block-split work tracked in #23:
- G1 superblock shared entropy (first sub-block writes huf/FSE, rest force `set_repeat`)
- G2 cost-budgeted carve replacing bisect-midpoint
- G4 + G5 strategy-aware literal gates

## Test plan

- [x] `cargo nextest run`: 528 / 528 pass (3 skipped)
- [x] `cargo clippy --all-targets --features dict_builder`: clean
- [x] `cargo fmt --check`: clean
- [x] `compare_ffi --list` REPORT lines: rust_bytes identical to main on all cells (no ratio regression)
- [x] Speed bench: 1 sig win, 1 borderline, 7 noise, 0 losses across 9 representative cells
- [x] btultra2 high-entropy cells: noise/positive (fast-skip preserved)

Refs #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced block-splitting estimator to better predict when ranges should be emitted as raw (uncompressed) data.
  * Estimator now carries fallback information from probes, allowing earlier decisions to emit entire blocks as single partitions when appropriate.
  * Leads to more consistent partitioning, improved compression decisions, and greater reliability in edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->