### PR TITLE
perf(encoder): bump Fast window_log to 19 (donor parity, large-log-stream ratio fix)

### DIFF
--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1752,9 +1752,11 @@ mod tests {
             crate::decoding::Dictionary::from_raw_content(dict_id, b"abcdefgh".to_vec())
                 .expect("raw dictionary should be valid");
 
-        // Payload must exceed the encoder's advertised window (128 KiB for
-        // Fastest) so the test actually exercises cross-window-boundary behavior.
-        let payload = b"abcdefgh".repeat(128 * 1024 / 8 + 64);
+        // Payload must exceed the encoder's advertised window (512 KiB
+        // for Fastest after `window_log = 19` alignment with donor's
+        // L1 fast row in `clevels.h`) so the test actually exercises
+        // cross-window-boundary behavior.
+        let payload = b"abcdefgh".repeat(512 * 1024 / 8 + 64);
         let matcher = MatchGeneratorDriver::new(1024, 1);
 
         let mut no_dict_output = Vec::new();

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -280,7 +280,7 @@ fn row_hash_bits_for_window(max_window_size: usize) -> usize {
 const LEVEL_TABLE: [LevelParams; 22] = [
     // Lvl  Strategy       wlog  step  lazy  HC config                                   row config
     // ---  -------------- ----  ----  ----  ------------------------------------------  ----------
-    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 17, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 19, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, hash_fill_step: 1, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
@@ -420,12 +420,16 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                 // Negative levels: ultra-fast with the Simple backend.
                 // Acceleration grows with magnitude, expressed as larger
                 // hash_fill_step (fewer positions indexed).
+                // `window_log = 19` matches donor's "base for negative
+                // levels" row in `clevels.h`, so the SuffixStore-per-
+                // WindowEntry has enough span to recall periodic
+                // patterns across `MAX_BLOCK_SIZE` boundaries.
                 let acceleration =
                     (n.saturating_abs() as usize).min((-CompressionLevel::MIN_LEVEL) as usize);
                 let step = (acceleration + 3).min(128);
                 LevelParams {
                     strategy_tag: super::strategy::StrategyTag::Fast,
-                    window_log: 17,
+                    window_log: 19,
                     hash_fill_step: step,
                     lazy_depth: 0,
                     hc: HC_CONFIG,
@@ -3984,7 +3988,7 @@ fn driver_switches_backends_and_initializes_dfast_via_reset() {
     assert_eq!(reconstructed, b"abcabcabcabcabcabcabcabc");
 
     driver.reset(CompressionLevel::Fastest);
-    assert_eq!(driver.window_size(), (1u64 << 17));
+    assert_eq!(driver.window_size(), (1u64 << 19));
 }
 
 #[test]
@@ -5706,7 +5710,7 @@ fn driver_best_to_fastest_releases_oversized_hc_tables() {
     // exists; the assertion that storage is now `Simple` covers the
     // invariant the old hash_table/chain_table checks were proxying.
     driver.reset(CompressionLevel::Fastest);
-    assert_eq!(driver.window_size(), (1u64 << 17));
+    assert_eq!(driver.window_size(), (1u64 << 19));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Simple);
 }
 


### PR DESCRIPTION
## Summary

Bump Fast strategy `window_log` from 17 to 19 to match donor's
`{ 19, 13, 14, 1, 7, 0, ZSTD_fast }` row in `clevels.h`. The Fast
matcher keeps a per-`WindowEntry` `SuffixStore`; at `window_log = 17`
the ring held exactly one `MAX_BLOCK_SIZE` block, so each new block
evicted the previous block's hash entries and the matcher could not
recall periodic patterns that span a block boundary. Bumping to 19
gives the ring ~4 blocks of history.

## Impact

On `large-log-stream` (100 MiB of repeating 4-line log cycle,
~380 byte period, ~800 blocks at MAX_BLOCK_SIZE) the Fast matcher
previously re-emitted the cycle's first ~380 bytes as literals at the
head of every block. Final output was 94 175 bytes vs donor's 9 752.
After the bump:

| level | rust_bytes before | rust_bytes after | donor | ratio after |
|---|---:|---:|---:|---:|
| L1 fast × large-log-stream | 94 175 | 11 355 | 9 752 | 1.16× |
| L−7 fast × large-log-stream | (similar regression) | 11 348 | 14 592 | 0.78× |
| L−4 fast × large-log-stream | (similar regression) | 11 353 | 12 182 | 0.93× |

Full Fast matrix (8 levels × 7 scenarios = 56 cells) re-measured —
no scenario regressed by more than +16 bytes. The remaining
non-trivial costs:

- `low-entropy-1m` L−2..L1: rust 176 vs donor 160-167 (1.05-1.10×)
- `large-log-stream` L−2..L1 cluster: rust ~11.35 KiB vs donor
  9.7-10.6 KiB (under 1.2×)

Both are dwarfed by the ~80 KiB win on the L1 cell.

## Verification

- 534/534 lib tests pass
- clippy + fmt clean
- Full ratio matrix re-measured via REPORT lines for Fast levels
  across all 7 scenarios
- Two existing tests updated (window-size assertions on
  `CompressionLevel::Fastest`; cross-window-boundary payload size in
  the dictionary roundtrip test)

## Test fixups

- `dictionary_roundtrip_stays_valid_after_output_exceeds_window`:
  payload bumped from `128 KiB + 64` to `512 KiB + 64` so it still
  crosses the advertised window boundary at the new Fastest size.
- `driver_*_releases_oversized_hc_tables` and adjacent driver tests:
  `1u64 << 17` → `1u64 << 19` in two `window_size` assertions on
  `CompressionLevel::Fastest`.

## Related

- Closes #186 — the large-log-stream Fast L1 ratio investigation
- #184 — lazy investigation (parallel track; different code path)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictionary validation to correctly handle larger payloads across window boundaries.

* **Performance**
  * Adjusted fast compression level tuning for improved compression window sizing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->