### PR TITLE
ci: skip full pipeline on docs/dashboard-only commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,25 @@ name: CI
 on:
   push:
     branches: [main]
+    # Docs-only / dashboard-only commits don't touch code, tests, or
+    # bench inputs — no reason to spin up the full lint → test (3 OS) →
+    # cross-i686 → msrv → codecov → fuzz → 27-shard bench pipeline.
+    # The dashboard's `index.html` republish path lives in
+    # `pages-only.yml`, which is gated on these same paths inversely.
+    paths-ignore:
+      - '**.md'
+      - '.github/bench-dashboard/**'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.gitignore'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.github/bench-dashboard/**'
+      - 'docs/**'
+      - 'LICENSE*'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/pages-only.yml
+++ b/.github/workflows/pages-only.yml
@@ -1,0 +1,56 @@
+name: Pages-only deploy
+
+# Lightweight companion to ci.yml: deploys the dashboard shell
+# (`.github/bench-dashboard/index.html`) to gh-pages without running
+# the full bench/test/build pipeline. Triggered ONLY when paths that
+# ci.yml ignores actually change — the two workflows partition the
+# push space so every commit hits exactly one of them.
+#
+# Bench data files (benchmark-report.md, benchmark-delta.json, etc.)
+# on gh-pages are NOT touched here — they're produced by the bench
+# pipeline in ci.yml and remain authoritative.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/bench-dashboard/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-only-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy-dashboard:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          token: ${{ steps.bot-token.outputs.token }}
+          path: gh-pages
+
+      - name: Copy dashboard shell and push
+        run: |
+          mkdir -p gh-pages/dev/bench
+          cp .github/bench-dashboard/index.html gh-pages/dev/bench/index.html
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dev/bench/index.html
+          git diff --cached --quiet || git commit -m "chore(dashboard): refresh index.html"
+          git push origin gh-pages


### PR DESCRIPTION
## Summary

- `ci.yml`: add `paths-ignore` for `**.md`, `.github/bench-dashboard/**`, `docs/**`, `LICENSE*`, `.gitignore` on both `push` and `pull_request` triggers
- `pages-only.yml`: new lightweight workflow that copies `bench-dashboard/index.html` to gh-pages on dashboard-only main pushes (~30s vs full 27-shard pipeline)

## Why

Commit 8cfa86dc touched only `README.md` + `bench-dashboard/index.html` but spun up the entire pipeline: lint, test (3 OS), cross-i686, msrv, codecov, fuzz, 27 bench shards, aggregate, pages, regression check. `ci.yml` had zero `paths` filters.

## Partitioning

- README-only commit → nothing runs
- `bench-dashboard/index.html`-only commit → `pages-only.yml` only (fast dashboard refresh)
- Code commit → full `ci.yml` as before; `benchmark-pages` job remains authoritative for bench data files (`benchmark-report.md`, `benchmark-delta.json`, etc.)

## Test plan

- [ ] Open this PR with only `.github/workflows/*` changes → `ci.yml` skips itself (workflow file path itself isn't in code paths but is also not in ignore list — verify behaviour)
- [ ] After merge, push README-only change → no workflows run
- [ ] After merge, push `bench-dashboard/index.html`-only change → only `pages-only.yml` runs and updates gh-pages

Closes #195