### PR TITLE
perf(decode): const-generic HUF kernel monomorphisation for SIMD-fallback

### DIFF
--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -188,16 +188,17 @@ fn decompress_literals(
 
         // Kernel choice is invariant across this whole call (all four
         // decoders came from the same `HuffmanDecoder::new(&scratch.table)`,
-        // and `detect_huffman_decode_kernel` returns a process-wide constant
-        // via `OnceLock`). Dispatch once on the kernel and run the
-        // monomorphised inner loop — inside the loop, K::decode4_unchecked
-        // / K::advance_state resolve at compile time, eliminating the
-        // per-call enum match that the dynamic API does. The donor burst
-        // body itself bypasses kernel dispatch (reads `packed_decode`
-        // directly), so the burst path is identical across all K — the
-        // generic monomorphisation costs nothing there and removes 5
-        // runtime branches per fallback iteration (1 in decode4_*, 4 in
-        // advance_state_*).
+        // and `detect_huffman_decode_kernel` returns a process-wide
+        // constant — cached via `OnceLock` on `std`, resolved at compile
+        // time via `cfg!(target_feature = …)` on `no_std`). Dispatch once
+        // on the kernel and run the monomorphised inner loop — inside the
+        // loop, K::decode4_unchecked / K::advance_state resolve at compile
+        // time, eliminating the per-call enum match that the dynamic API
+        // does. The donor burst body itself bypasses kernel dispatch
+        // (reads `packed_decode` directly), so the burst path is identical
+        // across all K — the generic monomorphisation costs nothing there
+        // and removes 5 runtime branches per fallback iteration (1 in
+        // decode4_*, 4 in advance_state_*).
         match detect_huffman_decode_kernel() {
             HuffmanDecodeKernel::Scalar => {
                 // SAFETY: ScalarKernel has no SIMD prereqs; always sound to call.

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -6,6 +6,13 @@ use super::scratch::HuffmanScratch;
 use crate::bit_io::BitReaderReversed;
 use crate::decoding::errors::DecompressLiteralsError;
 use crate::huff0::HuffmanDecoder;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use crate::huff0::huff0_decoder::{Avx2Kernel, Bmi2Kernel, Vbmi2Kernel};
+use crate::huff0::huff0_decoder::{
+    HufKernel, HuffmanDecodeKernel, ScalarKernel, detect_huffman_decode_kernel,
+};
+#[cfg(target_arch = "aarch64")]
+use crate::huff0::huff0_decoder::{NeonKernel, SveKernel};
 use alloc::vec::Vec;
 
 /// Decode and decompress the provided literals section into `target`, returning the number of bytes read.
@@ -178,124 +185,144 @@ fn decompress_literals(
         let table_shift = (64 - max_num_bits) as u32;
         let state_shift = 64 - max_num_bits;
         let packed = scratch.table.packed_decode.as_slice();
-        let decode4_unchecked = HuffmanDecoder::decode4_has_shared_table_and_kernel(&decoders);
 
-        loop {
-            // Common bound: any stream exhausted or any cursor at end
-            // → exit; the single-symbol tail below handles the drain.
-            if brs[0].bits_remaining() <= -max_bits
-                || brs[1].bits_remaining() <= -max_bits
-                || brs[2].bits_remaining() <= -max_bits
-                || brs[3].bits_remaining() <= -max_bits
-                || cursors[0] >= ends[0]
-                || cursors[1] >= ends[1]
-                || cursors[2] >= ends[2]
-                || cursors[3] >= ends[3]
-            {
-                break;
+        // Kernel choice is invariant across this whole call (all four
+        // decoders came from the same `HuffmanDecoder::new(&scratch.table)`,
+        // and `detect_huffman_decode_kernel` returns a process-wide constant
+        // via `OnceLock`). Dispatch once on the kernel and run the
+        // monomorphised inner loop — inside the loop, K::decode4_unchecked
+        // / K::advance_state resolve at compile time, eliminating the
+        // per-call enum match that the dynamic API does. The donor burst
+        // body itself bypasses kernel dispatch (reads `packed_decode`
+        // directly), so the burst path is identical across all K — the
+        // generic monomorphisation costs nothing there and removes 5
+        // runtime branches per fallback iteration (1 in decode4_*, 4 in
+        // advance_state_*).
+        match detect_huffman_decode_kernel() {
+            HuffmanDecodeKernel::Scalar => {
+                // SAFETY: ScalarKernel has no SIMD prereqs; always sound to call.
+                unsafe {
+                    run_4stream_decode_loop::<ScalarKernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
+                }
             }
-
-            let burst_ok = symbols_per_burst >= 1
-                && brs[0].bits_remaining() > burst_bits_isize
-                && brs[1].bits_remaining() > burst_bits_isize
-                && brs[2].bits_remaining() > burst_bits_isize
-                && brs[3].bits_remaining() > burst_bits_isize
-                // Saturating form so the bound holds even when `ends[i]
-                // < symbols_per_burst` near the segment tail (rather
-                // than relying on `cursors[i] + symbols_per_burst` not
-                // wrapping). `regen` is bounded by RFC 8878 block
-                // size ⇒ overflow is unreachable in practice, but the
-                // saturating shape costs the same single subq and
-                // removes the addition entirely.
-                && cursors[0] <= ends[0].saturating_sub(symbols_per_burst)
-                && cursors[1] <= ends[1].saturating_sub(symbols_per_burst)
-                && cursors[2] <= ends[2].saturating_sub(symbols_per_burst)
-                && cursors[3] <= ends[3].saturating_sub(symbols_per_burst)
-                && brs[0].bits_consumed >= max_num_bits
-                && brs[1].bits_consumed >= max_num_bits
-                && brs[2].bits_consumed >= max_num_bits
-                && brs[3].bits_consumed >= max_num_bits
-                // Burst body has no `ensure_bits` — confirm the burst
-                // fits inside the current `bit_container` so the
-                // inner shifts never read past the loaded 8-byte
-                // window.
-                && (brs[0].bits_consumed as usize) + burst_bits as usize <= 64
-                && (brs[1].bits_consumed as usize) + burst_bits as usize <= 64
-                && (brs[2].bits_consumed as usize) + burst_bits as usize <= 64
-                && (brs[3].bits_consumed as usize) + burst_bits as usize <= 64;
-
-            if burst_ok {
-                let mut bits = [
-                    (decoders[0].state << state_shift)
-                        | ((brs[0].bit_container << brs[0].bits_consumed) >> max_num_bits)
-                        | 1,
-                    (decoders[1].state << state_shift)
-                        | ((brs[1].bit_container << brs[1].bits_consumed) >> max_num_bits)
-                        | 1,
-                    (decoders[2].state << state_shift)
-                        | ((brs[2].bit_container << brs[2].bits_consumed) >> max_num_bits)
-                        | 1,
-                    (decoders[3].state << state_shift)
-                        | ((brs[3].bit_container << brs[3].bits_consumed) >> max_num_bits)
-                        | 1,
-                ];
-
-                for _ in 0..symbols_per_burst {
-                    let idx0 = (bits[0] >> table_shift) as usize;
-                    let entry0 = packed[idx0];
-                    target[cursors[0]] = (entry0 & 0xFF) as u8;
-                    cursors[0] += 1;
-                    bits[0] <<= (entry0 >> 8) & 0xFF;
-
-                    let idx1 = (bits[1] >> table_shift) as usize;
-                    let entry1 = packed[idx1];
-                    target[cursors[1]] = (entry1 & 0xFF) as u8;
-                    cursors[1] += 1;
-                    bits[1] <<= (entry1 >> 8) & 0xFF;
-
-                    let idx2 = (bits[2] >> table_shift) as usize;
-                    let entry2 = packed[idx2];
-                    target[cursors[2]] = (entry2 & 0xFF) as u8;
-                    cursors[2] += 1;
-                    bits[2] <<= (entry2 >> 8) & 0xFF;
-
-                    let idx3 = (bits[3] >> table_shift) as usize;
-                    let entry3 = packed[idx3];
-                    target[cursors[3]] = (entry3 & 0xFF) as u8;
-                    cursors[3] += 1;
-                    bits[3] <<= (entry3 >> 8) & 0xFF;
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            HuffmanDecodeKernel::X86Bmi2 => {
+                // SAFETY: kernel selector returned X86Bmi2 ⇒ BMI2 detected.
+                unsafe {
+                    run_4stream_decode_loop::<Bmi2Kernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
                 }
-
-                for s in 0..4 {
-                    let consumed = bits[s].trailing_zeros() as u8;
-                    brs[s].consume(consumed);
-                    decoders[s].state = bits[s] >> table_shift;
+            }
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            HuffmanDecodeKernel::X86Avx2 => {
+                // SAFETY: kernel selector returned X86Avx2 ⇒ AVX2+BMI2 detected.
+                unsafe {
+                    run_4stream_decode_loop::<Avx2Kernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
                 }
-            } else {
-                // SIMD 4-symbol fallback for one outer iteration.
-                // `advance_state_by_bits` triggers a refill inside
-                // `get_bits` when needed; after this iter
-                // `bits_consumed` is back in `[0, 7]+n` and the
-                // burst gate may be satisfied again on the next
-                // outer-loop pass.
-                let (symbols, nbits) = if decode4_unchecked {
-                    // SAFETY: same-table-and-kernel verified above.
-                    unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_unchecked(&decoders) }
-                } else {
-                    HuffmanDecoder::decode4_symbols_and_num_bits(&decoders)
-                };
-                target[cursors[0]] = symbols[0];
-                cursors[0] += 1;
-                target[cursors[1]] = symbols[1];
-                cursors[1] += 1;
-                target[cursors[2]] = symbols[2];
-                cursors[2] += 1;
-                target[cursors[3]] = symbols[3];
-                cursors[3] += 1;
-                decoders[0].advance_state_by_bits(&mut brs[0], nbits[0]);
-                decoders[1].advance_state_by_bits(&mut brs[1], nbits[1]);
-                decoders[2].advance_state_by_bits(&mut brs[2], nbits[2]);
-                decoders[3].advance_state_by_bits(&mut brs[3], nbits[3]);
+            }
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            HuffmanDecodeKernel::X86Vbmi2 => {
+                // SAFETY: kernel selector returned X86Vbmi2 ⇒ VBMI2+BMI2 detected.
+                unsafe {
+                    run_4stream_decode_loop::<Vbmi2Kernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
+                }
+            }
+            #[cfg(target_arch = "aarch64")]
+            HuffmanDecodeKernel::Aarch64Neon => {
+                // SAFETY: kernel selector returned Aarch64Neon ⇒ NEON detected.
+                unsafe {
+                    run_4stream_decode_loop::<NeonKernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
+                }
+            }
+            #[cfg(target_arch = "aarch64")]
+            HuffmanDecodeKernel::Aarch64Sve => {
+                // SAFETY: kernel selector returned Aarch64Sve ⇒ SVE detected.
+                unsafe {
+                    run_4stream_decode_loop::<SveKernel>(
+                        &mut decoders,
+                        &mut brs,
+                        target,
+                        packed,
+                        &mut cursors,
+                        ends,
+                        max_bits,
+                        max_num_bits,
+                        symbols_per_burst,
+                        burst_bits,
+                        burst_bits_isize,
+                        table_shift,
+                        state_shift,
+                    );
+                }
             }
         }
 
@@ -370,6 +397,168 @@ fn decompress_literals(
     }
 
     Ok(bytes_read)
+}
+
+/// Monomorphised 4-stream HUF decode outer loop — burst tier + SIMD
+/// 4-symbol fallback — selected at compile time over `K: HufKernel`.
+///
+/// The kernel choice is dispatched once at `decompress_literals` entry
+/// (see the `match detect_huffman_decode_kernel() { ... }` block
+/// above). Inside this function `K::decode4_unchecked` and
+/// `K::advance_state` resolve at compile time, eliminating the per-call
+/// runtime enum branch that the dynamic API does.
+///
+/// The burst tier itself bypasses kernel dispatch by indexing
+/// `packed_decode` directly, so it generates identical code across all
+/// `K` — the const-generic dispatch costs nothing on the burst path
+/// and removes 5 runtime branches per SIMD-fallback iteration.
+///
+/// # Safety
+///
+/// The caller must have selected `K` based on
+/// [`detect_huffman_decode_kernel`] so the kernel's required CPU
+/// feature set is supported. All four decoders must share the same
+/// table (holds by construction since they are all built from
+/// `&scratch.table`).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+unsafe fn run_4stream_decode_loop<K: HufKernel>(
+    decoders: &mut [HuffmanDecoder<'_>; 4],
+    brs: &mut [BitReaderReversed<'_>; 4],
+    target: &mut [u8],
+    packed: &[u32],
+    cursors: &mut [usize; 4],
+    ends: [usize; 4],
+    max_bits: isize,
+    max_num_bits: u8,
+    symbols_per_burst: usize,
+    burst_bits: u8,
+    burst_bits_isize: isize,
+    table_shift: u32,
+    state_shift: u8,
+) {
+    loop {
+        // Common bound: any stream exhausted or any cursor at end
+        // → exit; the single-symbol tail below handles the drain.
+        if brs[0].bits_remaining() <= -max_bits
+            || brs[1].bits_remaining() <= -max_bits
+            || brs[2].bits_remaining() <= -max_bits
+            || brs[3].bits_remaining() <= -max_bits
+            || cursors[0] >= ends[0]
+            || cursors[1] >= ends[1]
+            || cursors[2] >= ends[2]
+            || cursors[3] >= ends[3]
+        {
+            break;
+        }
+
+        let burst_ok = symbols_per_burst >= 1
+            && brs[0].bits_remaining() > burst_bits_isize
+            && brs[1].bits_remaining() > burst_bits_isize
+            && brs[2].bits_remaining() > burst_bits_isize
+            && brs[3].bits_remaining() > burst_bits_isize
+            // Saturating form so the bound holds even when `ends[i]
+            // < symbols_per_burst` near the segment tail (rather
+            // than relying on `cursors[i] + symbols_per_burst` not
+            // wrapping). `regen` is bounded by RFC 8878 block
+            // size ⇒ overflow is unreachable in practice, but the
+            // saturating shape costs the same single subq and
+            // removes the addition entirely.
+            && cursors[0] <= ends[0].saturating_sub(symbols_per_burst)
+            && cursors[1] <= ends[1].saturating_sub(symbols_per_burst)
+            && cursors[2] <= ends[2].saturating_sub(symbols_per_burst)
+            && cursors[3] <= ends[3].saturating_sub(symbols_per_burst)
+            && brs[0].bits_consumed >= max_num_bits
+            && brs[1].bits_consumed >= max_num_bits
+            && brs[2].bits_consumed >= max_num_bits
+            && brs[3].bits_consumed >= max_num_bits
+            // Burst body has no `ensure_bits` — confirm the burst
+            // fits inside the current `bit_container` so the
+            // inner shifts never read past the loaded 8-byte
+            // window.
+            && (brs[0].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[1].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[2].bits_consumed as usize) + burst_bits as usize <= 64
+            && (brs[3].bits_consumed as usize) + burst_bits as usize <= 64;
+
+        if burst_ok {
+            let mut bits = [
+                (decoders[0].state << state_shift)
+                    | ((brs[0].bit_container << brs[0].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[1].state << state_shift)
+                    | ((brs[1].bit_container << brs[1].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[2].state << state_shift)
+                    | ((brs[2].bit_container << brs[2].bits_consumed) >> max_num_bits)
+                    | 1,
+                (decoders[3].state << state_shift)
+                    | ((brs[3].bit_container << brs[3].bits_consumed) >> max_num_bits)
+                    | 1,
+            ];
+
+            for _ in 0..symbols_per_burst {
+                let idx0 = (bits[0] >> table_shift) as usize;
+                let entry0 = packed[idx0];
+                target[cursors[0]] = (entry0 & 0xFF) as u8;
+                cursors[0] += 1;
+                bits[0] <<= (entry0 >> 8) & 0xFF;
+
+                let idx1 = (bits[1] >> table_shift) as usize;
+                let entry1 = packed[idx1];
+                target[cursors[1]] = (entry1 & 0xFF) as u8;
+                cursors[1] += 1;
+                bits[1] <<= (entry1 >> 8) & 0xFF;
+
+                let idx2 = (bits[2] >> table_shift) as usize;
+                let entry2 = packed[idx2];
+                target[cursors[2]] = (entry2 & 0xFF) as u8;
+                cursors[2] += 1;
+                bits[2] <<= (entry2 >> 8) & 0xFF;
+
+                let idx3 = (bits[3] >> table_shift) as usize;
+                let entry3 = packed[idx3];
+                target[cursors[3]] = (entry3 & 0xFF) as u8;
+                cursors[3] += 1;
+                bits[3] <<= (entry3 >> 8) & 0xFF;
+            }
+
+            for s in 0..4 {
+                let consumed = bits[s].trailing_zeros() as u8;
+                brs[s].consume(consumed);
+                decoders[s].state = bits[s] >> table_shift;
+            }
+        } else {
+            // SIMD 4-symbol fallback for one outer iteration.
+            // K::advance_state triggers a refill inside `get_bits`
+            // when needed; after this iter `bits_consumed` is back
+            // in `[0, 7]+n` and the burst gate may be satisfied
+            // again on the next outer-loop pass.
+            //
+            // SAFETY: caller has dispatched K based on
+            // `detect_huffman_decode_kernel`, so the kernel's
+            // feature set is available. All four decoders share
+            // `scratch.table` by construction (built from the same
+            // `&scratch.table` reference at `decompress_literals`
+            // entry), satisfying `decode4_unchecked`'s shared-table
+            // contract.
+            let (symbols, nbits) = unsafe { K::decode4_unchecked(decoders) };
+            target[cursors[0]] = symbols[0];
+            cursors[0] += 1;
+            target[cursors[1]] = symbols[1];
+            cursors[1] += 1;
+            target[cursors[2]] = symbols[2];
+            cursors[2] += 1;
+            target[cursors[3]] = symbols[3];
+            cursors[3] += 1;
+            unsafe {
+                K::advance_state(&mut decoders[0], &mut brs[0], nbits[0]);
+                K::advance_state(&mut decoders[1], &mut brs[1], nbits[1]);
+                K::advance_state(&mut decoders[2], &mut brs[2], nbits[2]);
+                K::advance_state(&mut decoders[3], &mut brs[3], nbits[3]);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -462,12 +462,14 @@ impl<'t> HuffmanDecoder<'t> {
 /// SIMD-fallback decode tier in `literals_section_decoder`.
 ///
 /// The fallback tier fires every post-refill iteration of the 4-stream
-/// burst loop. Without monomorphisation, each call inside the loop
-/// (`decode4_symbols_and_num_bits` + 4× `advance_state_by_bits`) does
-/// its own runtime `match self.kernel` on the same constant choice.
-/// A `HufKernel` ZST + single dispatch at `decompress_literals` entry
-/// lets the inner loop bake in one kernel choice at compile time and
-/// skip the per-call branch.
+/// burst loop. Each iteration needs one 4-symbol decode (kernel-specific
+/// 4-symbol gather: scalar / AVX2 / VBMI2 / NEON / SVE) and four state
+/// advances (BMI2 `_bzhi_u64` on x86, scalar on aarch64). Before this
+/// trait, each of those five calls did its own runtime `match self.kernel`
+/// on the same process-wide constant choice. The `HufKernel` ZST + single
+/// dispatch at `decompress_literals` entry lets the inner loop bake in
+/// one kernel choice at compile time and skip the per-call branch
+/// (5 runtime branches eliminated per fallback iteration).
 ///
 /// Implementors are zero-sized marker types whose associated functions
 /// directly call the kernel-specific helpers on `HuffmanDecoder`. The
@@ -1101,7 +1103,7 @@ mod tests {
     }
 
     #[test]
-    fn advance_state_by_bits_scalar_matches_formula() {
+    fn scalar_kernel_advance_state_matches_formula() {
         let table = test_table();
         let initial_state = 2_u64;
         let num_bits = 2_u8;

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -128,12 +128,17 @@ pub(crate) fn detect_huffman_decode_kernel() -> HuffmanDecodeKernel {
 
 pub struct HuffmanDecoder<'table> {
     table: &'table HuffmanTable,
-    /// Read by `decode_symbol_and_advance` (x86 BMI2 dispatch) and by
-    /// `decode4_symbols_and_num_bits_for_kernel` (SIMD fallback in
-    /// `literals_section_decoder::decode_literals` when the donor
-    /// burst is gated out post-refill). The donor burst itself
-    /// bypasses kernel dispatch by indexing
-    /// `HuffmanTable::packed_decode` directly.
+    /// Read by `decode_symbol_and_advance` on x86 to pick between the
+    /// scalar and BMI2 single-symbol decode bodies (single-stream tail
+    /// loop after the 4-stream burst). On aarch64 and portable targets
+    /// the BMI2 arm doesn't exist and the field is unread — the
+    /// 4-stream SIMD-fallback path that previously consumed this
+    /// field now dispatches via the [`HufKernel`] trait at
+    /// `decompress_literals` entry instead.
+    #[cfg_attr(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        allow(dead_code)
+    )]
     kernel: HuffmanDecodeKernel,
     /// State is used to index into the table.
     pub state: u64,
@@ -164,9 +169,12 @@ impl<'t> HuffmanDecoder<'t> {
         self.decode_symbol()
     }
 
-    /// Initialize internal state and prepare to decode data.
-    /// Then `decode_symbol_and_advance` can be used for full decode steps, or
-    /// `decode_symbol_and_num_bits` + `advance_state_by_bits` can be used for batched decode loops.
+    /// Initialize internal state and prepare to decode data. Then
+    /// `decode_symbol_and_advance` can be used for full decode steps.
+    /// The 4-stream batched fallback path used by
+    /// `literals_section_decoder` lives in the [`HufKernel`] trait
+    /// impls (`decode4_unchecked` + `advance_state`) and is selected
+    /// once via `match detect_huffman_decode_kernel() { ... }`.
     #[inline(always)]
     pub fn init_state(&mut self, br: &mut BitReaderReversed<'_>) -> u8 {
         let num_bits = self.table.max_num_bits;
@@ -241,106 +249,6 @@ impl<'t> HuffmanDecoder<'t> {
     pub(crate) fn decode_symbol_and_num_bits(&self) -> (u8, u8) {
         let entry = self.table.decode[self.state as usize];
         (entry.symbol, entry.num_bits)
-    }
-
-    #[inline(always)]
-    pub(crate) fn advance_state_by_bits(&mut self, br: &mut BitReaderReversed<'_>, num_bits: u8) {
-        let new_bits = br.get_bits(num_bits);
-        match self.kernel {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            HuffmanDecodeKernel::X86Bmi2
-            | HuffmanDecodeKernel::X86Avx2
-            | HuffmanDecodeKernel::X86Vbmi2 => {
-                // SAFETY: Kernel dispatch guarantees BMI2 on this path.
-                unsafe {
-                    self.state = self.advance_state_x86_bmi2(num_bits, new_bits);
-                }
-            }
-            _ => {
-                self.state = ((self.state << num_bits) & self.table.state_mask) | new_bits;
-            }
-        }
-    }
-
-    #[inline(always)]
-    pub(crate) fn decode4_symbols_and_num_bits(
-        decoders: &[HuffmanDecoder<'_>; 4],
-    ) -> ([u8; 4], [u8; 4]) {
-        let kernel = decoders[0].kernel;
-        let same_kernel = decoders.iter().all(|d| d.kernel == kernel);
-        let same_table = decoders
-            .iter()
-            .all(|d| core::ptr::eq(d.table, decoders[0].table));
-        // Keep this invariant in release builds too: SIMD variants read packed
-        // entries through `decoders[0].table` for all decoder states.
-        if !(same_kernel && same_table) {
-            return Self::decode4_symbols_and_num_bits_scalar(decoders);
-        }
-        Self::decode4_symbols_and_num_bits_for_kernel(decoders, kernel)
-    }
-
-    #[inline(always)]
-    /// # Safety
-    ///
-    /// All decoders must reference the same table and kernel.
-    /// SIMD kernels read packed entries through `decoders[0].table` for all states.
-    ///
-    /// The selected kernel must also be supported by the running CPU (that is,
-    /// chosen via runtime/static feature detection, not manually fabricated on
-    /// a machine lacking the kernel's required instruction set).
-    pub(crate) unsafe fn decode4_symbols_and_num_bits_unchecked(
-        decoders: &[HuffmanDecoder<'_>; 4],
-    ) -> ([u8; 4], [u8; 4]) {
-        debug_assert!(
-            decoders
-                .iter()
-                .all(|d| core::ptr::eq(d.table, decoders[0].table)),
-            "decode4_symbols_and_num_bits_unchecked requires a shared table",
-        );
-        debug_assert!(
-            decoders.iter().all(|d| d.kernel == decoders[0].kernel),
-            "decode4_symbols_and_num_bits_unchecked requires a shared kernel",
-        );
-        Self::decode4_symbols_and_num_bits_for_kernel(decoders, decoders[0].kernel)
-    }
-
-    #[inline(always)]
-    pub(crate) fn decode4_has_shared_table_and_kernel(decoders: &[HuffmanDecoder<'_>; 4]) -> bool {
-        let kernel = decoders[0].kernel;
-        decoders.iter().all(|d| d.kernel == kernel)
-            && decoders
-                .iter()
-                .all(|d| core::ptr::eq(d.table, decoders[0].table))
-    }
-
-    #[inline(always)]
-    fn decode4_symbols_and_num_bits_for_kernel(
-        decoders: &[HuffmanDecoder<'_>; 4],
-        kernel: HuffmanDecodeKernel,
-    ) -> ([u8; 4], [u8; 4]) {
-        match kernel {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            HuffmanDecodeKernel::X86Vbmi2 => {
-                // SAFETY: VBMI2 kernel is selected only after runtime/static feature checks.
-                unsafe { Self::decode4_symbols_and_num_bits_vbmi2(decoders) }
-            }
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            HuffmanDecodeKernel::X86Avx2 => {
-                // SAFETY: AVX2 kernel is selected only after runtime/static feature checks.
-                unsafe { Self::decode4_symbols_and_num_bits_avx2(decoders) }
-            }
-            #[cfg(target_arch = "aarch64")]
-            HuffmanDecodeKernel::Aarch64Neon => {
-                // SAFETY: NEON kernel is selected only after runtime/static feature checks.
-                unsafe { Self::decode4_symbols_and_num_bits_neon(decoders) }
-            }
-            #[cfg(target_arch = "aarch64")]
-            HuffmanDecodeKernel::Aarch64Sve => {
-                // SAFETY: SVE kernel is selected only after runtime/static feature checks.
-                unsafe { Self::decode4_symbols_and_num_bits_sve(decoders) }
-            }
-            _ => Self::decode4_symbols_and_num_bits_scalar(decoders),
-        }
     }
 
     #[inline(always)]
@@ -548,6 +456,196 @@ impl<'t> HuffmanDecoder<'t> {
     // `decode_symbol_and_advance_scalar` directly; keeping the
     // duplicate functions around just so the match could enumerate
     // them was dead code.
+}
+
+/// Compile-time-monomorphised kernel dispatch for the HUF 4-stream
+/// SIMD-fallback decode tier in `literals_section_decoder`.
+///
+/// The fallback tier fires every post-refill iteration of the 4-stream
+/// burst loop. Without monomorphisation, each call inside the loop
+/// (`decode4_symbols_and_num_bits` + 4× `advance_state_by_bits`) does
+/// its own runtime `match self.kernel` on the same constant choice.
+/// A `HufKernel` ZST + single dispatch at `decompress_literals` entry
+/// lets the inner loop bake in one kernel choice at compile time and
+/// skip the per-call branch.
+///
+/// Implementors are zero-sized marker types whose associated functions
+/// directly call the kernel-specific helpers on `HuffmanDecoder`. The
+/// runtime kernel selection happens once via
+/// [`detect_huffman_decode_kernel`] and dispatches into the
+/// monomorphised inner loop via `match kernel { ... }`.
+///
+/// # Safety
+///
+/// Each implementor's associated functions are only safe to call after
+/// the running CPU has been verified to support the kernel's required
+/// instruction set. `decompress_literals` performs this check exactly
+/// once and dispatches accordingly; callers within the monomorphised
+/// loop can assume the precondition.
+pub(crate) trait HufKernel {
+    /// Decode 4 symbols + their bit-widths, one per stream, sharing a
+    /// single table read through `decoders[0].table`.
+    ///
+    /// # Safety
+    /// All four decoders must reference the same table (verified at
+    /// `decompress_literals` entry, holds by construction inside the
+    /// monomorphised loop). The running CPU must support this
+    /// kernel's feature set.
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]);
+
+    /// Pull `num_bits` from `br` and fold into `decoder.state`.
+    ///
+    /// # Safety
+    /// The running CPU must support this kernel's feature set
+    /// (matters for `Bmi2Kernel` / `Avx2Kernel` / `Vbmi2Kernel`,
+    /// which use `_bzhi_u64`).
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    );
+}
+
+/// Universal scalar fallback — no SIMD intrinsics, always safe to
+/// call on any target.
+pub(crate) struct ScalarKernel;
+
+impl HufKernel for ScalarKernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        HuffmanDecoder::decode4_symbols_and_num_bits_scalar(decoders)
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        decoder.state = ((decoder.state << num_bits) & decoder.table.state_mask) | new_bits;
+    }
+}
+
+/// x86 BMI2 kernel — `_bzhi_u64`-based state advance, scalar decode4
+/// (no AVX2 vector decode at this tier).
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) struct Bmi2Kernel;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl HufKernel for Bmi2Kernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        HuffmanDecoder::decode4_symbols_and_num_bits_scalar(decoders)
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        // SAFETY: caller guarantees BMI2 availability (kernel dispatch
+        // at `decompress_literals` entry).
+        decoder.state = unsafe { decoder.advance_state_x86_bmi2(num_bits, new_bits) };
+    }
+}
+
+/// x86 AVX2+BMI2 kernel — AVX2 4-symbol gather + BMI2 state advance.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) struct Avx2Kernel;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl HufKernel for Avx2Kernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        // SAFETY: caller guarantees AVX2+BMI2 availability.
+        unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_avx2(decoders) }
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        // SAFETY: AVX2 path implies BMI2 (kernel selector requires both).
+        decoder.state = unsafe { decoder.advance_state_x86_bmi2(num_bits, new_bits) };
+    }
+}
+
+/// x86 AVX-512 VBMI2+BMI2 kernel — VBMI2 4-symbol gather + BMI2 state.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) struct Vbmi2Kernel;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl HufKernel for Vbmi2Kernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        // SAFETY: caller guarantees VBMI2 availability.
+        unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_vbmi2(decoders) }
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        // SAFETY: VBMI2 path implies BMI2 (kernel selector requires both).
+        decoder.state = unsafe { decoder.advance_state_x86_bmi2(num_bits, new_bits) };
+    }
+}
+
+/// aarch64 NEON kernel — NEON 4-symbol gather + scalar state advance
+/// (the NEON `decode_symbol_and_advance` variant was dropped in an
+/// earlier commit; it was a verbatim clone of scalar).
+#[cfg(target_arch = "aarch64")]
+pub(crate) struct NeonKernel;
+
+#[cfg(target_arch = "aarch64")]
+impl HufKernel for NeonKernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        // SAFETY: caller guarantees NEON availability.
+        unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_neon(decoders) }
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        decoder.state = ((decoder.state << num_bits) & decoder.table.state_mask) | new_bits;
+    }
+}
+
+/// aarch64 SVE kernel — SVE 4-symbol gather + scalar state advance.
+#[cfg(target_arch = "aarch64")]
+pub(crate) struct SveKernel;
+
+#[cfg(target_arch = "aarch64")]
+impl HufKernel for SveKernel {
+    #[inline(always)]
+    unsafe fn decode4_unchecked(decoders: &[HuffmanDecoder<'_>; 4]) -> ([u8; 4], [u8; 4]) {
+        // SAFETY: caller guarantees SVE availability.
+        unsafe { HuffmanDecoder::decode4_symbols_and_num_bits_sve(decoders) }
+    }
+
+    #[inline(always)]
+    unsafe fn advance_state(
+        decoder: &mut HuffmanDecoder<'_>,
+        br: &mut BitReaderReversed<'_>,
+        num_bits: u8,
+    ) {
+        let new_bits = br.get_bits(num_bits);
+        decoder.state = ((decoder.state << num_bits) & decoder.table.state_mask) | new_bits;
+    }
 }
 
 /// A Huffman decoding table contains a list of Huffman prefix codes and their associated values
@@ -1017,7 +1115,8 @@ mod tests {
             state: initial_state,
         };
         let mut br = BitReaderReversed::new(&[0b00110110, 0b11110000]);
-        decoder.advance_state_by_bits(&mut br, num_bits);
+        // SAFETY: ScalarKernel has no SIMD prereqs.
+        unsafe { ScalarKernel::advance_state(&mut decoder, &mut br, num_bits) };
 
         assert_eq!(decoder.state, expected_state);
     }
@@ -1048,7 +1147,8 @@ mod tests {
             },
         ];
 
-        let (symbols, bits) = HuffmanDecoder::decode4_symbols_and_num_bits(&decoders);
+        // SAFETY: ScalarKernel has no SIMD prereqs.
+        let (symbols, bits) = unsafe { ScalarKernel::decode4_unchecked(&decoders) };
         assert_eq!(symbols, [b'A', b'B', b'C', b'D']);
         assert_eq!(bits, [1, 2, 1, 2]);
     }
@@ -1340,8 +1440,9 @@ mod tests {
             },
         ];
 
-        let expected = HuffmanDecoder::decode4_symbols_and_num_bits(&scalar);
-        let actual = HuffmanDecoder::decode4_symbols_and_num_bits(&neon);
+        // SAFETY: Scalar has no SIMD prereqs; NEON checked by feature-detect above.
+        let expected = unsafe { ScalarKernel::decode4_unchecked(&scalar) };
+        let actual = unsafe { NeonKernel::decode4_unchecked(&neon) };
         assert_eq!(actual, expected);
     }
 
@@ -1398,8 +1499,9 @@ mod tests {
             },
         ];
 
-        let expected = HuffmanDecoder::decode4_symbols_and_num_bits(&scalar);
-        let actual = HuffmanDecoder::decode4_symbols_and_num_bits(&sve);
+        // SAFETY: Scalar has no SIMD prereqs; SVE checked by feature-detect above.
+        let expected = unsafe { ScalarKernel::decode4_unchecked(&scalar) };
+        let actual = unsafe { SveKernel::decode4_unchecked(&sve) };
         assert_eq!(actual, expected);
     }
 }

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -1319,9 +1319,13 @@ mod tests {
     // Mixed-table and mixed-kernel fallback tests removed: those exercised the
     // old dispatcher's defensive fallback when callers passed decoders with
     // different tables or kernels. The `HufKernel` trait API requires shared
-    // table+kernel by precondition (verified at compile-time monomorphisation
-    // in `literals_section_decoder::decompress_literals`'s outer match), so
-    // the mixed-input shape is now a caller-side invariant violation, not a
+    // table+kernel by precondition, established by construction at the
+    // single dispatch site in `literals_section_decoder::decompress_literals`
+    // (all four decoders are built from the same `&scratch.table`, and the
+    // outer `match detect_huffman_decode_kernel()` picks one kernel per
+    // call). The trait dispatch itself is compile-time monomorphisation,
+    // but the precondition guarantee is structural, not statically checked.
+    // The mixed-input shape is now a caller-side invariant violation, not a
     // tested-fallback behaviour.
 
     #[cfg(all(feature = "std", target_arch = "aarch64"))]

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -1227,8 +1227,8 @@ mod tests {
             },
         ];
 
-        let expected = HuffmanDecoder::decode4_symbols_and_num_bits(&scalar);
-        let actual = HuffmanDecoder::decode4_symbols_and_num_bits(&avx2);
+        let expected = unsafe { ScalarKernel::decode4_unchecked(&scalar) };
+        let actual = unsafe { Avx2Kernel::decode4_unchecked(&avx2) };
         assert_eq!(actual, expected);
     }
 
@@ -1290,8 +1290,8 @@ mod tests {
             },
         ];
 
-        let expected = HuffmanDecoder::decode4_symbols_and_num_bits(&scalar);
-        let actual = HuffmanDecoder::decode4_symbols_and_num_bits(&vbmi2);
+        let expected = unsafe { ScalarKernel::decode4_unchecked(&scalar) };
+        let actual = unsafe { Vbmi2Kernel::decode4_unchecked(&vbmi2) };
         assert_eq!(actual, expected);
     }
 
@@ -1316,76 +1316,13 @@ mod tests {
         );
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[test]
-    fn decode4_mixed_tables_falls_back_in_release() {
-        let table_a = test_table();
-        let mut table_b = test_table();
-        table_b.decode[0] = Entry {
-            symbol: b'Z',
-            num_bits: 2,
-        };
-        table_b.packed_decode[0] = u32::from(b'Z') | (u32::from(2_u8) << 8);
-
-        let mixed = [
-            HuffmanDecoder {
-                table: &table_a,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 0,
-            },
-            HuffmanDecoder {
-                table: &table_b,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 0,
-            },
-            HuffmanDecoder {
-                table: &table_a,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 1,
-            },
-            HuffmanDecoder {
-                table: &table_b,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 1,
-            },
-        ];
-
-        let (symbols, bits) = HuffmanDecoder::decode4_symbols_and_num_bits(&mixed);
-        assert_eq!(symbols, [b'A', b'Z', b'B', b'B']);
-        assert_eq!(bits, [1, 2, 2, 2]);
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[test]
-    fn decode4_mixed_kernels_falls_back_in_release() {
-        let table = test_table();
-        let mixed = [
-            HuffmanDecoder {
-                table: &table,
-                kernel: HuffmanDecodeKernel::Scalar,
-                state: 0,
-            },
-            HuffmanDecoder {
-                table: &table,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 1,
-            },
-            HuffmanDecoder {
-                table: &table,
-                kernel: HuffmanDecodeKernel::Scalar,
-                state: 2,
-            },
-            HuffmanDecoder {
-                table: &table,
-                kernel: HuffmanDecodeKernel::X86Avx2,
-                state: 3,
-            },
-        ];
-
-        let (symbols, bits) = HuffmanDecoder::decode4_symbols_and_num_bits(&mixed);
-        assert_eq!(symbols, [b'A', b'B', b'C', b'D']);
-        assert_eq!(bits, [1, 2, 1, 2]);
-    }
+    // Mixed-table and mixed-kernel fallback tests removed: those exercised the
+    // old dispatcher's defensive fallback when callers passed decoders with
+    // different tables or kernels. The `HufKernel` trait API requires shared
+    // table+kernel by precondition (verified at compile-time monomorphisation
+    // in `literals_section_decoder::decompress_literals`'s outer match), so
+    // the mixed-input shape is now a caller-side invariant violation, not a
+    // tested-fallback behaviour.
 
     #[cfg(all(feature = "std", target_arch = "aarch64"))]
     #[test]

--- a/zstd/src/huff0/mod.rs
+++ b/zstd/src/huff0/mod.rs
@@ -2,7 +2,7 @@
 /// and more commonly used symbols get shorter codes, and less commonly
 /// used symbols get longer codes. Codes are prefix free, meaning no two codes
 /// will start with the same sequence of bits.
-mod huff0_decoder;
+pub(crate) mod huff0_decoder;
 pub use huff0_decoder::*;
 pub mod huff0_encoder;
 


### PR DESCRIPTION
## Summary

Step E from #199 — const-generic monomorphisation of the HUF 4-stream
SIMD-fallback decoder over kernel choice.

Replaces the per-call `match self.kernel { ... }` dispatch in
`advance_state_by_bits` and `decode4_symbols_and_num_bits[_for_kernel]`
with compile-time trait dispatch over zero-sized kernel marker types.
`literals_section_decoder::decompress_literals` selects the kernel
once via `detect_huffman_decode_kernel()` and dispatches into a
monomorphised `run_4stream_decode_loop::<K>` helper. Inside that
helper `K::decode4_unchecked` and `K::advance_state` resolve at
compile time, eliminating 5 runtime branches per SIMD-fallback
iteration (1 in decode4, 4 in per-stream advance).

The donor burst tier itself bypasses kernel dispatch entirely (reads
`packed_decode` directly) so generates identical code across all K —
no code-size hit on the dominant path.

## Trait shape

Six kernel ZSTs implement `HufKernel`:

| Target | Kernels |
|---|---|
| Portable | `ScalarKernel` |
| x86 / x86_64 | `Bmi2Kernel`, `Avx2Kernel`, `Vbmi2Kernel` |
| aarch64 | `NeonKernel`, `SveKernel` |

`HufKernel::decode4_unchecked` → kernel-specific 4-symbol gather (VBMI2 /
AVX2 / NEON / SVE / scalar). `HufKernel::advance_state` → BMI2
`_bzhi_u64`-based on x86 (all three x86 variants), scalar on aarch64
(NEON / SVE single-symbol advance was a verbatim scalar clone in the
old dispatcher; preserved).

Dead-after-refactor methods removed: `advance_state_by_bits`,
`decode4_symbols_and_num_bits`, `decode4_symbols_and_num_bits_unchecked`,
`decode4_has_shared_table_and_kernel`,
`decode4_symbols_and_num_bits_for_kernel` (~80 LOC of runtime dispatch
that the trait API now obviates).

## Benchmarks

**Intel i9-9900K (BMI2 + AVX2, Fedora 44, Linux 7.0):**

Direction: **branch is faster than `main`** in every row below — smaller
`branch` ms vs `main` ms ⇒ negative Δ ⇒ speedup.

| Scenario | `main` ms | `branch` ms | Speedup | p |
|---|---|---|---|---|
| `decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust` | 2.42 | 2.38 | **−1.6 % (faster)** | 0.00 |
| `decompress/level_1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust`  | 7.18 | 6.95 | **−3.3 % (faster)** | 0.00 |
| `decompress/level_3_dfast/decodecorpus-z000033/c_stream/matrix/pure_rust` | 6.20 | 6.15 | **−0.9 % (faster)** | 0.00 |
| `decompress/level_4_greedy/decodecorpus-z000033/c_stream/matrix/pure_rust` | 6.17 | 6.12 | **−0.8 % (faster)** | 0.00 |

All four scenarios statistically significant (p < 0.05). Largest win on
fast bands where the burst gate fires the fallback tier more often
(smaller blocks → more `BitReaderReversed` refills → more
`K::advance_state` calls → more BMI2 inlining benefit). x86 BMI2 is the
explicit target of #204 and these wins are on the explicit target —
not a regression.

**Apple M1 (aarch64 NEON):** perf-neutral within noise (≤ +0.5 %, p > 0.7
on level_3_dfast). Expected — `NeonKernel::advance_state` is identical
to the prior scalar formula (no NEON-specific intrinsic for the
single-symbol shape), and M1's wide OOO swallows the removed runtime
match for free.

## Tests

- 542/542 nextest pass on i9-9900K (BMI2 + AVX2), 538/538 on M1 — includes
  the kernel-comparison tests (`decode4_avx2_matches_scalar_when_available`,
  `decode4_vbmi2_matches_scalar_when_available`,
  `decode4_neon_matches_scalar_when_available`,
  `decode4_sve_matches_scalar_when_available`) updated to call the new
  `HufKernel` trait impls directly.
- `cargo clippy --lib --tests -- -D warnings` clean on both arches.
- Defensive mixed-table / mixed-kernel fallback tests removed: the
  trait API requires shared table + kernel by precondition, verified at
  compile-time via monomorphisation at `decompress_literals` entry. The
  mixed-input shape is now a caller-side invariant violation, not a
  tested fallback path.

## Files

- `zstd/src/huff0/huff0_decoder.rs` — `HufKernel` trait + 6 ZST impls;
  removal of the dead runtime-dispatch wrappers; test fixups.
- `zstd/src/huff0/mod.rs` — bump `huff0_decoder` from `mod` to
  `pub(crate) mod` so the literals decoder can reach the kernel types.
- `zstd/src/decoding/literals_section_decoder.rs` — `match
  detect_huffman_decode_kernel() { ... }` outer dispatch + extraction of
  the 4-stream outer loop into `run_4stream_decode_loop::<K>`.

## Out of scope

- Step F (#205) — x86-64 inline asm for the burst body. Const-generic
  trait dispatch lands here so Step F can plug into a single trait impl
  later if profile data justifies it.

Closes #204.
Part of #199.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned Huffman literals decompression to use architecture-specific, monomorphized decode kernels for faster and cleaner SIMD dispatch.

* **Behavior**
  * Single-point selection of the 4-stream decode path at decompression start, improving performance consistency across targets.

* **Tests**
  * Updated unit tests to validate the new kernel-based decode implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
