### PR TITLE
perf(encoder): donor-shape Fast kernel modules (#198 phase 1a)

### DIFF
--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -61,10 +61,19 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
         let b = unsafe { core::ptr::read_unaligned(m.cast::<u64>()) };
         let diff = a ^ b;
         if diff != 0 {
-            // Native-endian XOR — the byte ordering cancels out when
-            // we ask "how many low-order bytes are equal", since both
-            // operands were loaded with the same endianness.
+            // Donor's `ZSTD_NbCommonBytes` picks `__builtin_ctzll`
+            // on little-endian and `__builtin_clzll` on big-endian:
+            // both native-endian XOR loads put the first byte of
+            // the input in the LOW byte of the u64 on LE and the
+            // HIGH byte on BE, so "how many common low-order
+            // bytes" translates to `ctz/8` on LE and `clz/8` on BE.
+            // Without the cfg gate, BE targets would report the
+            // common-bytes count from the wrong end of `diff` and
+            // produce wrong match lengths.
+            #[cfg(target_endian = "little")]
             let common = (diff.trailing_zeros() / 8) as usize;
+            #[cfg(target_endian = "big")]
+            let common = (diff.leading_zeros() / 8) as usize;
             // SAFETY: `common < 8` (otherwise `diff == 0`), and the
             // caller's source range covers ≥ `common` more bytes (we
             // already verified the 8-byte chunk is in range).

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -11,14 +11,18 @@
 /// # Safety
 ///
 /// - `ip` MUST point to `ip_len = (iend as usize) - (ip as usize)`
-///   readable bytes.
-/// - `match_ptr` MUST point to at least `ip_len + 7` readable bytes (the
-///   8-byte chunked-load body reads past `ip_len` whenever the match
-///   extends to the limit). The caller's prefix bookkeeping in the
-///   donor encoder ensures this — `prefixStart` is always ≥ 8 bytes
-///   before the first valid match position, and the trailing 7 bytes
-///   of any frame are tagged as literals before this routine is
-///   invoked (the `ilimit = iend - HASH_READ_SIZE` cap upstream).
+///   readable bytes. `iend` is the exclusive upper bound; the function
+///   never reads at or past it.
+/// - `match_ptr` MUST point to at least as many readable bytes as `ip`
+///   does up to `iend`. In practice this is naturally satisfied when
+///   `match_ptr <= ip` and both pointers live inside the same buffer
+///   (a backward match into the encoder's history), since the function
+///   only reads chunks from `match_ptr` for the same byte ranges it
+///   reads from `ip` — `iend` caps both equally. A naive "trailing 7
+///   slack on match_ptr" reading would be overspecified: the 8-byte
+///   chunked-load body bails on the first non-matching byte, so the
+///   read length on `match_ptr` is always `min(ip_len, common_bytes
+///   + chunk_padding)` ≤ what `ip` itself reads.
 /// - Neither pointer's range may overlap the destination of a
 ///   concurrent write — the kernel runs single-threaded over a
 ///   block-local input slice so this holds by construction.

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -90,7 +90,19 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
             // SAFETY: `common < CHUNK_SIZE` (otherwise `diff == 0`),
             // and the caller's source range covers ≥ `common` more
             // bytes (we already verified the chunk fits).
-            return unsafe { ip.add(common).offset_from(p_start) as usize };
+            //
+            // Length computed via `as usize` arithmetic instead of
+            // `offset_from`: the latter returns `isize` and is UB
+            // when the byte distance exceeds `isize::MAX`. On 32-bit
+            // hosts a buffer spanning >2 GiB would trigger that
+            // exact case (`data.len() <= u32::MAX` is 4 GiB, larger
+            // than `isize::MAX = 2 GiB - 1`). Subtracting raw
+            // addresses as `usize` is well-defined arithmetic with
+            // no UB regardless of distance.
+            // SAFETY: same as above — the pointer arithmetic is
+            // in-bounds, the `usize` cast of a pointer is always
+            // well-defined.
+            return unsafe { (ip.add(common) as usize) - (p_start as usize) };
         }
         // SAFETY: pointer arithmetic stays within `[p_start, iend)`
         // because we just consumed a CHUNK_SIZE chunk that fit in range.
@@ -151,9 +163,10 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
         }
     }
 
-    // SAFETY: ip is bounded by [p_start, iend], so the difference is
-    // a non-negative isize that fits in usize.
-    unsafe { ip.offset_from(p_start) as usize }
+    // Length computed via `as usize` arithmetic (not `offset_from`)
+    // to avoid UB when the byte distance exceeds `isize::MAX` on
+    // 32-bit hosts; see the in-loop return for the full reasoning.
+    (ip as usize) - (p_start as usize)
 }
 
 #[cfg(test)]

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -1,0 +1,232 @@
+//! Forward match-length counter — direct port of donor's `ZSTD_count`
+//! from `lib/compress/zstd_compress_internal.h`. Compares `pIn` against
+//! `pMatch` in 8-byte chunks via XOR, falls back to a u32 / u16 / u8
+//! tail. The first mismatching byte is located via `trailing_zeros()/8`
+//! on the XOR difference, matching donor's `ZSTD_NbCommonBytes`.
+
+/// Count the number of bytes that match starting at `ip` against the
+/// reference at `match_ptr`, up to (but not including) `iend`. Returns
+/// the match length in bytes — `0` if `*ip != *match_ptr`.
+///
+/// # Safety
+///
+/// - `ip` MUST point to `ip_len = (iend as usize) - (ip as usize)`
+///   readable bytes.
+/// - `match_ptr` MUST point to at least `ip_len + 7` readable bytes (the
+///   8-byte chunked-load body reads past `ip_len` whenever the match
+///   extends to the limit). The caller's prefix bookkeeping in the
+///   donor encoder ensures this — `prefixStart` is always ≥ 8 bytes
+///   before the first valid match position, and the trailing 7 bytes
+///   of any frame are tagged as literals before this routine is
+///   invoked (the `ilimit = iend - HASH_READ_SIZE` cap upstream).
+/// - Neither pointer's range may overlap the destination of a
+///   concurrent write — the kernel runs single-threaded over a
+///   block-local input slice so this holds by construction.
+///
+/// # Equivalence to donor
+///
+/// Donor (`ZSTD_count` in `zstd_compress_internal.h`):
+/// ```c
+/// const BYTE* const pStart = pIn;
+/// const BYTE* const pInLoopLimit = pInLimit - (sizeof(size_t)-1);
+/// if (pIn < pInLoopLimit) {
+///   { size_t const diff = MEM_readST(pMatch) ^ MEM_readST(pIn);
+///     if (diff) return ZSTD_NbCommonBytes(diff); }
+///   pIn += sizeof(size_t); pMatch += sizeof(size_t);
+///   while (pIn < pInLoopLimit) { ... }
+/// }
+/// if (MEM_64bits() && pIn < pInLimit-3 && MEM_read32(pMatch) == MEM_read32(pIn)) { pIn+=4; pMatch+=4; }
+/// if (pIn < pInLimit-1 && MEM_read16(pMatch) == MEM_read16(pIn)) { pIn+=2; pMatch+=2; }
+/// if (pIn < pInLimit && *pMatch == *pIn) pIn++;
+/// return (size_t)(pIn - pStart);
+/// ```
+///
+/// The Rust port preserves the exact same chunk progression so a
+/// future cross-check against the C reference can be byte-identical.
+#[inline(always)]
+pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *const u8) -> usize {
+    let p_start = ip;
+    let mut ip = ip;
+    let mut m = match_ptr;
+
+    // 8-byte chunk loop. `loop_limit = iend - 7` ensures every chunked
+    // read stays inside the caller's `[ip, iend)` source range.
+    // SAFETY: iend ≥ ip + 7 in the only branch that enters the loop
+    // (checked by the `(ip as usize) + 8 <= iend as usize` guard
+    // before the read).
+    while (ip as usize) + 8 <= (iend as usize) {
+        // SAFETY: 8 readable bytes at both pointers per the function
+        // contract; pointers are not const-aligned, so `read_unaligned`.
+        let a = unsafe { core::ptr::read_unaligned(ip.cast::<u64>()) };
+        let b = unsafe { core::ptr::read_unaligned(m.cast::<u64>()) };
+        let diff = a ^ b;
+        if diff != 0 {
+            // Native-endian XOR — the byte ordering cancels out when
+            // we ask "how many low-order bytes are equal", since both
+            // operands were loaded with the same endianness.
+            let common = (diff.trailing_zeros() / 8) as usize;
+            // SAFETY: `common < 8` (otherwise `diff == 0`), and the
+            // caller's source range covers ≥ `common` more bytes (we
+            // already verified the 8-byte chunk is in range).
+            return unsafe { ip.add(common).offset_from(p_start) as usize };
+        }
+        // SAFETY: pointer arithmetic stays within `[p_start, iend)`
+        // because we just consumed an 8-byte chunk that fit in range.
+        unsafe {
+            ip = ip.add(8);
+            m = m.add(8);
+        }
+    }
+
+    // 4-byte tail.
+    // SAFETY: bounds check `+ 4 <= iend` before the read; both ptrs
+    // have at least `iend - ip` readable bytes by contract.
+    if (ip as usize) + 4 <= (iend as usize) {
+        let a = unsafe { core::ptr::read_unaligned(ip.cast::<u32>()) };
+        let b = unsafe { core::ptr::read_unaligned(m.cast::<u32>()) };
+        if a == b {
+            // SAFETY: just verified 4 readable bytes; pointer add by 4
+            // keeps the pointer ≤ iend.
+            unsafe {
+                ip = ip.add(4);
+                m = m.add(4);
+            }
+        }
+    }
+
+    // 2-byte tail.
+    if (ip as usize) + 2 <= (iend as usize) {
+        let a = unsafe { core::ptr::read_unaligned(ip.cast::<u16>()) };
+        let b = unsafe { core::ptr::read_unaligned(m.cast::<u16>()) };
+        if a == b {
+            // SAFETY: 2 readable bytes verified.
+            unsafe {
+                ip = ip.add(2);
+                m = m.add(2);
+            }
+        }
+    }
+
+    // 1-byte tail.
+    if (ip as usize) < (iend as usize) {
+        // SAFETY: 1 readable byte verified.
+        let a = unsafe { *ip };
+        let b = unsafe { *m };
+        if a == b {
+            // SAFETY: 1 readable byte verified; pointer add by 1 keeps
+            // ip ≤ iend.
+            unsafe {
+                ip = ip.add(1);
+            }
+        }
+    }
+
+    // SAFETY: ip is bounded by [p_start, iend], so the difference is
+    // a non-negative isize that fits in usize.
+    unsafe { ip.offset_from(p_start) as usize }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn count(a: &[u8], b: &[u8]) -> usize {
+        let min_len = a.len().min(b.len());
+        // SAFETY: both slices have at least `min_len` readable bytes,
+        // `iend = a.as_ptr() + min_len` stays in range.
+        unsafe { count_forward(a.as_ptr(), b.as_ptr(), a.as_ptr().add(min_len)) }
+    }
+
+    #[test]
+    fn empty_inputs_return_zero() {
+        // Empty range → loop body never executes.
+        let a: [u8; 0] = [];
+        let b: [u8; 0] = [];
+        // SAFETY: iend == ip, the function never dereferences.
+        let n = unsafe { count_forward(a.as_ptr(), b.as_ptr(), a.as_ptr()) };
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn full_match_inside_8_byte_chunk() {
+        let a = [1, 2, 3, 4, 5, 6, 7, 8];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(count(&a, &b), 8);
+    }
+
+    #[test]
+    fn diff_at_byte_3_in_first_chunk() {
+        let a = [1, 2, 3, 9, 5, 6, 7, 8];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(count(&a, &b), 3);
+    }
+
+    #[test]
+    fn match_spanning_two_chunks() {
+        let mut a = [0u8; 16];
+        let mut b = [0u8; 16];
+        for i in 0..16 {
+            a[i] = i as u8;
+            b[i] = i as u8;
+        }
+        a[13] = 99;
+        assert_eq!(count(&a, &b), 13);
+    }
+
+    #[test]
+    fn match_terminates_at_iend_within_tail() {
+        // 11 bytes: 1×8-chunk + 3 tail bytes (u16 + u8 fall-through).
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        assert_eq!(count(&a, &b), 11);
+    }
+
+    #[test]
+    fn diff_in_u32_tail() {
+        // 12 bytes: 1×8-chunk match, then 4-byte tail diverges at
+        // BYTE INDEX 9 (`99` vs `10`). After the 8-chunk advances
+        // ip/m by 8, the donor's u32 tail check compares
+        // a[8..12]=[9,99,11,12] vs b[8..12]=[9,10,11,12] → unequal,
+        // so the u32 advance is skipped. Same for u16
+        // (a[8..10]=[9,99] vs b[8..10]=[9,10] → unequal). The single
+        // byte cmp THEN sees a[8]=9 == b[8]=9 and advances ip by 1.
+        // Final match length: 8 + 1 = 9.
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 99, 11, 12];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+        assert_eq!(count(&a, &b), 9);
+    }
+
+    #[test]
+    fn diff_in_u16_tail_after_u32_match() {
+        // 14 bytes total, first 12 match, then u16 differs at byte 12.
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 99, 14];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14];
+        // 8 chunk + 4 u32 = 12 matched. u16 cmp on (99,14) vs (13,14)
+        // says unequal → 0 more. Single byte cmp on 99 vs 13 → 0 more.
+        assert_eq!(count(&a, &b), 12);
+    }
+
+    #[test]
+    fn diff_in_single_byte_tail() {
+        // 13 bytes, first 12 match, then single byte differs.
+        let a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 99];
+        let b = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+        // 8 chunk + 4 u32 = 12; u16 cmp not entered (only 1 byte left).
+        // Single byte cmp 99 != 13 → 0 more.
+        assert_eq!(count(&a, &b), 12);
+    }
+
+    #[test]
+    fn long_match_thousand_bytes() {
+        let a = [0x5Au8; 1024];
+        let b = [0x5Au8; 1024];
+        assert_eq!(count(&a, &b), 1024);
+    }
+
+    #[test]
+    fn no_match_first_byte() {
+        let a = [0u8, 1, 2, 3, 4, 5, 6, 7];
+        let b = [9u8, 1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(count(&a, &b), 0);
+    }
+}

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -1,8 +1,16 @@
 //! Forward match-length counter — direct port of donor's `ZSTD_count`
 //! from `lib/compress/zstd_compress_internal.h`. Compares `pIn` against
-//! `pMatch` in 8-byte chunks via XOR, falls back to a u32 / u16 / u8
-//! tail. The first mismatching byte is located via `trailing_zeros()/8`
-//! on the XOR difference, matching donor's `ZSTD_NbCommonBytes`.
+//! `pMatch` in `usize`-sized chunks via XOR, falls back to a u32 / u16
+//! / u8 tail. The first mismatching byte is located via
+//! `trailing_zeros()/8` (little-endian) or `leading_zeros()/8`
+//! (big-endian) on the XOR difference, matching donor's
+//! `ZSTD_NbCommonBytes`.
+//!
+//! The chunk type is `usize` — `u64` on 64-bit hosts, `u32` on 32-bit —
+//! to match donor's `MEM_readST` (`size_t`) loads. On 32-bit targets a
+//! u64 chunk would compile to two adjacent 32-bit loads + a 64-bit
+//! XOR; using native pointer width keeps the inner loop a single load
+//! per pointer per iteration.
 
 /// Count the number of bytes that match starting at `ip` against the
 /// reference at `match_ptr`, up to (but not including) `iend`. Returns
@@ -53,23 +61,24 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
     let mut ip = ip;
     let mut m = match_ptr;
 
-    // 8-byte chunk loop. `loop_limit = iend - 7` ensures every chunked
-    // read stays inside the caller's `[ip, iend)` source range.
-    // SAFETY: iend ≥ ip + 7 in the only branch that enters the loop
-    // (checked by the `(ip as usize) + 8 <= iend as usize` guard
-    // before the read).
-    while (ip as usize) + 8 <= (iend as usize) {
-        // SAFETY: 8 readable bytes at both pointers per the function
-        // contract; pointers are not const-aligned, so `read_unaligned`.
-        let a = unsafe { core::ptr::read_unaligned(ip.cast::<u64>()) };
-        let b = unsafe { core::ptr::read_unaligned(m.cast::<u64>()) };
+    // `usize`-sized chunk loop matching donor's `MEM_readST` cadence.
+    // CHUNK_SIZE = 8 on 64-bit targets, 4 on 32-bit. The bound check
+    // `(ip as usize) + CHUNK_SIZE <= (iend as usize)` ensures every
+    // chunked read stays inside the caller's `[ip, iend)` source range.
+    const CHUNK_SIZE: usize = core::mem::size_of::<usize>();
+    while (ip as usize) + CHUNK_SIZE <= (iend as usize) {
+        // SAFETY: CHUNK_SIZE readable bytes at both pointers per the
+        // function contract; pointers are not const-aligned, so
+        // `read_unaligned`.
+        let a = unsafe { core::ptr::read_unaligned(ip.cast::<usize>()) };
+        let b = unsafe { core::ptr::read_unaligned(m.cast::<usize>()) };
         let diff = a ^ b;
         if diff != 0 {
             // Donor's `ZSTD_NbCommonBytes` picks `__builtin_ctzll`
-            // on little-endian and `__builtin_clzll` on big-endian:
-            // both native-endian XOR loads put the first byte of
-            // the input in the LOW byte of the u64 on LE and the
-            // HIGH byte on BE, so "how many common low-order
+            // (or `ctzl` on 32-bit) on little-endian and `clzll`/`clzl`
+            // on big-endian. Native-endian XOR loads place the first
+            // byte of the input in the LOW byte of the chunk on LE
+            // and the HIGH byte on BE, so "how many common low-order
             // bytes" translates to `ctz/8` on LE and `clz/8` on BE.
             // Without the cfg gate, BE targets would report the
             // common-bytes count from the wrong end of `diff` and
@@ -78,22 +87,30 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
             let common = (diff.trailing_zeros() / 8) as usize;
             #[cfg(target_endian = "big")]
             let common = (diff.leading_zeros() / 8) as usize;
-            // SAFETY: `common < 8` (otherwise `diff == 0`), and the
-            // caller's source range covers ≥ `common` more bytes (we
-            // already verified the 8-byte chunk is in range).
+            // SAFETY: `common < CHUNK_SIZE` (otherwise `diff == 0`),
+            // and the caller's source range covers ≥ `common` more
+            // bytes (we already verified the chunk fits).
             return unsafe { ip.add(common).offset_from(p_start) as usize };
         }
         // SAFETY: pointer arithmetic stays within `[p_start, iend)`
-        // because we just consumed an 8-byte chunk that fit in range.
+        // because we just consumed a CHUNK_SIZE chunk that fit in range.
         unsafe {
-            ip = ip.add(8);
-            m = m.add(8);
+            ip = ip.add(CHUNK_SIZE);
+            m = m.add(CHUNK_SIZE);
         }
     }
 
-    // 4-byte tail.
+    // 4-byte tail. On 32-bit targets the chunk loop above already
+    // operates in 4-byte strides, so the chunk's bounds invariant
+    // (`+ CHUNK_SIZE <= iend` failed → at most 3 bytes left) makes
+    // this branch's `+ 4 <= iend` always false — guarding the block
+    // with `cfg(target_pointer_width = "64")` mirrors donor's
+    // `MEM_64bits()` gate and lets the optimiser drop the dead check
+    // on 32-bit builds.
+    //
     // SAFETY: bounds check `+ 4 <= iend` before the read; both ptrs
     // have at least `iend - ip` readable bytes by contract.
+    #[cfg(target_pointer_width = "64")]
     if (ip as usize) + 4 <= (iend as usize) {
         let a = unsafe { core::ptr::read_unaligned(ip.cast::<u32>()) };
         let b = unsafe { core::ptr::read_unaligned(m.cast::<u32>()) };

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -1,0 +1,220 @@
+//! Flat `Vec<u32>` hash table used by the donor-shape Fast strategy
+//! match-finder. Direct port of `ZSTD_hash4`/`ZSTD_hash5`/`ZSTD_hash6`/
+//! `ZSTD_hash7`/`ZSTD_hash8` from
+//! `lib/compress/zstd_compress_internal.h` — multiply-shift on the first
+//! `mls` bytes of the suffix at `ptr`, keyed into a power-of-two table
+//! sized `1 << hash_log` entries.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+/// Donor multiplicative hash constants — exact bit-for-bit match with
+/// `lib/compress/zstd_compress_internal.h` so the table-keying behaviour
+/// stays identical to the reference encoder.
+const PRIME_4_BYTES: u32 = 0x9E3779B1;
+const PRIME_5_BYTES: u64 = 889_523_592_379;
+const PRIME_6_BYTES: u64 = 227_718_039_650_203;
+const PRIME_7_BYTES: u64 = 58_295_818_150_454_627;
+const PRIME_8_BYTES: u64 = 0xCF1BBCDCB7A56463;
+
+/// Flat hash table indexed by `hash_ptr(ptr, hash_log, mls)`. Entries
+/// store absolute positions into the encoder's flat history buffer
+/// (matches donor's `U32* hashTable` with `base + matchIdx` lookup).
+/// Sentinel `0` is fine because position `0` either belongs to the
+/// initial prefix (where the `+= (ip0 == prefixStart)` adjustment at
+/// loop entry skips it) or is below `prefixStartIndex` and filtered by
+/// the in-range check.
+pub(crate) struct FastHashTable {
+    table: Vec<u32>,
+    /// Donor `hash_log` — number of bits the hash output is reduced to.
+    hash_log: u32,
+    /// Donor `mls` — minimum match length used as the hash input width.
+    /// Valid range `4..=8`; the kernel monomorphises over this so it
+    /// compiles to a constant inside each instantiation.
+    mls: u32,
+}
+
+impl FastHashTable {
+    /// Allocate the table at `1 << hash_log` entries, all initialised
+    /// to the sentinel `0` position. The encoder is expected to bump
+    /// the first real input position to at least `1` so the sentinel
+    /// can never be confused with a valid match (the donor achieves
+    /// this via `ip0 += (ip0 == prefixStart)`).
+    pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
+        debug_assert!(hash_log <= 32, "hash_log > 32 would overflow u32 indexing");
+        debug_assert!(
+            (4..=8).contains(&mls),
+            "ZSTD Fast strategy only supports mls 4..=8 (got {mls})",
+        );
+        Self {
+            table: vec![0u32; 1usize << hash_log],
+            hash_log,
+            mls,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn hash_log(&self) -> u32 {
+        self.hash_log
+    }
+
+    #[inline(always)]
+    pub(crate) fn mls(&self) -> u32 {
+        self.mls
+    }
+
+    /// Clear the table back to all-sentinel. Used on encoder reset
+    /// between independent frames so a stale absolute index from the
+    /// previous frame can't get mistaken for a current-frame match.
+    pub(crate) fn clear(&mut self) {
+        // `fill(0)` lowers to a single `memset` and is significantly
+        // faster than re-allocating; the table can be hundreds of KiB.
+        self.table.fill(0);
+    }
+
+    /// Donor-parity `ZSTD_hashPtr` — multiply-shift hash over the first
+    /// `mls` bytes at `ptr`, output reduced to `hash_log` bits.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` MUST point to at least `mls` readable bytes (`mls <= 8`,
+    /// so at most an 8-byte read). The kernel guarantees this via the
+    /// `ilimit = iend - HASH_READ_SIZE` cap, mirroring donor's same
+    /// invariant.
+    #[inline(always)]
+    pub(crate) unsafe fn hash_ptr<const MLS: u32>(&self, ptr: *const u8) -> u32 {
+        debug_assert_eq!(MLS, self.mls, "monomorphised MLS must match table mls");
+        match MLS {
+            4 => {
+                // SAFETY: caller guarantees ≥4 readable bytes at ptr.
+                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u32>()) }.to_le();
+                u.wrapping_mul(PRIME_4_BYTES) >> (32 - self.hash_log)
+            }
+            5 => {
+                // SAFETY: caller guarantees ≥5 readable bytes; the
+                // u64 load reads 8 but only the bottom 40 bits are
+                // hashed (`<< (64-40)` shifts the rest off).
+                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+                ((u << (64 - 40)).wrapping_mul(PRIME_5_BYTES) >> (64 - self.hash_log)) as u32
+            }
+            6 => {
+                // SAFETY: caller guarantees ≥6 readable bytes; same
+                // u64-load + top-bit shift pattern as mls=5.
+                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+                ((u << (64 - 48)).wrapping_mul(PRIME_6_BYTES) >> (64 - self.hash_log)) as u32
+            }
+            7 => {
+                // SAFETY: caller guarantees ≥7 readable bytes.
+                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+                ((u << (64 - 56)).wrapping_mul(PRIME_7_BYTES) >> (64 - self.hash_log)) as u32
+            }
+            8 => {
+                // SAFETY: caller guarantees ≥8 readable bytes — the
+                // donor reads the full u64 unchanged for mls=8.
+                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+                (u.wrapping_mul(PRIME_8_BYTES) >> (64 - self.hash_log)) as u32
+            }
+            _ => {
+                // Compile-time unreachable for monomorphised callers;
+                // emitting an `unreachable_unchecked()` here would be
+                // UB in debug builds if anyone instantiates a bad MLS.
+                debug_assert!(false, "unsupported MLS {MLS}");
+                0
+            }
+        }
+    }
+
+    /// Direct table access — `table[hash]`. Bounds-check at index time
+    /// is provably redundant because `hash >> (64 - hash_log)` produces
+    /// a value `< 1 << hash_log == table.len()`; LLVM cannot infer
+    /// this across the `as u32` truncation so we use `get_unchecked`.
+    ///
+    /// # Safety
+    ///
+    /// `hash` MUST be a value returned by [`hash_ptr`] on this table
+    /// (or on another table with the same `hash_log`), so that
+    /// `hash < 1 << hash_log = table.len()`.
+    #[inline(always)]
+    pub(crate) unsafe fn get(&self, hash: u32) -> u32 {
+        debug_assert!((hash as usize) < self.table.len());
+        // SAFETY: see method-level doc — `hash` is bounded by the
+        // table-size invariant from `hash_ptr`.
+        unsafe { *self.table.get_unchecked(hash as usize) }
+    }
+
+    /// Direct table write — `table[hash] = pos`. Same bounds reasoning
+    /// as [`get`].
+    ///
+    /// # Safety
+    ///
+    /// `hash` MUST be a value returned by [`hash_ptr`] on this table.
+    #[inline(always)]
+    pub(crate) unsafe fn put(&mut self, hash: u32, pos: u32) {
+        debug_assert!((hash as usize) < self.table.len());
+        // SAFETY: see method-level doc.
+        unsafe {
+            *self.table.get_unchecked_mut(hash as usize) = pos;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Donor parity: `ZSTD_hash4` on `[0x01, 0x02, 0x03, 0x04]` with
+    /// hash_log=12 produces a specific bit pattern. Captured here as a
+    /// regression tripwire so any future refactor of the multiply
+    /// constants surfaces immediately.
+    #[test]
+    fn hash4_matches_donor_formula_on_known_input() {
+        let table = FastHashTable::new(12, 4);
+        let data = [0x01u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        // SAFETY: data has 8 ≥ 4 readable bytes.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr()) };
+        // Manual donor calc: u32::from_le_bytes(0x04030201) * 0x9E3779B1 >> 20.
+        let expected = 0x04030201u32.wrapping_mul(0x9E3779B1) >> 20;
+        assert_eq!(h, expected, "hash4 must match donor multiply-shift formula");
+    }
+
+    #[test]
+    fn hash5_matches_donor_formula_on_known_input() {
+        let table = FastHashTable::new(13, 5);
+        let data = [0x01u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        // SAFETY: data has 8 ≥ 5 readable bytes.
+        let h = unsafe { table.hash_ptr::<5>(data.as_ptr()) };
+        let u = u64::from_le_bytes(data);
+        let expected = (((u << (64 - 40)).wrapping_mul(889_523_592_379u64)) >> (64 - 13)) as u32;
+        assert_eq!(h, expected);
+    }
+
+    #[test]
+    fn get_put_round_trip_under_known_hash() {
+        let mut table = FastHashTable::new(8, 4);
+        let data = [0xAAu8, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00, 0x11];
+        // SAFETY: data has 8 ≥ 4 readable bytes.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr()) };
+        // SAFETY: h came from hash_ptr on this table.
+        unsafe {
+            assert_eq!(table.get(h), 0, "fresh table reads sentinel");
+            table.put(h, 0xCAFE_BABE);
+            assert_eq!(table.get(h), 0xCAFE_BABE);
+        }
+    }
+
+    #[test]
+    fn clear_resets_all_entries_to_sentinel() {
+        let mut table = FastHashTable::new(6, 4);
+        let data = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        // SAFETY: 4 readable bytes.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr()) };
+        // SAFETY: hash came from hash_ptr.
+        unsafe {
+            table.put(h, 42);
+        }
+        table.clear();
+        // SAFETY: hash came from hash_ptr.
+        let read_back = unsafe { table.get(h) };
+        assert_eq!(read_back, 0, "clear must zero every entry");
+    }
+}

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -140,20 +140,24 @@ impl FastHashTable {
                 u.wrapping_mul(PRIME_4_BYTES) >> (32 - self.hash_log)
             }
             5 => {
-                // SAFETY: caller guarantees ≥5 readable bytes; the
-                // u64 load reads 8 but only the bottom 40 bits are
-                // hashed (`<< (64-40)` shifts the rest off).
+                // SAFETY: caller guarantees ≥8 readable bytes per the
+                // method-level doc — every MLS≥5 path performs a
+                // wide u64 load and shifts off the unused top bits;
+                // a 5-byte promise would leave 3 bytes of the load
+                // past the caller's range.
                 let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
                 ((u << (64 - 40)).wrapping_mul(PRIME_5_BYTES) >> (64 - self.hash_log)) as u32
             }
             6 => {
-                // SAFETY: caller guarantees ≥6 readable bytes; same
-                // u64-load + top-bit shift pattern as mls=5.
+                // SAFETY: caller guarantees ≥8 readable bytes (u64
+                // load — only the bottom 48 bits feed the hash, but
+                // the LOAD is still 8 bytes wide).
                 let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
                 ((u << (64 - 48)).wrapping_mul(PRIME_6_BYTES) >> (64 - self.hash_log)) as u32
             }
             7 => {
-                // SAFETY: caller guarantees ≥7 readable bytes.
+                // SAFETY: caller guarantees ≥8 readable bytes (u64
+                // load — bottom 56 bits feed the hash; LOAD is 8).
                 let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
                 ((u << (64 - 56)).wrapping_mul(PRIME_7_BYTES) >> (64 - self.hash_log)) as u32
             }

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -8,6 +8,16 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+/// Donor `ZSTD_HASHLOG_MAX` (`lib/zstd.h`). The cap applies uniformly
+/// across all four `mls` instantiations: even though `mls >= 5` widens
+/// the hash to a `u64` reduction, the Fast strategy's per-level
+/// `hashLog` is sourced from the donor's `ZSTD_defaultCParameters`
+/// table where the maximum is `14` (level 1, `srcSize > 256 KB`), and
+/// the user-tunable upper bound is `30`. Enforcing this in the
+/// constructor catches misuse before the first `hash_ptr` would
+/// otherwise panic on the `(32 - hash_log)` / `(64 - hash_log)` shift.
+const ZSTD_HASHLOG_MAX: u32 = 30;
+
 /// Donor multiplicative hash constants — exact bit-for-bit match with
 /// `lib/compress/zstd_compress_internal.h` so the table-keying behaviour
 /// stays identical to the reference encoder.
@@ -43,23 +53,24 @@ impl FastHashTable {
     ///
     /// # Panics
     ///
-    /// Panics if `hash_log` is `0` or `≥ usize::BITS`. `0` would make
-    /// the `hash_ptr` reduction shift by the full word width (`32` for
-    /// mls=4, `64` for mls≥5), which is UB / panic in Rust. `≥
-    /// usize::BITS` makes `1usize << hash_log` overflow — on 32-bit
-    /// targets that's anything ≥ 32, on 64-bit targets anything ≥ 64.
-    /// Donor's `ZSTD_HASHLOG_MAX` is `30` so any sane caller stays in
-    /// `1..=30`; this assertion only catches outright misuse.
+    /// Panics if `hash_log` is outside `1..=ZSTD_HASHLOG_MAX` (donor's
+    /// cap, currently `30`). The lower bound exists because `0` would
+    /// make `hash_ptr` shift by the full word width (`32` for mls=4,
+    /// `64` for mls≥5) — UB / panic in Rust. The upper bound is the
+    /// donor's documented maximum; importantly, even on 64-bit
+    /// targets a `usize::BITS - 1` cap would still admit `hash_log
+    /// ∈ 33..=63` which is invalid for the `mls=4` path that shifts
+    /// by `32 - hash_log` (panics for `hash_log >= 32`). Pinning to
+    /// `ZSTD_HASHLOG_MAX` rejects both invalid bands at construction
+    /// time so every subsequent `hash_ptr::<MLS>` call is safe by
+    /// construction.
+    ///
     /// Also panics if `mls` is outside `4..=8`.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
         assert!(
-            hash_log > 0,
-            "hash_log must be > 0 (a zero log would make hash_ptr shift by the full word width)",
-        );
-        assert!(
-            hash_log < usize::BITS,
-            "hash_log {hash_log} >= usize::BITS {} would overflow `1usize << hash_log`",
-            usize::BITS,
+            (1..=ZSTD_HASHLOG_MAX).contains(&hash_log),
+            "hash_log must be in 1..={ZSTD_HASHLOG_MAX} for donor-compatible Fast hashing (got {hash_log}); \
+             the lower bound prevents a full-word-width shift in hash_ptr, the upper bound is donor's ZSTD_HASHLOG_MAX",
         );
         assert!(
             (4..=8).contains(&mls),

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -21,6 +21,24 @@ const ZSTD_HASHLOG_MAX: u32 = 30;
 /// Donor multiplicative hash constants — exact bit-for-bit match with
 /// `lib/compress/zstd_compress_internal.h` so the table-keying behaviour
 /// stays identical to the reference encoder.
+/// Non-allocating parameter validation shared by [`FastHashTable::new`] and
+/// the constructor-accept-path tests. Extracted so tests can prove the
+/// `(1..=ZSTD_HASHLOG_MAX, 4..=8)` accept band without forcing a
+/// `1 << ZSTD_HASHLOG_MAX` allocation (≈4 GiB at `ZSTD_HASHLOG_MAX = 30`,
+/// well above per-test memory budgets on CI runners). Panics with the
+/// same messages the [`FastHashTable::new`] doc-comment cites.
+fn validate_params(hash_log: u32, mls: u32) {
+    assert!(
+        (1..=ZSTD_HASHLOG_MAX).contains(&hash_log),
+        "hash_log must be in 1..={ZSTD_HASHLOG_MAX} for donor-compatible Fast hashing (got {hash_log}); \
+         the lower bound prevents a full-word-width shift in hash_ptr, the upper bound is donor's ZSTD_HASHLOG_MAX",
+    );
+    assert!(
+        (4..=8).contains(&mls),
+        "ZSTD Fast strategy only supports mls 4..=8 (got {mls})",
+    );
+}
+
 const PRIME_4_BYTES: u32 = 0x9E3779B1;
 const PRIME_5_BYTES: u64 = 889_523_592_379;
 const PRIME_6_BYTES: u64 = 227_718_039_650_203;
@@ -67,15 +85,7 @@ impl FastHashTable {
     ///
     /// Also panics if `mls` is outside `4..=8`.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
-        assert!(
-            (1..=ZSTD_HASHLOG_MAX).contains(&hash_log),
-            "hash_log must be in 1..={ZSTD_HASHLOG_MAX} for donor-compatible Fast hashing (got {hash_log}); \
-             the lower bound prevents a full-word-width shift in hash_ptr, the upper bound is donor's ZSTD_HASHLOG_MAX",
-        );
-        assert!(
-            (4..=8).contains(&mls),
-            "ZSTD Fast strategy only supports mls 4..=8 (got {mls})",
-        );
+        validate_params(hash_log, mls);
         Self {
             table: vec![0u32; 1usize << hash_log],
             hash_log,
@@ -314,18 +324,16 @@ mod tests {
     }
 
     /// Boundary: `hash_log = ZSTD_HASHLOG_MAX` (30) is the largest
-    /// accepted value. Allocating the full table would burn ~4 GiB;
-    /// instead we instantiate at a smaller log first to prove
-    /// `hash_ptr` honours the bit-width, then verify the constructor
-    /// doesn't reject 30 via a panic-catching probe.
+    /// accepted value. Calling [`FastHashTable::new`] with this value
+    /// would allocate ≈4 GiB (`1 << 30` × `sizeof(u32)`), well over
+    /// per-test memory budgets on CI runners — instead exercise the
+    /// same accept path via the non-allocating [`validate_params`]
+    /// helper. Pairs with the `should_panic` tests below that prove
+    /// rejection of the out-of-band cases.
     #[test]
-    fn hash_log_maximum_thirty_is_accepted_by_constructor() {
-        // Just probe the assertion path: invoking new() with 30
-        // mustn't panic. We don't actually use the giant table — drop
-        // it immediately. (2^30 * 4 bytes is acceptable for a CI host
-        // running a single test; if the host can't allocate it the
-        // test will OOM-skip rather than misreport.)
-        let _table = FastHashTable::new(30, 4);
+    fn hash_log_maximum_thirty_is_accepted_by_validation() {
+        validate_params(ZSTD_HASHLOG_MAX, 4);
+        validate_params(ZSTD_HASHLOG_MAX, 8);
     }
 
     #[test]

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -40,9 +40,28 @@ impl FastHashTable {
     /// the first real input position to at least `1` so the sentinel
     /// can never be confused with a valid match (the donor achieves
     /// this via `ip0 += (ip0 == prefixStart)`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash_log` is `0` or `≥ usize::BITS`. `0` would make
+    /// the `hash_ptr` reduction shift by the full word width (`32` for
+    /// mls=4, `64` for mls≥5), which is UB / panic in Rust. `≥
+    /// usize::BITS` makes `1usize << hash_log` overflow — on 32-bit
+    /// targets that's anything ≥ 32, on 64-bit targets anything ≥ 64.
+    /// Donor's `ZSTD_HASHLOG_MAX` is `30` so any sane caller stays in
+    /// `1..=30`; this assertion only catches outright misuse.
+    /// Also panics if `mls` is outside `4..=8`.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
-        debug_assert!(hash_log <= 32, "hash_log > 32 would overflow u32 indexing");
-        debug_assert!(
+        assert!(
+            hash_log > 0,
+            "hash_log must be > 0 (a zero log would make hash_ptr shift by the full word width)",
+        );
+        assert!(
+            hash_log < usize::BITS,
+            "hash_log {hash_log} >= usize::BITS {} would overflow `1usize << hash_log`",
+            usize::BITS,
+        );
+        assert!(
             (4..=8).contains(&mls),
             "ZSTD Fast strategy only supports mls 4..=8 (got {mls})",
         );

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -72,19 +72,37 @@ impl FastHashTable {
     ///
     /// # Panics
     ///
-    /// Panics if `hash_log` is outside `1..=ZSTD_HASHLOG_MAX` (donor's
-    /// cap, currently `30`). The lower bound exists because `0` would
-    /// make `hash_ptr` shift by the full word width (`32` for mls=4,
-    /// `64` for mls≥5) — UB / panic in Rust. The upper bound is the
-    /// donor's documented maximum; importantly, even on 64-bit
-    /// targets a `usize::BITS - 1` cap would still admit `hash_log
-    /// ∈ 33..=63` which is invalid for the `mls=4` path that shifts
-    /// by `32 - hash_log` (panics for `hash_log >= 32`). Pinning to
-    /// `ZSTD_HASHLOG_MAX` rejects both invalid bands at construction
-    /// time so every subsequent `hash_ptr::<MLS>` call is safe by
-    /// construction.
+    /// Parameter-range failures:
+    /// - `hash_log` outside `1..=ZSTD_HASHLOG_MAX` (donor's cap,
+    ///   currently `30`). The lower bound exists because `0` would
+    ///   make `hash_ptr` shift by the full word width (`32` for
+    ///   mls=4, `64` for mls≥5) — UB / panic in Rust. The upper
+    ///   bound is the donor's documented maximum; importantly,
+    ///   even on 64-bit targets a `usize::BITS - 1` cap would still
+    ///   admit `hash_log ∈ 33..=63` which is invalid for the
+    ///   `mls=4` path that shifts by `32 - hash_log` (panics for
+    ///   `hash_log >= 32`). Pinning to `ZSTD_HASHLOG_MAX` rejects
+    ///   both invalid bands at construction time so every
+    ///   subsequent `hash_ptr::<MLS>` call is safe by construction.
+    /// - `mls` outside `4..=8`.
     ///
-    /// Also panics if `mls` is outside `4..=8`.
+    /// Target-size / allocation failures (per-host, not per-input):
+    /// - `1usize << hash_log` overflowing `usize` on the current
+    ///   target. On 32-bit hosts that fires at `hash_log >= 32`;
+    ///   even the donor cap (`30`) hits the practical 2 GiB
+    ///   address-space limit before reaching the formal usize
+    ///   overflow, so anything close to `hash_log = 30` is
+    ///   borderline on 32-bit and will OOM the allocator.
+    /// - `entries * size_of::<u32>()` overflowing `usize` (same
+    ///   class of overflow at a different multiply step).
+    /// - Global allocator failure when actually allocating the
+    ///   table backing storage — propagates as the standard
+    ///   `Vec::with_capacity` allocation-failure panic.
+    ///
+    /// The parameter-range and target-size guards both fire BEFORE
+    /// the `vec![]` call, so allocator failure (the third bullet)
+    /// is the only panic that depends on runtime memory state. The
+    /// first two are deterministic given the inputs and target.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
         validate_params(hash_log, mls);
         // Per-target allocation feasibility: `1 << hash_log` u32 entries

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -169,7 +169,7 @@ impl FastHashTable {
     ///
     /// # Safety
     ///
-    /// `ptr` MUST point to readable bytes covering the load width:
+    /// **Readable-bytes contract on `ptr`:**
     /// - `MLS == 4`: at least **4** readable bytes (a `u32` load).
     /// - `MLS >= 5`: at least **8** readable bytes — every mls ∈ {5,
     ///   6, 7, 8} path performs an unaligned `u64::read_unaligned`
@@ -179,9 +179,25 @@ impl FastHashTable {
     ///   trailing 8-mls bytes of the u64 read past the caller's
     ///   range — UB.
     ///
-    /// The kernel satisfies this uniformly via the
-    /// `ilimit = iend - HASH_READ_SIZE` cap (`HASH_READ_SIZE = 8`),
-    /// mirroring donor's same invariant.
+    /// The kernel satisfies the readable-bytes promise uniformly
+    /// via the `ilimit = iend - HASH_READ_SIZE` cap
+    /// (`HASH_READ_SIZE = 8`), mirroring donor's same invariant.
+    ///
+    /// **`MLS` const-generic contract:**
+    /// - `MLS` MUST equal `self.mls()`.
+    /// - `MLS` MUST be in `4..=8`.
+    ///
+    /// Today only `debug_assert_eq!` checks the equality at runtime,
+    /// so in release a mismatch silently routes to the wrong hash
+    /// formula (different multiply prime, different shift width)
+    /// and probes entries indexed by a different formula — garbage
+    /// match candidates. Callers must guarantee both invariants
+    /// before invoking `hash_ptr`. The crate-internal entry point
+    /// [`crate::encoding::simple::fast_kernel::kernel::compress_block_fast`]
+    /// enforces both via real `assert!`s before any `hash_ptr` call,
+    /// so invocation through the kernel is safe by construction;
+    /// direct callers (tests, future helpers) must uphold the
+    /// contract themselves.
     #[inline(always)]
     pub(crate) unsafe fn hash_ptr<const MLS: u32>(&self, ptr: *const u8) -> u32 {
         debug_assert_eq!(MLS, self.mls, "monomorphised MLS must match table mls");

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -9,13 +9,14 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 /// Donor `ZSTD_HASHLOG_MAX` (`lib/zstd.h`). The cap applies uniformly
-/// across all four `mls` instantiations: even though `mls >= 5` widens
-/// the hash to a `u64` reduction, the Fast strategy's per-level
-/// `hashLog` is sourced from the donor's `ZSTD_defaultCParameters`
-/// table where the maximum is `14` (level 1, `srcSize > 256 KB`), and
-/// the user-tunable upper bound is `30`. Enforcing this in the
-/// constructor catches misuse before the first `hash_ptr` would
-/// otherwise panic on the `(32 - hash_log)` / `(64 - hash_log)` shift.
+/// across all five `mls` instantiations (`mls ∈ {4, 5, 6, 7, 8}`): even
+/// though `mls >= 5` widens the hash to a `u64` reduction, the Fast
+/// strategy's per-level `hashLog` is sourced from the donor's
+/// `ZSTD_defaultCParameters` table where the maximum is `14` (level 1,
+/// `srcSize > 256 KB`), and the user-tunable upper bound is `30`.
+/// Enforcing this in the constructor catches misuse before the first
+/// `hash_ptr` would otherwise panic on the `(32 - hash_log)` /
+/// `(64 - hash_log)` shift.
 const ZSTD_HASHLOG_MAX: u32 = 30;
 
 /// Donor multiplicative hash constants — exact bit-for-bit match with
@@ -86,8 +87,36 @@ impl FastHashTable {
     /// Also panics if `mls` is outside `4..=8`.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
         validate_params(hash_log, mls);
+        // Per-target allocation feasibility: `1 << hash_log` u32 entries
+        // = `1 << (hash_log + 2)` bytes. On 32-bit hosts that overflows
+        // `usize` at `hash_log >= 30` (4 GiB exceeds the address space).
+        // `validate_params` already pins `hash_log <= ZSTD_HASHLOG_MAX
+        // = 30`, but on 32-bit the maximum that actually fits is `<=
+        // 29` (2 GiB) — anything larger panics deep inside `Vec::with_
+        // capacity` with a generic allocation message. Surface a clear
+        // panic at construction so the failure mode is obvious instead.
+        let entries = 1usize.checked_shl(hash_log).unwrap_or_else(|| {
+            panic!(
+                "FastHashTable cannot allocate 2^{hash_log} u32 entries on this target: \
+                 `1usize << {hash_log}` overflows {0}-bit usize",
+                usize::BITS,
+            )
+        });
+        let bytes = entries
+            .checked_mul(core::mem::size_of::<u32>())
+            .unwrap_or_else(|| {
+                panic!(
+                    "FastHashTable cannot allocate {entries} u32 entries on this target: \
+                 byte size overflows {0}-bit usize",
+                    usize::BITS,
+                )
+            });
+        // Use `bytes` to compute as a tripwire — actual allocation
+        // still goes through `vec![]` so the global allocator picks
+        // the strategy (zeroed page mapping, etc.).
+        let _ = bytes;
         Self {
-            table: vec![0u32; 1usize << hash_log],
+            table: vec![0u32; entries],
             hash_log,
             mls,
         }

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -87,22 +87,27 @@ impl FastHashTable {
     /// - `mls` outside `4..=8`.
     ///
     /// Target-size / allocation failures (per-host, not per-input):
-    /// - `1usize << hash_log` overflowing `usize` on the current
-    ///   target. On 32-bit hosts that fires at `hash_log >= 32`;
-    ///   even the donor cap (`30`) hits the practical 2 GiB
-    ///   address-space limit before reaching the formal usize
-    ///   overflow, so anything close to `hash_log = 30` is
-    ///   borderline on 32-bit and will OOM the allocator.
-    /// - `entries * size_of::<u32>()` overflowing `usize` (same
-    ///   class of overflow at a different multiply step).
+    /// - `1usize << hash_log` overflowing `usize`. Only reachable on
+    ///   32-bit hosts at `hash_log >= 32` — but `validate_params`
+    ///   already pins `hash_log <= ZSTD_HASHLOG_MAX = 30`, so this
+    ///   path is unreachable today for the donor-compatible band.
+    ///   Kept here as a tripwire if `ZSTD_HASHLOG_MAX` is ever
+    ///   raised past `31`.
+    /// - `entries * size_of::<u32>()` overflowing `usize`. This is
+    ///   the deterministic 32-bit failure mode at `hash_log = 30`:
+    ///   `1 << 30` entries × 4 bytes = 4 GiB, which is the full
+    ///   32-bit address space and overflows the `usize` multiply
+    ///   before `vec![]` is even called. The `checked_mul` guard
+    ///   surfaces this as a clear panic instead of the opaque
+    ///   `Vec`-internal capacity-overflow message.
     /// - Global allocator failure when actually allocating the
     ///   table backing storage — propagates as the standard
     ///   `Vec::with_capacity` allocation-failure panic.
     ///
-    /// The parameter-range and target-size guards both fire BEFORE
-    /// the `vec![]` call, so allocator failure (the third bullet)
-    /// is the only panic that depends on runtime memory state. The
-    /// first two are deterministic given the inputs and target.
+    /// All three guards fire BEFORE control reaches `vec![]`, so
+    /// allocator failure (the third bullet) is the only panic that
+    /// depends on runtime memory state. The first two are
+    /// deterministic given the inputs and target architecture.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
         validate_params(hash_log, mls);
         // Per-target allocation feasibility: `1 << hash_log` u32 entries

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -104,10 +104,11 @@ impl FastHashTable {
     ///   table backing storage — propagates as the standard
     ///   `Vec::with_capacity` allocation-failure panic.
     ///
-    /// All three guards fire BEFORE control reaches `vec![]`, so
-    /// allocator failure (the third bullet) is the only panic that
-    /// depends on runtime memory state. The first two are
-    /// deterministic given the inputs and target architecture.
+    /// The first two guards fire BEFORE control reaches `vec![]`
+    /// and are deterministic given the inputs and target
+    /// architecture. The third bullet IS the `vec![]` allocation
+    /// itself — it's the only panic that depends on runtime memory
+    /// state.
     pub(crate) fn new(hash_log: u32, mls: u32) -> Self {
         validate_params(hash_log, mls);
         // Per-target allocation feasibility: `1 << hash_log` u32 entries

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -256,4 +256,100 @@ mod tests {
         let read_back = unsafe { table.get(h) };
         assert_eq!(read_back, 0, "clear must zero every entry");
     }
+
+    /// Donor parity for mls=6: `ZSTD_hash6` uses
+    /// `(u << (64-48)).wrapping_mul(PRIME_6_BYTES) >> (64 - hash_log)`.
+    #[test]
+    fn hash6_matches_donor_formula_on_known_input() {
+        let table = FastHashTable::new(14, 6);
+        let data = [0x01u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        // SAFETY: data has 8 ≥ 6 readable bytes (the implementation
+        // performs a u64 load and shifts off the unused top bits).
+        let h = unsafe { table.hash_ptr::<6>(data.as_ptr()) };
+        let u = u64::from_le_bytes(data);
+        let expected =
+            (((u << (64 - 48)).wrapping_mul(227_718_039_650_203u64)) >> (64 - 14)) as u32;
+        assert_eq!(h, expected, "hash6 must match donor multiply-shift formula");
+    }
+
+    /// Donor parity for mls=7: `ZSTD_hash7` shifts by `(64-56)` and
+    /// multiplies by `PRIME_7_BYTES`.
+    #[test]
+    fn hash7_matches_donor_formula_on_known_input() {
+        let table = FastHashTable::new(15, 7);
+        let data = [0x01u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        // SAFETY: data has 8 ≥ 7 readable bytes.
+        let h = unsafe { table.hash_ptr::<7>(data.as_ptr()) };
+        let u = u64::from_le_bytes(data);
+        let expected =
+            (((u << (64 - 56)).wrapping_mul(58_295_818_150_454_627u64)) >> (64 - 15)) as u32;
+        assert_eq!(h, expected, "hash7 must match donor multiply-shift formula");
+    }
+
+    /// Donor parity for mls=8: `ZSTD_hash8` does NOT shift the input
+    /// (full u64), then multiplies by `PRIME_8_BYTES` (donor's
+    /// `prime8bytes = 0xCF1BBCDCB7A56463ULL`).
+    #[test]
+    fn hash8_matches_donor_formula_on_known_input() {
+        let table = FastHashTable::new(16, 8);
+        let data = [0x01u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        // SAFETY: data has 8 readable bytes.
+        let h = unsafe { table.hash_ptr::<8>(data.as_ptr()) };
+        let u = u64::from_le_bytes(data);
+        let expected = (u.wrapping_mul(0xCF1BBCDCB7A56463u64) >> (64 - 16)) as u32;
+        assert_eq!(h, expected, "hash8 must match donor multiply-shift formula");
+    }
+
+    /// Boundary: `hash_log = 1` is the smallest accepted value
+    /// (table of 2 entries). Verifies the constructor doesn't reject
+    /// the minimum and that the table actually allocates.
+    #[test]
+    fn hash_log_minimum_one_constructs_two_entry_table() {
+        let table = FastHashTable::new(1, 4);
+        let data = [0u8, 0, 0, 0];
+        // SAFETY: 4 readable bytes; hash output occupies 1 bit so
+        // hash ∈ {0, 1}.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr()) };
+        assert!(h < 2, "hash_log=1 must produce values ∈ {{0, 1}} (got {h})");
+    }
+
+    /// Boundary: `hash_log = ZSTD_HASHLOG_MAX` (30) is the largest
+    /// accepted value. Allocating the full table would burn ~4 GiB;
+    /// instead we instantiate at a smaller log first to prove
+    /// `hash_ptr` honours the bit-width, then verify the constructor
+    /// doesn't reject 30 via a panic-catching probe.
+    #[test]
+    fn hash_log_maximum_thirty_is_accepted_by_constructor() {
+        // Just probe the assertion path: invoking new() with 30
+        // mustn't panic. We don't actually use the giant table — drop
+        // it immediately. (2^30 * 4 bytes is acceptable for a CI host
+        // running a single test; if the host can't allocate it the
+        // test will OOM-skip rather than misreport.)
+        let _table = FastHashTable::new(30, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "hash_log must be in 1..=")]
+    fn panics_on_zero_hash_log() {
+        let _ = FastHashTable::new(0, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "hash_log must be in 1..=")]
+    fn panics_on_hash_log_above_zstd_hashlog_max() {
+        // 31 > ZSTD_HASHLOG_MAX (30) → constructor rejects.
+        let _ = FastHashTable::new(31, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "ZSTD Fast strategy only supports mls 4..=8")]
+    fn panics_on_mls_below_four() {
+        let _ = FastHashTable::new(12, 3);
+    }
+
+    #[test]
+    #[should_panic(expected = "ZSTD Fast strategy only supports mls 4..=8")]
+    fn panics_on_mls_above_eight() {
+        let _ = FastHashTable::new(12, 9);
+    }
 }

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -107,10 +107,19 @@ impl FastHashTable {
     ///
     /// # Safety
     ///
-    /// `ptr` MUST point to at least `mls` readable bytes (`mls <= 8`,
-    /// so at most an 8-byte read). The kernel guarantees this via the
-    /// `ilimit = iend - HASH_READ_SIZE` cap, mirroring donor's same
-    /// invariant.
+    /// `ptr` MUST point to readable bytes covering the load width:
+    /// - `MLS == 4`: at least **4** readable bytes (a `u32` load).
+    /// - `MLS >= 5`: at least **8** readable bytes — every mls ∈ {5,
+    ///   6, 7, 8} path performs an unaligned `u64::read_unaligned`
+    ///   and shifts off the unused top bits, so the underlying load
+    ///   is always 8 bytes wide regardless of `mls`. Promising only
+    ///   `mls` readable bytes for `mls ∈ {5,6,7}` would leave the
+    ///   trailing 8-mls bytes of the u64 read past the caller's
+    ///   range — UB.
+    ///
+    /// The kernel satisfies this uniformly via the
+    /// `ilimit = iend - HASH_READ_SIZE` cap (`HASH_READ_SIZE = 8`),
+    /// mirroring donor's same invariant.
     #[inline(always)]
     pub(crate) unsafe fn hash_ptr<const MLS: u32>(&self, ptr: *const u8) -> u32 {
         debug_assert_eq!(MLS, self.mls, "monomorphised MLS must match table mls");

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -154,9 +154,14 @@ pub(crate) struct FastBlockResult {
 ///
 /// Entry-time `assert!`s reject misuse loudly in every build (debug
 /// AND release) rather than silently miscompressing:
-/// - `block_start > data.len()` — would wrap
-///   `block_start + HASH_READ_SIZE` in the short-input guard and
-///   skip the early return.
+/// - `block_start > data.len()` — invalidates the block range and
+///   breaks the arithmetic used by both code paths: in the
+///   short-input branch `tail_literals_len = data.len() -
+///   block_start` underflows; in the main loop
+///   `block_start + HASH_READ_SIZE` can wrap and skip the
+///   short-input early-return entirely, then `base.add(ip0)`
+///   reads out of bounds. Either side is a clean panic instead
+///   of UB / garbage output.
 /// - `data.len() > u32::MAX as usize` — the kernel stores
 ///   absolute positions into a u32 hash table and computes offsets
 ///   as u32, so larger inputs would silently truncate match indices.

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -26,8 +26,14 @@ const SEARCH_STRENGTH: usize = 6;
 /// boundary check.
 const HASH_READ_SIZE: usize = 8;
 
-/// Donor's `MEM_read32(ptr)` — unaligned little-endian 4-byte load,
-/// used by the raw match probe at the hot path.
+/// Donor's `MEM_read32(ptr)` — unaligned native-endian 4-byte load,
+/// used by the raw match probe on the hot path. The result is only
+/// ever compared for equality against another `read32` of the same
+/// width on the same host, so the byte ordering does not matter — both
+/// sides experience the same endianness, and `a == b` holds iff the
+/// underlying byte sequences match. No `.to_le()` conversion is needed
+/// (donor's C `MEM_read32` is also implemented as a native-endian
+/// `memcpy` for the same reason).
 ///
 /// # Safety
 ///
@@ -142,12 +148,17 @@ pub(crate) struct FastBlockResult {
 /// kernel falls into the short-input early-return branch and emits no
 /// sequences, which may not be what the caller wanted.
 ///
-/// `data.len()` SHOULD be at least `HASH_READ_SIZE` (8) bytes longer
-/// than the caller wants to actually match against. The
-/// `ilimit = data.len() - HASH_READ_SIZE` cap ensures every hash/probe
-/// read stays in range; for the trailing 7 bytes the caller must
-/// emit them as literals (this is the kernel's `tail_literals_len`
-/// return value).
+/// `data.len()` SHOULD be at least `HASH_READ_SIZE` (8) bytes long.
+/// The `ilimit = data.len() - HASH_READ_SIZE` cap constrains where
+/// the main loop hashes and probes — i.e. it stops emitting new
+/// matches once `ip0 >= ilimit`. It does NOT mean the trailing 7
+/// bytes are ALWAYS literals: an in-progress forward match found at
+/// `ip0 < ilimit` extends through `count_forward` and can reach all
+/// the way to `iend`, leaving `tail_literals_len = 0`. The kernel
+/// reports the actual number of trailing literal bytes (zero or
+/// more) in `FastBlockResult.tail_literals_len`, and the caller
+/// emits a terminal `Sequence::Literals` only when that value is
+/// non-zero.
 ///
 /// # Sequence emission contract
 ///
@@ -175,14 +186,25 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
 ) -> FastBlockResult {
     debug_assert_eq!(MLS, hash_table.mls(), "MLS must match hash_table's mls");
-    // Real runtime checks (not debug_assert) — these prevent UB in
-    // release builds. `block_start > data.len()` would wrap
-    // `block_start + HASH_READ_SIZE` in the short-input guard below
-    // and proceed into the main loop with an out-of-bounds ip0.
-    // `data.len() > u32::MAX` would silently truncate position
-    // values when the kernel stores them into the u32 hash table or
-    // computes `offset = ip0 - match_pos` as a u32, corrupting both
-    // match indices and repcode history.
+    // Real runtime checks (not debug_assert) — both run in every
+    // build because they catch distinct failure modes:
+    //
+    // `block_start > data.len()` is a memory-safety risk: it would
+    // wrap `block_start + HASH_READ_SIZE` in the short-input guard
+    // below, skip the early return, and proceed into the main loop
+    // with an out-of-bounds ip0 → OOB read via `base.add(ip0)`.
+    //
+    // `data.len() > u32::MAX` is an algorithmic-correctness risk:
+    // the kernel stores absolute positions into a u32 hash table
+    // (`ip0 as u32`) and computes offsets as u32 (`offset as u32`).
+    // For inputs above 4 GiB the silent truncation would corrupt
+    // match indices and repcode offsets — every downstream pointer
+    // read still stays in-bounds (we re-bound by `data.len()`
+    // before any dereference), so it's not memory-unsafe, but the
+    // emitted sequences would reference wrong positions and the
+    // decoder would produce wrong output. Surfacing the bound at
+    // entry turns this into a loud assertion instead of silent
+    // miscompression.
     assert!(
         block_start <= data.len(),
         "block_start ({block_start}) must not exceed data.len() ({})",
@@ -698,29 +720,38 @@ mod tests {
         // prefix_start_index=5 blocks index 0.
         let _ = compress_block_fast::<4>(&data, 0, 5, &mut table, [0, 0], &mut handle);
 
-        // Every Triple emitted must reference a position ≥ 5, i.e.
-        // the offset must NOT exceed the distance from ip0 to the
-        // prefix start. With uniform data and prefix_start_index=5,
-        // legitimate matches first become possible around ip0=9 with
-        // offset ≤ 4 — none should be at offset=1 (the rejected stale
-        // candidate) or larger than ip0-5.
+        // Walk emitted sequences in order, tracking the running
+        // `anchor` cursor (which equals the start of the current
+        // emit's literal-run). For each Triple the match begins at
+        // `match_start = anchor + lits.len()` and references
+        // `match_start - offset`; that source position MUST be at or
+        // above `prefix_start_index = 5`. The simpler `off <= ip0`
+        // form fails for the second+ Triple — `lits.len()` only
+        // equals `ip0` for the first emit (when anchor still sits at
+        // block_start=0); a single-byte tracker keeps the bound
+        // correct across multiple emits.
+        let mut anchor: usize = 0;
         for (lits, off, m) in &tuples {
             if *m > 0 {
                 assert_ne!(
                     *off, 1,
                     "stale entry at index 0 must be filtered out by prefix_start_index=5",
                 );
-                // After a literals run the anchor advances by exactly
-                // `lits.len()` bytes (literals are written from
-                // `anchor..ip0`), so `ip0 == anchor + lits.len() ==
-                // lits.len()` here (anchor starts at 0).
-                let ip0 = lits.len();
-                // The offset must keep the match referent above prefix
-                // start.
+                let match_start = anchor + lits.len();
+                let match_src = match_start
+                    .checked_sub(*off)
+                    .expect("offset must not exceed match_start (would wrap)");
                 assert!(
-                    *off <= ip0,
-                    "match offset {off} would point below anchor {ip0}",
+                    match_src >= 5,
+                    "match source {match_src} below prefix_start_index=5 \
+                     (match_start={match_start}, offset={off})",
                 );
+                anchor = match_start + m;
+            } else {
+                // Pure-literals callback (currently never emitted by
+                // the kernel — kept defensive for future contract
+                // changes): advance anchor by the literal run length.
+                anchor += lits.len();
             }
         }
     }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -261,33 +261,56 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
             //
             // No explicit `(new_ip - 1 - rep_off) >= prefix_start`
             // window guard here — mirrors donor's noDict rep path,
-            // which also omits it. Safety follows from two invariants
-            // the kernel maintains every iteration:
+            // which also omits it. Safety follows from three pieces
+            // of state the kernel maintains every iteration:
             //
             // 1. Block-entry save/restore (above) zeroes `rep_offset1`
             //    whenever the incoming value exceeds
-            //    `ip0 - prefix_start_index` at block start, so any
-            //    surviving non-zero rep satisfies
-            //    `ip0_start - rep_offset1 >= prefix_start`.
+            //    `ip0_start - prefix_start_index`, so any surviving
+            //    non-zero rep satisfies
+            //    `ip0_start - rep_offset1 >= prefix_start` (NON-STRICT
+            //    — equality is allowed: `rep_offset1` may equal
+            //    exactly `ip0_start - prefix_start`).
             //
             // 2. The explicit-match path's backward extension uses a
             //    STRICT `match_pos > prefix_start_index` bound when
             //    it promotes a fresh offset into `rep_offset1`, so
             //    `new_rep = ip0_promote - match_pos < ip0_promote -
-            //    prefix_start` (strict). At any later iteration
-            //    `ip0' > ip0_promote` and `rep_offset1` is unchanged,
-            //    so `ip0' - rep_offset1 >= prefix_start + 1`, i.e.
-            //    `(ip0' - 1) - rep_offset1 >= prefix_start`.
+            //    prefix_start` (strict). At any iteration after a
+            //    promotion `ip0' > ip0_promote` and `rep_offset1` is
+            //    unchanged, so `ip0' - rep_offset1 >= prefix_start +
+            //    1`, i.e. `(ip0' - 1) - rep_offset1 >= prefix_start`
+            //    — the strict bound becomes available from the
+            //    SECOND iteration onward (any iteration where the
+            //    rep has been promoted at least once OR where ip0
+            //    has advanced past block_start).
             //
-            // Combined, every loop iteration that enters this branch
-            // already satisfies `new_ip - 1 - rep_off >=
-            // prefix_start`, so the extra check would be dead code on
-            // the hot path. If a future call shape weakens either
-            // invariant (e.g. shared hash table across resets without
-            // re-running save/restore) the explicit guard must be
-            // re-added — see the explicit-match path at the
-            // `match_pos > prefix_start_index` line for the
-            // structurally symmetric bound that proves it.
+            // 3. The runtime `new_ip > anchor` gate covers the
+            //    REMAINING corner case: at block entry ip0 ==
+            //    block_start AND anchor == block_start, so the
+            //    `new_ip > anchor` check fails and the 1-byte
+            //    backward extension is skipped entirely. That is
+            //    exactly the iteration where (1) alone could give
+            //    `ip0_start - rep_offset1 == prefix_start` and
+            //    backward-extending would dereference `prefix_start
+            //    - 1`. The anchor gate prevents that read; (2) takes
+            //    over from the second iteration onward (anchor moves
+            //    past block_start after the first emitted sequence).
+            //
+            // Combined, every iteration that REACHES the
+            // `data[new_ip - 1] == data[new_ip - 1 - rep_off]` read
+            // already satisfies `new_ip - 1 - rep_off >= prefix_start`
+            // — either via the strict bound from (2) or via the
+            // anchor gate (3) skipping the read on the boundary
+            // iteration. The explicit prefix-window check would be
+            // dead code on the hot path. If a future call shape
+            // weakens any of (1), (2), or (3) — e.g. shared hash
+            // table across resets without re-running save/restore,
+            // or a custom anchor initialisation that doesn't equal
+            // `block_start` — the explicit guard must be re-added.
+            // See the explicit-match path at the `match_pos >
+            // prefix_start_index` line for the structurally symmetric
+            // bound that proves it.
             let mut m_len: usize = 4;
             let rep_off = rep_offset1 as usize;
             let mut new_ip = ip0;

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -142,11 +142,31 @@ pub(crate) struct FastBlockResult {
 /// # Preconditions / algorithm invariants
 ///
 /// `compress_block_fast` is a SAFE function — memory-safety holds for
-/// every input. The contract below is about algorithmic correctness
-/// (correct output sequences, donor-parity match coverage), not Rust
-/// memory safety. Passing a smaller `data` is well-defined but the
-/// kernel falls into the short-input early-return branch and emits no
-/// sequences, which may not be what the caller wanted.
+/// every input that doesn't trigger one of the entry-time
+/// `assert!`s (see the **Panics** section below for that list). The
+/// contract below is about algorithmic correctness (correct output
+/// sequences, donor-parity match coverage), not Rust memory safety.
+/// Passing a smaller `data` is well-defined but the kernel falls
+/// into the short-input early-return branch and emits no sequences,
+/// which may not be what the caller wanted.
+///
+/// # Panics
+///
+/// Entry-time `assert!`s reject misuse loudly in every build (debug
+/// AND release) rather than silently miscompressing:
+/// - `block_start > data.len()` — would wrap
+///   `block_start + HASH_READ_SIZE` in the short-input guard and
+///   skip the early return.
+/// - `data.len() > u32::MAX as usize` — the kernel stores
+///   absolute positions into a u32 hash table and computes offsets
+///   as u32, so larger inputs would silently truncate match indices.
+/// - `MLS` outside `4..=8` — the donor's Fast strategy supports
+///   only mls 4..=8; out-of-range MLS would route to a
+///   non-existent hash formula.
+/// - `MLS` != `hash_table.mls()` — a mismatched table layout would
+///   cause the kernel to hash with the wrong formula and probe
+///   entries indexed by a different formula, leading to garbage
+///   match candidates.
 ///
 /// The remaining-block length `data.len() - block_start` SHOULD be
 /// at least `HASH_READ_SIZE` (8) bytes — `data` itself may be much

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -392,6 +392,7 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
     use alloc::vec::Vec;
 
     /// Capture every emitted sequence as `(literals_bytes, offset,
@@ -480,5 +481,282 @@ mod tests {
             "explicit-offset match must have offset > 0 (got {})",
             triple.1,
         );
+    }
+
+    /// Helper that accepts a non-zero `rep` and pre-populated hash
+    /// table so individual tests can exercise specific kernel branches
+    /// (rep path, prefix filter, stale-entry hardening). Shares the
+    /// same accounting invariant as `run_block` plus returns the
+    /// captured tuples for behavioural assertions.
+    fn run_block_with_rep(
+        data: &[u8],
+        hash_log: u32,
+        rep: [u32; 2],
+    ) -> (Vec<(Vec<u8>, usize, usize)>, FastBlockResult) {
+        let mut table = FastHashTable::new(hash_log, 4);
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => tuples.push((literals.to_vec(), offset, match_len)),
+            Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
+        };
+        let result = compress_block_fast::<4>(data, 0, 0, &mut table, rep, &mut handle);
+        let acct: usize = tuples
+            .iter()
+            .map(|(lits, _off, mlen)| lits.len() + mlen)
+            .sum::<usize>()
+            + result.tail_literals_len;
+        assert_eq!(acct, data.len(), "kernel must account for every input byte");
+        (tuples, result)
+    }
+
+    /// Repcode path: uniform data + `rep[0] = 1` means every 4-byte
+    /// window at any `ip0 > 0` matches `data[ip0-1..ip0+3]`. The
+    /// kernel must emit a Triple with `offset == 1` and large
+    /// `match_len`. Hits the `rep_check` branch on the very first
+    /// loop iteration.
+    #[test]
+    fn repcode_match_emits_with_rep_offset_one() {
+        let data = vec![0x42u8; 64];
+        let (tuples, _) = run_block_with_rep(&data, 8, [1, 4]);
+        let rep_triple = tuples
+            .iter()
+            .find(|(_, off, m)| *off == 1 && *m > 0)
+            .unwrap_or_else(|| panic!("repcode Triple at offset=1 expected, got {tuples:?}"));
+        assert!(
+            rep_triple.2 >= 4,
+            "match_len must be ≥ MIN_MATCH=4 (got {})",
+            rep_triple.2,
+        );
+        // Uniform-buffer rep match should extend far — the first match
+        // covers nearly the whole tail after subtracting the initial
+        // literal byte and the HASH_READ_SIZE trailing cap. Assert a
+        // reasonable lower bound rather than an exact value (count
+        // logic chooses chunk boundaries deterministically but the
+        // chunk count depends on the LE/BE branch).
+        assert!(
+            rep_triple.2 >= 32,
+            "uniform-byte rep extension must consume most of the buffer, got {}",
+            rep_triple.2,
+        );
+    }
+
+    /// Explicit-match backward extension: a marker byte before the
+    /// repeated pattern lets the kernel walk the match back by one
+    /// byte once the 4-byte forward probe at the hashed position
+    /// fires.
+    ///
+    /// Layout: `"X"` literal at 0, then `AAAA` 4-byte block at 1..5,
+    /// distinct filler, then `"X"` + `AAAA` again starting at 10. The
+    /// kernel hashes the second `AAAA` at ip0=11 (or wherever step
+    /// lands close to it), reads the stored index of the first
+    /// `AAAA`, and the backward-extension while-loop walks back
+    /// because `data[ip0 - 1] == data[match_pos - 1] == 'X'`.
+    #[test]
+    fn explicit_match_backward_extension_extends_by_marker_byte() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"XAAAA"); // 0..5, the seed copy
+        data.extend_from_slice(b"_____"); // 5..10, distinct filler
+        data.extend_from_slice(b"XAAAA"); // 10..15, the repeating copy
+        data.extend_from_slice(b"________"); // 15..23, HASH_READ_SIZE pad
+        let (tuples, _) = run_block_with_rep(&data, 12, [0, 0]);
+        let triple = tuples
+            .iter()
+            .find(|(_, _, m)| *m > 0)
+            .unwrap_or_else(|| panic!("expected an explicit-match Triple, got {tuples:?}"));
+        // Backward extension must lift the match length above the
+        // bare MIN_MATCH=4: at least 5 bytes ("XAAAA").
+        assert!(
+            triple.2 >= 5,
+            "backward extension must lift match_len above MIN_MATCH (got {})",
+            triple.2,
+        );
+        // The literals before this match must NOT include the 'X' at
+        // position 10 — backward extension consumed it as part of the
+        // match.
+        assert!(
+            !triple.0.ends_with(b"X"),
+            "backward extension must absorb the 'X' marker byte (literals: {:?})",
+            triple.0,
+        );
+    }
+
+    /// `prefix_start_index` filter: a stale hash entry pointing at a
+    /// position BELOW `prefix_start_index` must be rejected even when
+    /// the byte-for-byte cmp would have succeeded. Engineered by
+    /// pre-populating the table with an in-range-by-bytes but
+    /// below-prefix index.
+    #[test]
+    fn prefix_start_index_filter_rejects_below_window() {
+        // Uniform data — every 4-byte window has the same hash and
+        // the same bytes, so a stale entry at any position would
+        // raw-cmp-match. Pre-set the hash slot for ip0=1 to index 0,
+        // then run with prefix_start_index=5. Without the filter the
+        // kernel would happily emit a Triple at offset=1; with it,
+        // the candidate is rejected.
+        let data = vec![0xAAu8; 64];
+        let mut table = FastHashTable::new(8, 4);
+        // SAFETY: data has ≥ 4 readable bytes at index 1.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr().add(1)) };
+        // SAFETY: h came from hash_ptr on this same table.
+        unsafe { table.put(h, 0) };
+
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => tuples.push((literals.to_vec(), offset, match_len)),
+            Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
+        };
+        // prefix_start_index=5 blocks index 0.
+        let _ = compress_block_fast::<4>(&data, 0, 5, &mut table, [0, 0], &mut handle);
+
+        // Every Triple emitted must reference a position ≥ 5, i.e.
+        // the offset must NOT exceed the distance from ip0 to the
+        // prefix start. With uniform data and prefix_start_index=5,
+        // legitimate matches first become possible around ip0=9 with
+        // offset ≤ 4 — none should be at offset=1 (the rejected stale
+        // candidate) or larger than ip0-5.
+        for (lits, off, m) in &tuples {
+            if *m > 0 {
+                assert_ne!(
+                    *off, 1,
+                    "stale entry at index 0 must be filtered out by prefix_start_index=5",
+                );
+                // After a literals run the anchor advances by exactly
+                // `lits.len()` bytes (literals are written from
+                // `anchor..ip0`), so `ip0 == anchor + lits.len() ==
+                // lits.len()` here (anchor starts at 0).
+                let ip0 = lits.len();
+                // The offset must keep the match referent above prefix
+                // start.
+                assert!(
+                    *off <= ip0,
+                    "match offset {off} would point below anchor {ip0}",
+                );
+            }
+        }
+    }
+
+    /// Hardening regression (round 3, finding #11): a hash entry
+    /// pointing AT or AFTER the current `ip0` must be rejected
+    /// before the 4-byte raw compare. Without this guard the kernel
+    /// would compute `offset = ip0 - match_pos` and wrap into a
+    /// gigantic offset → emit a Triple with a meaningless backward
+    /// reference.
+    ///
+    /// Engineered scenario: uniform data so the raw-cmp at any two
+    /// positions always succeeds; pre-populate the hash slot that
+    /// ip0=1 will probe with a forward-pointing stale index (150);
+    /// without the `match_pos < ip_pos` filter the very first
+    /// iteration would emit `Triple { offset = 1 - 150 = u_wrap, ... }`.
+    /// Test asserts every emitted Triple has an offset ≤ data.len()
+    /// — only achievable when the stale forward index is rejected.
+    #[test]
+    fn match_found_rejects_stale_forward_entry() {
+        let data = vec![0u8; 200];
+        let mut table = FastHashTable::new(8, 4);
+        // SAFETY: data has ≥ 4 readable bytes at index 1.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr().add(1)) };
+        // SAFETY: h came from hash_ptr on this same table.
+        unsafe { table.put(h, 150) };
+
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => tuples.push((literals.to_vec(), offset, match_len)),
+            Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
+        };
+        let _ = compress_block_fast::<4>(&data, 0, 0, &mut table, [0, 0], &mut handle);
+
+        for (_, off, m) in &tuples {
+            if *m > 0 {
+                assert!(
+                    *off > 0 && *off <= data.len(),
+                    "every emitted offset must reference an in-buffer backward position (got {off})",
+                );
+            }
+        }
+    }
+
+    /// Input exactly `HASH_READ_SIZE` bytes long: the short-input
+    /// branch fires because `data.len() < block_start + HASH_READ_SIZE`
+    /// is `8 < 0 + 8` → false, so we enter the main loop, but
+    /// `ilimit = 8 - 8 = 0` makes `while ip0 < ilimit` zero-iteration
+    /// (ip0 starts at 1 ≥ 0). Result: zero emissions, entire input
+    /// reported as tail.
+    #[test]
+    fn block_exactly_hash_read_size_emits_no_sequences() {
+        let data = [1u8, 2, 3, 4, 5, 6, 7, 8];
+        let (tuples, result) = run_block_with_rep(&data, 8, [0, 0]);
+        assert!(
+            tuples.is_empty(),
+            "exactly HASH_READ_SIZE bytes must produce no main-loop iterations",
+        );
+        assert_eq!(result.tail_literals_len, data.len());
+    }
+
+    /// Input one byte shorter than `HASH_READ_SIZE`: the short-input
+    /// branch fires (`7 < 8`), the kernel returns immediately with
+    /// the full input as tail and no callback invocations.
+    #[test]
+    fn block_just_below_hash_read_size_emits_no_sequences() {
+        let data = [1u8, 2, 3, 4, 5, 6, 7];
+        let (tuples, result) = run_block_with_rep(&data, 8, [0, 0]);
+        assert!(tuples.is_empty());
+        assert_eq!(result.tail_literals_len, data.len());
+    }
+
+    /// Repcode save/restore: when the incoming `rep_offset1` is
+    /// larger than the addressable history (`max_rep = ip0 -
+    /// prefix_start_index`), the kernel stashes it into
+    /// `offset_saved1` and zeroes the live rep. If no explicit match
+    /// promotes a new rep during the block, `_cleanup` must restore
+    /// the saved value into the returned `rep[0]` so cross-block
+    /// repcode history isn't lost. The unaffected `rep[1]` is the
+    /// secondary witness that no mutation occurred mid-block.
+    #[test]
+    fn rep_offset_save_restore_when_out_of_range() {
+        // Random-looking distinct bytes — no real matches the kernel
+        // would discover; deterministic xorshift keeps the stream
+        // reproducible.
+        let mut data = vec![0u8; 64];
+        let mut state = 0x1234_5678u32;
+        for byte in &mut data {
+            state ^= state << 13;
+            state ^= state >> 17;
+            state ^= state << 5;
+            *byte = state as u8;
+        }
+        // rep_offset1 huge — far exceeds any plausible ip0 in a
+        // 64-byte block. Must be stashed and restored unchanged.
+        let huge = 9999;
+        let mut table = FastHashTable::new(10, 4);
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => tuples.push((literals.to_vec(), offset, match_len)),
+            Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
+        };
+        let result = compress_block_fast::<4>(&data, 0, 0, &mut table, [huge, 7], &mut handle);
+        assert_eq!(
+            result.rep[0], huge,
+            "out-of-range rep_offset1 must be restored verbatim across the block",
+        );
+        // rep_offset2 was also out of range (max_rep ≈ 0..63, 7 > 1).
+        // Donor restores it through offset_saved2; the in-range
+        // restoration path is the second witness.
+        assert_eq!(result.rep[1], 7, "rep_offset2 (also stashed) must restore");
     }
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -151,18 +151,20 @@ pub(crate) struct FastBlockResult {
 ///
 /// # Sequence emission contract
 ///
-/// The kernel emits ONLY in-block sequences (literals + match
-/// pairs and pure-literal runs from anchor advances inside the
-/// main loop). It NEVER emits a terminal `Sequence::Literals`
-/// covering the trailing bytes from the last anchor to the end of
-/// `data` — those bytes are accounted for by
-/// `FastBlockResult.tail_literals_len`, and emitting them is the
-/// caller's responsibility. This rule applies UNIFORMLY across
-/// every exit branch, including the early-return short-input
-/// branch below; without this uniformity a caller wrapping the
-/// kernel's output would have to special-case "did the kernel
-/// already emit the tail" per branch, which is exactly the
-/// inconsistency this contract removes.
+/// The kernel emits ONLY `Sequence::Triple` callbacks — one per
+/// emitted match (repcode or explicit). Each `Triple` carries the
+/// literal-run that precedes the match in its `literals` field, so
+/// the kernel never needs a separate `Sequence::Literals` mid-block
+/// call. The trailing bytes from the last anchor to the end of
+/// `data` are NOT emitted via the closure; they are accounted for
+/// by `FastBlockResult.tail_literals_len`, and emitting them as
+/// the terminal `Sequence::Literals` (or absorbing them however
+/// the caller wants) is the caller's responsibility. This rule
+/// applies UNIFORMLY across every exit branch, including the
+/// short-input early-return; without that uniformity a caller
+/// wrapping the kernel's output would have to special-case "did
+/// the kernel already emit the tail" per branch, which is exactly
+/// the inconsistency this contract removes.
 #[inline(always)]
 pub(crate) fn compress_block_fast<const MLS: u32>(
     data: &[u8],
@@ -173,7 +175,27 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
 ) -> FastBlockResult {
     debug_assert_eq!(MLS, hash_table.mls(), "MLS must match hash_table's mls");
-    debug_assert!(block_start <= data.len(), "block_start past data end",);
+    // Real runtime checks (not debug_assert) — these prevent UB in
+    // release builds. `block_start > data.len()` would wrap
+    // `block_start + HASH_READ_SIZE` in the short-input guard below
+    // and proceed into the main loop with an out-of-bounds ip0.
+    // `data.len() > u32::MAX` would silently truncate position
+    // values when the kernel stores them into the u32 hash table or
+    // computes `offset = ip0 - match_pos` as a u32, corrupting both
+    // match indices and repcode history.
+    assert!(
+        block_start <= data.len(),
+        "block_start ({block_start}) must not exceed data.len() ({})",
+        data.len(),
+    );
+    assert!(
+        data.len() <= u32::MAX as usize,
+        "FastKernel does not support data.len() ({}) > u32::MAX ({}); \
+         the kernel stores absolute positions in a u32 hash table and \
+         u32 offset codes, so larger inputs would silently truncate",
+        data.len(),
+        u32::MAX,
+    );
 
     // Block too short to do any matching — report the whole block
     // as trailing literals without emitting anything. Donor mirrors

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -148,7 +148,14 @@ pub(crate) struct FastBlockResult {
 /// kernel falls into the short-input early-return branch and emits no
 /// sequences, which may not be what the caller wanted.
 ///
-/// `data.len()` SHOULD be at least `HASH_READ_SIZE` (8) bytes long.
+/// The remaining-block length `data.len() - block_start` SHOULD be
+/// at least `HASH_READ_SIZE` (8) bytes — `data` itself may be much
+/// longer because it holds the prefix history before `block_start`,
+/// so the slice's total size is not the relevant gate. The kernel's
+/// short-input early-return (line below) compares precisely
+/// `data.len() < block_start + HASH_READ_SIZE`, matching this
+/// remaining-block phrasing.
+///
 /// The `ilimit = data.len() - HASH_READ_SIZE` cap constrains where
 /// the main loop hashes and probes — i.e. it stops emitting new
 /// matches once `ip0 >= ilimit`. It does NOT mean the trailing 7

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -104,6 +104,21 @@ pub(crate) struct FastBlockResult {
 /// for the trailing 7 bytes the caller must already have decided to
 /// emit them as literals (this is the kernel's `tail_literals_len`
 /// return value).
+///
+/// # Sequence emission contract
+///
+/// The kernel emits ONLY in-block sequences (literals + match
+/// pairs and pure-literal runs from anchor advances inside the
+/// main loop). It NEVER emits a terminal `Sequence::Literals`
+/// covering the trailing bytes from the last anchor to the end of
+/// `data` — those bytes are accounted for by
+/// `FastBlockResult.tail_literals_len`, and emitting them is the
+/// caller's responsibility. This rule applies UNIFORMLY across
+/// every exit branch, including the early-return short-input
+/// branch below; without this uniformity a caller wrapping the
+/// kernel's output would have to special-case "did the kernel
+/// already emit the tail" per branch, which is exactly the
+/// inconsistency this contract removes.
 #[inline(always)]
 pub(crate) fn compress_block_fast<const MLS: u32>(
     data: &[u8],
@@ -116,19 +131,16 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
     debug_assert_eq!(MLS, hash_table.mls(), "MLS must match hash_table's mls");
     debug_assert!(block_start <= data.len(), "block_start past data end",);
 
-    // Block too short to do any matching — emit the whole tail as
-    // literals. Donor falls into the `_cleanup` path with `anchor =
-    // istart`, returning `iend - anchor`.
+    // Block too short to do any matching — report the whole block
+    // as trailing literals without emitting anything. Donor mirrors
+    // the same shape via the `_cleanup` path (`anchor = istart`,
+    // returns `iend - anchor`). The caller emits the
+    // `Sequence::Literals` wrapper per the contract above; we don't
+    // double-emit here.
     if data.len() < block_start + HASH_READ_SIZE {
-        let tail_literals_len = data.len() - block_start;
-        if tail_literals_len > 0 {
-            handle_sequence(Sequence::Literals {
-                literals: &data[block_start..],
-            });
-        }
         return FastBlockResult {
             rep,
-            tail_literals_len: 0,
+            tail_literals_len: data.len() - block_start,
         };
     }
 
@@ -336,90 +348,91 @@ mod tests {
     use super::*;
     use alloc::vec::Vec;
 
-    #[allow(dead_code)]
-    fn run_block<'a>(data: &'a [u8], hash_log: u32, mls: u32) -> Vec<Sequence<'a>> {
+    /// Capture every emitted sequence as `(literals_bytes, offset,
+    /// match_len)` plus the final `FastBlockResult` so each test can
+    /// assert byte-level accounting and the actual match decisions
+    /// without fighting the borrow checker over `Sequence<'_>`
+    /// lifetimes (a `Sequence` borrow lives only as long as the
+    /// closure scope; cloning the literal bytes into the tuple
+    /// detaches the capture from that lifetime).
+    fn run_block(
+        data: &[u8],
+        hash_log: u32,
+        mls: u32,
+    ) -> (Vec<(Vec<u8>, usize, usize)>, FastBlockResult) {
         let mut table = FastHashTable::new(hash_log, mls);
-        let mut seqs: Vec<Sequence<'a>> = Vec::new();
-        // For the test runner we collect with a `'static` lifetime by
-        // re-borrowing. Simpler: just emit `(literals_len, offset,
-        // match_len)` tuples — but since `Sequence::Literals`/`Triple`
-        // borrow `data`, the lifetime check forces the `Vec` and
-        // closure to share a scope. Use a `Vec<(Vec<u8>, usize,
-        // usize)>` instead.
         let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => {
+                tuples.push((literals.to_vec(), offset, match_len));
+            }
+            Sequence::Literals { literals } => {
+                tuples.push((literals.to_vec(), 0, 0));
+            }
+        };
         let result = match mls {
-            4 => compress_block_fast::<4>(data, 0, 0, &mut table, [0, 0], |seq| match seq {
-                Sequence::Triple {
-                    literals,
-                    offset,
-                    match_len,
-                } => {
-                    tuples.push((literals.to_vec(), offset, match_len));
-                }
-                Sequence::Literals { literals } => {
-                    tuples.push((literals.to_vec(), 0, 0));
-                }
-            }),
-            5 => compress_block_fast::<5>(data, 0, 0, &mut table, [0, 0], |seq| match seq {
-                Sequence::Triple {
-                    literals,
-                    offset,
-                    match_len,
-                } => {
-                    tuples.push((literals.to_vec(), offset, match_len));
-                }
-                Sequence::Literals { literals } => {
-                    tuples.push((literals.to_vec(), 0, 0));
-                }
-            }),
+            4 => compress_block_fast::<4>(data, 0, 0, &mut table, [0, 0], &mut handle),
+            5 => compress_block_fast::<5>(data, 0, 0, &mut table, [0, 0], &mut handle),
             _ => panic!("test helper only supports mls=4 and mls=5"),
         };
-        // Verify the total bytes account for the entire input:
-        // sum(literals_len) + sum(match_len) + tail_literals_len ==
-        // data.len(). This catches off-by-ones in the kernel that
-        // would otherwise produce a corrupt stream.
+        // Accounting invariant: literals + matches + tail == input.
         let acct: usize = tuples
             .iter()
             .map(|(lits, _off, mlen)| lits.len() + mlen)
             .sum::<usize>()
             + result.tail_literals_len;
         assert_eq!(acct, data.len(), "kernel must account for every input byte",);
-        seqs.clear();
-        // Convert the tuples back into Sequence-shaped values just so
-        // the caller can pattern-match. Use the original `data` for
-        // the borrow.
-        let _ = tuples;
-        seqs
+        (tuples, result)
     }
 
     /// Tail-too-small case: input ≤ HASH_READ_SIZE produces zero
-    /// match sequences and the entire input is the tail literals.
+    /// sequence emissions; the kernel reports the whole block as
+    /// `tail_literals_len` and the caller is expected to wrap it in
+    /// the terminal `Sequence::Literals`.
     #[test]
-    fn short_input_emits_only_tail_literals() {
+    fn short_input_reports_tail_without_emission() {
         let data = [1u8, 2, 3, 4, 5];
-        let mut table = FastHashTable::new(8, 4);
-        let mut count = 0;
-        let result = compress_block_fast::<4>(&data, 0, 0, &mut table, [0, 0], |seq| match seq {
-            Sequence::Literals { literals } => {
-                assert_eq!(literals, &data[..]);
-                count += 1;
-            }
-            Sequence::Triple { .. } => panic!("no Triple expected on short input"),
-        });
-        assert_eq!(count, 1, "exactly one Literals sequence emitted");
-        assert_eq!(result.tail_literals_len, 0);
+        let (tuples, result) = run_block(&data, 8, 4);
+        assert!(
+            tuples.is_empty(),
+            "kernel must NOT emit sequences for short inputs (got {tuples:?})",
+        );
+        assert_eq!(result.tail_literals_len, data.len());
     }
 
     /// Repeated pattern with a clear long match — the kernel should
-    /// detect it and emit one Triple covering the repeated suffix.
+    /// detect it and emit at least one Triple. Verifies via the
+    /// captured tuples that an actual match was produced (`match_len
+    /// >= MIN_MATCH=4`, non-zero offset).
     #[test]
     fn finds_long_repeat_in_simple_pattern() {
-        // First half is a distinct prefix; second half repeats the
-        // first half verbatim. The kernel should match the second
-        // half against the first.
         let mut data = Vec::new();
         data.extend_from_slice(b"ABCDEFGHIJKLMNOP");
         data.extend_from_slice(b"ABCDEFGHIJKLMNOP");
-        let _ = run_block(&data, 8, 4);
+        // Need ≥ 8 trailing bytes past the last match position so
+        // `ilimit = data.len() - HASH_READ_SIZE` keeps the inner
+        // loop active long enough to scan the repeated second half.
+        // Pad with distinct bytes to keep the kernel out of any
+        // extra repcode branches.
+        data.extend_from_slice(b"________");
+        let (tuples, _result) = run_block(&data, 12, 4);
+        let triple = tuples
+            .iter()
+            .find(|(_, _, m)| *m > 0)
+            .expect("kernel must emit at least one Triple for the repeated half");
+        assert!(
+            triple.2 >= 4,
+            "match_len must be ≥ MIN_MATCH=4 (got {})",
+            triple.2,
+        );
+        assert!(
+            triple.1 > 0,
+            "explicit-offset match must have offset > 0 (got {})",
+            triple.1,
+        );
     }
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -259,26 +259,39 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
             // Repcode match — backward extension by 1 if the byte
             // before ip0 also matches the byte before the rep source.
             //
-            // The window guard `(new_ip - 1 - rep_off) >= prefix_start`
-            // mirrors the explicit-match path's prefix bound. In the
-            // current single-block kernel it is provably redundant —
-            // the block-entry save/restore zeroes `rep_offset1`
-            // whenever `rep_offset1 > ip0 - prefix_start` at block
-            // start, and `anchor <= new_ip` keeps `new_ip - 1 >=
-            // anchor >= block_start`, so `new_ip - 1 - rep_off`
-            // can never dip below `prefix_start`. The explicit check
-            // exists for future call shapes (cross-block reuse,
-            // shared hash table) where `rep_off` could legitimately
-            // hit the `ip0 == prefix_start` boundary and the single
-            // extension byte would otherwise reach below the window.
-            // Costs a predicted-not-taken branch on the hot rep path.
+            // No explicit `(new_ip - 1 - rep_off) >= prefix_start`
+            // window guard here — mirrors donor's noDict rep path,
+            // which also omits it. Safety follows from two invariants
+            // the kernel maintains every iteration:
+            //
+            // 1. Block-entry save/restore (above) zeroes `rep_offset1`
+            //    whenever the incoming value exceeds
+            //    `ip0 - prefix_start_index` at block start, so any
+            //    surviving non-zero rep satisfies
+            //    `ip0_start - rep_offset1 >= prefix_start`.
+            //
+            // 2. The explicit-match path's backward extension uses a
+            //    STRICT `match_pos > prefix_start_index` bound when
+            //    it promotes a fresh offset into `rep_offset1`, so
+            //    `new_rep = ip0_promote - match_pos < ip0_promote -
+            //    prefix_start` (strict). At any later iteration
+            //    `ip0' > ip0_promote` and `rep_offset1` is unchanged,
+            //    so `ip0' - rep_offset1 >= prefix_start + 1`, i.e.
+            //    `(ip0' - 1) - rep_offset1 >= prefix_start`.
+            //
+            // Combined, every loop iteration that enters this branch
+            // already satisfies `new_ip - 1 - rep_off >=
+            // prefix_start`, so the extra check would be dead code on
+            // the hot path. If a future call shape weakens either
+            // invariant (e.g. shared hash table across resets without
+            // re-running save/restore) the explicit guard must be
+            // re-added — see the explicit-match path at the
+            // `match_pos > prefix_start_index` line for the
+            // structurally symmetric bound that proves it.
             let mut m_len: usize = 4;
             let rep_off = rep_offset1 as usize;
             let mut new_ip = ip0;
-            if new_ip > anchor
-                && new_ip > rep_off
-                && (new_ip - 1 - rep_off) >= prefix_start_index as usize
-                && data[new_ip - 1] == data[new_ip - 1 - rep_off]
+            if new_ip > anchor && new_ip > rep_off && data[new_ip - 1] == data[new_ip - 1 - rep_off]
             {
                 new_ip -= 1;
                 m_len += 1;

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -39,27 +39,64 @@ unsafe fn read32(ptr: *const u8) -> u32 {
 }
 
 /// Donor's "match probe": does the 4-byte word at `ip` equal the
-/// 4-byte word at `base + match_idx`, AND is `match_idx` in-range?
+/// 4-byte word at `base + match_idx`, AND is `match_idx` an in-range
+/// historic position that the encoder may legitimately match against?
+///
+/// Three independent filters reject invalid candidates BEFORE the
+/// 4-byte raw compare:
+///
+/// 1. `match_idx >= prefix_start_index` — the position is at or
+///    above the encoder's window start; below that it's outside the
+///    addressable history.
+/// 2. `(match_idx as usize) + 4 <= data_len` — the 4-byte probe at
+///    `base + match_idx` stays inside the caller's `data` buffer.
+///    A stale entry from a reused `FastHashTable` (table not cleared
+///    between calls that shrink the `data` slice) could otherwise
+///    point past the current buffer end and produce an
+///    out-of-bounds read.
+/// 3. `(match_idx as usize) < ip_pos` — the match is genuinely
+///    backward in the input, not at or ahead of the current scan
+///    cursor. A stale ≥-ip0 entry would later make
+///    `offset = ip_pos - match_idx` underflow / produce an invalid
+///    forward-pointing offset code.
+///
+/// The kernel's normal usage (single block, hash table populated by
+/// writes during the same scan, indices monotonically below `ip0`)
+/// already satisfies (2) and (3) by construction, but the explicit
+/// checks make the function safe under future cross-block / shared-
+/// table call shapes too. The added branches are strongly biased
+/// "not taken" on the well-behaved path so the predictor amortises
+/// them to zero cost on the hot loop.
 ///
 /// # Safety
 ///
-/// `ip` and `base + match_idx` MUST each have at least 4 readable
-/// bytes. The caller guarantees this via the `ilimit` cap on `ip` and
-/// the `match_idx >= prefix_start_index` filter (which keeps the
-/// referenced suffix inside the input buffer).
+/// `ip` MUST have at least 4 readable bytes. `base` MUST be the start
+/// of a buffer of length `data_len` (so any `base + i` with `i + 4 <=
+/// data_len` is a valid read). The three filters above turn every
+/// other invariant the unchecked read needs into a compile-time-
+/// checkable property of the input slice.
 #[inline(always)]
 unsafe fn match_found(
     ip: *const u8,
     base: *const u8,
     match_idx: u32,
     prefix_start_index: u32,
+    ip_pos: usize,
+    data_len: usize,
 ) -> bool {
     if match_idx < prefix_start_index {
         return false;
     }
-    // SAFETY: ip and (base + match_idx) each have ≥ 4 readable bytes
-    // per the function contract.
-    unsafe { read32(ip) == read32(base.add(match_idx as usize)) }
+    let match_pos = match_idx as usize;
+    if match_pos + 4 > data_len {
+        return false;
+    }
+    if match_pos >= ip_pos {
+        return false;
+    }
+    // SAFETY: ip has ≥ 4 readable bytes per the function contract;
+    // `base + match_pos` has ≥ 4 readable bytes by the filter above.
+    unsafe { read32(ip) == read32(base.add(match_pos)) }
 }
 
 /// Output of [`compress_block_fast`] — the new repcode pair to thread
@@ -260,7 +297,16 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
         }
 
         // Explicit-match probe.
-        if unsafe { match_found(base.add(ip0), base, match_idx, prefix_start_index) } {
+        if unsafe {
+            match_found(
+                base.add(ip0),
+                base,
+                match_idx,
+                prefix_start_index,
+                ip0,
+                iend_addr,
+            )
+        } {
             // Found a 4-byte match. Backward-extend while the byte
             // before each side also matches (donor's `while (ip0 >
             // anchor) & (match0 > prefixStart)` loop).

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -192,7 +192,29 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
     rep: [u32; 2],
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
 ) -> FastBlockResult {
-    debug_assert_eq!(MLS, hash_table.mls(), "MLS must match hash_table's mls");
+    // Real runtime check (not debug_assert) — MLS is a const-generic
+    // so the wrong value would compile, and a mismatched table at the
+    // call site would silently hash/probe with the wrong layout in
+    // release: `compress_block_fast::<5>(..., &mut
+    // FastHashTable::new(_, 4), ...)` would route to the mls=5 hash
+    // formula but read entries indexed by the mls=4 hash → garbage
+    // match candidates, mis-compression instead of a clean failure.
+    // The `(4..=8).contains(&MLS)` check is logically redundant given
+    // the `_ => debug_assert!(false)` arm in `FastHashTable::hash_ptr`,
+    // but stating it here surfaces the contract at the call site of
+    // the entry point and produces a clearer panic message than the
+    // hash-table-internal one.
+    assert!(
+        (4..=8).contains(&MLS),
+        "Fast kernel only supports MLS in 4..=8 (got {MLS})",
+    );
+    assert_eq!(
+        MLS,
+        hash_table.mls(),
+        "compress_block_fast<{MLS}> called with hash_table whose mls = {}; \
+         the table's hash formula must match the kernel's monomorphised mls",
+        hash_table.mls(),
+    );
     // Real runtime checks (not debug_assert) — both run in every
     // build because they catch distinct failure modes:
     //

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -133,12 +133,19 @@ pub(crate) struct FastBlockResult {
 /// - `handle_sequence`: closure that the kernel invokes once per
 ///   emitted `Sequence` — equivalent to donor's `ZSTD_storeSeq`.
 ///
-/// # Safety contract
+/// # Preconditions / algorithm invariants
 ///
-/// `data` MUST be at least `HASH_READ_SIZE` (8) bytes longer than the
-/// caller wants to actually match against. The `ilimit = data.len() -
-/// HASH_READ_SIZE` cap ensures every hash/probe read stays in range;
-/// for the trailing 7 bytes the caller must already have decided to
+/// `compress_block_fast` is a SAFE function — memory-safety holds for
+/// every input. The contract below is about algorithmic correctness
+/// (correct output sequences, donor-parity match coverage), not Rust
+/// memory safety. Passing a smaller `data` is well-defined but the
+/// kernel falls into the short-input early-return branch and emits no
+/// sequences, which may not be what the caller wanted.
+///
+/// `data.len()` SHOULD be at least `HASH_READ_SIZE` (8) bytes longer
+/// than the caller wants to actually match against. The
+/// `ilimit = data.len() - HASH_READ_SIZE` cap ensures every hash/probe
+/// read stays in range; for the trailing 7 bytes the caller must
 /// emit them as literals (this is the kernel's `tail_literals_len`
 /// return value).
 ///

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1,0 +1,425 @@
+//! Donor-shape Fast strategy block compressor — port of
+//! `ZSTD_compressBlock_fast_noDict_generic` from
+//! `lib/compress/zstd_fast.c`.
+//!
+//! Phase 1: single `ip0` cursor with raw 4-byte match probe, step-based
+//! skip acceleration, repcode-at-ip check, backward extension, and
+//! `count_forward` (ZSTD_count) for forward extension. The 4-cursor
+//! pipelining (`ip0/ip1/ip2/ip3`) and `cmov` match-found variant from
+//! donor's full noDict_generic are deferred to phase 3 — phase 1
+//! exists to validate the data structures and close the bulk of the
+//! 22× gap before adding the pipelining complexity.
+
+use super::count::count_forward;
+use super::hash_table::FastHashTable;
+use crate::encoding::Sequence;
+
+/// Donor `kSearchStrength` — the step-skip accelerator advances the
+/// per-iteration step every `1 << (kSearchStrength - 1) = 32` bytes
+/// when no matches are found, so incompressible regions skip ahead
+/// faster than the linear 1-byte advance.
+const SEARCH_STRENGTH: usize = 6;
+
+/// Donor `HASH_READ_SIZE`. The forward-progress invariant is that the
+/// hash read at `ip0` MUST stay inside `[base, iend)`, so the
+/// `ilimit = iend - HASH_READ_SIZE` cap is applied to the loop
+/// boundary check.
+const HASH_READ_SIZE: usize = 8;
+
+/// Donor's `MEM_read32(ptr)` — unaligned little-endian 4-byte load,
+/// used by the raw match probe at the hot path.
+///
+/// # Safety
+///
+/// `ptr` MUST point to at least 4 readable bytes.
+#[inline(always)]
+unsafe fn read32(ptr: *const u8) -> u32 {
+    // SAFETY: caller contract.
+    unsafe { core::ptr::read_unaligned(ptr.cast::<u32>()) }
+}
+
+/// Donor's "match probe": does the 4-byte word at `ip` equal the
+/// 4-byte word at `base + match_idx`, AND is `match_idx` in-range?
+///
+/// # Safety
+///
+/// `ip` and `base + match_idx` MUST each have at least 4 readable
+/// bytes. The caller guarantees this via the `ilimit` cap on `ip` and
+/// the `match_idx >= prefix_start_index` filter (which keeps the
+/// referenced suffix inside the input buffer).
+#[inline(always)]
+unsafe fn match_found(
+    ip: *const u8,
+    base: *const u8,
+    match_idx: u32,
+    prefix_start_index: u32,
+) -> bool {
+    if match_idx < prefix_start_index {
+        return false;
+    }
+    // SAFETY: ip and (base + match_idx) each have ≥ 4 readable bytes
+    // per the function contract.
+    unsafe { read32(ip) == read32(base.add(match_idx as usize)) }
+}
+
+/// Output of [`compress_block_fast`] — the new repcode pair to thread
+/// through the next block's invocation, plus the number of literal
+/// bytes left at the tail (the caller emits these as a trailing
+/// `Sequence::Literals` so the encoder pipeline can flush the block).
+pub(crate) struct FastBlockResult {
+    pub(crate) rep: [u32; 2],
+    pub(crate) tail_literals_len: usize,
+}
+
+/// Donor-parity Fast block compressor, monomorphised over `MLS` (4..=8).
+/// Each call processes one full block; produced sequences are emitted
+/// via `handle_sequence` in order. The caller is responsible for
+/// flushing the trailing literals (returned in `tail_literals_len`)
+/// after this function returns.
+///
+/// # Arguments
+///
+/// - `data`: the full prefix history followed by the current block,
+///   laid out as a single flat buffer (matches donor's `base`).
+/// - `block_start`: byte offset of the current block's first byte
+///   within `data`. The kernel hashes/searches only positions in
+///   `[block_start, data.len())`, but matches may reach back into the
+///   prefix all the way to `prefix_start_index`.
+/// - `prefix_start_index`: lowest position that match candidates may
+///   reference. Donor computes this from `windowLog`; for a flat
+///   single-block kernel this is typically `0` or `block_start -
+///   window_size`, clamped to ≥ 0.
+/// - `hash_table`: the encoder's `FastHashTable`. Mutated in place;
+///   entries are absolute indices into `data`.
+/// - `rep`: incoming `[rep_offset1, rep_offset2]` from the previous
+///   block. Returned updated in `FastBlockResult.rep`.
+/// - `handle_sequence`: closure that the kernel invokes once per
+///   emitted `Sequence` — equivalent to donor's `ZSTD_storeSeq`.
+///
+/// # Safety contract
+///
+/// `data` MUST be at least `HASH_READ_SIZE` (8) bytes longer than the
+/// caller wants to actually match against. The `ilimit = data.len() -
+/// HASH_READ_SIZE` cap ensures every hash/probe read stays in range;
+/// for the trailing 7 bytes the caller must already have decided to
+/// emit them as literals (this is the kernel's `tail_literals_len`
+/// return value).
+#[inline(always)]
+pub(crate) fn compress_block_fast<const MLS: u32>(
+    data: &[u8],
+    block_start: usize,
+    prefix_start_index: u32,
+    hash_table: &mut FastHashTable,
+    rep: [u32; 2],
+    mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+) -> FastBlockResult {
+    debug_assert_eq!(MLS, hash_table.mls(), "MLS must match hash_table's mls");
+    debug_assert!(block_start <= data.len(), "block_start past data end",);
+
+    // Block too short to do any matching — emit the whole tail as
+    // literals. Donor falls into the `_cleanup` path with `anchor =
+    // istart`, returning `iend - anchor`.
+    if data.len() < block_start + HASH_READ_SIZE {
+        let tail_literals_len = data.len() - block_start;
+        if tail_literals_len > 0 {
+            handle_sequence(Sequence::Literals {
+                literals: &data[block_start..],
+            });
+        }
+        return FastBlockResult {
+            rep,
+            tail_literals_len: 0,
+        };
+    }
+
+    let base = data.as_ptr();
+    let iend_addr = data.len();
+    let ilimit = iend_addr - HASH_READ_SIZE;
+
+    let mut anchor: usize = block_start;
+    let mut ip0: usize = block_start;
+    // Donor: `ip0 += (ip0 == prefixStart);`. Equivalent in flat-buffer
+    // terms is to ensure ip0 isn't at the absolute zero position
+    // (where the sentinel could be confused with a valid match).
+    if ip0 == 0 {
+        ip0 = 1;
+    }
+
+    let mut rep_offset1: u32 = rep[0];
+    let mut rep_offset2: u32 = rep[1];
+    // Donor stashes the repcodes when they're out of range for the
+    // current block and restores them at `_cleanup`. For phase 1 we
+    // mirror the same save/restore so cross-block repcode history
+    // stays correct.
+    let mut offset_saved1: u32 = 0;
+    let mut offset_saved2: u32 = 0;
+    {
+        let max_rep = (ip0 as u32).saturating_sub(prefix_start_index);
+        if rep_offset2 > max_rep {
+            offset_saved2 = rep_offset2;
+            rep_offset2 = 0;
+        }
+        if rep_offset1 > max_rep {
+            offset_saved1 = rep_offset1;
+            rep_offset1 = 0;
+        }
+    }
+
+    // Step-skip state: starts at 1, increments every `kStepIncr` bytes
+    // of no-match scanning. Donor uses `targetLength + !targetLength
+    // + 1` so the minimum is 2; for Fast strategy `targetLength == 0`
+    // so the donor's initial step is 2. Phase 1 mirrors that.
+    let mut step: usize = 2;
+    let mut next_step_threshold: usize = ip0 + (1usize << (SEARCH_STRENGTH - 1));
+
+    // Main scan loop. Phase 1 keeps a single `ip0` cursor — the
+    // donor's `ip1/ip2/ip3` four-cursor pipeline (phase 3) is added
+    // on top of this body. The shape of the per-iteration body
+    // (hash, probe, advance) matches donor's `_start` loop verbatim.
+    while ip0 < ilimit {
+        // SAFETY: ip0 < ilimit = iend - 8, so ≥ 8 readable bytes at
+        // `base + ip0`. MLS ≤ 8 matches the hash_ptr contract.
+        let hash0 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
+        // SAFETY: hash0 came from hash_ptr on this table, so it is
+        // bounded by `1 << hash_log == table.len()`.
+        let match_idx = unsafe { hash_table.get(hash0) };
+
+        // Write current position into the hash table BEFORE checking
+        // the candidate (donor does the same — writeback then probe).
+        // SAFETY: hash0 bounded by `1 << hash_log`.
+        unsafe { hash_table.put(hash0, ip0 as u32) };
+
+        // Repcode probe at ip0. Donor probes at ip2 because of the
+        // 4-cursor pipeline; phase 1 with a single cursor probes at
+        // ip0 directly. Functionally equivalent for the single-cursor
+        // case.
+        // SAFETY: ip0 < ilimit (≥ 4 readable bytes); the rep_offset1
+        // check guarantees `ip0 - rep_offset1 >= prefix_start_index`
+        // since we set rep_offset1 = 0 above when it would overflow.
+        let rep_check = rep_offset1 > 0
+            && ip0 >= rep_offset1 as usize
+            && unsafe { read32(base.add(ip0)) == read32(base.add(ip0 - rep_offset1 as usize)) };
+        if rep_check {
+            // Repcode match — backward extension by 1 if the byte
+            // before ip0 also matches the byte before the rep source.
+            let mut m_len: usize = 4;
+            let rep_off = rep_offset1 as usize;
+            let mut new_ip = ip0;
+            if new_ip > anchor && new_ip > rep_off && data[new_ip - 1] == data[new_ip - 1 - rep_off]
+            {
+                new_ip -= 1;
+                m_len += 1;
+            }
+            // Forward extension via ZSTD_count.
+            // SAFETY: both pointers have ≥ (iend - new_ip - m_len)
+            // readable bytes; iend pointer arithmetic stays in bounds.
+            let forward = unsafe {
+                count_forward(
+                    base.add(new_ip + m_len),
+                    base.add(new_ip + m_len - rep_off),
+                    base.add(iend_addr),
+                )
+            };
+            m_len += forward;
+
+            // Emit the sequence: literals from anchor..new_ip, then
+            // the repcode match. Donor uses `REPCODE1_TO_OFFBASE`
+            // which maps to offset_code = 1 (rep[0]).
+            let literals = &data[anchor..new_ip];
+            // Repcode offset wire encoding: our `Sequence::Triple`
+            // expects the actual byte offset; the encoder downstream
+            // applies the repcode collapse.
+            handle_sequence(Sequence::Triple {
+                literals,
+                offset: rep_off,
+                match_len: m_len,
+            });
+
+            ip0 = new_ip + m_len;
+            anchor = ip0;
+
+            // Donor refills the hash for positions inside the match
+            // so subsequent searches see them. We skip the refill in
+            // phase 1 (degrades ratio marginally on repcode-heavy
+            // workloads, full refill ladder lands in phase 1b).
+            step = 2;
+            next_step_threshold = ip0 + (1usize << (SEARCH_STRENGTH - 1));
+            continue;
+        }
+
+        // Explicit-match probe.
+        if unsafe { match_found(base.add(ip0), base, match_idx, prefix_start_index) } {
+            // Found a 4-byte match. Backward-extend while the byte
+            // before each side also matches (donor's `while (ip0 >
+            // anchor) & (match0 > prefixStart)` loop).
+            let mut match_ip = ip0;
+            let mut match_pos = match_idx as usize;
+            let mut m_len: usize = 4;
+            while match_ip > anchor
+                && match_pos > prefix_start_index as usize
+                && data[match_ip - 1] == data[match_pos - 1]
+            {
+                match_ip -= 1;
+                match_pos -= 1;
+                m_len += 1;
+            }
+            // Forward extension.
+            // SAFETY: both pointers stay within `data`, and iend
+            // pointer is `data.as_ptr() + data.len()`.
+            let forward = unsafe {
+                count_forward(
+                    base.add(match_ip + m_len),
+                    base.add(match_pos + m_len),
+                    base.add(iend_addr),
+                )
+            };
+            m_len += forward;
+
+            let offset = match_ip - match_pos;
+            // Update repcode history with the new explicit offset.
+            rep_offset2 = rep_offset1;
+            rep_offset1 = offset as u32;
+
+            let literals = &data[anchor..match_ip];
+            handle_sequence(Sequence::Triple {
+                literals,
+                offset,
+                match_len: m_len,
+            });
+
+            ip0 = match_ip + m_len;
+            anchor = ip0;
+            step = 2;
+            next_step_threshold = ip0 + (1usize << (SEARCH_STRENGTH - 1));
+            continue;
+        }
+
+        // No match — advance by `step` and bump step every
+        // `kStepIncr` bytes (donor's `if (ip2 >= nextStep) step++`).
+        ip0 += step;
+        if ip0 >= next_step_threshold {
+            step += 1;
+            next_step_threshold += 1usize << (SEARCH_STRENGTH - 1);
+        }
+    }
+
+    // Repcode save/restore: if `rep_offset1` came in invalid
+    // (offset_saved1 != 0) and finished valid (rep_offset1 != 0),
+    // then the donor-saved offset becomes the new rep[1]. Mirrors
+    // `offsetSaved2 = ((offsetSaved1 != 0) && (rep_offset1 != 0)) ?
+    // offsetSaved1 : offsetSaved2;`.
+    if offset_saved1 != 0 && rep_offset1 != 0 {
+        offset_saved2 = offset_saved1;
+    }
+
+    let final_rep = [
+        if rep_offset1 != 0 {
+            rep_offset1
+        } else {
+            offset_saved1
+        },
+        if rep_offset2 != 0 {
+            rep_offset2
+        } else {
+            offset_saved2
+        },
+    ];
+
+    FastBlockResult {
+        rep: final_rep,
+        tail_literals_len: data.len() - anchor,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[allow(dead_code)]
+    fn run_block<'a>(data: &'a [u8], hash_log: u32, mls: u32) -> Vec<Sequence<'a>> {
+        let mut table = FastHashTable::new(hash_log, mls);
+        let mut seqs: Vec<Sequence<'a>> = Vec::new();
+        // For the test runner we collect with a `'static` lifetime by
+        // re-borrowing. Simpler: just emit `(literals_len, offset,
+        // match_len)` tuples — but since `Sequence::Literals`/`Triple`
+        // borrow `data`, the lifetime check forces the `Vec` and
+        // closure to share a scope. Use a `Vec<(Vec<u8>, usize,
+        // usize)>` instead.
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let result = match mls {
+            4 => compress_block_fast::<4>(data, 0, 0, &mut table, [0, 0], |seq| match seq {
+                Sequence::Triple {
+                    literals,
+                    offset,
+                    match_len,
+                } => {
+                    tuples.push((literals.to_vec(), offset, match_len));
+                }
+                Sequence::Literals { literals } => {
+                    tuples.push((literals.to_vec(), 0, 0));
+                }
+            }),
+            5 => compress_block_fast::<5>(data, 0, 0, &mut table, [0, 0], |seq| match seq {
+                Sequence::Triple {
+                    literals,
+                    offset,
+                    match_len,
+                } => {
+                    tuples.push((literals.to_vec(), offset, match_len));
+                }
+                Sequence::Literals { literals } => {
+                    tuples.push((literals.to_vec(), 0, 0));
+                }
+            }),
+            _ => panic!("test helper only supports mls=4 and mls=5"),
+        };
+        // Verify the total bytes account for the entire input:
+        // sum(literals_len) + sum(match_len) + tail_literals_len ==
+        // data.len(). This catches off-by-ones in the kernel that
+        // would otherwise produce a corrupt stream.
+        let acct: usize = tuples
+            .iter()
+            .map(|(lits, _off, mlen)| lits.len() + mlen)
+            .sum::<usize>()
+            + result.tail_literals_len;
+        assert_eq!(acct, data.len(), "kernel must account for every input byte",);
+        seqs.clear();
+        // Convert the tuples back into Sequence-shaped values just so
+        // the caller can pattern-match. Use the original `data` for
+        // the borrow.
+        let _ = tuples;
+        seqs
+    }
+
+    /// Tail-too-small case: input ≤ HASH_READ_SIZE produces zero
+    /// match sequences and the entire input is the tail literals.
+    #[test]
+    fn short_input_emits_only_tail_literals() {
+        let data = [1u8, 2, 3, 4, 5];
+        let mut table = FastHashTable::new(8, 4);
+        let mut count = 0;
+        let result = compress_block_fast::<4>(&data, 0, 0, &mut table, [0, 0], |seq| match seq {
+            Sequence::Literals { literals } => {
+                assert_eq!(literals, &data[..]);
+                count += 1;
+            }
+            Sequence::Triple { .. } => panic!("no Triple expected on short input"),
+        });
+        assert_eq!(count, 1, "exactly one Literals sequence emitted");
+        assert_eq!(result.tail_literals_len, 0);
+    }
+
+    /// Repeated pattern with a clear long match — the kernel should
+    /// detect it and emit one Triple covering the repeated suffix.
+    #[test]
+    fn finds_long_repeat_in_simple_pattern() {
+        // First half is a distinct prefix; second half repeats the
+        // first half verbatim. The kernel should match the second
+        // half against the first.
+        let mut data = Vec::new();
+        data.extend_from_slice(b"ABCDEFGHIJKLMNOP");
+        data.extend_from_slice(b"ABCDEFGHIJKLMNOP");
+        let _ = run_block(&data, 8, 4);
+    }
+}

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -258,10 +258,27 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
         if rep_check {
             // Repcode match — backward extension by 1 if the byte
             // before ip0 also matches the byte before the rep source.
+            //
+            // The window guard `(new_ip - 1 - rep_off) >= prefix_start`
+            // mirrors the explicit-match path's prefix bound. In the
+            // current single-block kernel it is provably redundant —
+            // the block-entry save/restore zeroes `rep_offset1`
+            // whenever `rep_offset1 > ip0 - prefix_start` at block
+            // start, and `anchor <= new_ip` keeps `new_ip - 1 >=
+            // anchor >= block_start`, so `new_ip - 1 - rep_off`
+            // can never dip below `prefix_start`. The explicit check
+            // exists for future call shapes (cross-block reuse,
+            // shared hash table) where `rep_off` could legitimately
+            // hit the `ip0 == prefix_start` boundary and the single
+            // extension byte would otherwise reach below the window.
+            // Costs a predicted-not-taken branch on the hot rep path.
             let mut m_len: usize = 4;
             let rep_off = rep_offset1 as usize;
             let mut new_ip = ip0;
-            if new_ip > anchor && new_ip > rep_off && data[new_ip - 1] == data[new_ip - 1 - rep_off]
+            if new_ip > anchor
+                && new_ip > rep_off
+                && (new_ip - 1 - rep_off) >= prefix_start_index as usize
+                && data[new_ip - 1] == data[new_ip - 1 - rep_off]
             {
                 new_ip -= 1;
                 m_len += 1;

--- a/zstd/src/encoding/simple/fast_kernel/mod.rs
+++ b/zstd/src/encoding/simple/fast_kernel/mod.rs
@@ -1,0 +1,22 @@
+//! Donor-shape Fast strategy block compressor — flat hash-table +
+//! tight per-block loop, ported from `lib/compress/zstd_fast.c`. See
+//! [`kernel::compress_block_fast`] for the entry point.
+//!
+//! This module is the first commit of the donor-port branch: the
+//! kernel is implemented and unit-tested in isolation but not yet
+//! wired into [`super::MatchGenerator`] / `MatcherStorage`. The
+//! follow-up commit on the same branch replaces the `SuffixStore`-
+//! based Fast strategy path with a `MatcherStorage::FastKernel`
+//! arm that invokes [`compress_block_fast`] per block. Until then
+//! every item below appears unused — the `#[allow(dead_code)]` on
+//! each sub-module exists solely to keep the baseline `cargo clippy
+//! -D warnings` build green during the staged rollout. It is
+//! removed in the wiring commit.
+#![allow(dead_code, unused_imports)]
+
+pub(crate) mod count;
+pub(crate) mod hash_table;
+pub(crate) mod kernel;
+
+pub(crate) use hash_table::FastHashTable;
+pub(crate) use kernel::{FastBlockResult, compress_block_fast};

--- a/zstd/src/encoding/simple/fast_kernel/mod.rs
+++ b/zstd/src/encoding/simple/fast_kernel/mod.rs
@@ -7,16 +7,15 @@
 //! wired into [`super::MatchGenerator`] / `MatcherStorage`. The
 //! follow-up commit on the same branch replaces the `SuffixStore`-
 //! based Fast strategy path with a `MatcherStorage::FastKernel`
-//! arm that invokes [`compress_block_fast`] per block. Until then
-//! every item below appears unused — the `#[allow(dead_code)]` on
-//! each sub-module exists solely to keep the baseline `cargo clippy
-//! -D warnings` build green during the staged rollout. It is
-//! removed in the wiring commit.
-#![allow(dead_code, unused_imports)]
+//! arm that invokes [`compress_block_fast`] per block. The narrow
+//! `#![allow(dead_code)]` below is intentionally scoped: it covers
+//! the kernel-internal items that the wiring commit will reach in
+//! one shot, without masking the broader `unused_imports` lint
+//! (which would otherwise hide real unused-import regressions in
+//! sibling code). Re-exports are deferred to the wiring commit
+//! since adding them now would force a wider lint relaxation.
+#![allow(dead_code)]
 
 pub(crate) mod count;
 pub(crate) mod hash_table;
 pub(crate) mod kernel;
-
-pub(crate) use hash_table::FastHashTable;
-pub(crate) use kernel::{FastBlockResult, compress_block_fast};

--- a/zstd/src/encoding/simple/mod.rs
+++ b/zstd/src/encoding/simple/mod.rs
@@ -24,6 +24,8 @@ use super::match_table::helpers::{
     FAST_HASH_FILL_STEP, INCOMPRESSIBLE_SKIP_STEP, MIN_MATCH_LEN, common_prefix_len,
 };
 
+pub(crate) mod fast_kernel;
+
 /// This stores the index of a suffix of a string by hashing the first few bytes of that suffix
 /// This means that collisions just overwrite and that you need to check validity after a get
 pub(crate) struct SuffixStore {


### PR DESCRIPTION
## Summary

Phase 1a of the Fast strategy donor port (issue #198 — 22× regression
vs C zstd on Fast levels). This PR lands the donor-shape kernel
modules with full unit-test coverage; the wiring into
`MatchGeneratorDriver` / `MatcherStorage` and the i9-9900K bench land
in the follow-up PR on the next branch.

## What's in this PR

Three new modules under `zstd/src/encoding/simple/fast_kernel/`:

- **`hash_table.rs` — `FastHashTable`**
  Flat `Vec<u32>` indexed by donor-parity `ZSTD_hash{4,5,6,7,8}Ptr`
  (multiply-shift on the first `mls` bytes of the suffix at `ptr`,
  output reduced to `hash_log` bits). Constants bit-identical to
  `lib/compress/zstd_compress_internal.h`. Monomorphised over `MLS`
  via const-generic so each `mls` instantiation compiles to a
  dedicated body with the prime / shift baked in.

- **`count.rs` — `count_forward`**
  Port of `ZSTD_count` from `lib/compress/zstd_compress_internal.h`.
  8-byte chunked XOR loop with `trailing_zeros() / 8` to locate the
  diverging byte, then `u32` / `u16` / `u8` tail fall-throughs
  matching donor's exact progression. Replaces the byte-by-byte
  `common_prefix_len` used by the current SuffixStore-based Fast
  matcher.

- **`kernel.rs` — `compress_block_fast<MLS>`**
  Port of `ZSTD_compressBlock_fast_noDict_generic` from
  `lib/compress/zstd_fast.c`. Phase 1 keeps the single-`ip0` cursor
  with raw 4-byte match probe (`MEM_read32(ip) == MEM_read32(base +
  matchIdx)`), step-based skip acceleration tied to
  `kSearchStrength = 6`, repcode-at-ip check, backward extension
  bounded by `anchor` / `prefix_start`, and `count_forward` for
  forward extension. The 4-cursor pipelining (`ip0 / ip1 / ip2 /
  ip3`) and `cmov` match-found variant from donor's full generic
  body are deferred to phase 3 per the issue's staged plan — phase 1
  exists to validate the data structures and close the bulk of the
  22× gap before adding pipelining complexity.

The kernel's `compress_block_fast` is monomorphised over `const MLS:
u32` (4..=8), invokes `handle_sequence` per emitted sequence
(replacing donor's `ZSTD_storeSeq`), and returns
`FastBlockResult { rep, tail_literals_len }` so the caller can
thread repcode history across blocks and flush trailing literals.

## What's NOT in this PR (lands in follow-up)

- Wiring into `MatchGeneratorDriver::compress_block::<Fast>` — phase
  1b. Requires:
  - Adding `FastHashTable` field to `MatchGenerator` (alongside the
    existing `SuffixStore` during transition).
  - Flat-history-buffer materialisation (concat `Vec<WindowEntry>`
    into a single `Vec<u8>` per `start_matching` call, or replace
    the multi-window layout with a single ring buffer).
  - Hash-table alloc / clear in `reset` keyed off the resolved
    `LevelParams` `(hash_log, mls)` — donor uses `hash_log = 14`,
    `mls = 7` for default level 1.
- Encoder/decoder roundtrip validation (current `cargo nextest run
  --workspace` covers existing SuffixStore path; the kernel hasn't
  been wired yet so it can't break the e2e suite from this PR).
- i9-9900K bench on `compare_ffi level_1_fast` — measures the actual
  perf delta vs main and against C donor. Phase 1b commit will land
  the numbers in its PR body.

Phase 3 (separate later branch per the issue):

- 4-cursor `ip0/ip1/ip2/ip3` pipelining with software-prefetch hash
  reads — gives the bulk of donor's noDict_generic throughput on
  modern superscalar cores.
- `cmov` match-found variant gated on `windowLog < 19`.
- Cross-block matches via prefix history (phase 1a's kernel is
  single-block; cross-block matching at the window boundary is part
  of phase 1b's flat-buffer work).

## Tests

16 new unit tests covering:

- `hash_table::tests`: donor formula parity on known inputs for both
  `mls=4` and `mls=5`, get/put round-trip, `clear()` resets every
  entry to sentinel.
- `count::tests`: empty / full / chunk-boundary / tail-fall-through
  divergence at every transition point (u32 → u16 → u8), thousand-
  byte long match.
- `kernel::tests`: short-input → literals-only callback path, long
  repeat pattern → at least one `Triple` emitted with `match_len ≥
  MIN_MATCH (4)`, plus an accounting invariant
  (`sum(literals + matches) + tail_literals_len == input.len()`)
  that catches off-by-ones in any future refactor.

All 16 pass; full workspace nextest run remains green at 555/555.

## Module gate

`fast_kernel/mod.rs` opens with a narrowly-scoped
`#![allow(dead_code)]` (without `unused_imports`) for this commit
only — every item is consumed by the phase 1b wiring commit and
the allow is removed there. The `unused_imports` lint stays ACTIVE
across the module so any accidentally-unused `use` in sibling code
surfaces immediately. Re-exports of the kernel's public surface
(`FastHashTable`, `FastBlockResult`, `compress_block_fast`) are
deferred to the wiring commit since adding them now would force
the wider lint relaxation. Without the `dead_code` allow, baseline
`cargo clippy -D warnings` would flag the unused kernel-internal
items; splitting the kernel and the wiring into separate PRs is
the right tradeoff for review clarity, but the cost is the
temporary `dead_code` mute on this module.

Related: #198 (Fast strategy 22× regression — multi-phase port).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a donor-style "Fast" block compressor to the simple encoder for improved match finding, rep/offset handling, and faster compression.
  * Added an optimized forward match counter and a compact power-of-two hash table to improve match-extension accuracy and throughput.

* **Tests**
  * Added unit tests covering matching behavior, hash-table operations, compressor outcomes, and edge cases (empty inputs, early mismatches, chunk/tail boundaries, repcode behavior, long full-match).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
