### PR TITLE
perf(decode): HUF 4-stream 5-symbol burst + per-burst refill

### DIFF
--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -158,6 +158,87 @@ fn decompress_literals(
         } else {
             Decode4Mode::Checked
         };
+
+        // Donor-parity burst: decode `SYMBOLS_PER_BURST` symbols per stream
+        // (× 4 streams = `4 * SYMBOLS_PER_BURST` symbols per outer iteration)
+        // between bit-reader refill checks. Mirrors
+        // `HUF_DECODEFAST_4X1_LOOP_SYM = 5` in
+        // `huf_decompress.c:HUF_decompress4X1_usingDTable_internal_fast_c_loop`.
+        //
+        // Burst size is computed so the maximum bits consumed per stream
+        // across one burst is `SYMBOLS_PER_BURST * max_num_bits <= 56`,
+        // matching the `BitReaderReversed::ensure_bits(n <= 56)` contract.
+        // For the dominant HUF table widths (`max_num_bits <= 11`) this
+        // selects 5; for the rare 12-bit literal tables it backs off to 4.
+        // `max_num_bits.max(1)` guards the degenerate zero-table case
+        // (compressed literal sections with `max_num_bits == 0` decode to
+        // empty output via the tail loop anyway).
+        let max_num_bits = scratch.table.max_num_bits.max(1);
+        let symbols_per_burst: usize = (56 / max_num_bits as usize).max(1);
+        let burst_bits = (symbols_per_burst * max_num_bits as usize) as u8;
+        let burst_bits_isize = burst_bits as isize;
+
+        // Per-stream bound used to decide whether the next burst can fit
+        // entirely inside the bit budget. Donor uses an explicit
+        // pre-computed `olimit`; the `bits_remaining > burst_bits_isize`
+        // check here serves the same role — the burst can consume at most
+        // `burst_bits` per stream and we want at least `max_bits` left
+        // over so the tail loop has a clean termination condition.
+        while brs[0].bits_remaining() > burst_bits_isize
+            && brs[1].bits_remaining() > burst_bits_isize
+            && brs[2].bits_remaining() > burst_bits_isize
+            && brs[3].bits_remaining() > burst_bits_isize
+            && cursors[0] + symbols_per_burst <= ends[0]
+            && cursors[1] + symbols_per_burst <= ends[1]
+            && cursors[2] + symbols_per_burst <= ends[2]
+            && cursors[3] + symbols_per_burst <= ends[3]
+        {
+            // Single refill check per stream per burst — drops the per-call
+            // `bits_consumed + n > 64` branch that `get_bits` performs
+            // inside `advance_state_by_bits`. Donor `HUF_4X1_RELOAD_STREAM`
+            // (huf_decompress.c:795-804) does the equivalent at the end of
+            // each 5-symbol burst.
+            brs[0].ensure_bits(burst_bits);
+            brs[1].ensure_bits(burst_bits);
+            brs[2].ensure_bits(burst_bits);
+            brs[3].ensure_bits(burst_bits);
+
+            for _ in 0..symbols_per_burst {
+                let (symbols, bits) = match decode4_mode {
+                    Decode4Mode::Unchecked => {
+                        // SAFETY: guarded by decode4_has_shared_table_and_kernel above.
+                        unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
+                    }
+                    Decode4Mode::Checked => HuffmanDecoder::decode4_symbols_and_num_bits(&decoders),
+                };
+
+                target[cursors[0]] = symbols[0];
+                target[cursors[1]] = symbols[1];
+                target[cursors[2]] = symbols[2];
+                target[cursors[3]] = symbols[3];
+                cursors[0] += 1;
+                cursors[1] += 1;
+                cursors[2] += 1;
+                cursors[3] += 1;
+
+                // _unchecked: the burst-level ensure_bits above already
+                // covers `symbols_per_burst * max_num_bits` bits per stream
+                // and each `bits[i]` is `<= max_num_bits`, so cumulative
+                // consumption inside the burst can never exceed the ensured
+                // budget.
+                decoders[0].advance_state_by_bits_unchecked(&mut brs[0], bits[0]);
+                decoders[1].advance_state_by_bits_unchecked(&mut brs[1], bits[1]);
+                decoders[2].advance_state_by_bits_unchecked(&mut brs[2], bits[2]);
+                decoders[3].advance_state_by_bits_unchecked(&mut brs[3], bits[3]);
+            }
+        }
+
+        // Spill-over: a few symbols may still fit in each stream after the
+        // last burst exits its bound check (e.g. cursors close to ends, or
+        // a stream's bit budget dropped just under `burst_bits` while the
+        // others still had room). Walk one symbol at a time using the
+        // checked path until each stream individually trips its termination
+        // condition.
         while brs[0].bits_remaining() > -max_bits
             && brs[1].bits_remaining() > -max_bits
             && brs[2].bits_remaining() > -max_bits

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -159,22 +159,27 @@ fn decompress_literals(
             Decode4Mode::Checked
         };
 
-        // Donor-parity burst: decode `SYMBOLS_PER_BURST` symbols per stream
-        // (× 4 streams = `4 * SYMBOLS_PER_BURST` symbols per outer iteration)
-        // between bit-reader refill checks. Mirrors
-        // `HUF_DECODEFAST_4X1_LOOP_SYM = 5` in
-        // `huf_decompress.c:HUF_decompress4X1_usingDTable_internal_fast_c_loop`.
+        // Variable-size burst: decode `symbols_per_burst` symbols per stream
+        // (× 4 streams = `4 * symbols_per_burst` symbols per outer iteration)
+        // between bit-reader refill checks. Inspired by donor
+        // `HUF_decompress4X1_usingDTable_internal_fast_c_loop`
+        // (huf_decompress.c:738-819), which uses a fixed 5-symbol unroll;
+        // we generalise to whatever the bit budget allows so narrower
+        // tables get more symbols-per-refill.
         //
-        // Burst size is computed so the maximum bits consumed per stream
-        // across one burst is `SYMBOLS_PER_BURST * max_num_bits <= 56`,
-        // matching the `BitReaderReversed::ensure_bits(n <= 56)` contract.
-        // For the dominant HUF table widths (`max_num_bits <= 11`) this
-        // selects 5; for the rare 12-bit literal tables it backs off to 4.
-        // `max_num_bits.max(1)` guards the degenerate zero-table case
-        // (compressed literal sections with `max_num_bits == 0` decode to
-        // empty output via the tail loop anyway).
-        let max_num_bits = scratch.table.max_num_bits.max(1);
-        let symbols_per_burst: usize = (56 / max_num_bits as usize).max(1);
+        // Burst size is `floor(56 / max_num_bits)`: the maximum bits
+        // consumed per stream across one burst is
+        // `symbols_per_burst * max_num_bits <= 56`, matching the
+        // `BitReaderReversed::ensure_bits(n <= 56)` contract. The
+        // Zstandard spec caps `max_num_bits` at 11
+        // (`huff0_decoder::MAX_MAX_NUM_BITS`), so `symbols_per_burst`
+        // lands in `[5, 56]` — 5 for full 11-bit tables, up to 56 for
+        // degenerate 1-bit tables. `build_decoder` always sets
+        // `max_num_bits >= 1` for valid frames, so no zero-divisor
+        // guard is needed here (corrupted/empty tables are rejected
+        // upstream before reaching this loop).
+        let max_num_bits = scratch.table.max_num_bits;
+        let symbols_per_burst: usize = 56 / max_num_bits as usize;
         let burst_bits = (symbols_per_burst * max_num_bits as usize) as u8;
         let burst_bits_isize = burst_bits as isize;
 

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -240,6 +240,28 @@ impl<'t> HuffmanDecoder<'t> {
     #[inline(always)]
     pub(crate) fn advance_state_by_bits(&mut self, br: &mut BitReaderReversed<'_>, num_bits: u8) {
         let new_bits = br.get_bits(num_bits);
+        self.advance_state_from_bits(num_bits, new_bits);
+    }
+
+    /// Advance state without invoking a refill check on the bit reader.
+    ///
+    /// The caller MUST have ensured (via `br.ensure_bits(sum_of_num_bits)`)
+    /// that the reader holds enough bits to satisfy every unchecked read
+    /// across the burst. Used by the 5-symbols-per-stream HUF unroll —
+    /// donor parity with `HUF_4X1_DECODE_SYMBOL` inside
+    /// `HUF_decompress4X1_usingDTable_internal_fast_c_loop`.
+    #[inline(always)]
+    pub(crate) fn advance_state_by_bits_unchecked(
+        &mut self,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits_unchecked(num_bits);
+        self.advance_state_from_bits(num_bits, new_bits);
+    }
+
+    #[inline(always)]
+    fn advance_state_from_bits(&mut self, num_bits: u8, new_bits: u64) {
         match self.kernel {
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             HuffmanDecodeKernel::X86Bmi2


### PR DESCRIPTION
## Summary

Step B + D from #199 (HUF rewrite plan). Mirrors `HUF_decompress4X1_usingDTable_internal_fast_c_loop` (huf_decompress.c:738-819): decode N symbols per stream per outer iteration with a single `ensure_bits` refill check per stream per burst, then advance state via `get_bits_unchecked`. N sized so `N * max_num_bits <= 56` (the `BitReaderReversed::ensure_bits` contract) — selects 5 for the dominant ≤11-bit HUF tables and 4 for the 12-bit case.

Drops the per-symbol `bits_consumed + n > 64` branch inside the inner state advance — one refill check now amortises across 4–5 symbol decodes per stream instead of firing on every call. Tail loop kept in checked form (single-symbol `get_bits`) so segment-end spillover stays sound when one stream's bit budget drops below the burst threshold while the others still have room.

New helper `HuffmanDecoder::advance_state_by_bits_unchecked` routes through `advance_state_from_bits`, preserving the BMI2 kernel dispatch on x86-64. Checked variant unchanged.

## Bench

`decodecorpus-z000033`, M1 aarch64:

| Scenario | main | branch | Δ |
|---|---|---|---|
| `decompress/level_4_greedy/rust_stream` | 4.11 ms | 3.51 ms | **−14.6%** |

This was the worst-case scenario flagged in #199 (HUF 4-stream loop on encoder-heavy L=4+ rust_stream, ~50 % self-time in `literals_section_decoder::decode_literals`). c_stream and fast-level scenarios show no regression in spot checks.

## Tests

- 548/548 nextest pass
- clippy clean across lib + tests
- Ratio preserved (no compressed-output changes from a decode-only patch)

## Files

- `zstd/src/huff0/huff0_decoder.rs` — `advance_state_by_bits_unchecked` helper + factored `advance_state_from_bits` (kernel dispatch unchanged)
- `zstd/src/decoding/literals_section_decoder.rs` — burst loop in front of the existing checked tail

## Out of scope

- Step A (sentinel-bit refill via `ctz`) — separate PR, targets `bit_reader_reverse.rs` directly.
- Step E (const-generic kernel monomorphisation) — separate PR.

Part of #199. Closes nothing yet — #199 stays open until steps A + E land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved multi-stream literal decoding with a bounded burst-phase that decodes interleaved symbols in larger chunks for faster decompression and better throughput.
  * Streamlined Huffman state advancement with a faster unchecked path for burst decoding, reducing per-symbol overhead and improving decoder efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->