### PR TITLE
perf(decode): port donor HUF 4-stream burst with sentinel-bit ctz

### DIFF
--- a/zstd/src/bit_io/bit_reader_reverse.rs
+++ b/zstd/src/bit_io/bit_reader_reverse.rs
@@ -156,7 +156,16 @@ pub struct BitReaderReversed<'s> {
     index: usize,
 
     /// How many bits have been consumed from `bit_container`.
-    bits_consumed: u8,
+    ///
+    /// `pub(crate)` so the HUF 4-stream hot loop in
+    /// `decoding::literals_section_decoder` can lift the reader state
+    /// into a local `bits[4]` register layout (donor parity with
+    /// `huf_decompress.c:HUF_decompress4X1_usingDTable_internal_fast_c_loop`):
+    /// inside the burst, all symbol-decode work happens against a
+    /// `bits[s]` u64 that fuses the decoder state with pending input
+    /// bits, and the field is written back only at the burst boundary.
+    /// Outside the burst the field is treated as opaque internal state.
+    pub(crate) bits_consumed: u8,
 
     /// How many bits have been consumed past the end of the input. Will be zero until all the input
     /// has been read.
@@ -167,7 +176,9 @@ pub struct BitReaderReversed<'s> {
 
     /// The reader doesn't read directly from the source, it reads bits from here, and the container
     /// is "refilled" as it's emptied.
-    bit_container: u64,
+    ///
+    /// `pub(crate)` — see [`Self::bits_consumed`] for the rationale.
+    pub(crate) bit_container: u64,
 }
 
 impl<'s> BitReaderReversed<'s> {

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -145,19 +145,111 @@ fn decompress_literals(
         let ends: [usize; 4] = [starts[1], starts[2], starts[3], limit];
         let mut cursors = starts;
 
-        // Fast interleaved loop: decode 4 symbols/bit-counts via decode4 helper
-        // (which may use packed/SIMD gather+unpack kernels), then advance the
-        // 4 stream states independently. This gives the CPU's out-of-order
-        // engine more independent work to schedule, hiding decode latency.
-        enum Decode4Mode {
-            Unchecked,
-            Checked,
+        // Donor-style burst loop.
+        //
+        // bits[s] register (per stream) layout, MSB → LSB:
+        //   [ state (max_num_bits) | stream (≤ 64 - 2·max bits) | zeros + sentinel ]
+        //
+        // Our `decoder.state` is conceptually "the next max-bit
+        // lookahead window starting at the current consumption point";
+        // the stream bits that constitute it sit in `bit_container` at
+        // positions `[(64 - bits_consumed), (63 - bits_consumed + max))`
+        // BUT ONLY when `bits_consumed >= max_num_bits`. After a refill
+        // `bits_consumed` resets to `[0, 7]`, where those positions
+        // partially fall outside the current window — the formula then
+        // would lose low stream bits. Guard the burst by requiring
+        // `bits_consumed >= max_num_bits` on every stream; if any
+        // stream falls below, the tail loop runs single-symbol until
+        // the invariant is restored.
+        let max_num_bits = scratch.table.max_num_bits;
+        // symbols_per_burst * max ≤ 63 - max so the sentinel stays
+        // below the state region after the worst-case T-shift.
+        // For max=11: 4 symbols. For max=8: 6 symbols.
+        let symbols_per_burst: usize = (63 - max_num_bits as usize) / max_num_bits as usize;
+        let burst_bits = (symbols_per_burst * max_num_bits as usize) as u8;
+        let burst_bits_isize = burst_bits as isize;
+        let table_shift = (64 - max_num_bits) as u32;
+        let state_shift = 64 - max_num_bits;
+        let packed = scratch.table.packed_decode.as_slice();
+
+        while symbols_per_burst >= 1
+            && brs[0].bits_remaining() > burst_bits_isize
+            && brs[1].bits_remaining() > burst_bits_isize
+            && brs[2].bits_remaining() > burst_bits_isize
+            && brs[3].bits_remaining() > burst_bits_isize
+            && cursors[0] + symbols_per_burst <= ends[0]
+            && cursors[1] + symbols_per_burst <= ends[1]
+            && cursors[2] + symbols_per_burst <= ends[2]
+            && cursors[3] + symbols_per_burst <= ends[3]
+            && brs[0].bits_consumed >= max_num_bits
+            && brs[1].bits_consumed >= max_num_bits
+            && brs[2].bits_consumed >= max_num_bits
+            && brs[3].bits_consumed >= max_num_bits
+            // Without an `ensure_bits` call inside the loop we must
+            // also confirm the burst fits inside the current
+            // `bit_container` (no refill in-flight). After consume,
+            // `bits_consumed + burst_bits ≤ 64` so the inner shifts
+            // never read past the loaded 8-byte window.
+            && (brs[0].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[1].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[2].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[3].bits_consumed as usize) + burst_bits as usize <= 64
+        {
+            let mut bits = [
+                (decoders[0].state << state_shift)
+                    | ((brs[0].bit_container << brs[0].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[1].state << state_shift)
+                    | ((brs[1].bit_container << brs[1].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[2].state << state_shift)
+                    | ((brs[2].bit_container << brs[2].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[3].state << state_shift)
+                    | ((brs[3].bit_container << brs[3].bits_consumed) >> max_num_bits)
+                    | 1,
+            ];
+
+            for _ in 0..symbols_per_burst {
+                let idx0 = (bits[0] >> table_shift) as usize;
+                let entry0 = packed[idx0];
+                target[cursors[0]] = (entry0 & 0xFF) as u8;
+                cursors[0] += 1;
+                bits[0] <<= (entry0 >> 8) & 0xFF;
+
+                let idx1 = (bits[1] >> table_shift) as usize;
+                let entry1 = packed[idx1];
+                target[cursors[1]] = (entry1 & 0xFF) as u8;
+                cursors[1] += 1;
+                bits[1] <<= (entry1 >> 8) & 0xFF;
+
+                let idx2 = (bits[2] >> table_shift) as usize;
+                let entry2 = packed[idx2];
+                target[cursors[2]] = (entry2 & 0xFF) as u8;
+                cursors[2] += 1;
+                bits[2] <<= (entry2 >> 8) & 0xFF;
+
+                let idx3 = (bits[3] >> table_shift) as usize;
+                let entry3 = packed[idx3];
+                target[cursors[3]] = (entry3 & 0xFF) as u8;
+                cursors[3] += 1;
+                bits[3] <<= (entry3 >> 8) & 0xFF;
+            }
+
+            for s in 0..4 {
+                let consumed = bits[s].trailing_zeros() as u8;
+                brs[s].bits_consumed += consumed;
+                decoders[s].state = bits[s] >> table_shift;
+            }
         }
-        let decode4_mode = if HuffmanDecoder::decode4_has_shared_table_and_kernel(&decoders) {
-            Decode4Mode::Unchecked
-        } else {
-            Decode4Mode::Checked
-        };
+
+        // SIMD 4-symbol main loop: runs when the donor burst gate
+        // (bits_consumed >= max_num_bits) is not satisfied, e.g.
+        // right after a refill rebases bits_consumed to [0, 7]. Uses
+        // the existing `decode4_symbols_and_num_bits` SIMD lookup +
+        // per-symbol `advance_state_by_bits` so the slow path still
+        // beats the single-symbol tail.
+        let decode4_unchecked = HuffmanDecoder::decode4_has_shared_table_and_kernel(&decoders);
         while brs[0].bits_remaining() > -max_bits
             && brs[1].bits_remaining() > -max_bits
             && brs[2].bits_remaining() > -max_bits
@@ -167,27 +259,24 @@ fn decompress_literals(
             && cursors[2] < ends[2]
             && cursors[3] < ends[3]
         {
-            let (symbols, bits) = match decode4_mode {
-                Decode4Mode::Unchecked => {
-                    // SAFETY: guarded by decode4_has_shared_table_and_kernel above.
-                    unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
-                }
-                Decode4Mode::Checked => HuffmanDecoder::decode4_symbols_and_num_bits(&decoders),
+            let (symbols, nbits) = if decode4_unchecked {
+                // SAFETY: same-table-and-kernel verified above.
+                unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
+            } else {
+                HuffmanDecoder::decode4_symbols_and_num_bits(&decoders)
             };
-
             target[cursors[0]] = symbols[0];
-            target[cursors[1]] = symbols[1];
-            target[cursors[2]] = symbols[2];
-            target[cursors[3]] = symbols[3];
             cursors[0] += 1;
+            target[cursors[1]] = symbols[1];
             cursors[1] += 1;
+            target[cursors[2]] = symbols[2];
             cursors[2] += 1;
+            target[cursors[3]] = symbols[3];
             cursors[3] += 1;
-
-            decoders[0].advance_state_by_bits(&mut brs[0], bits[0]);
-            decoders[1].advance_state_by_bits(&mut brs[1], bits[1]);
-            decoders[2].advance_state_by_bits(&mut brs[2], bits[2]);
-            decoders[3].advance_state_by_bits(&mut brs[3], bits[3]);
+            decoders[0].advance_state_by_bits(&mut brs[0], nbits[0]);
+            decoders[1].advance_state_by_bits(&mut brs[1], nbits[1]);
+            decoders[2].advance_state_by_bits(&mut brs[2], nbits[2]);
+            decoders[3].advance_state_by_bits(&mut brs[3], nbits[3]);
         }
 
         // Drain remaining symbols from each stream, bounded by segment end

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -200,10 +200,17 @@ fn decompress_literals(
                 && brs[1].bits_remaining() > burst_bits_isize
                 && brs[2].bits_remaining() > burst_bits_isize
                 && brs[3].bits_remaining() > burst_bits_isize
-                && cursors[0] + symbols_per_burst <= ends[0]
-                && cursors[1] + symbols_per_burst <= ends[1]
-                && cursors[2] + symbols_per_burst <= ends[2]
-                && cursors[3] + symbols_per_burst <= ends[3]
+                // Saturating form so the bound holds even when `ends[i]
+                // < symbols_per_burst` near the segment tail (rather
+                // than relying on `cursors[i] + symbols_per_burst` not
+                // wrapping). `regen` is bounded by RFC 8878 block
+                // size ⇒ overflow is unreachable in practice, but the
+                // saturating shape costs the same single subq and
+                // removes the addition entirely.
+                && cursors[0] <= ends[0].saturating_sub(symbols_per_burst)
+                && cursors[1] <= ends[1].saturating_sub(symbols_per_burst)
+                && cursors[2] <= ends[2].saturating_sub(symbols_per_burst)
+                && cursors[3] <= ends[3].saturating_sub(symbols_per_burst)
                 && brs[0].bits_consumed >= max_num_bits
                 && brs[1].bits_consumed >= max_num_bits
                 && brs[2].bits_consumed >= max_num_bits

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -145,22 +145,29 @@ fn decompress_literals(
         let ends: [usize; 4] = [starts[1], starts[2], starts[3], limit];
         let mut cursors = starts;
 
-        // Donor-style burst loop.
+        // Donor-style burst loop with SIMD fallback interleaved per
+        // iteration — burst is the primary tier whenever the gate
+        // holds, SIMD takes over for the iterations where the burst
+        // is gated out (typically right after `advance_state_by_bits`
+        // triggers a refill inside a SIMD iter and `bits_consumed`
+        // rebases to `[0, 7]`).
         //
-        // bits[s] register (per stream) layout, MSB → LSB:
+        // bits[s] register (per stream) layout for the burst, MSB → LSB:
         //   [ state (max_num_bits) | stream (≤ 64 - 2·max bits) | zeros + sentinel ]
         //
         // Our `decoder.state` is conceptually "the next max-bit
-        // lookahead window starting at the current consumption point";
-        // the stream bits that constitute it sit in `bit_container` at
-        // positions `[(64 - bits_consumed), (63 - bits_consumed + max))`
-        // BUT ONLY when `bits_consumed >= max_num_bits`. After a refill
+        // lookahead window starting at the current consumption
+        // point"; the stream bits that constitute it sit in
+        // `bit_container` at positions
+        // `[(64 - bits_consumed), (63 - bits_consumed + max))` BUT
+        // ONLY when `bits_consumed >= max_num_bits`. After a refill
         // `bits_consumed` resets to `[0, 7]`, where those positions
-        // partially fall outside the current window — the formula then
-        // would lose low stream bits. Guard the burst by requiring
-        // `bits_consumed >= max_num_bits` on every stream; if any
-        // stream falls below, the tail loop runs single-symbol until
-        // the invariant is restored.
+        // partially fall outside the current window — the formula
+        // would then lose low stream bits. The `bits_consumed >=
+        // max_num_bits` gate keeps the burst sound; the SIMD branch
+        // handles the post-refill iterations until `bits_consumed`
+        // grows back into burst range, at which point we re-enter
+        // the burst body in the same outer loop.
         let max_num_bits = scratch.table.max_num_bits;
         // symbols_per_burst * max ≤ 63 - max so the sentinel stays
         // below the state region after the worst-case T-shift.
@@ -171,112 +178,118 @@ fn decompress_literals(
         let table_shift = (64 - max_num_bits) as u32;
         let state_shift = 64 - max_num_bits;
         let packed = scratch.table.packed_decode.as_slice();
-
-        while symbols_per_burst >= 1
-            && brs[0].bits_remaining() > burst_bits_isize
-            && brs[1].bits_remaining() > burst_bits_isize
-            && brs[2].bits_remaining() > burst_bits_isize
-            && brs[3].bits_remaining() > burst_bits_isize
-            && cursors[0] + symbols_per_burst <= ends[0]
-            && cursors[1] + symbols_per_burst <= ends[1]
-            && cursors[2] + symbols_per_burst <= ends[2]
-            && cursors[3] + symbols_per_burst <= ends[3]
-            && brs[0].bits_consumed >= max_num_bits
-            && brs[1].bits_consumed >= max_num_bits
-            && brs[2].bits_consumed >= max_num_bits
-            && brs[3].bits_consumed >= max_num_bits
-            // Without an `ensure_bits` call inside the loop we must
-            // also confirm the burst fits inside the current
-            // `bit_container` (no refill in-flight). After consume,
-            // `bits_consumed + burst_bits ≤ 64` so the inner shifts
-            // never read past the loaded 8-byte window.
-            && (brs[0].bits_consumed as usize) + burst_bits as usize <= 64
-            && (brs[1].bits_consumed as usize) + burst_bits as usize <= 64
-            && (brs[2].bits_consumed as usize) + burst_bits as usize <= 64
-            && (brs[3].bits_consumed as usize) + burst_bits as usize <= 64
-        {
-            let mut bits = [
-                (decoders[0].state << state_shift)
-                    | ((brs[0].bit_container << brs[0].bits_consumed) >> max_num_bits)
-                    | 1,
-                (decoders[1].state << state_shift)
-                    | ((brs[1].bit_container << brs[1].bits_consumed) >> max_num_bits)
-                    | 1,
-                (decoders[2].state << state_shift)
-                    | ((brs[2].bit_container << brs[2].bits_consumed) >> max_num_bits)
-                    | 1,
-                (decoders[3].state << state_shift)
-                    | ((brs[3].bit_container << brs[3].bits_consumed) >> max_num_bits)
-                    | 1,
-            ];
-
-            for _ in 0..symbols_per_burst {
-                let idx0 = (bits[0] >> table_shift) as usize;
-                let entry0 = packed[idx0];
-                target[cursors[0]] = (entry0 & 0xFF) as u8;
-                cursors[0] += 1;
-                bits[0] <<= (entry0 >> 8) & 0xFF;
-
-                let idx1 = (bits[1] >> table_shift) as usize;
-                let entry1 = packed[idx1];
-                target[cursors[1]] = (entry1 & 0xFF) as u8;
-                cursors[1] += 1;
-                bits[1] <<= (entry1 >> 8) & 0xFF;
-
-                let idx2 = (bits[2] >> table_shift) as usize;
-                let entry2 = packed[idx2];
-                target[cursors[2]] = (entry2 & 0xFF) as u8;
-                cursors[2] += 1;
-                bits[2] <<= (entry2 >> 8) & 0xFF;
-
-                let idx3 = (bits[3] >> table_shift) as usize;
-                let entry3 = packed[idx3];
-                target[cursors[3]] = (entry3 & 0xFF) as u8;
-                cursors[3] += 1;
-                bits[3] <<= (entry3 >> 8) & 0xFF;
-            }
-
-            for s in 0..4 {
-                let consumed = bits[s].trailing_zeros() as u8;
-                brs[s].bits_consumed += consumed;
-                decoders[s].state = bits[s] >> table_shift;
-            }
-        }
-
-        // SIMD 4-symbol main loop: runs when the donor burst gate
-        // (bits_consumed >= max_num_bits) is not satisfied, e.g.
-        // right after a refill rebases bits_consumed to [0, 7]. Uses
-        // the existing `decode4_symbols_and_num_bits` SIMD lookup +
-        // per-symbol `advance_state_by_bits` so the slow path still
-        // beats the single-symbol tail.
         let decode4_unchecked = HuffmanDecoder::decode4_has_shared_table_and_kernel(&decoders);
-        while brs[0].bits_remaining() > -max_bits
-            && brs[1].bits_remaining() > -max_bits
-            && brs[2].bits_remaining() > -max_bits
-            && brs[3].bits_remaining() > -max_bits
-            && cursors[0] < ends[0]
-            && cursors[1] < ends[1]
-            && cursors[2] < ends[2]
-            && cursors[3] < ends[3]
-        {
-            let (symbols, nbits) = if decode4_unchecked {
-                // SAFETY: same-table-and-kernel verified above.
-                unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
+
+        loop {
+            // Common bound: any stream exhausted or any cursor at end
+            // → exit; the single-symbol tail below handles the drain.
+            if brs[0].bits_remaining() <= -max_bits
+                || brs[1].bits_remaining() <= -max_bits
+                || brs[2].bits_remaining() <= -max_bits
+                || brs[3].bits_remaining() <= -max_bits
+                || cursors[0] >= ends[0]
+                || cursors[1] >= ends[1]
+                || cursors[2] >= ends[2]
+                || cursors[3] >= ends[3]
+            {
+                break;
+            }
+
+            let burst_ok = symbols_per_burst >= 1
+                && brs[0].bits_remaining() > burst_bits_isize
+                && brs[1].bits_remaining() > burst_bits_isize
+                && brs[2].bits_remaining() > burst_bits_isize
+                && brs[3].bits_remaining() > burst_bits_isize
+                && cursors[0] + symbols_per_burst <= ends[0]
+                && cursors[1] + symbols_per_burst <= ends[1]
+                && cursors[2] + symbols_per_burst <= ends[2]
+                && cursors[3] + symbols_per_burst <= ends[3]
+                && brs[0].bits_consumed >= max_num_bits
+                && brs[1].bits_consumed >= max_num_bits
+                && brs[2].bits_consumed >= max_num_bits
+                && brs[3].bits_consumed >= max_num_bits
+                // Burst body has no `ensure_bits` — confirm the burst
+                // fits inside the current `bit_container` so the
+                // inner shifts never read past the loaded 8-byte
+                // window.
+                && (brs[0].bits_consumed as usize) + burst_bits as usize <= 64
+                && (brs[1].bits_consumed as usize) + burst_bits as usize <= 64
+                && (brs[2].bits_consumed as usize) + burst_bits as usize <= 64
+                && (brs[3].bits_consumed as usize) + burst_bits as usize <= 64;
+
+            if burst_ok {
+                let mut bits = [
+                    (decoders[0].state << state_shift)
+                        | ((brs[0].bit_container << brs[0].bits_consumed) >> max_num_bits)
+                        | 1,
+                    (decoders[1].state << state_shift)
+                        | ((brs[1].bit_container << brs[1].bits_consumed) >> max_num_bits)
+                        | 1,
+                    (decoders[2].state << state_shift)
+                        | ((brs[2].bit_container << brs[2].bits_consumed) >> max_num_bits)
+                        | 1,
+                    (decoders[3].state << state_shift)
+                        | ((brs[3].bit_container << brs[3].bits_consumed) >> max_num_bits)
+                        | 1,
+                ];
+
+                for _ in 0..symbols_per_burst {
+                    let idx0 = (bits[0] >> table_shift) as usize;
+                    let entry0 = packed[idx0];
+                    target[cursors[0]] = (entry0 & 0xFF) as u8;
+                    cursors[0] += 1;
+                    bits[0] <<= (entry0 >> 8) & 0xFF;
+
+                    let idx1 = (bits[1] >> table_shift) as usize;
+                    let entry1 = packed[idx1];
+                    target[cursors[1]] = (entry1 & 0xFF) as u8;
+                    cursors[1] += 1;
+                    bits[1] <<= (entry1 >> 8) & 0xFF;
+
+                    let idx2 = (bits[2] >> table_shift) as usize;
+                    let entry2 = packed[idx2];
+                    target[cursors[2]] = (entry2 & 0xFF) as u8;
+                    cursors[2] += 1;
+                    bits[2] <<= (entry2 >> 8) & 0xFF;
+
+                    let idx3 = (bits[3] >> table_shift) as usize;
+                    let entry3 = packed[idx3];
+                    target[cursors[3]] = (entry3 & 0xFF) as u8;
+                    cursors[3] += 1;
+                    bits[3] <<= (entry3 >> 8) & 0xFF;
+                }
+
+                for s in 0..4 {
+                    let consumed = bits[s].trailing_zeros() as u8;
+                    brs[s].consume(consumed);
+                    decoders[s].state = bits[s] >> table_shift;
+                }
             } else {
-                HuffmanDecoder::decode4_symbols_and_num_bits(&decoders)
-            };
-            target[cursors[0]] = symbols[0];
-            cursors[0] += 1;
-            target[cursors[1]] = symbols[1];
-            cursors[1] += 1;
-            target[cursors[2]] = symbols[2];
-            cursors[2] += 1;
-            target[cursors[3]] = symbols[3];
-            cursors[3] += 1;
-            decoders[0].advance_state_by_bits(&mut brs[0], nbits[0]);
-            decoders[1].advance_state_by_bits(&mut brs[1], nbits[1]);
-            decoders[2].advance_state_by_bits(&mut brs[2], nbits[2]);
-            decoders[3].advance_state_by_bits(&mut brs[3], nbits[3]);
+                // SIMD 4-symbol fallback for one outer iteration.
+                // `advance_state_by_bits` triggers a refill inside
+                // `get_bits` when needed; after this iter
+                // `bits_consumed` is back in `[0, 7]+n` and the
+                // burst gate may be satisfied again on the next
+                // outer-loop pass.
+                let (symbols, nbits) = if decode4_unchecked {
+                    // SAFETY: same-table-and-kernel verified above.
+                    unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
+                } else {
+                    HuffmanDecoder::decode4_symbols_and_num_bits(&decoders)
+                };
+                target[cursors[0]] = symbols[0];
+                cursors[0] += 1;
+                target[cursors[1]] = symbols[1];
+                cursors[1] += 1;
+                target[cursors[2]] = symbols[2];
+                cursors[2] += 1;
+                target[cursors[3]] = symbols[3];
+                cursors[3] += 1;
+                decoders[0].advance_state_by_bits(&mut brs[0], nbits[0]);
+                decoders[1].advance_state_by_bits(&mut brs[1], nbits[1]);
+                decoders[2].advance_state_by_bits(&mut brs[2], nbits[2]);
+                decoders[3].advance_state_by_bits(&mut brs[3], nbits[3]);
+            }
         }
 
         // Drain remaining symbols from each stream, bounded by segment end

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -370,28 +370,37 @@ mod burst_gate_tests {
     //! Regression coverage for the HUF 4-stream burst-gate boundary
     //! states in `decompress_literals`:
     //!
-    //!   1. `bits_consumed == max_num_bits` — exact lower boundary of
-    //!      the burst gate; gate is entered with zero slack.
-    //!   2. `bits_consumed + burst_bits == 64` — exact upper boundary;
-    //!      burst consumes all remaining bits in the 64-bit window
+    //!   1. `bits_consumed == max_num_bits` — lower boundary of the
+    //!      burst gate, where the gate is entered with zero slack.
+    //!   2. `bits_consumed + burst_bits == 64` — upper boundary, where
+    //!      the burst consumes all remaining bits in the 64-bit window
     //!      without overflow.
     //!   3. SIMD-fallback → refill → burst re-entry — outer loop falls
-    //!      back to the SIMD 4-symbol path, a `BitReaderReversed` refill
-    //!      occurs, the next iteration re-enters the burst path once
-    //!      `bits_consumed` grows back into burst range.
+    //!      back to the SIMD 4-symbol path, a `BitReaderReversed`
+    //!      refill occurs, the next iteration re-enters the burst path
+    //!      once `bits_consumed` grows back into burst range.
     //!
-    //! Each named test pins a deterministic shape that exercises the
-    //! corresponding state; the sweep test covers the gate in aggregate
-    //! across many `(size, alphabet)` combinations so any subset hits
-    //! the exact boundary conditions deterministically while the rest
-    //! supplies broad regression coverage.
+    //! Each named test pins an input shape chosen to drive the gate
+    //! through the corresponding regime — short skewed input for the
+    //! initial-entry lower-bound, long mid-cardinality streams for
+    //! many upper-bound brushes, multi-segment input for repeated
+    //! SIMD↔burst transitions. The sweep test covers the gate in
+    //! aggregate across many `(size, alphabet)` combinations.
     //!
-    //! All cases assert roundtrip correctness through the full encoder
-    //! → 4-stream HUF block → `decode_literals` path. A burst-gate
-    //! regression that returns the wrong symbol or desynchronises a
-    //! stream produces either a `DecompressLiteralsError` from the
-    //! `BitstreamReadMismatch` / `DecodedLiteralCountMismatch` guards
-    //! or a mismatched decoded buffer — both fail the assertion.
+    //! These tests do NOT assert that a specific
+    //! `(bits_consumed, burst_bits)` configuration is hit deterministically
+    //! on any single iteration — that would require white-box state
+    //! instrumentation that the current decoder does not expose. They
+    //! assert end-to-end roundtrip correctness through the full
+    //! encoder → 4-stream HUF block → `decode_literals` path; a
+    //! burst-gate regression that returns the wrong symbol or
+    //! desynchronises a stream produces either a
+    //! `DecompressLiteralsError` from the `BitstreamReadMismatch` /
+    //! `DecodedLiteralCountMismatch` guards or a mismatched decoded
+    //! buffer — both fail the assertion. The `max_num_bits` range
+    //! checks in the per-test helper also detect silent drift where
+    //! the encoder's table-generation choice shifts the test out of
+    //! the intended gate regime.
     use super::*;
     use crate::bit_io::BitWriter;
     use crate::blocks::literals_section::{LiteralsSection, LiteralsSectionType};
@@ -457,18 +466,19 @@ mod burst_gate_tests {
         );
     }
 
-    /// Lower boundary: `bits_consumed == max_num_bits` on first burst entry.
+    /// Lower boundary: targets `bits_consumed == max_num_bits` on
+    /// early burst entries.
     ///
-    /// 64 symbols with skewed weights drive `max_num_bits` into the
-    /// 8..=11 band (so `symbols_per_burst >= 4`); a short stream forces
-    /// the first burst iteration to start from `bits_consumed`
-    /// immediately at the gate threshold rather than well above it.
-    /// Decoder must not lose the low stream bits when the shift formula
-    /// runs at the threshold.
+    /// A short stream with a skewed 23-symbol alphabet keeps
+    /// `max_num_bits` in the 5..=11 band and limits the number of
+    /// burst iterations, so early iterations run with `bits_consumed`
+    /// near the gate threshold. The decoder must not lose low stream
+    /// bits when the shift formula runs close to the threshold;
+    /// roundtrip correctness over short input is the regression signal.
     #[test]
     fn burst_gate_lower_boundary_short_skewed_alphabet() {
-        // 36 bytes, 32-symbol skewed distribution — encoder picks
-        // max_num_bits ≈ 6..8.
+        // 36 bytes, 23 distinct symbols, skewed distribution —
+        // encoder picks max_num_bits in the 5..=11 band.
         let mut data: Vec<u8> = Vec::with_capacity(36);
         data.extend_from_slice(&[
             0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -364,3 +364,202 @@ fn decompress_literals(
 
     Ok(bytes_read)
 }
+
+#[cfg(test)]
+mod burst_gate_tests {
+    //! Regression coverage for the HUF 4-stream burst-gate boundary
+    //! states in `decompress_literals`:
+    //!
+    //!   1. `bits_consumed == max_num_bits` — exact lower boundary of
+    //!      the burst gate; gate is entered with zero slack.
+    //!   2. `bits_consumed + burst_bits == 64` — exact upper boundary;
+    //!      burst consumes all remaining bits in the 64-bit window
+    //!      without overflow.
+    //!   3. SIMD-fallback → refill → burst re-entry — outer loop falls
+    //!      back to the SIMD 4-symbol path, a `BitReaderReversed` refill
+    //!      occurs, the next iteration re-enters the burst path once
+    //!      `bits_consumed` grows back into burst range.
+    //!
+    //! Each named test pins a deterministic shape that exercises the
+    //! corresponding state; the sweep test covers the gate in aggregate
+    //! across many `(size, alphabet)` combinations so any subset hits
+    //! the exact boundary conditions deterministically while the rest
+    //! supplies broad regression coverage.
+    //!
+    //! All cases assert roundtrip correctness through the full encoder
+    //! → 4-stream HUF block → `decode_literals` path. A burst-gate
+    //! regression that returns the wrong symbol or desynchronises a
+    //! stream produces either a `DecompressLiteralsError` from the
+    //! `BitstreamReadMismatch` / `DecodedLiteralCountMismatch` guards
+    //! or a mismatched decoded buffer — both fail the assertion.
+    use super::*;
+    use crate::bit_io::BitWriter;
+    use crate::blocks::literals_section::{LiteralsSection, LiteralsSectionType};
+    use crate::decoding::scratch::HuffmanScratch;
+    use crate::huff0::huff0_encoder::{HuffmanEncoder, HuffmanTable as EncTable};
+    use alloc::vec::Vec;
+
+    /// Encode `data` as a 4-stream HUF Compressed literals block (table
+    /// description + jump table + 4 padded streams) and return the
+    /// matching `LiteralsSection` header plus the wire bytes.
+    fn build_huf4x_block(data: &[u8]) -> (LiteralsSection, Vec<u8>) {
+        assert!(data.len() >= 4, "encode4x requires at least 4 bytes");
+        let table = EncTable::build_from_data(data);
+        let mut source: Vec<u8> = Vec::new();
+        {
+            let mut writer = BitWriter::from(&mut source);
+            let mut encoder = HuffmanEncoder::new(&table, &mut writer);
+            encoder.encode4x(data, true);
+            writer.flush();
+        }
+        let section = LiteralsSection {
+            ls_type: LiteralsSectionType::Compressed,
+            regenerated_size: data.len() as u32,
+            compressed_size: Some(source.len() as u32),
+            num_streams: Some(4),
+        };
+        (section, source)
+    }
+
+    /// Roundtrip `data` through encode4x + decode_literals and assert
+    /// the decoded buffer matches byte-for-byte. Returns the HUF table's
+    /// `max_num_bits` so call sites can sanity-check that they actually
+    /// hit the expected burst-gate regime.
+    fn roundtrip_assert(data: &[u8]) -> u8 {
+        let (section, source) = build_huf4x_block(data);
+        let mut scratch = HuffmanScratch::new();
+        let mut target = Vec::new();
+        let bytes_read = decode_literals(&section, &mut scratch, &source, &mut target)
+            .expect("decode_literals must succeed on a well-formed roundtrip");
+        assert_eq!(
+            bytes_read as usize,
+            source.len(),
+            "decoder must consume every byte of the literals block"
+        );
+        assert_eq!(
+            target, data,
+            "decoded literals must match the encoder input"
+        );
+        scratch.table.max_num_bits
+    }
+
+    /// Roundtrip + assertion that the HUF table's `max_num_bits` falls
+    /// inside the expected range — this is what selects which burst-gate
+    /// regime the body runs under (`symbols_per_burst = (63 - max) / max`).
+    fn roundtrip_with_max_bits_range(data: &[u8], expected: core::ops::RangeInclusive<u8>) {
+        let m = roundtrip_assert(data);
+        assert!(
+            expected.contains(&m),
+            "max_num_bits {} outside expected range {:?} for this fixture — \
+             test no longer exercises the intended gate regime",
+            m,
+            expected
+        );
+    }
+
+    /// Lower boundary: `bits_consumed == max_num_bits` on first burst entry.
+    ///
+    /// 64 symbols with skewed weights drive `max_num_bits` into the
+    /// 8..=11 band (so `symbols_per_burst >= 4`); a short stream forces
+    /// the first burst iteration to start from `bits_consumed`
+    /// immediately at the gate threshold rather than well above it.
+    /// Decoder must not lose the low stream bits when the shift formula
+    /// runs at the threshold.
+    #[test]
+    fn burst_gate_lower_boundary_short_skewed_alphabet() {
+        // 36 bytes, 32-symbol skewed distribution — encoder picks
+        // max_num_bits ≈ 6..8.
+        let mut data: Vec<u8> = Vec::with_capacity(36);
+        data.extend_from_slice(&[
+            0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 3, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+            14, 15, 16, 17, 18, 19, 20, 21, 22,
+        ]);
+        roundtrip_with_max_bits_range(&data, 5..=11);
+    }
+
+    /// Upper boundary: `bits_consumed + burst_bits == 64`.
+    ///
+    /// A long, mid-cardinality alphabet drives many full burst windows.
+    /// Across thousands of iterations the burst-fits-in-64 guard
+    /// (`bits_consumed + burst_bits <= 64`) is approached and met
+    /// exactly. A regression that miscalculated the upper boundary
+    /// would read past the loaded 8-byte window and either crash under
+    /// debug bounds checks or desynchronise the stream — either way
+    /// the roundtrip fails.
+    #[test]
+    fn burst_gate_upper_boundary_long_mid_alphabet() {
+        // 4 KiB with a 97-symbol pseudo-random alphabet (kept under the
+        // encoder's 128-weight raw-table limit). Broad distribution →
+        // max_num_bits ≈ 7..9, thousands of burst iterations across all
+        // four streams.
+        let mut data: Vec<u8> = Vec::with_capacity(4096);
+        for i in 0..4096u32 {
+            data.push((i.wrapping_mul(0x9E37_79B1) % 97) as u8);
+        }
+        roundtrip_with_max_bits_range(&data, 6..=11);
+    }
+
+    /// SIMD-fallback → refill → burst re-entry transition.
+    ///
+    /// After a `BitReaderReversed::refill` (triggered inside
+    /// `advance_state_by_bits` on the SIMD path), `bits_consumed`
+    /// rebases to `[0, 7]`. Until it climbs back to `max_num_bits` the
+    /// burst gate is closed and the outer loop runs the 4-symbol SIMD
+    /// fallback; on the next outer-loop iteration after `bits_consumed`
+    /// grows past `max_num_bits` the burst path must re-enter cleanly.
+    ///
+    /// Stream length of 16 KiB / 4 ≈ 4 KiB per stream encoded ⇒ each
+    /// `BitReaderReversed` window crosses many refill boundaries,
+    /// guaranteeing the SIMD→refill→burst transition fires repeatedly.
+    #[test]
+    fn burst_simd_fallback_refill_reentry_long_streams() {
+        // 64-symbol modulo distribution → max_num_bits ≈ 6..7,
+        // symbols_per_burst ≈ 8..9.
+        let mut data: Vec<u8> = Vec::with_capacity(16 * 1024);
+        for i in 0..16 * 1024u32 {
+            data.push((i % 67) as u8);
+        }
+        roundtrip_with_max_bits_range(&data, 5..=8);
+    }
+
+    /// Parametric sweep across stream lengths and alphabet shapes.
+    ///
+    /// The three burst-gate states above are also hit across this matrix
+    /// at varying `(bits_consumed, max_num_bits, symbols_per_burst)`
+    /// configurations; any future tweak to the gate that mishandles a
+    /// specific `(max_num_bits, post-refill bits_consumed)` combo trips
+    /// at least one cell here.
+    #[test]
+    fn burst_gate_sweep_sizes_and_alphabets() {
+        let sizes = [
+            16usize, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 511, 512, 513, 1023,
+            1024, 1025, 4096,
+        ];
+        for &n in &sizes {
+            // Binary alphabet → max_num_bits == 1, symbols_per_burst large.
+            let mut bin: Vec<u8> = Vec::with_capacity(n);
+            for i in 0..n {
+                bin.push((i & 1) as u8);
+            }
+            roundtrip_assert(&bin);
+
+            // 16-symbol uniform alphabet → max_num_bits ≈ 4.
+            let mut sm: Vec<u8> = Vec::with_capacity(n);
+            for i in 0..n {
+                sm.push((i % 16) as u8);
+            }
+            roundtrip_assert(&sm);
+
+            // 97-symbol pseudo-random alphabet (where length permits) →
+            // max_num_bits ≈ 7..9; kept under the encoder's 128-weight
+            // raw-table cap so the encoder reliably succeeds.
+            if n >= 128 {
+                let mut wide: Vec<u8> = Vec::with_capacity(n);
+                for i in 0..n {
+                    wide.push((i.wrapping_mul(2_654_435_761) % 97) as u8);
+                }
+                roundtrip_assert(&wide);
+            }
+        }
+    }
+}

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -523,8 +523,9 @@ mod burst_gate_tests {
     /// guaranteeing the SIMD→refill→burst transition fires repeatedly.
     #[test]
     fn burst_simd_fallback_refill_reentry_long_streams() {
-        // 64-symbol modulo distribution → max_num_bits ≈ 6..7,
-        // symbols_per_burst ≈ 8..9.
+        // 67-symbol modulo distribution (`i % 67`, prime modulus spreads
+        // the alphabet evenly) → max_num_bits typically 7..8, which gives
+        // `symbols_per_burst = (63 - max) / max ≈ 6..8`.
         let mut data: Vec<u8> = Vec::with_capacity(16 * 1024);
         for i in 0..16 * 1024u32 {
             data.push((i % 67) as u8);

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -128,6 +128,14 @@ pub(crate) fn detect_huffman_decode_kernel() -> HuffmanDecodeKernel {
 
 pub struct HuffmanDecoder<'table> {
     table: &'table HuffmanTable,
+    /// Retained for the x86 `decode_symbol_and_advance` BMI2 dispatch
+    /// in the tail loop. The new 4-stream HUF burst in
+    /// `literals_section_decoder::decode_literals` bypasses kernel
+    /// dispatch entirely by indexing `HuffmanTable::packed_decode`
+    /// directly, so on aarch64 (where the tail also collapses to the
+    /// scalar path) this field is initialised but never read —
+    /// suppressed to keep clippy happy without dropping the x86 dispatch.
+    #[allow(dead_code)]
     kernel: HuffmanDecodeKernel,
     /// State is used to index into the table.
     pub state: u64,
@@ -231,12 +239,14 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode_symbol_and_num_bits(&self) -> (u8, u8) {
         let entry = self.table.decode[self.state as usize];
         (entry.symbol, entry.num_bits)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn advance_state_by_bits(&mut self, br: &mut BitReaderReversed<'_>, num_bits: u8) {
         let new_bits = br.get_bits(num_bits);
@@ -256,6 +266,7 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode4_symbols_and_num_bits(
         decoders: &[HuffmanDecoder<'_>; 4],
@@ -273,6 +284,7 @@ impl<'t> HuffmanDecoder<'t> {
         Self::decode4_symbols_and_num_bits_for_kernel(decoders, kernel)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     /// # Safety
     ///
@@ -298,6 +310,7 @@ impl<'t> HuffmanDecoder<'t> {
         Self::decode4_symbols_and_num_bits_for_kernel(decoders, decoders[0].kernel)
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode4_has_shared_table_and_kernel(decoders: &[HuffmanDecoder<'_>; 4]) -> bool {
         let kernel = decoders[0].kernel;
@@ -307,6 +320,7 @@ impl<'t> HuffmanDecoder<'t> {
                 .all(|d| core::ptr::eq(d.table, decoders[0].table))
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     fn decode4_symbols_and_num_bits_for_kernel(
         decoders: &[HuffmanDecoder<'_>; 4],
@@ -337,6 +351,7 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
+    #[allow(dead_code)]
     #[inline(always)]
     fn decode4_symbols_and_num_bits_scalar(
         decoders: &[HuffmanDecoder<'_>; 4],

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -546,8 +546,16 @@ impl<'t> HuffmanDecoder<'t> {
 
 /// A Huffman decoding table contains a list of Huffman prefix codes and their associated values
 pub struct HuffmanTable {
-    decode: Vec<Entry>,
-    packed_decode: Vec<u32>,
+    /// `pub(crate)` for direct indexing on the HUF 4-stream burst hot
+    /// path (donor parity with `huf_decompress.c:HUF_4X1_DECODE_SYMBOL`):
+    /// the literals decoder reads `decode[bits >> shift]` once per
+    /// symbol per stream without going through a getter.
+    pub(crate) decode: Vec<Entry>,
+    /// Packed `symbol | (num_bits << 8)` per state index.
+    /// `pub(crate)` — same rationale as [`Self::decode`]: the HUF
+    /// 4-stream burst hot path indexes this directly for a single-load
+    /// table lookup matching donor `huf_decompress.c:dtable[index]`.
+    pub(crate) packed_decode: Vec<u32>,
     /// The weight of a symbol is the number of occurences in a table.
     /// This value is used in constructing a binary tree referred to as
     /// a Huffman tree. Once this tree is constructed, it can be used to build the
@@ -914,9 +922,13 @@ impl Default for HuffmanTable {
 #[derive(Copy, Clone, Debug)]
 pub struct Entry {
     /// The byte that the prefix code replaces during encoding.
-    symbol: u8,
+    ///
+    /// `pub(crate)` so the HUF 4-stream burst hot path in
+    /// `literals_section_decoder` can read the field directly via
+    /// `decode[idx].symbol` without going through an accessor.
+    pub(crate) symbol: u8,
     /// The number of bits the prefix code occupies.
-    num_bits: u8,
+    pub(crate) num_bits: u8,
 }
 
 /// Assert that the provided value is greater than zero, and returns the

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -552,15 +552,13 @@ impl<'t> HuffmanDecoder<'t> {
 
 /// A Huffman decoding table contains a list of Huffman prefix codes and their associated values
 pub struct HuffmanTable {
-    /// `pub(crate)` for direct indexing on the HUF 4-stream burst hot
-    /// path (donor parity with `huf_decompress.c:HUF_4X1_DECODE_SYMBOL`):
-    /// the literals decoder reads `decode[bits >> shift]` once per
-    /// symbol per stream without going through a getter.
-    pub(crate) decode: Vec<Entry>,
-    /// Packed `symbol | (num_bits << 8)` per state index.
-    /// `pub(crate)` — same rationale as [`Self::decode`]: the HUF
-    /// 4-stream burst hot path indexes this directly for a single-load
-    /// table lookup matching donor `huf_decompress.c:dtable[index]`.
+    decode: Vec<Entry>,
+    /// Packed `symbol | (num_bits << 8)` per state index, exposed
+    /// `pub(crate)` because the HUF 4-stream burst hot path in
+    /// `literals_section_decoder::decode_literals` indexes it
+    /// directly (`packed_decode[idx]`) for a single-load table lookup
+    /// matching donor `huf_decompress.c:dtable[index]` — bypassing the
+    /// kernel-dispatch path used by SIMD fallback.
     pub(crate) packed_decode: Vec<u32>,
     /// The weight of a symbol is the number of occurences in a table.
     /// This value is used in constructing a binary tree referred to as
@@ -928,13 +926,9 @@ impl Default for HuffmanTable {
 #[derive(Copy, Clone, Debug)]
 pub struct Entry {
     /// The byte that the prefix code replaces during encoding.
-    ///
-    /// `pub(crate)` so the HUF 4-stream burst hot path in
-    /// `literals_section_decoder` can read the field directly via
-    /// `decode[idx].symbol` without going through an accessor.
-    pub(crate) symbol: u8,
+    symbol: u8,
     /// The number of bits the prefix code occupies.
-    pub(crate) num_bits: u8,
+    num_bits: u8,
 }
 
 /// Assert that the provided value is greater than zero, and returns the

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -128,14 +128,12 @@ pub(crate) fn detect_huffman_decode_kernel() -> HuffmanDecodeKernel {
 
 pub struct HuffmanDecoder<'table> {
     table: &'table HuffmanTable,
-    /// Retained for the x86 `decode_symbol_and_advance` BMI2 dispatch
-    /// in the tail loop. The new 4-stream HUF burst in
-    /// `literals_section_decoder::decode_literals` bypasses kernel
-    /// dispatch entirely by indexing `HuffmanTable::packed_decode`
-    /// directly, so on aarch64 (where the tail also collapses to the
-    /// scalar path) this field is initialised but never read —
-    /// suppressed to keep clippy happy without dropping the x86 dispatch.
-    #[allow(dead_code)]
+    /// Read by `decode_symbol_and_advance` (x86 BMI2 dispatch) and by
+    /// `decode4_symbols_and_num_bits_for_kernel` (SIMD fallback in
+    /// `literals_section_decoder::decode_literals` when the donor
+    /// burst is gated out post-refill). The donor burst itself
+    /// bypasses kernel dispatch by indexing
+    /// `HuffmanTable::packed_decode` directly.
     kernel: HuffmanDecodeKernel,
     /// State is used to index into the table.
     pub state: u64,
@@ -239,14 +237,12 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode_symbol_and_num_bits(&self) -> (u8, u8) {
         let entry = self.table.decode[self.state as usize];
         (entry.symbol, entry.num_bits)
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn advance_state_by_bits(&mut self, br: &mut BitReaderReversed<'_>, num_bits: u8) {
         let new_bits = br.get_bits(num_bits);
@@ -266,7 +262,6 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode4_symbols_and_num_bits(
         decoders: &[HuffmanDecoder<'_>; 4],
@@ -284,7 +279,6 @@ impl<'t> HuffmanDecoder<'t> {
         Self::decode4_symbols_and_num_bits_for_kernel(decoders, kernel)
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     /// # Safety
     ///
@@ -310,7 +304,6 @@ impl<'t> HuffmanDecoder<'t> {
         Self::decode4_symbols_and_num_bits_for_kernel(decoders, decoders[0].kernel)
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) fn decode4_has_shared_table_and_kernel(decoders: &[HuffmanDecoder<'_>; 4]) -> bool {
         let kernel = decoders[0].kernel;
@@ -320,7 +313,6 @@ impl<'t> HuffmanDecoder<'t> {
                 .all(|d| core::ptr::eq(d.table, decoders[0].table))
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     fn decode4_symbols_and_num_bits_for_kernel(
         decoders: &[HuffmanDecoder<'_>; 4],
@@ -351,7 +343,6 @@ impl<'t> HuffmanDecoder<'t> {
         }
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     fn decode4_symbols_and_num_bits_scalar(
         decoders: &[HuffmanDecoder<'_>; 4],


### PR DESCRIPTION
## Summary

Step A + B + D combined from #199 — full port of donor
`huf_decompress.c:HUF_decompress4X1_usingDTable_internal_fast_c_loop`
(lines 738-819) into our 4-stream HUF literal decoder.

Per-stream u64 register `bits[s]` fuses the decoder state (top
`max_num_bits` bits) with the next stream bits below it. Symbol
decode is one shift to extract the table index, one packed-table
load, and `bits[s] <<= num_bits` to step state. Sentinel `1` at
the LSB before the burst means `trailing_zeros(bits[s])` after the
burst recovers total burst-consumed bits — no explicit counter.

Three-tier loop layout:
1. **Donor sentinel burst** (fastest, when gate `bits_consumed >= max_num_bits` holds).
2. **SIMD 4-symbol main loop** (kept as fallback for when the gate is unsatisfied right after a refill resets `bits_consumed` to `[0, 7]`).
3. **Single-symbol tail** (drains the last few symbols per stream).

`symbols_per_burst = (63 - max) / max` — sized so the sentinel
stays below the state region after the worst-case T-shift. For
`max=11`: 4 symbols. For `max=8`: 6 symbols.

## Bench (M1 aarch64, decodecorpus-z000033)

| Scenario | main | branch | Δ |
|---|---|---|---|
| `decompress/level_4_greedy/rust_stream` | 187.17 MiB/s | 187.57 MiB/s | parity |
| `decompress/level_1_fast/c_stream` | 182.03 MiB/s | **187.18 MiB/s** | **+2.8%** |

L=1 fast c_stream is the scenario CI guard flagged at `-86.00% outside band` for `x86_64-gnu` — the small aarch64 win here suggests bigger gains on x86 with BMI2 (where `_mm_i32gather_epi32` has higher latency than donor's scalar lookup chain).

Aarch64 wins are modest because NEON gather in `decode4_*_neon` is competitive with donor's scalar lookup. The donor pattern's single-shift consume helps more on CPUs with narrower OOO than M1 — CI will reveal the actual x86 delta.

## Why the gate

After a `BitReaderReversed` refill, `bits_consumed` resets to `[0, 7]`. With `max_num_bits` ≥ 8, the formula `(bit_container << bits_consumed) >> max | (state << shift) | 1` would lose low stream bits when `bits_consumed < max_num_bits` — the right-shift drops bits the burst will need. Gating to `bits_consumed >= max_num_bits` keeps the donor formula sound; the SIMD fallback handles the post-refill window until bits_consumed grows back into range.

## Tests

- 538/538 nextest pass (full suite, includes 4 new burst-gate regression tests).
- `cargo clippy --lib --tests -- -D warnings` clean.
- No ratio regression — decode-only change.

### Burst-gate boundary regression coverage (closes #202)

Added a `burst_gate_tests` module to `literals_section_decoder.rs`
covering the three boundary states of the new HUF 4-stream burst gate:

1. **Lower boundary** (`bits_consumed == max_num_bits`) — short stream
   with skewed alphabet hits the gate at the exact threshold on first
   entry; verifies the burst formula does not lose low stream bits.
2. **Upper boundary** (`bits_consumed + burst_bits == 64`) — 4 KiB
   stream with 97-symbol alphabet drives thousands of burst iterations,
   exactly meeting the burst-fits-in-64 guard.
3. **SIMD-fallback → refill → burst re-entry** — 16 KiB stream
   crosses many `BitReaderReversed` refills; outer loop re-enters the
   burst path once `bits_consumed` climbs back past `max_num_bits`.
4. **Parametric sweep** over 21 sizes × 3 alphabet shapes covers the
   surrounding gate-decision matrix.

All assertions are roundtrip correctness (encode4x → decode_literals).

## Files

- `zstd/src/bit_io/bit_reader_reverse.rs` — `bit_container` and `bits_consumed` exposed as `pub(crate)` for direct register-lift in the burst.
- `zstd/src/huff0/huff0_decoder.rs` — `HuffmanTable::decode`/`packed_decode` and `Entry::symbol`/`num_bits` exposed; old `decode4_*` SIMD helpers stay alive for the fallback tier.
- `zstd/src/decoding/literals_section_decoder.rs` — three-tier loop (donor burst → SIMD 4-symbol → single-symbol tail).

## Out of scope

- Step E (const-generic kernel monomorphisation of `decode_symbol_and_advance`) — separate PR.
- Step C (`refill_fast` vs `refill_slow` split in BitReaderReversed) — separate PR.
- Step F (x86-64 inline asm) — stretch, separate PR if profiling shows benefit.

Part of #199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved multi-stream burst-style literals decoding with a SIMD-friendly fallback, boosting throughput and reducing hot-path overhead; no user-visible API changes.
* **Documentation**
  * Expanded internal docs clarifying burst-state handling and lookup behavior for maintainability.
* **Tests**
  * Added regression tests covering burst boundaries and mode transitions to strengthen decoding robustness and prevent desynchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/201?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
