### PR TITLE
perf(encoder): inline hash-chain walk into hash_chain_candidate (lazy L1)

### DIFF
--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -227,6 +227,26 @@ impl HcMatcher {
             return None;
         }
 
+        // Chain walk is inlined below — avoids the per-call 4 KiB
+        // `[usize; MAX_HC_SEARCH_DEPTH]` array that
+        // [`Self::chain_candidates`] materializes (zero-init on entry,
+        // memcpy on return). At lazy_depth=2 (L7+) `pick_lazy_match`
+        // triggers up to three chain walks per committed position, so
+        // the array form costs ~12 KiB of stack traffic per accepted
+        // match. Donor (`zstd_lazy.c` `ZSTD_HcFindBestMatch`) runs a
+        // single fused loop with no intermediate buffer; mirror that.
+        // `chain_candidates` is kept under `#[cfg(test)]` callers as a
+        // dump-style helper for the chain-walk unit tests.
+        let hash = table.hash_position(&concat[current_idx..]);
+        let chain_mask = (1usize << table.chain_log) - 1;
+        let mut cur = table.hash_table[hash];
+        // Cap loop at MAX_HC_SEARCH_DEPTH so a misconfigured
+        // `search_depth > MAX_HC_SEARCH_DEPTH` (BT modes set it from the
+        // donor config, which can exceed our cap) cannot run forever.
+        let max_chain_steps = self.search_depth.min(MAX_HC_SEARCH_DEPTH);
+        let mut steps = 0usize;
+        let history_abs_start = table.history_abs_start;
+
         let mut best: Option<MatchCandidate> = None;
         // Donor speculative tail check (`zstd_lazy.c:714`,
         // `ZSTD_HcFindBestMatch`): once `best` is set, gate the
@@ -277,51 +297,106 @@ impl HcMatcher {
         //   walks we fall through to the full `common_prefix_len` so
         //   the offset-bits advantage is given a chance to win.
         let history_tail = concat.len();
-        for candidate_abs in self.chain_candidates(table, abs_pos) {
-            if candidate_abs == usize::MAX {
+        while steps < max_chain_steps {
+            if cur == HC_EMPTY {
                 break;
             }
-            let candidate_idx = candidate_abs - table.history_abs_start;
-            // `abs_pos > candidate_abs` is invariant for in-range chain
-            // entries (filtered by `chain_candidates`), so the subtraction
-            // never underflows.
-            let new_offset = abs_pos - candidate_abs;
-            if let Some(best_ref) = best
-                && new_offset >= best_ref.offset
-                && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
+            let candidate_rel = cur.wrapping_sub(1) as usize;
+            let candidate_abs_opt =
+                super::match_table::storage::MatchTable::stored_abs_position_fast(
+                    cur,
+                    table.position_base,
+                    table.index_shift,
+                );
+            let next = table.chain_table[candidate_rel & chain_mask];
+            steps += 1;
+            // Self-loop: two positions share `candidate_rel & chain_mask`;
+            // stop after processing this slot.
+            let self_loop = next == cur;
+
+            // Only process candidates in the live window [history_abs_start, abs_pos).
+            if let Some(candidate_abs) = candidate_abs_opt
+                && candidate_abs >= history_abs_start
+                && candidate_abs < abs_pos
             {
-                let m_end = candidate_idx + tail_off + 4;
-                let i_end = current_idx + tail_off + 4;
-                // Bounds-fail (`i_end > history_tail`) is a SAFE skip — not
-                // a missed optimization. Under the per-iteration
-                // precondition `new_offset >= best.offset`, new candidates
-                // have equal-or-worse `offset_bits`, so to outscore `best`
-                // they need strictly *larger* `match_len`. Bounds fail
-                // ⟺ `current_idx + best.match_len − lit_len + 1 >
-                // history_tail` ⟺ forward bytes at `current_idx`
-                // (`F_max := history_tail − current_idx`) satisfy
-                // `F_max ≤ best.match_len − lit_len`. Any candidate at
-                // `current_idx` has `match_len ≤ F_max + lit_len ≤
-                // best.match_len`, so it cannot strictly outscore. Falling
-                // through to `common_prefix_len` would only run a wasted
-                // walk that can never improve `best`.
-                if i_end > history_tail || m_end > history_tail {
-                    continue;
-                }
-                if concat[candidate_idx + tail_off..m_end] != concat[current_idx + tail_off..i_end]
+                let candidate_idx = candidate_abs - history_abs_start;
+                // `abs_pos > candidate_abs` is invariant under the bounds check
+                // above, so the subtraction never underflows.
+                let new_offset = abs_pos - candidate_abs;
+                // Donor speculative tail check (`zstd_lazy.c:714`,
+                // `ZSTD_HcFindBestMatch`): once `best` is set, gate the
+                // expensive `common_prefix_len` walk on a 4-byte tail compare
+                // proving the new candidate can possibly reach the *forward*
+                // length required to outscore `best` under
+                // [`Self::better_candidate`] (gain = `len*4 - offset_bits`).
+                //
+                // Correctness — backward-extension–aware bound:
+                //   `best.match_len` is the *total* length stored by
+                //   [`Self::extend_backwards`]: forward bytes from
+                //   `current_idx` plus up to `lit_len` backward bytes
+                //   (`B_best = abs_pos − best.start`, capped by `lit_len`).
+                //   A new candidate can in principle replace `B_best` of its
+                //   own length with up to `lit_len` backward bytes, so the
+                //   worst-case forward length it needs to outscore `best`
+                //   is `best.match_len − lit_len + 1`. The 4-byte tail probe
+                //   at offset `best.match_len − lit_len − 3` covers exactly
+                //   that boundary.
+                //
+                // Walk-order argument (offset monotonicity — REQUIRED gate
+                // precondition, enforced per-iteration):
+                //   Chain walks are LIFO in their dense form (newest first →
+                //   strictly increasing offset). But the chain table is
+                //   `chain_log`-bits wide; when a position is re-inserted at
+                //   the same masked chain index after the cycle wraps, an
+                //   older chain link can point into a slot that has since
+                //   been overwritten with a newer (closer) position, breaking
+                //   monotonicity. The gate's bound is only sound when
+                //   `new_offset >= best.offset`; otherwise fall through to
+                //   the full `common_prefix_len` so the offset-bits advantage
+                //   is given a chance to win.
+                let mut skip = false;
+                if let Some(best_ref) = best
+                    && new_offset >= best_ref.offset
+                    && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
                 {
-                    continue;
+                    let m_end = candidate_idx + tail_off + 4;
+                    let i_end = current_idx + tail_off + 4;
+                    // Bounds-fail is a SAFE skip — see longer rationale in the
+                    // gate's git history. Briefly: under the monotonicity
+                    // precondition above, bounds-fail proves no in-range
+                    // candidate at this `current_idx` can outscore `best`.
+                    if i_end > history_tail
+                        || m_end > history_tail
+                        || concat[candidate_idx + tail_off..m_end]
+                            != concat[current_idx + tail_off..i_end]
+                    {
+                        skip = true;
+                    }
+                }
+
+                if !skip {
+                    let match_len =
+                        common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
+                    if match_len >= HC_MIN_MATCH_LEN {
+                        let candidate = Self::extend_backwards(
+                            table,
+                            candidate_abs,
+                            abs_pos,
+                            match_len,
+                            lit_len,
+                        );
+                        best = Self::better_candidate(best, Some(candidate));
+                        if best.is_some_and(|b| b.match_len >= self.target_len) {
+                            return best;
+                        }
+                    }
                 }
             }
-            let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
-            if match_len >= HC_MIN_MATCH_LEN {
-                let candidate =
-                    Self::extend_backwards(table, candidate_abs, abs_pos, match_len, lit_len);
-                best = Self::better_candidate(best, Some(candidate));
-                if best.is_some_and(|b| b.match_len >= self.target_len) {
-                    return best;
-                }
+
+            if self_loop {
+                break;
             }
+            cur = next;
         }
         best
     }

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -235,8 +235,14 @@ impl HcMatcher {
         // the array form costs ~12 KiB of stack traffic per accepted
         // match. Donor (`zstd_lazy.c` `ZSTD_HcFindBestMatch`) runs a
         // single fused loop with no intermediate buffer; mirror that.
-        // `chain_candidates` is kept under `#[cfg(test)]` callers as a
-        // dump-style helper for the chain-walk unit tests.
+        //
+        // `chain_candidates` itself is still alive — the chain-walk
+        // unit tests drive it directly, and the BT-optimal HC
+        // candidate collector in `match_generator.rs` consumes it
+        // through a macro pipeline that inherits the array form.
+        // Inlining the array out of that BT-optimal callsite is a
+        // separate, larger refactor; this commit only addresses the
+        // lazy hot path.
         let hash = table.hash_position(&concat[current_idx..]);
         let chain_mask = (1usize << table.chain_log) - 1;
         let mut cur = table.hash_table[hash];
@@ -323,37 +329,9 @@ impl HcMatcher {
                 // `abs_pos > candidate_abs` is invariant under the bounds check
                 // above, so the subtraction never underflows.
                 let new_offset = abs_pos - candidate_abs;
-                // Donor speculative tail check (`zstd_lazy.c:714`,
-                // `ZSTD_HcFindBestMatch`): once `best` is set, gate the
-                // expensive `common_prefix_len` walk on a 4-byte tail compare
-                // proving the new candidate can possibly reach the *forward*
-                // length required to outscore `best` under
-                // [`Self::better_candidate`] (gain = `len*4 - offset_bits`).
-                //
-                // Correctness — backward-extension–aware bound:
-                //   `best.match_len` is the *total* length stored by
-                //   [`Self::extend_backwards`]: forward bytes from
-                //   `current_idx` plus up to `lit_len` backward bytes
-                //   (`B_best = abs_pos − best.start`, capped by `lit_len`).
-                //   A new candidate can in principle replace `B_best` of its
-                //   own length with up to `lit_len` backward bytes, so the
-                //   worst-case forward length it needs to outscore `best`
-                //   is `best.match_len − lit_len + 1`. The 4-byte tail probe
-                //   at offset `best.match_len − lit_len − 3` covers exactly
-                //   that boundary.
-                //
-                // Walk-order argument (offset monotonicity — REQUIRED gate
-                // precondition, enforced per-iteration):
-                //   Chain walks are LIFO in their dense form (newest first →
-                //   strictly increasing offset). But the chain table is
-                //   `chain_log`-bits wide; when a position is re-inserted at
-                //   the same masked chain index after the cycle wraps, an
-                //   older chain link can point into a slot that has since
-                //   been overwritten with a newer (closer) position, breaking
-                //   monotonicity. The gate's bound is only sound when
-                //   `new_offset >= best.offset`; otherwise fall through to
-                //   the full `common_prefix_len` so the offset-bits advantage
-                //   is given a chance to win.
+                // Speculative tail gate — full rationale (backward-extension
+                // bound + walk-order/offset-monotonicity precondition) is in
+                // the comment block right above this loop.
                 let mut skip = false;
                 if let Some(best_ref) = best
                     && new_offset >= best_ref.offset


### PR DESCRIPTION
## Summary

Inline the hash-chain walk directly into `hash_chain_candidate` to
eliminate the 4 KiB-per-call stack array that `chain_candidates`
materialized. With `lazy_depth = 2` (levels 7+), `pick_lazy_match`
triggers three chain walks per committed position, so the array form
cost ~12 KiB of stack zero-fill + return-copy traffic per accepted
match before any useful comparison happened. Donor
`ZSTD_HcFindBestMatch` runs a single fused loop with no intermediate
buffer; this mirrors that.

`chain_candidates` itself stays live — the chain-walk unit tests
drive it directly, and the BT-optimal HC candidate collector in
`match_generator.rs` (around line 2437) consumes it through a macro
pipeline that inherits the array form. Inlining the array out of that
BT-optimal site is a separate, larger refactor and is NOT in this PR.

## Scope (only lazy hot path)

Single file changed: `zstd/src/encoding/hc/mod.rs`.

- `hash_chain_candidate`: chain walk is now inlined. Loop body fuses
  candidate-position extraction, range check, donor speculative tail
  gate, `common_prefix_len`, `extend_backwards`, and `best` update.
- `chain_candidates`: unchanged signature and behavior, still used by
  the BT-optimal HC collector and the chain-walk unit tests.
- No public API changes, no behavior changes outside the lazy band's
  internal candidate selection (same candidates considered, same
  `better_candidate` ordering).

## Measurements

`compress/level_{5,8,12,15}_lazy/decodecorpus-z000033/matrix/pure_rust`
— criterion 10 samples each, clean back-to-back vs `origin/main`,
`p = 0.00` across all four cells:

| level | main thrpt | branch thrpt | speedup |
|---|---|---|---|
| L5 lazy | 13.5 MiB/s | 25.8 MiB/s | 1.91× |
| L8 lazy | 9.6 MiB/s | 17.0 MiB/s | 1.77× |
| L12 lazy | 8.3 MiB/s | 14.0 MiB/s | 1.69× |
| L15 lazy | 8.1 MiB/s | 13.7 MiB/s | 1.70× |

Ratio (full lazy × scenario matrix via REPORT lines, 77 cells):
**bit-identical to `origin/main`**. No ratio change anywhere, no
correctness change — the inlined walk visits the same chain links in
the same order and applies the same predicates.

## Verification

- 534/534 lib tests pass (debug profile)
- lint pass — clean
- format check — clean
- Ratio matrix unchanged vs main

## Out of scope (tracked in #184)

- **L2**: fuse chain-walk and speculative gate further; add donor
  `PREFETCH_L1(chain_table[next & chain_mask])`
- **L3**: share rep + chain results across the lazy lookahead at
  `pos`, `pos+1`, `pos+2`
- **L4**: validate `target_len` early-exit parity vs donor
- BT-optimal `chain_candidates` callsite inlining

## Related

- #184 — lazy investigation parent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal compression matching logic to improve efficiency and reduce memory overhead.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->