### PR TITLE
perf(decode): SIMD-16 fast path for short offsets {1, 2, 4}

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -289,30 +289,71 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             offset > 0,
             "offset must be non-zero to avoid modulo by zero in short-offset path"
         );
-        let mut base = [0u8; 8];
+
+        // Read the repeating period (`offset` bytes) from the existing
+        // buffer surface. Cap the read at 7 so callers with offset > 7
+        // never reach this function — `repeat_overlapping` dispatches
+        // the offset >= 8 cases elsewhere.
+        debug_assert!(offset <= 7, "repeat_short_offset is the offset<8 path");
+        let mut base = [0u8; 7];
         for (i, slot) in base.iter_mut().take(offset).enumerate() {
             *slot = self.byte_at(start_idx + i);
         }
 
-        let mut phase_patterns = [[0u8; 8]; 7];
+        // Fast path: offset ∈ {1, 2, 4} — the period divides 16, so
+        // every 16-byte window of the repeating pattern is identical
+        // and one pre-built chunk feeds the entire loop with zero
+        // phase tracking. Inner loop = one 16-byte SIMD store + one
+        // add.
+        if matches!(offset, 1 | 2 | 4) {
+            let mut chunk16 = [0u8; 16];
+            for i in 0..16 {
+                chunk16[i] = base[i % offset];
+            }
+            let mut copied = 0usize;
+            while copied + 16 <= match_length {
+                self.buffer.extend(&chunk16);
+                copied += 16;
+            }
+            if copied < match_length {
+                let tail = match_length - copied;
+                self.buffer.extend(&chunk16[..tail]);
+            }
+            return;
+        }
+
+        // offset ∈ {3, 5, 6, 7}: the period does NOT divide 16, so each
+        // 16-byte window starts at a different sub-position of the
+        // repeating pattern. Pre-build all `offset` phase-shifted
+        // 16-byte windows and index by the current phase; advancing the
+        // cursor by 16 bytes shifts the phase by `16 % offset`. This
+        // keeps the inner-loop store at 16 bytes (same throughput as
+        // the divides-16 fast path), trading a 7×16 = 112-byte stack
+        // buffer + one modulo-by-small-constant for the doubled width
+        // vs the previous 8-byte phase pattern.
+        //
+        // LCM(offset, 16) = 48 / 80 / 48 / 112 bytes for offset
+        // ∈ {3, 5, 6, 7}; the phase cycles through every `offset` 16-
+        // byte stores so the steady-state period equals the LCM.
+        let mut phase_patterns_16 = [[0u8; 16]; 7];
         for phase in 0..offset {
-            for i in 0..8 {
-                phase_patterns[phase][i] = base[(phase + i) % offset];
+            for i in 0..16 {
+                phase_patterns_16[phase][i] = base[(phase + i) % offset];
             }
         }
 
-        let phase_step = 8 % offset;
+        let phase_step = 16 % offset;
         let mut phase = 0usize;
         let mut copied = 0usize;
-        while copied + 8 <= match_length {
-            self.buffer.extend(&phase_patterns[phase]);
-            copied += 8;
+        while copied + 16 <= match_length {
+            self.buffer.extend(&phase_patterns_16[phase]);
+            copied += 16;
             phase = (phase + phase_step) % offset;
         }
 
         if copied < match_length {
             let tail = match_length - copied;
-            self.buffer.extend(&phase_patterns[phase][..tail]);
+            self.buffer.extend(&phase_patterns_16[phase][..tail]);
         }
     }
 
@@ -856,5 +897,47 @@ mod tests {
         }
         let drain_len = model.len() - window;
         model.drain(0..drain_len).collect()
+    }
+
+    /// Drive `DecodeBuffer::repeat` through the short-offset path and
+    /// compare against the canonical `output[i] = base[i % offset]`
+    /// reference, covering offsets that hit both the SIMD-16 fast path
+    /// (1, 2, 4) and the 8-byte phase-pattern path (3, 5, 6, 7).
+    ///
+    /// Regression guard for the SIMD-16 specialisation: when `period
+    /// divides 16` (offset ∈ {1,2,4}), the inner loop emits 16-byte
+    /// chunks via a pre-built `[u8; 16]` instead of 8-byte phase
+    /// patterns. Tail lengths span both `match_length % 16 == 0` and
+    /// non-zero remainders so the tail-extend codepath is also
+    /// exercised.
+    #[test]
+    fn repeat_short_offset_matches_canonical_for_all_offsets_and_lengths() {
+        for offset in 1usize..=7 {
+            let mut base = [0u8; 7];
+            for (i, slot) in base.iter_mut().enumerate().take(offset) {
+                *slot = b'A' + (i as u8);
+            }
+            for &match_length in &[
+                1usize, 2, 3, 4, 5, 6, 7, 8, 9, 15, 16, 17, 23, 24, 25, 31, 32, 33, 47, 48, 49, 64,
+                127, 128, 4096,
+            ] {
+                let mut buf = DecodeBuffer::<RingBuffer>::new(8192);
+                buf.push(&base[..offset]);
+                buf.repeat(offset, match_length).unwrap_or_else(|e| {
+                    panic!("repeat failed for offset={offset} match_length={match_length}: {e:?}")
+                });
+
+                let actual = buf.drain();
+                let mut expected = Vec::with_capacity(offset + match_length);
+                expected.extend_from_slice(&base[..offset]);
+                for i in 0..match_length {
+                    expected.push(base[i % offset]);
+                }
+                assert_eq!(
+                    actual, expected,
+                    "mismatch at offset={offset} match_length={match_length}",
+                );
+            }
+        }
     }
 }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -322,38 +322,40 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             return;
         }
 
-        // offset ∈ {3, 5, 6, 7}: the period does NOT divide 16, so each
-        // 16-byte window starts at a different sub-position of the
-        // repeating pattern. Pre-build all `offset` phase-shifted
-        // 16-byte windows and index by the current phase; advancing the
-        // cursor by 16 bytes shifts the phase by `16 % offset`. This
-        // keeps the inner-loop store at 16 bytes (same throughput as
-        // the divides-16 fast path), trading a 7×16 = 112-byte stack
-        // buffer + one modulo-by-small-constant for the doubled width
-        // vs the previous 8-byte phase pattern.
+        // offset ∈ {3, 5, 6, 7}: 8-byte phase-pattern path. Each phase
+        // is the 8-byte view of the repeating period starting at that
+        // sub-position; advancing the cursor by 8 bytes shifts the
+        // phase by `8 % offset` (mod offset).
         //
-        // LCM(offset, 16) = 48 / 80 / 48 / 112 bytes for offset
-        // ∈ {3, 5, 6, 7}; the phase cycles through every `offset` 16-
-        // byte stores so the steady-state period equals the LCM.
-        let mut phase_patterns_16 = [[0u8; 16]; 7];
+        // A 16-byte version (LCM(offset, 16) ∈ {48, 80, 48, 112}) was
+        // measured on Intel i9-9900K — the doubled inner-loop store
+        // width was offset by a 7×16 = 112-byte phase-pattern setup
+        // cost (2× the 8-byte setup). On `decodecorpus-z000033`
+        // short-offset matches are short enough that setup dominates
+        // total cost, so the 16-byte version was a net regression on
+        // every level except `level_1_fast` (where it broke even). The
+        // 8-byte path retained here keeps the setup small (7×8 = 56 B)
+        // and is the fastest measured option for these offsets on
+        // realistic input.
+        let mut phase_patterns = [[0u8; 8]; 7];
         for phase in 0..offset {
-            for i in 0..16 {
-                phase_patterns_16[phase][i] = base[(phase + i) % offset];
+            for i in 0..8 {
+                phase_patterns[phase][i] = base[(phase + i) % offset];
             }
         }
 
-        let phase_step = 16 % offset;
+        let phase_step = 8 % offset;
         let mut phase = 0usize;
         let mut copied = 0usize;
-        while copied + 16 <= match_length {
-            self.buffer.extend(&phase_patterns_16[phase]);
-            copied += 16;
+        while copied + 8 <= match_length {
+            self.buffer.extend(&phase_patterns[phase]);
+            copied += 8;
             phase = (phase + phase_step) % offset;
         }
 
         if copied < match_length {
             let tail = match_length - copied;
-            self.buffer.extend(&phase_patterns_16[phase][..tail]);
+            self.buffer.extend(&phase_patterns[phase][..tail]);
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the 8-byte phase-pattern inner loop in `repeat_short_offset`
with a 16-byte SIMD store for the three short offsets whose repeating
period divides 16 — `offset ∈ {1, 2, 4}` (RLE byte, 2-byte alternation,
4-byte aligned-word repeat). Offsets {3, 5, 6, 7} stay on the existing
8-byte phase-pattern path.

For `offset ∈ {1, 2, 4}` the period divides 16, so a single pre-built
16-byte chunk feeds the entire loop with zero phase tracking. Inner
loop = one 16-byte SIMD store + one add.

## Why the SIMD-16 path is restricted to `offset ∈ {1, 2, 4}`

A first attempt extended the 16-byte path to all short offsets via
phase-shifted 16-byte windows for offsets {3, 5, 6, 7} (LCM(offset, 16)
= 48 / 80 / 48 / 112 byte steady-state period). On
`decodecorpus-z000033` the doubled inner-loop store width was offset by
a 7×16 = 112 B phase-pattern setup cost (2× the existing 8-byte setup),
which regressed every measured scenario except `level_1_fast` (where it
broke even).

Real short-offset matches on this workload are short enough that setup
dominates total per-call cost; doubling setup for marginal inner-loop
wins is a net loss. The 8-byte phase-pattern path (7×8 = 56 B setup)
turned out to be the fastest measured option for {3, 5, 6, 7} on
realistic input. The 16-byte fast path is therefore kept only where
setup is trivially small (one 16-byte chunk), i.e. for offsets whose
period divides 16.

## Benchmarks

**Intel i9-9900K (BMI2 + AVX2, Fedora 44, Linux 7.0):**

Direction: branch faster than main where Δ is negative.

| Scenario | `main` ms | `branch` ms | Speedup | p |
|---|---|---|---|---|
| `decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust` | 2.373 | 2.360 | **−0.55 % (faster)** | 0.00 |
| `decompress/level_1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust`  | 6.965 | 6.816 | **−2.14 % (faster)** | 0.00 |
| `decompress/level_3_dfast/decodecorpus-z000033/c_stream/matrix/pure_rust` | 6.159 | 6.096 | **−1.02 % (faster)** | 0.00 |
| `decompress/level_4_greedy/decodecorpus-z000033/c_stream/matrix/pure_rust` | 6.127 | 6.064 | **−1.03 % (faster)** | 0.00 |

All four scenarios statistically significant (p < 0.05). Largest win on
`level_1_fast` where the fast strategy emits the highest fraction of
short-offset literal repeats.

## Tests

- 539/539 nextest pass.
- `cargo clippy --lib --tests -- -D warnings` clean.
- New regression test
  `repeat_short_offset_matches_canonical_for_all_offsets_and_lengths`
  compares `DecodeBuffer::repeat` output against the canonical
  `output[i] = base[i % offset]` reference for every offset 1..=7
  across 25 match-lengths covering both the chunk-aligned cases
  (16/32/48/64/128) and the tail-path remainders (1, 2, 3, 5, 9, 15,
  17, 23, 25, 31, 33, 47, 49, 127, 4096).

## Files

- `zstd/src/decoding/decode_buffer.rs` — `repeat_short_offset` SIMD-16
  fast path for offset ∈ {1, 2, 4}; regression test added.

Closes #209.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decompression robustness through optimized buffer handling.

* **Tests**
  * Added regression test suite validating decompression correctness across all supported data patterns and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->