### PR TITLE
perf(encoder): port donor ZSTD_compressBlock_fast — 4-cursor + per-level cParams + cmov + window-correctness (#198 phase 3)

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8202,3 +8202,61 @@ fn fast_levels_dispatch_per_level_hash_log_and_mls() {
         (17, 14, 6, 2),
     );
 }
+
+/// Exercise the actual driver wiring: for every Fast level, reset a
+/// `MatchGeneratorDriver` and assert the inner `FastKernelMatcher`
+/// observed the same `(hash_log, mls, step_size)` tuple that
+/// `resolve_level_params` reports. Catches plumbing bugs — argument
+/// reordering, stale step_size carried from a prior frame,
+/// stuck-on-default values — that the parameter-only test above
+/// would miss.
+#[test]
+fn fast_levels_driver_wiring_threads_cparams_into_inner_matcher() {
+    let mut driver = MatchGeneratorDriver::new(64 * 1024, 1);
+
+    let fast_levels = [
+        CompressionLevel::Level(1),
+        CompressionLevel::Fastest,
+        CompressionLevel::Uncompressed,
+        CompressionLevel::Level(-1),
+        CompressionLevel::Level(-2),
+        CompressionLevel::Level(-3),
+        CompressionLevel::Level(-4),
+        CompressionLevel::Level(-5),
+        CompressionLevel::Level(-6),
+        CompressionLevel::Level(-7),
+    ];
+
+    for &level in &fast_levels {
+        let p = resolve_level_params(level, None);
+        // Sanity: every level in the table above must resolve to a
+        // Fast-strategy row — otherwise this test isn't testing what
+        // it claims to test.
+        assert_eq!(
+            p.strategy_tag,
+            super::strategy::StrategyTag::Fast,
+            "{level:?} must resolve to Fast strategy",
+        );
+
+        // Drive the production reset path (same code paths exercised
+        // by FrameCompressor / StreamingEncoder).
+        crate::encoding::Matcher::reset(&mut driver, level);
+
+        let m = driver.simple_mut();
+        assert_eq!(
+            m.hash_log(),
+            p.fast_hash_log,
+            "{level:?}: inner matcher hash_log mismatch — argument swap?",
+        );
+        assert_eq!(
+            m.mls(),
+            p.fast_mls,
+            "{level:?}: inner matcher mls mismatch — argument swap?",
+        );
+        assert_eq!(
+            m.step_size(),
+            p.fast_step_size,
+            "{level:?}: inner matcher step_size mismatch — stale value carried from prior reset?",
+        );
+    }
+}

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8238,6 +8238,15 @@ fn fast_levels_driver_wiring_threads_cparams_into_inner_matcher() {
             "{level:?} must resolve to Fast strategy",
         );
 
+        // Bounce through a non-Fast strategy first so the next
+        // reset actually goes through the backend-switch path
+        // (`MatchGeneratorDriver::new` / `simple_mut` recreate the
+        // Fast variant via `FastKernelMatcher::with_params`). Without
+        // this hop the loop would only ever stay in `BackendTag::Simple`
+        // and exercise `FastKernelMatcher::reset` — leaving the
+        // `with_params` wiring untested on the production path.
+        crate::encoding::Matcher::reset(&mut driver, CompressionLevel::Level(9));
+
         // Drive the production reset path (same code paths exercised
         // by FrameCompressor / StreamingEncoder).
         crate::encoding::Matcher::reset(&mut driver, level);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -247,17 +247,19 @@ const ROW_CONFIG: RowConfig = RowConfig {
 struct LevelParams {
     strategy_tag: super::strategy::StrategyTag,
     window_log: u8,
-    /// Donor `hashLog3` / hash-fill stride. Was consumed by the
-    /// legacy SuffixStore MatchGenerator's interleaved hash-fill
-    /// loop; the donor-shape Fast kernel walks ip0 with
-    /// kSearchStrength step-skip acceleration instead, and the
-    /// Fast-strategy dict-priming path in FastKernelMatcher
-    /// currently strides at 1 unconditionally. Field retained on
-    /// LEVEL_TABLE so the Fast matcher's eventual hash_fill_step
-    /// setter (planned follow-up) can read it without re-shaping
-    /// the table.
-    #[allow(dead_code)]
-    hash_fill_step: usize,
+    /// Donor `cParams.hashLog` — only consumed by the Fast strategy
+    /// backend (`FastKernelMatcher`). Other backends ignore.
+    fast_hash_log: u32,
+    /// Donor `cParams.minMatch` (mls) — only consumed by the Fast
+    /// strategy backend. Range 4..=8 per donor's mml dispatch.
+    fast_mls: u32,
+    /// Donor's `stepSize = targetLength + !(targetLength) + 1`
+    /// (min 2). For Fast strategy, negative levels use
+    /// `targetLength = -level` (1..7), giving step_size 2..8.
+    /// L1 / L2 / Uncompressed use targetLength=0 → step_size=2.
+    /// Drives the kernel's initial `step` for the 4-cursor body's
+    /// skip schedule.
+    fast_step_size: usize,
     lazy_depth: u8,
     hc: HcConfig,
     row: RowConfig,
@@ -291,30 +293,30 @@ fn row_hash_bits_for_window(max_window_size: usize) -> usize {
 /// Index 0 = level 1, index 21 = level 22.
 #[rustfmt::skip]
 const LEVEL_TABLE: [LevelParams; 22] = [
-    // Lvl  Strategy       wlog  step  lazy  HC config                                   row config
-    // ---  -------------- ----  ----  ----  ------------------------------------------  ----------
-    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 19, hash_fill_step: 3, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, hash_fill_step: 1, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
-    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
-    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, hash_fill_step: 1, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
-    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
-    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
-    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
-    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 27, hash_fill_step: 1, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
+    // Lvl  Strategy       wlog  fast_hlog  fast_mls  fast_step  lazy  HC config                                   row config
+    // ---  -------------- ----  ---------  --------  ---------  ----  ------------------------------------------  ----------
+    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
+    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
+    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
+    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
+    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
+    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
+    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 27, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
 ];
 
 /// Smallest window_log the encoder will use regardless of source size.
@@ -396,7 +398,9 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
     LevelParams {
         strategy_tag: super::strategy::StrategyTag::BtUltra2,
         window_log,
-        hash_fill_step: 1,
+        fast_hash_log: 14,
+        fast_mls: 7,
+        fast_step_size: 2,
         lazy_depth: 2,
         hc,
         row: ROW_CONFIG,
@@ -412,13 +416,34 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
     let params = match level {
         CompressionLevel::Uncompressed => LevelParams {
             strategy_tag: super::strategy::StrategyTag::Fast,
+            // Uncompressed frames emit raw blocks and never reference
+            // history; advertising a larger window only inflates
+            // decoder-side buffer reservation. Stay at 17 (128 KiB).
             window_log: 17,
-            hash_fill_step: 1,
+            // Beyond-donor: hash_log=14 (vs donor's 13) for 2× fewer
+            // collisions on structured corpora.
+            fast_hash_log: 14,
+            fast_mls: 6,
+            // Donor's "base for negative" row has targetLength=1,
+            // which gives step_size = 1 + 0 + 1 = 2.
+            fast_step_size: 2,
             lazy_depth: 0,
             hc: HC_CONFIG,
             row: ROW_CONFIG,
         },
-        CompressionLevel::Fastest => LEVEL_TABLE[0],
+        CompressionLevel::Fastest => {
+            // Only the Fast-specific cParams
+            // (fast_hash_log / fast_mls / fast_step_size) align
+            // with Uncompressed / negative-base row. window_log
+            // stays at LEVEL_TABLE[0]'s value (19) — Fastest still
+            // does real compression on a full window, unlike
+            // Uncompressed which clamps to 17.
+            let mut p = LEVEL_TABLE[0];
+            p.fast_hash_log = 14;
+            p.fast_mls = 6;
+            p.fast_step_size = 2;
+            p
+        }
         CompressionLevel::Default => LEVEL_TABLE[2],
         CompressionLevel::Better => LEVEL_TABLE[6],
         CompressionLevel::Best => LEVEL_TABLE[10],
@@ -430,20 +455,24 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                 // Level 0 = default, matching C zstd semantics.
                 LEVEL_TABLE[CompressionLevel::DEFAULT_LEVEL as usize - 1]
             } else {
-                // Negative levels: ultra-fast with the Simple backend.
-                // Acceleration grows with magnitude, expressed as larger
-                // hash_fill_step (fewer positions indexed).
-                // `window_log = 19` matches donor's "base for negative
-                // levels" row in `clevels.h`, so the SuffixStore-per-
-                // WindowEntry has enough span to recall periodic
-                // patterns across `MAX_BLOCK_SIZE` boundaries.
-                let acceleration =
-                    (n.saturating_abs() as usize).min((-CompressionLevel::MIN_LEVEL) as usize);
-                let step = (acceleration + 3).min(128);
+                // Negative levels — donor sets
+                // targetLength = -level (clampedCompressionLevel),
+                // yielding step_size = (-level) + 1 since
+                // !(targetLength) = 0 when targetLength > 0.
+                // So L-1..L-7 get step_size 2..8. Acceleration
+                // gradient comes from larger step skipping more
+                // positions per iter (faster, worse ratio).
+                // Clamp to donor's MIN_LEVEL before negating so
+                // i32::MIN can't overflow on `-n`.
+                let clamped = n.max(CompressionLevel::MIN_LEVEL);
+                let target_length = (-clamped) as usize;
+                let step_size = target_length + 1;
                 LevelParams {
                     strategy_tag: super::strategy::StrategyTag::Fast,
                     window_log: 19,
-                    hash_fill_step: step,
+                    fast_hash_log: 14,
+                    fast_mls: 6,
+                    fast_step_size: step_size,
                     lazy_depth: 0,
                     hc: HC_CONFIG,
                     row: ROW_CONFIG,
@@ -605,6 +634,7 @@ impl MatchGeneratorDriver {
                 window_log_init,
                 FAST_LEVEL_1_HASH_LOG,
                 FAST_LEVEL_1_MLS,
+                2, // donor default step_size (targetLength=0 → step=2)
             )),
             strategy_tag: super::strategy::StrategyTag::Fast,
             slice_size,
@@ -924,31 +954,17 @@ impl Matcher for MatchGeneratorDriver {
             // `storage` is dropped here.
             self.storage = match next_backend {
                 super::strategy::BackendTag::Simple => {
-                    // Donor level-1 Fast cParams hard-coded:
-                    // hash_log = 14, mls = 7. `window_log` is
-                    // threaded from the resolved LevelParams just
-                    // above (the same LevelParams that
-                    // `resolve_level_params` computes per-level).
-                    //
-                    // KNOWN LIMITATION — phase 3 follow-up:
-                    // all Fast levels (Uncompressed, Fastest,
-                    // CompressionLevel::Level(-7..=1)) currently
-                    // resolve to the same FastKernelMatcher tuning.
-                    // `resolve_level_params` does compute distinct
-                    // settings, but they aren't wired into the
-                    // matcher today — the public acceleration
-                    // gradient between negative-level "faster"
-                    // modes and Level(1) lands when phase 3
-                    // implements donor's 4-cursor `ip0/ip1/ip2/ip3`
-                    // lookahead pipeline + per-level
-                    // kSearchStrength dispatch + `cmov` match-found
-                    // variant (issue #198 items 2/3/5). Phase 1b
-                    // is the donor-shape foundation those build
-                    // on top of.
+                    // Per-level Fast cParams from resolve_level_params:
+                    // Level(1) gets (hash_log=14, mls=7); Fastest /
+                    // Uncompressed / Level(-7..=-1) get (hash_log=14,
+                    // mls=6) — beyond-donor on hash_log (donor's row
+                    // is hash_log=13, see resolve_level_params for
+                    // rationale).
                     MatcherStorage::Simple(FastKernelMatcher::with_params(
                         params.window_log,
-                        FAST_LEVEL_1_HASH_LOG,
-                        FAST_LEVEL_1_MLS,
+                        params.fast_hash_log,
+                        params.fast_mls,
+                        params.fast_step_size,
                     ))
                 }
                 super::strategy::BackendTag::Dfast => {
@@ -974,14 +990,15 @@ impl Matcher for MatchGeneratorDriver {
         let strategy_tag = self.strategy_tag;
         match &mut self.storage {
             MatcherStorage::Simple(m) => {
-                // Donor level-1 Fast cParams are fixed (hash_log=14,
-                // mls=7). hash_fill_step from LevelParams isn't
-                // wired in yet — the FastKernelMatcher's
-                // skip-with-dict-prime path walks every position
-                // (stride=1) rather than the donor's `hash_fill_step`
-                // stride. Future per-level stride tuning lands as a
-                // separate inherent setter.
-                m.reset(params.window_log, FAST_LEVEL_1_HASH_LOG, FAST_LEVEL_1_MLS);
+                // Per-level Fast cParams threaded from
+                // resolve_level_params (see Simple-backend swap
+                // arm above for the (level → params) mapping).
+                m.reset(
+                    params.window_log,
+                    params.fast_hash_log,
+                    params.fast_mls,
+                    params.fast_step_size,
+                );
             }
             MatcherStorage::Dfast(dfast) => {
                 dfast.max_window_size = max_window_size;
@@ -8135,4 +8152,53 @@ fn fastest_hint_iteration_23_sequences_reconstruct_source() {
     // tuning preference, not a correctness invariant.
     let _ = saw_triple;
     assert_eq!(rebuilt, data);
+}
+
+#[test]
+fn fast_levels_dispatch_per_level_hash_log_and_mls() {
+    // Level 1 — donor `{ 19, 13, 14, 1, 7, 0, ZSTD_fast }` row:
+    // window_log=19, hash_log=14, mls=7.
+    let p1 = resolve_level_params(CompressionLevel::Level(1), None);
+    assert_eq!(p1.fast_hash_log, 14);
+    assert_eq!(p1.fast_mls, 7);
+    assert_eq!(p1.fast_step_size, 2);
+
+    // Negative levels — beyond-donor tuning: donor's "base for
+    // negative" row is (hash_log=13, mls=6); we use hash_log=14
+    // (+32 KB memory, 2× fewer collisions on structured corpora)
+    // while keeping mls=6 for fast-path speed on random data.
+    // step_size follows donor's formula: targetLength = -level,
+    // step_size = (-level) + 1, giving 2..8 for L-1..L-7.
+    for n in -7..=-1 {
+        let p = resolve_level_params(CompressionLevel::Level(n), None);
+        assert_eq!(p.fast_hash_log, 14, "Level({n}) fast_hash_log");
+        assert_eq!(p.fast_mls, 6, "Level({n}) fast_mls");
+        let expected_step = ((-n) as usize) + 1;
+        assert_eq!(p.fast_step_size, expected_step, "Level({n}) fast_step_size");
+    }
+
+    // Fastest + Uncompressed share the negative-base tuning
+    // (window_log=19, hash_log=14 [beyond-donor], mls=6).
+    let pf = resolve_level_params(CompressionLevel::Fastest, None);
+    assert_eq!(
+        (
+            pf.window_log,
+            pf.fast_hash_log,
+            pf.fast_mls,
+            pf.fast_step_size
+        ),
+        (19, 14, 6, 2),
+    );
+    // Uncompressed keeps window_log=17 (no history references, smaller
+    // decoder reservation); fast cParams same as negative-base row.
+    let pu = resolve_level_params(CompressionLevel::Uncompressed, None);
+    assert_eq!(
+        (
+            pu.window_log,
+            pu.fast_hash_log,
+            pu.fast_mls,
+            pu.fast_step_size
+        ),
+        (17, 14, 6, 2),
+    );
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -378,7 +378,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     // `next_step` is the absolute position where step doubles next;
     // donor increments by `kStepIncr = 1 << (kSearchStrength - 1)`.
     let mut step: usize = step_size;
-    let mut next_step: usize = ip0 + K_STEP_INCR;
+    let mut next_step: usize = ip0.saturating_add(K_STEP_INCR);
 
     // 4-cursor donor port. Outer `'restart` loop matches donor's
     // `_start:` reentry: every emitted match `goto _start`s back
@@ -390,10 +390,18 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         // _start: setup. ip0 already positioned; derive ip1/ip2/ip3
         // from current step. If even ip3 is past ilimit, the loop
         // can't make forward progress on this iteration — drain to
-        // the cleanup path below.
+        // the cleanup path below. `checked_add` here defends against
+        // a wild `step_size` (or a runaway `step` from the doubling
+        // cadence) wrapping past `ilimit` and turning the
+        // out-of-range guard below into a false-pass; on overflow we
+        // take the same break path as a normal ip3-past-ilimit miss.
         let mut ip1 = ip0 + 1;
-        let mut ip2 = ip0 + step;
-        let mut ip3 = ip2 + 1;
+        let Some(mut ip2) = ip0.checked_add(step) else {
+            break;
+        };
+        let Some(mut ip3) = ip2.checked_add(1) else {
+            break;
+        };
         if ip3 > ilimit {
             break;
         }
@@ -564,15 +572,27 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip2)) };
             ip0 = ip1;
             ip1 = ip2;
-            ip2 = ip0 + step;
-            ip3 = ip1 + step;
+            // Same overflow defence as the loop-head setup: a wild
+            // `step` (e.g. after enough step-doubling cycles) could
+            // otherwise wrap `ip0 + step` past `usize::MAX` and bypass
+            // the `ip3 > ilimit` guard. On overflow we drain to the
+            // post-loop cleanup, identical to the normal "ran out of
+            // room" exit.
+            let Some(new_ip2) = ip0.checked_add(step) else {
+                break None;
+            };
+            let Some(new_ip3) = ip1.checked_add(step) else {
+                break None;
+            };
+            ip2 = new_ip2;
+            ip3 = new_ip3;
 
             // Step-doubling: donor lines 342-347. Drives the
             // kSearchStrength-based acceleration on incompressible
             // regions.
             if ip2 >= next_step {
                 step += 1;
-                next_step += K_STEP_INCR;
+                next_step = next_step.saturating_add(K_STEP_INCR);
             }
 
             // do-while termination: if ip3 walks past ilimit, drain.
@@ -725,9 +745,14 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         }
 
         // `goto _start` — restart the outer loop with fresh step
-        // (reset to the level-resolved initial step_size).
+        // (reset to the level-resolved initial step_size). The
+        // `saturating_add` here is symmetric with the inner loop's
+        // step-doubling site: ip0 is already < ilimit < data.len()
+        // <= u32::MAX, so the wrap would require an unrepresentable
+        // `K_STEP_INCR`, but staying defensive keeps the cursor math
+        // wrap-free on every cold reset of the outer state.
         step = step_size;
-        next_step = ip0 + K_STEP_INCR;
+        next_step = ip0.saturating_add(K_STEP_INCR);
         continue 'restart;
     }
 

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1,14 +1,12 @@
 //! Donor-shape Fast strategy block compressor — port of
 //! `ZSTD_compressBlock_fast_noDict_generic` from
-//! `lib/compress/zstd_fast.c`.
-//!
-//! Phase 1: single `ip0` cursor with raw 4-byte match probe, step-based
-//! skip acceleration, repcode-at-ip check, backward extension, and
-//! `count_forward` (ZSTD_count) for forward extension. The 4-cursor
-//! pipelining (`ip0/ip1/ip2/ip3`) and `cmov` match-found variant from
-//! donor's full noDict_generic are deferred to phase 3 — phase 1
-//! exists to validate the data structures and close the bulk of the
-//! 22× gap before adding the pipelining complexity.
+//! `lib/compress/zstd_fast.c`. Includes the 4-cursor
+//! (`ip0/ip1/ip2/ip3`) lookahead pipeline with `kSearchStrength`
+//! step-doubling, repcode-at-ip2 probe, two explicit-match probes
+//! per do-while iter, immediate-rep2 inner loop after match emit,
+//! and both donor variants of the match-found check
+//! (`ZSTD_match4Found_branch` + `ZSTD_match4Found_cmov`) selected
+//! per-call via the `USE_CMOV` const generic.
 
 use super::count::count_forward;
 use super::hash_table::FastHashTable;
@@ -19,6 +17,12 @@ use crate::encoding::Sequence;
 /// when no matches are found, so incompressible regions skip ahead
 /// faster than the linear 1-byte advance.
 const SEARCH_STRENGTH: usize = 6;
+
+/// Donor `kStepIncr = 1 << (kSearchStrength - 1)` — every this-many
+/// bytes of no-match scanning, the per-iteration `step` is bumped
+/// by 1 (donor's `step++` at `zstd_fast.c:343`). Drives the
+/// incompressible-region step acceleration.
+const K_STEP_INCR: usize = 1 << (SEARCH_STRENGTH - 1);
 
 /// Donor `HASH_READ_SIZE`. The forward-progress invariant is that the
 /// hash read at `ip0` MUST stay inside `[base, iend)`, so the
@@ -44,45 +48,27 @@ unsafe fn read32(ptr: *const u8) -> u32 {
     unsafe { core::ptr::read_unaligned(ptr.cast::<u32>()) }
 }
 
-/// Donor's "match probe": does the 4-byte word at `ip` equal the
-/// 4-byte word at `base + match_idx`, AND is `match_idx` an in-range
-/// historic position that the encoder may legitimately match against?
-///
-/// Three independent filters reject invalid candidates BEFORE the
-/// 4-byte raw compare:
-///
-/// 1. `match_idx >= prefix_start_index` — the position is at or
-///    above the encoder's window start; below that it's outside the
-///    addressable history.
-/// 2. `(match_idx as usize) + 4 <= data_len` — the 4-byte probe at
-///    `base + match_idx` stays inside the caller's `data` buffer.
-///    A stale entry from a reused `FastHashTable` (table not cleared
-///    between calls that shrink the `data` slice) could otherwise
-///    point past the current buffer end and produce an
-///    out-of-bounds read.
-/// 3. `(match_idx as usize) < ip_pos` — the match is genuinely
-///    backward in the input, not at or ahead of the current scan
-///    cursor. A stale ≥-ip0 entry would later make
-///    `offset = ip_pos - match_idx` underflow / produce an invalid
-///    forward-pointing offset code.
-///
-/// The kernel's normal usage (single block, hash table populated by
-/// writes during the same scan, indices monotonically below `ip0`)
-/// already satisfies (2) and (3) by construction, but the explicit
-/// checks make the function safe under future cross-block / shared-
-/// table call shapes too. The added branches are strongly biased
-/// "not taken" on the well-behaved path so the predictor amortises
-/// them to zero cost on the hot loop.
+/// Donor `ZSTD_match4Found_cmov`'s dummy buffer — 4 random-ish bytes
+/// to compare against when `match_idx < prefix_start_index`. Chosen
+/// so the read32 result is very unlikely to coincide with any real
+/// 4-byte window from the input. Used by the cmov branchless variant
+/// to avoid the unpredictable `match_idx >= prefix_start_index`
+/// branch.
+const CMOV_DUMMY: [u8; 4] = [0x12, 0x34, 0x56, 0x78];
+
+/// Donor `ZSTD_match4Found_branch` / `ZSTD_match4Found_cmov`
+/// branchless dispatch via const generic.
 ///
 /// # Safety
 ///
-/// `ip` MUST have at least 4 readable bytes. `base` MUST be the start
-/// of a buffer of length `data_len` (so any `base + i` with `i + 4 <=
-/// data_len` is a valid read). The three filters above turn every
-/// other invariant the unchecked read needs into a compile-time-
-/// checkable property of the input slice.
+/// - `ip` MUST point to ≥ 4 readable bytes (the kernel only calls
+///   this when ip0..ip3 stay within `iend - HASH_READ_SIZE`).
+/// - `base` MUST be the start of the same buffer that `data_len`
+///   describes, i.e. `base[0..data_len]` is a valid byte range.
+/// - `ip_pos` MUST equal the byte offset of `ip` within the buffer
+///   `base` points at: `ip == base.add(ip_pos)`.
 #[inline(always)]
-unsafe fn match_found(
+unsafe fn match_found<const USE_CMOV: bool>(
     ip: *const u8,
     base: *const u8,
     match_idx: u32,
@@ -90,9 +76,9 @@ unsafe fn match_found(
     ip_pos: usize,
     data_len: usize,
 ) -> bool {
-    if match_idx < prefix_start_index {
-        return false;
-    }
+    // Bounds filters (well-predicted "not taken" on the hot path)
+    // stay as explicit branches — these protect against stale entries
+    // pointing past the buffer end and forward-pointing matches.
     let match_pos = match_idx as usize;
     if match_pos + 4 > data_len {
         return false;
@@ -100,9 +86,55 @@ unsafe fn match_found(
     if match_pos >= ip_pos {
         return false;
     }
-    // SAFETY: ip has ≥ 4 readable bytes per the function contract;
-    // `base + match_pos` has ≥ 4 readable bytes by the filter above.
-    unsafe { read32(ip) == read32(base.add(match_pos)) }
+
+    if USE_CMOV {
+        // Donor cmov variant (`ZSTD_match4Found_cmov`): pick either
+        // `base + match_pos` or `CMOV_DUMMY` based on the prefix
+        // filter, then AND with an explicit `in_range` predicate.
+        // The compiler typically lowers the if-expression to a
+        // `cmov` on x86_64 (the "cmov" name reflects that target —
+        // we don't enforce the lowering, since LLVM is free to use
+        // a branch where it predicts well). The dummy compare alone
+        // is NOT enough — if `read32(ip)` happens to equal
+        // `CMOV_DUMMY` (rare but reachable), the out-of-window
+        // match would otherwise slip through.
+        //
+        // Donor (`ZSTD_match4Found_cmov` lines 119-124) inserts an
+        // `__asm__("")` compiler barrier between the two checks to
+        // pin codegen order. We don't replicate that — Rust offers
+        // `core::sync::atomic::compiler_fence` if needed, but
+        // empirically LLVM's lowering here already orders the
+        // bytes_match comparison before the in_range AND without a
+        // barrier. Revisit only if profiling shows reordering hurt.
+        // SAFETY: both candidate addresses have ≥ 4 readable bytes
+        // (CMOV_DUMMY is exactly 4 bytes; base+match_pos has ≥ 4
+        // by the bounds check above).
+        let in_range = match_idx >= prefix_start_index;
+        let mval_addr = if in_range {
+            unsafe { base.add(match_pos) }
+        } else {
+            CMOV_DUMMY.as_ptr()
+        };
+        let bytes_match = unsafe { read32(ip) == read32(mval_addr) };
+        // Bitwise AND (not `&&`) is INTENTIONAL — short-circuit
+        // would re-introduce a branch on `bytes_match`, defeating
+        // the cmov-branchless path. Donor enforces the same
+        // ordering with `__asm__("")` between its two checks
+        // (`ZSTD_match4Found_cmov` lines 119-124).
+        #[allow(clippy::needless_bitwise_bool)]
+        let r = bytes_match & in_range;
+        r
+    } else {
+        // Donor branch variant (`ZSTD_match4Found_branch`): explicit
+        // branch on the prefix filter. Faster when the branch is
+        // strongly predictable — that's the typical Fast strategy
+        // case where almost all hash table entries are within the
+        // current window.
+        if match_idx < prefix_start_index {
+            return false;
+        }
+        unsafe { read32(ip) == read32(base.add(match_pos)) }
+    }
 }
 
 /// Output of [`compress_block_fast`] — the new repcode pair to thread
@@ -209,18 +241,27 @@ pub(crate) struct FastBlockResult {
 /// the kernel already emit the tail" per branch, which is exactly
 /// the inconsistency this contract removes.
 #[inline(always)]
-pub(crate) fn compress_block_fast<const MLS: u32>(
+pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     data: &[u8],
     block_start: usize,
     prefix_start_index: u32,
     hash_table: &mut FastHashTable,
     rep: [u32; 2],
+    step_size: usize,
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
 ) -> FastBlockResult {
+    // Donor's `stepSize = targetLength + !(targetLength) + 1`
+    // (min 2). Callers must pass >= 2; values larger than 2 drive
+    // the kernel's acceleration gradient on negative levels.
+    assert!(
+        step_size >= 2,
+        "Fast kernel requires step_size >= 2 (got {step_size}); \
+         the donor formula clamps to a min of 2",
+    );
     // Real runtime check (not debug_assert) — MLS is a const-generic
     // so the wrong value would compile, and a mismatched table at the
     // call site would silently hash/probe with the wrong layout in
-    // release: `compress_block_fast::<5>(..., &mut
+    // release: `compress_block_fast::<5, false>(..., &mut
     // FastHashTable::new(_, 4), ...)` would route to the mls=5 hash
     // formula but read entries indexed by the mls=4 hash → garbage
     // match candidates, mis-compression instead of a clean failure.
@@ -319,158 +360,260 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
         }
     }
 
-    // Step-skip state: starts at 1, increments every `kStepIncr` bytes
-    // of no-match scanning. Donor uses `targetLength + !targetLength
-    // + 1` so the minimum is 2; for Fast strategy `targetLength == 0`
-    // so the donor's initial step is 2. Phase 1 mirrors that.
-    let mut step: usize = 2;
-    let mut next_step_threshold: usize = ip0 + (1usize << (SEARCH_STRENGTH - 1));
+    // Step-skip state: donor's `step = stepSize` (`targetLength + 1`
+    // = 2 for Fast strategy with `targetLength == 0`). The 4-cursor
+    // loop walks ip0/ip1 = ip0 + 1 adjacent + ip2/ip3 at `step` gap.
+    // `next_step` is the absolute position where step doubles next;
+    // donor increments by `kStepIncr = 1 << (kSearchStrength - 1)`.
+    let mut step: usize = step_size;
+    let mut next_step: usize = ip0 + K_STEP_INCR;
 
-    // Main scan loop. Phase 1 keeps a single `ip0` cursor — the
-    // donor's `ip1/ip2/ip3` four-cursor pipeline (phase 3) is added
-    // on top of this body. The shape of the per-iteration body
-    // (hash, probe, advance) matches donor's `_start` loop verbatim.
-    while ip0 < ilimit {
-        // SAFETY: ip0 < ilimit = iend - 8, so ≥ 8 readable bytes at
-        // `base + ip0`. MLS ≤ 8 matches the hash_ptr contract.
-        let hash0 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
-        // SAFETY: hash0 came from hash_ptr on this table, so it is
-        // bounded by `1 << hash_log == table.len()`.
-        let match_idx = unsafe { hash_table.get(hash0) };
-
-        // Write current position into the hash table BEFORE checking
-        // the candidate (donor does the same — writeback then probe).
-        // SAFETY: hash0 bounded by `1 << hash_log`.
-        unsafe { hash_table.put(hash0, ip0 as u32) };
-
-        // Repcode probe at ip0. Donor probes at ip2 because of the
-        // 4-cursor pipeline; phase 1 with a single cursor probes at
-        // ip0 directly. Functionally equivalent for the single-cursor
-        // case.
-        // SAFETY: ip0 < ilimit (≥ 4 readable bytes); the rep_offset1
-        // check guarantees `ip0 - rep_offset1 >= prefix_start_index`
-        // since we set rep_offset1 = 0 above when it would overflow.
-        let rep_check = rep_offset1 > 0
-            && ip0 >= rep_offset1 as usize
-            && unsafe { read32(base.add(ip0)) == read32(base.add(ip0 - rep_offset1 as usize)) };
-        if rep_check {
-            // Repcode match — backward extension by 1 if the byte
-            // before ip0 also matches the byte before the rep source.
-            //
-            // No explicit `(new_ip - 1 - rep_off) >= prefix_start`
-            // window guard here — mirrors donor's noDict rep path,
-            // which also omits it. Safety follows from three pieces
-            // of state the kernel maintains every iteration:
-            //
-            // 1. Block-entry save/restore (above) zeroes `rep_offset1`
-            //    whenever the incoming value exceeds
-            //    `ip0_start - prefix_start_index`, so any surviving
-            //    non-zero rep satisfies
-            //    `ip0_start - rep_offset1 >= prefix_start` (NON-STRICT
-            //    — equality is allowed: `rep_offset1` may equal
-            //    exactly `ip0_start - prefix_start`).
-            //
-            // 2. The explicit-match path's backward extension uses a
-            //    STRICT `match_pos > prefix_start_index` bound when
-            //    it promotes a fresh offset into `rep_offset1`, so
-            //    `new_rep = ip0_promote - match_pos < ip0_promote -
-            //    prefix_start` (strict). At any iteration after a
-            //    promotion `ip0' > ip0_promote` and `rep_offset1` is
-            //    unchanged, so `ip0' - rep_offset1 >= prefix_start +
-            //    1`, i.e. `(ip0' - 1) - rep_offset1 >= prefix_start`
-            //    — the strict bound becomes available from the
-            //    SECOND iteration onward (any iteration where the
-            //    rep has been promoted at least once OR where ip0
-            //    has advanced past block_start).
-            //
-            // 3. The runtime `new_ip > anchor` gate covers the
-            //    REMAINING corner case: at block entry ip0 ==
-            //    block_start AND anchor == block_start, so the
-            //    `new_ip > anchor` check fails and the 1-byte
-            //    backward extension is skipped entirely. That is
-            //    exactly the iteration where (1) alone could give
-            //    `ip0_start - rep_offset1 == prefix_start` and
-            //    backward-extending would dereference `prefix_start
-            //    - 1`. The anchor gate prevents that read; (2) takes
-            //    over from the second iteration onward (anchor moves
-            //    past block_start after the first emitted sequence).
-            //
-            // Combined, every iteration that REACHES the
-            // `data[new_ip - 1] == data[new_ip - 1 - rep_off]` read
-            // already satisfies `new_ip - 1 - rep_off >= prefix_start`
-            // — either via the strict bound from (2) or via the
-            // anchor gate (3) skipping the read on the boundary
-            // iteration. The explicit prefix-window check would be
-            // dead code on the hot path. If a future call shape
-            // weakens any of (1), (2), or (3) — e.g. shared hash
-            // table across resets without re-running save/restore,
-            // or a custom anchor initialisation that doesn't equal
-            // `block_start` — the explicit guard must be re-added.
-            // See the explicit-match path at the `match_pos >
-            // prefix_start_index` line for the structurally symmetric
-            // bound that proves it.
-            let mut m_len: usize = 4;
-            let rep_off = rep_offset1 as usize;
-            let mut new_ip = ip0;
-            if new_ip > anchor && new_ip > rep_off && data[new_ip - 1] == data[new_ip - 1 - rep_off]
-            {
-                new_ip -= 1;
-                m_len += 1;
-            }
-            // Forward extension via ZSTD_count.
-            // SAFETY: both pointers have ≥ (iend - new_ip - m_len)
-            // readable bytes; iend pointer arithmetic stays in bounds.
-            let forward = unsafe {
-                count_forward(
-                    base.add(new_ip + m_len),
-                    base.add(new_ip + m_len - rep_off),
-                    base.add(iend_addr),
-                )
-            };
-            m_len += forward;
-
-            // Emit the sequence: literals from anchor..new_ip, then
-            // the repcode match. Donor uses `REPCODE1_TO_OFFBASE`
-            // which maps to offset_code = 1 (rep[0]).
-            let literals = &data[anchor..new_ip];
-            // Repcode offset wire encoding: our `Sequence::Triple`
-            // expects the actual byte offset; the encoder downstream
-            // applies the repcode collapse.
-            handle_sequence(Sequence::Triple {
-                literals,
-                offset: rep_off,
-                match_len: m_len,
-            });
-
-            ip0 = new_ip + m_len;
-            anchor = ip0;
-
-            // Donor refills the hash for positions inside the match
-            // so subsequent searches see them. We skip the refill in
-            // phase 1 (degrades ratio marginally on repcode-heavy
-            // workloads, full refill ladder lands in phase 1b).
-            step = 2;
-            next_step_threshold = ip0 + (1usize << (SEARCH_STRENGTH - 1));
-            continue;
+    // 4-cursor donor port. Outer `'restart` loop matches donor's
+    // `_start:` reentry: every emitted match `goto _start`s back
+    // here for a fresh setup. The inner `do-while` walks ip0..ip3
+    // with hash precomputation, repcode-at-ip2 probe, two explicit-
+    // match probes (at ip0 then at the shifted ip0), and a step-
+    // doubling cadence.
+    'restart: while ip0 < ilimit {
+        // _start: setup. ip0 already positioned; derive ip1/ip2/ip3
+        // from current step. If even ip3 is past ilimit, the loop
+        // can't make forward progress on this iteration — drain to
+        // the cleanup path below.
+        let mut ip1 = ip0 + 1;
+        let mut ip2 = ip0 + step;
+        let mut ip3 = ip2 + 1;
+        if ip3 > ilimit {
+            break;
         }
 
-        // Explicit-match probe.
-        if unsafe {
-            match_found(
-                base.add(ip0),
-                base,
+        // Hash precomputation for ip0 + ip1 (donor lines 261-262).
+        // SAFETY: ip0, ip1 < ilimit = iend - 8, so ≥ 8 readable
+        // bytes at each `base + ip*`. MLS ≤ 8 matches hash_ptr's
+        // contract.
+        let mut hash0 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
+        let mut hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip1)) };
+        let mut match_idx = unsafe { hash_table.get(hash0) };
+
+        // Inner do-while body. On any match, break out with the
+        // `MatchFound` enum carrying the match coordinates; the
+        // post-loop block handles backward/forward extension + emit.
+        enum MatchFound {
+            Rep {
+                new_ip: usize,
+                match0: usize,
+                m_len: usize,
+                // Donor's `current0` — position of the LAST hash
+                // writeback before the rep was found. For the
+                // rep-at-ip2 path that's the iter-start ip0 (the
+                // writeback at the top of the do-while body).
+                // Used post-emit to insert hash at `current0 + 2`
+                // (donor zstd_fast.c:407). Captured BEFORE the
+                // backward-extension decrement so it doesn't
+                // collapse onto new_ip for rep matches.
+                current0: usize,
+            },
+            Explicit {
+                new_ip: usize,
+                match_idx: u32,
+                // Same role as `current0` on the Rep variant: the
+                // position of the LAST writeback before the match.
+                // Path 1 (probe at iter-start ip0) → current0 == ip0;
+                // path 2 (probe at shifted ip0) → current0 == shifted
+                // ip0. Identical to new_ip for explicit since
+                // explicit emits don't decrement new_ip pre-emit.
+                current0: usize,
+            },
+        }
+        let found: Option<MatchFound> = loop {
+            // Repcode probe at ip2 (donor line 268). Load rval
+            // first so it stays consistent even if writeback below
+            // races. SAFETY: ip2 < ilimit ⇒ ≥ 4 readable bytes at
+            // ip2; ip2 ≥ rep_offset1 when rep_offset1 is non-zero
+            // because the save/restore prologue zeroed any
+            // rep_offset that exceeded the prefix-distance.
+            let rval = if rep_offset1 > 0 {
+                unsafe { read32(base.add(ip2 - rep_offset1 as usize)) }
+            } else {
+                // Sentinel — the equality check below can't pass
+                // when rep_offset1 == 0 anyway because the
+                // `rep_offset1 > 0` guard short-circuits.
+                0
+            };
+
+            // Writeback hash for ip0 (donor line 272). Donor writes
+            // BEFORE the rep probe so the hash table reflects ip0
+            // even if the iteration's match comes from rep at ip2.
+            // SAFETY: hash0 from hash_ptr ⇒ in-bounds; ip0 ≤ u32::MAX
+            // by the entry-point cap.
+            unsafe { hash_table.put(hash0, ip0 as u32) };
+
+            // Repcode-at-ip2 check.
+            if rep_offset1 > 0 && unsafe { read32(base.add(ip2)) } == rval {
+                // Repcode match. ip0 fast-forwards to ip2; backward-
+                // extend by 1 if the byte before ip2 also matches.
+                // Donor's `mLength = ip0[-1] == match0[-1]` is a
+                // single-byte extension with implicit `new_ip >
+                // anchor` AND `match > prefix` checks via the
+                // prologue's save/restore on rep_offset1.
+                let mut new_ip = ip2;
+                let mut match0 = new_ip - rep_offset1 as usize;
+                let mut m_len: usize = 4;
+                if new_ip > anchor
+                    && match0 > prefix_start_index as usize
+                    && data[new_ip - 1] == data[match0 - 1]
+                {
+                    new_ip -= 1;
+                    match0 -= 1;
+                    m_len += 1;
+                }
+                // Safe writeback for hash1 — ip1 is BEFORE ip2 (the
+                // match site), so its position won't conflict with
+                // the match's forward extension. Donor lines 286-287.
+                unsafe { hash_table.put(hash1, ip1 as u32) };
+                break Some(MatchFound::Rep {
+                    new_ip,
+                    match0,
+                    m_len,
+                    // Iter-start ip0 (the writeback at line 426
+                    // above) — donor's `current0` for this path.
+                    current0: ip0,
+                });
+            }
+
+            // First explicit-match probe at ip0 (donor line 292).
+            if unsafe {
+                match_found::<USE_CMOV>(
+                    base.add(ip0),
+                    base,
+                    match_idx,
+                    prefix_start_index,
+                    ip0,
+                    iend_addr,
+                )
+            } {
+                // Safe writeback for hash1 (ip1 = ip0 + 1, before
+                // search resumption). Donor line 296.
+                unsafe { hash_table.put(hash1, ip1 as u32) };
+                break Some(MatchFound::Explicit {
+                    new_ip: ip0,
+                    match_idx,
+                    current0: ip0,
+                });
+            }
+
+            // Shift: ip0 ← ip1, ip1 ← ip2, ip2 ← ip3. hash0 ← hash1
+            // (precomputed last iteration). hash1 is recomputed from
+            // the CURRENT ip2 (before the cursor shift below), which
+            // becomes the new ip1 — so post-shift `hash1` matches
+            // the new `ip1`, NOT the new `ip2`.
+            match_idx = unsafe { hash_table.get(hash1) };
+            hash0 = hash1;
+            hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip2)) };
+            ip0 = ip1;
+            ip1 = ip2;
+            ip2 = ip3;
+
+            // Writeback for new ip0. Donor lines 314-315.
+            unsafe { hash_table.put(hash0, ip0 as u32) };
+
+            // Second explicit-match probe at the shifted ip0
+            // (donor line 317).
+            if unsafe {
+                match_found::<USE_CMOV>(
+                    base.add(ip0),
+                    base,
+                    match_idx,
+                    prefix_start_index,
+                    ip0,
+                    iend_addr,
+                )
+            } {
+                // Conditional writeback: only safe if `step <= 4`
+                // (donor lines 319-324) — otherwise ip1 might fall
+                // past the match start when we resume scanning.
+                if step <= 4 {
+                    unsafe { hash_table.put(hash1, ip1 as u32) };
+                }
+                break Some(MatchFound::Explicit {
+                    new_ip: ip0,
+                    match_idx,
+                    // After the shift + writeback at line 488,
+                    // current0 == shifted ip0.
+                    current0: ip0,
+                });
+            }
+
+            // Shift again with the larger `step` gap. The second
+            // shift is the one that advances ip2/ip3 by `step`
+            // rather than by 1; this is where the step-skip kicks
+            // in. Donor lines 329-339.
+            match_idx = unsafe { hash_table.get(hash1) };
+            hash0 = hash1;
+            hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip2)) };
+            ip0 = ip1;
+            ip1 = ip2;
+            ip2 = ip0 + step;
+            ip3 = ip1 + step;
+
+            // Step-doubling: donor lines 342-347. Drives the
+            // kSearchStrength-based acceleration on incompressible
+            // regions.
+            if ip2 >= next_step {
+                step += 1;
+                next_step += K_STEP_INCR;
+            }
+
+            // do-while termination: if ip3 walks past ilimit, drain.
+            if ip3 > ilimit {
+                break None;
+            }
+        };
+
+        // _cleanup path: drain to the post-loop save/restore.
+        let Some(found) = found else {
+            break 'restart;
+        };
+
+        // _offset / _match — backward + forward extension + emit.
+        // Donor's `current0` = position of the LAST hash writeback
+        // before the match was found. Captured at break-time on
+        // each MatchFound variant so the Rep path's backward
+        // extension doesn't collapse `current0` onto the post-
+        // backward `new_ip` (donor zstd_fast.c:407 uses the
+        // pre-backward iter-start position).
+        let current0 = match found {
+            MatchFound::Rep { current0, .. } => current0,
+            MatchFound::Explicit { current0, .. } => current0,
+        };
+        let (mut match_ip, mut match_pos, mut m_len, offset, is_rep) = match found {
+            MatchFound::Rep {
+                new_ip,
+                match0,
+                m_len,
+                current0: _,
+            } => (new_ip, match0, m_len, rep_offset1 as usize, true),
+            MatchFound::Explicit {
+                new_ip,
                 match_idx,
-                prefix_start_index,
-                ip0,
-                iend_addr,
-            )
-        } {
-            // Found a 4-byte match. Backward-extend while the byte
-            // before each side also matches (donor's `while (ip0 >
-            // anchor) & (match0 > prefixStart)` loop).
-            let mut match_ip = ip0;
-            let mut match_pos = match_idx as usize;
-            let mut m_len: usize = 4;
+                current0: _,
+            } => {
+                let match_pos = match_idx as usize;
+                let offset = new_ip - match_pos;
+                // Rotate the rep stack ahead of backward extension
+                // — donor stores the offset BEFORE the backward
+                // walk (lines 381-383). This way the explicit-match
+                // path's backward extension is bounded by the
+                // anchor + prefix_start_index pair; subsequent
+                // iterations get a tighter rep_offset1.
+                rep_offset2 = rep_offset1;
+                rep_offset1 = offset as u32;
+                (new_ip, match_pos, 4usize, offset, false)
+            }
+        };
+
+        // Backward extension — only for explicit matches; rep path
+        // already handled the 1-byte backward step above.
+        if !is_rep {
             while match_ip > anchor
                 && match_pos > prefix_start_index as usize
                 && data[match_ip - 1] == data[match_pos - 1]
@@ -479,44 +622,101 @@ pub(crate) fn compress_block_fast<const MLS: u32>(
                 match_pos -= 1;
                 m_len += 1;
             }
-            // Forward extension.
-            // SAFETY: both pointers stay within `data`, and iend
-            // pointer is `data.as_ptr() + data.len()`.
-            let forward = unsafe {
-                count_forward(
-                    base.add(match_ip + m_len),
-                    base.add(match_pos + m_len),
-                    base.add(iend_addr),
-                )
-            };
-            m_len += forward;
-
-            let offset = match_ip - match_pos;
-            // Update repcode history with the new explicit offset.
-            rep_offset2 = rep_offset1;
-            rep_offset1 = offset as u32;
-
-            let literals = &data[anchor..match_ip];
-            handle_sequence(Sequence::Triple {
-                literals,
-                offset,
-                match_len: m_len,
-            });
-
-            ip0 = match_ip + m_len;
-            anchor = ip0;
-            step = 2;
-            next_step_threshold = ip0 + (1usize << (SEARCH_STRENGTH - 1));
-            continue;
         }
 
-        // No match — advance by `step` and bump step every
-        // `kStepIncr` bytes (donor's `if (ip2 >= nextStep) step++`).
-        ip0 += step;
-        if ip0 >= next_step_threshold {
-            step += 1;
-            next_step_threshold += 1usize << (SEARCH_STRENGTH - 1);
+        // Forward extension via ZSTD_count.
+        // SAFETY: both pointers stay within `data`; iend pointer
+        // arithmetic stays in bounds.
+        let forward = unsafe {
+            count_forward(
+                base.add(match_ip + m_len),
+                base.add(match_pos + m_len),
+                base.add(iend_addr),
+            )
+        };
+        m_len += forward;
+
+        // Emit.
+        let literals = &data[anchor..match_ip];
+        handle_sequence(Sequence::Triple {
+            literals,
+            offset,
+            match_len: m_len,
+        });
+
+        ip0 = match_ip + m_len;
+        anchor = ip0;
+
+        // Immediate-rep2 inner loop (donor lines 404-420). After a
+        // match emit, donor (a) refills the hash for `ip0 - 2` to
+        // give the next scan a head start, (b) probes for repcode-2
+        // matches at the new ip0 — if found, emit them as lit_len=0
+        // rep1 sequences (with rep stack swap) until exhausted.
+        if ip0 <= ilimit {
+            // Donor inserts TWO hashes after a match emit
+            // (zstd_fast.c:407-408): one at `current0 + 2` (2 bytes
+            // past the trigger-ip position, filling a slot inside
+            // the now-consumed match), one at `ip0 - 2` (2 bytes
+            // before the next scan start). Both are vital — missing
+            // either makes the hash table sparser than donor's and
+            // costs subsequent matches.
+            //
+            // SAFETY: each `base.add(N - 2)` covers ≥ 8 readable
+            // bytes when N - 2 ≤ ilimit (ilimit = iend - 8).
+            let current0_plus_2 = current0 + 2;
+            if current0_plus_2 + HASH_READ_SIZE <= iend_addr {
+                let h_fwd = unsafe { hash_table.hash_ptr::<MLS>(base.add(current0_plus_2)) };
+                unsafe { hash_table.put(h_fwd, current0_plus_2 as u32) };
+            }
+            if ip0 >= 2 {
+                let h_back = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0 - 2)) };
+                unsafe { hash_table.put(h_back, (ip0 - 2) as u32) };
+            }
+
+            // Repcode-2 inner loop. Donor swaps rep1 / rep2 on each
+            // hit so the just-found offset becomes the new rep1.
+            while rep_offset2 > 0
+                && ip0 <= ilimit
+                && ip0 >= rep_offset2 as usize
+                && unsafe { read32(base.add(ip0)) == read32(base.add(ip0 - rep_offset2 as usize)) }
+            {
+                // 4-byte match guaranteed by the equality probe.
+                // Extend forward via count_forward starting at
+                // ip0 + 4.
+                let r_off = rep_offset2 as usize;
+                let r_extra = unsafe {
+                    count_forward(
+                        base.add(ip0 + 4),
+                        base.add(ip0 + 4 - r_off),
+                        base.add(iend_addr),
+                    )
+                };
+                let r_len = 4 + r_extra;
+
+                // Swap rep1 / rep2 (donor line 414).
+                core::mem::swap(&mut rep_offset1, &mut rep_offset2);
+
+                // Hash refill at ip0 (donor line 415).
+                let h_at = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
+                unsafe { hash_table.put(h_at, ip0 as u32) };
+
+                // Emit lit_len=0 rep1 sequence.
+                handle_sequence(Sequence::Triple {
+                    literals: &data[anchor..ip0],
+                    offset: r_off,
+                    match_len: r_len,
+                });
+
+                ip0 += r_len;
+                anchor = ip0;
+            }
         }
+
+        // `goto _start` — restart the outer loop with fresh step
+        // (reset to the level-resolved initial step_size).
+        step = step_size;
+        next_step = ip0 + K_STEP_INCR;
+        continue 'restart;
     }
 
     // Repcode save/restore: if `rep_offset1` came in invalid
@@ -580,8 +780,8 @@ mod tests {
             }
         };
         let result = match mls {
-            4 => compress_block_fast::<4>(data, 0, 0, &mut table, [0, 0], &mut handle),
-            5 => compress_block_fast::<5>(data, 0, 0, &mut table, [0, 0], &mut handle),
+            4 => compress_block_fast::<4, false>(data, 0, 0, &mut table, [0, 0], 2, &mut handle),
+            5 => compress_block_fast::<5, false>(data, 0, 0, &mut table, [0, 0], 2, &mut handle),
             _ => panic!("test helper only supports mls=4 and mls=5"),
         };
         // Accounting invariant: literals + matches + tail == input.
@@ -661,7 +861,7 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let result = compress_block_fast::<4>(data, 0, 0, &mut table, rep, &mut handle);
+        let result = compress_block_fast::<4, false>(data, 0, 0, &mut table, rep, 2, &mut handle);
         let acct: usize = tuples
             .iter()
             .map(|(lits, _off, mlen)| lits.len() + mlen)
@@ -715,29 +915,49 @@ mod tests {
     /// because `data[ip0 - 1] == data[match_pos - 1] == 'X'`.
     #[test]
     fn explicit_match_backward_extension_extends_by_marker_byte() {
-        let mut data = Vec::new();
-        data.extend_from_slice(b"XAAAA"); // 0..5, the seed copy
-        data.extend_from_slice(b"_____"); // 5..10, distinct filler
-        data.extend_from_slice(b"XAAAA"); // 10..15, the repeating copy
-        data.extend_from_slice(b"________"); // 15..23, HASH_READ_SIZE pad
+        // Engineered so the FIRST emitted match deterministically
+        // backward-extends through a marker byte:
+        //
+        //   [0..15]   distinct prefix (no 'Z', no 'A') → table
+        //             writebacks here can't byte-match later AAAA
+        //   [15]      'Z' marker (first copy)
+        //   [16..24]  'AAAAAAAA' (first AAAA copy — table[hash("AAAA")]
+        //             gets written = 16 when ip0 reaches here)
+        //   [24..32]  distinct filler (no 'Z', no 'A')
+        //   [32]      'Z' marker (second copy)
+        //   [33..41]  'AAAAAAAA' (second AAAA copy — kernel matches
+        //             this against index 16; backward extension
+        //             walks back because data[32]='Z'==data[15]='Z')
+        //   [41..]    HASH_READ_SIZE tail
+        let mut data: Vec<u8> = (0..15u8).collect();
+        data.push(b'Z');
+        data.extend_from_slice(b"AAAAAAAA");
+        for i in 0..8u8 {
+            data.push(0x80 + i);
+        }
+        data.push(b'Z');
+        data.extend_from_slice(b"AAAAAAAA");
+        for i in 0..16u8 {
+            data.push(0x40 + (i % 16));
+        }
         let (tuples, _) = run_block_with_rep(&data, 12, [0, 0]);
         let triple = tuples
             .iter()
             .find(|(_, _, m)| *m > 0)
             .unwrap_or_else(|| panic!("expected an explicit-match Triple, got {tuples:?}"));
-        // Backward extension must lift the match length above the
-        // bare MIN_MATCH=4: at least 5 bytes ("XAAAA").
+        // Backward extension must lift match_len above MIN_MATCH=4 —
+        // the 'Z' marker at position 32 (matching the 'Z' at 15) is
+        // absorbed by the backward walk.
         assert!(
             triple.2 >= 5,
-            "backward extension must lift match_len above MIN_MATCH (got {})",
+            "expected match_len ≥ 5 from backward extension (got {})",
             triple.2,
         );
-        // The literals before this match must NOT include the 'X' at
-        // position 10 — backward extension consumed it as part of the
-        // match.
+        // Literals before the emit must NOT end with 'Z' — backward
+        // extension consumed the marker.
         assert!(
-            !triple.0.ends_with(b"X"),
-            "backward extension must absorb the 'X' marker byte (literals: {:?})",
+            !triple.0.ends_with(b"Z"),
+            "backward extension must consume the 'Z' marker (literals = {:?})",
             triple.0,
         );
     }
@@ -772,7 +992,7 @@ mod tests {
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
         // prefix_start_index=5 blocks index 0.
-        let _ = compress_block_fast::<4>(&data, 0, 5, &mut table, [0, 0], &mut handle);
+        let _ = compress_block_fast::<4, false>(&data, 0, 5, &mut table, [0, 0], 2, &mut handle);
 
         // Walk emitted sequences in order, tracking the running
         // `anchor` cursor (which equals the start of the current
@@ -787,10 +1007,11 @@ mod tests {
         let mut anchor: usize = 0;
         for (lits, off, m) in &tuples {
             if *m > 0 {
-                assert_ne!(
-                    *off, 1,
-                    "stale entry at index 0 must be filtered out by prefix_start_index=5",
-                );
+                // The real correctness check is `match_src >=
+                // prefix_start_index` below — the `offset != 1`
+                // form is too cadence-specific (4-cursor body's
+                // double writeback per iter can land an offset=1
+                // emit whose SOURCE is still ≥ prefix_start_index).
                 let match_start = anchor + lits.len();
                 let match_src = match_start
                     .checked_sub(*off)
@@ -842,7 +1063,7 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let _ = compress_block_fast::<4>(&data, 0, 0, &mut table, [0, 0], &mut handle);
+        let _ = compress_block_fast::<4, false>(&data, 0, 0, &mut table, [0, 0], 2, &mut handle);
 
         for (_, off, m) in &tuples {
             if *m > 0 {
@@ -916,7 +1137,8 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let result = compress_block_fast::<4>(&data, 0, 0, &mut table, [huge, 7], &mut handle);
+        let result =
+            compress_block_fast::<4, false>(&data, 0, 0, &mut table, [huge, 7], 2, &mut handle);
         assert_eq!(
             result.rep[0], huge,
             "out-of-range rep_offset1 must be restored verbatim across the block",
@@ -925,5 +1147,101 @@ mod tests {
         // Donor restores it through offset_saved2; the in-range
         // restoration path is the second witness.
         assert_eq!(result.rep[1], 7, "rep_offset2 (also stashed) must restore");
+    }
+
+    /// cmov variant: same correctness contract as branch variant —
+    /// produces identical output for the same input, just lowers
+    /// match_idx >= prefix_start_index to a cmov instead of a
+    /// branch. Run a known-good fixture through both and assert
+    /// byte-for-byte equality of the emitted Triple stream.
+    #[test]
+    fn cmov_variant_matches_branch_variant_output() {
+        let mut data = alloc::vec::Vec::new();
+        for i in 0..512u32 {
+            data.push((i & 0xFF) as u8);
+        }
+        // Repeat the first 64 bytes near the end so the kernel
+        // emits at least one explicit match Triple.
+        let tail = data[0..64].to_vec();
+        data.extend_from_slice(&tail);
+
+        let collect = |use_cmov: bool| -> alloc::vec::Vec<(alloc::vec::Vec<u8>, usize, usize)> {
+            let mut table = FastHashTable::new(12, 4);
+            let mut tuples = alloc::vec::Vec::new();
+            let mut handle = |seq: Sequence<'_>| match seq {
+                Sequence::Triple {
+                    literals,
+                    offset,
+                    match_len,
+                } => {
+                    tuples.push((literals.to_vec(), offset, match_len));
+                }
+                Sequence::Literals { literals } => {
+                    tuples.push((literals.to_vec(), 0, 0));
+                }
+            };
+            if use_cmov {
+                let _ =
+                    compress_block_fast::<4, true>(&data, 0, 0, &mut table, [0, 0], 2, &mut handle);
+            } else {
+                let _ = compress_block_fast::<4, false>(
+                    &data,
+                    0,
+                    0,
+                    &mut table,
+                    [0, 0],
+                    2,
+                    &mut handle,
+                );
+            }
+            tuples
+        };
+
+        let out_branch = collect(false);
+        let out_cmov = collect(true);
+        assert_eq!(
+            out_branch, out_cmov,
+            "cmov and branch variants must emit identical sequences"
+        );
+    }
+
+    /// Regression test for Copilot review thread on PR #219 — cmov
+    /// variant must NOT report a match when `match_idx <
+    /// prefix_start_index` even if the 4 bytes at `ip` happen to
+    /// equal `CMOV_DUMMY`. Without the explicit `in_range`
+    /// predicate the cmov path returns `true` here, producing an
+    /// out-of-window match the kernel would then encode with a
+    /// bogus offset.
+    #[test]
+    fn cmov_variant_rejects_out_of_window_when_ip_equals_dummy() {
+        // Layout (32 bytes total):
+        //   data[0..4]  = filler (not CMOV_DUMMY, won't accidentally match)
+        //   data[4..]   = CMOV_DUMMY bytes at position 16, so read32(ip)
+        //                 at ip_pos=16 equals read32(CMOV_DUMMY).
+        //
+        // match_idx=4 is below prefix_start=10 (out of window).
+        // ip_pos=16 satisfies `ip == base.add(ip_pos)`.
+        let mut data: alloc::vec::Vec<u8> = alloc::vec![0xAA; 32];
+        data[16] = 0x12;
+        data[17] = 0x34;
+        data[18] = 0x56;
+        data[19] = 0x78;
+        // SAFETY (test fixture): ip = base + 16; both buffers cover
+        // ≥ 4 readable bytes (data.len()=32 ≥ 16+4 and CMOV_DUMMY is
+        // 4 bytes by construction).
+        let base = data.as_ptr();
+        let ip_pos = 16usize;
+        let ip = unsafe { base.add(ip_pos) };
+        let branch_result = unsafe { match_found::<false>(ip, base, 4, 10, ip_pos, data.len()) };
+        assert!(
+            !branch_result,
+            "branch variant must reject out-of-window match_idx"
+        );
+        let cmov_result = unsafe { match_found::<true>(ip, base, 4, 10, ip_pos, data.len()) };
+        assert!(
+            !cmov_result,
+            "cmov variant must reject out-of-window match_idx even when \
+             ip bytes coincide with CMOV_DUMMY",
+        );
     }
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -253,10 +253,13 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     // Donor's `stepSize = targetLength + !(targetLength) + 1`
     // (min 2). Callers must pass >= 2; values larger than 2 drive
     // the kernel's acceleration gradient on negative levels.
-    // `with_params` / `reset` already enforce this on the matcher
-    // side, so a debug-only check is sufficient here — the release
-    // hot path skips the branch and the formatting machinery.
-    debug_assert!(
+    // Validated in release builds too: `compress_block_fast` is a
+    // safe `pub(crate)` boundary, so any direct caller bypassing
+    // `FastKernelMatcher::with_params` / `reset` must not silently
+    // mis-iterate the loop cadence on a mis-typed step. The
+    // once-per-block branch is negligible relative to the per-block
+    // hash/probe work that follows.
+    assert!(
         step_size >= 2,
         "Fast kernel requires step_size >= 2 (got {step_size}); \
          the donor formula clamps to a min of 2",

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -253,7 +253,10 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     // Donor's `stepSize = targetLength + !(targetLength) + 1`
     // (min 2). Callers must pass >= 2; values larger than 2 drive
     // the kernel's acceleration gradient on negative levels.
-    assert!(
+    // `with_params` / `reset` already enforce this on the matcher
+    // side, so a debug-only check is sufficient here — the release
+    // hot path skips the branch and the formatting machinery.
+    debug_assert!(
         step_size >= 2,
         "Fast kernel requires step_size >= 2 (got {step_size}); \
          the donor formula clamps to a min of 2",

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -80,7 +80,13 @@ unsafe fn match_found<const USE_CMOV: bool>(
     // stay as explicit branches — these protect against stale entries
     // pointing past the buffer end and forward-pointing matches.
     let match_pos = match_idx as usize;
-    if match_pos + 4 > data_len {
+    // `match_pos + 4` would wrap on 32-bit targets when `match_idx`
+    // approaches `u32::MAX`, allowing an OOB `read32` through.
+    // `checked_add` keeps the unsafe read fully guarded: `None` means
+    // overflow → reject; `Some(end)` mirrors the original predicate
+    // (`end > data_len` rejects). On 64-bit the optimizer collapses
+    // this to the same codegen as the previous form.
+    if match_pos.checked_add(4).is_none_or(|end| end > data_len) {
         return false;
     }
     if match_pos >= ip_pos {

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -366,10 +366,16 @@ impl FastKernelMatcher {
     /// driver-side `get_last_space` peek at the still-pending buffer
     /// without committing it to the matcher's hot path.
     ///
-    /// History budget is enforced lazily on the actual append (inside
-    /// [`Self::extend_history_with_pending`]) — checking it here
-    /// would force the eviction work even when the driver follows up
-    /// with `skip_matching` on incompressible data.
+    /// History budget is enforced EAGERLY in this function (not lazily
+    /// inside [`Self::extend_history_with_pending`]) so the driver's
+    /// `commit_space` can observe the eviction delta via a pre/post
+    /// `history.len()` comparison. That delta feeds
+    /// `retire_dictionary_budget`, which shrinks `max_window_size`
+    /// back to the frame's contracted window after dictionary priming
+    /// inflated it. Without commit-time visibility the dict-budget
+    /// retire never runs and the matcher can emit offsets exceeding
+    /// the frame header's reported window size (format-correctness
+    /// risk).
     pub(crate) fn accept_data(&mut self, space: Vec<u8>) {
         assert!(
             self.pending.is_none(),
@@ -444,17 +450,23 @@ impl FastKernelMatcher {
     /// 3. Clear the hash table — entries hold pre-drain absolute
     ///    positions that no longer reference live bytes.
     /// 4. `saturating_sub` `last_block_start` by `drop_n`.
-    /// 5. Rehash retained tail starting at position 0 so block N+1
-    ///    can find matches against the kept bytes (without this
-    ///    they'd be "dead history" — visible in the Vec but
-    ///    unlookupable).
+    /// 5. Rehash retained tail starting at the sentinel-0 floor
+    ///    ([`INITIAL_PREFIX_START_INDEX`] = 1) so block N+1 can find
+    ///    matches against the kept bytes (without this they'd be
+    ///    "dead history" — visible in the Vec but unlookupable).
+    ///    Starting from index 1 instead of 0 avoids hashing a position
+    ///    that the kernel's `match_idx >= prefix_start_index` filter
+    ///    would reject anyway.
     fn drain_real_prefix(&mut self, drop_n: usize) {
         let drain_end = HISTORY_DRAIN_BASE + drop_n;
         self.history.drain(HISTORY_DRAIN_BASE..drain_end);
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
         self.hash_table.clear();
         self.last_block_start = self.last_block_start.saturating_sub(drop_n);
-        self.prime_hash_table_for_range(HISTORY_DRAIN_BASE);
+        // Skip position 0 — `prefix_start_index = 1` means the kernel
+        // rejects any match resolving to index 0, so populating that
+        // slot would just pollute the table with an unreachable entry.
+        self.prime_hash_table_for_range(INITIAL_PREFIX_START_INDEX as usize);
     }
 
     /// Internal: drain `self.pending` into `self.history`, applying

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -318,7 +318,7 @@ impl FastKernelMatcher {
     /// assert the matcher's own internal record matches.
     #[cfg(test)]
     pub(crate) fn window_size(&self) -> u64 {
-        self.max_window_size as u64
+        1u64 << self.window_log
     }
 
     /// Read-only view of the most recently committed block — donor /

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -238,8 +238,9 @@ impl FastKernelMatcher {
 
     /// Explicit-parameter constructor used by the wiring commit when
     /// the level resolution produced a non-default `(window_log,
-    /// hash_log, mls)` triple (typically because a small source-size
-    /// hint clamped the window). Tests can also call this directly.
+    /// hash_log, mls, step_size)` tuple (typically because a small
+    /// source-size hint clamped the window). Tests can also call this
+    /// directly.
     pub(crate) fn with_params(window_log: u8, hash_log: u32, mls: u32, step_size: usize) -> Self {
         assert!(
             step_size >= 2,

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1031,8 +1031,7 @@ mod tests {
         assert_eq!(
             m.history.len(),
             payload.len() + HISTORY_DRAIN_BASE,
-            "skip_matching must append the pending buffer to history \
-             (above the HISTORY_DRAIN_BASE dummy)",
+            "skip_matching must append the pending buffer to history",
         );
         assert_eq!(m.rep, pre_rep, "skip must not touch rep state");
         assert_eq!(
@@ -1240,8 +1239,8 @@ mod tests {
         );
         assert!(
             m.history.len() <= m.max_window_size + 200 + HISTORY_DRAIN_BASE,
-            "post-append history = RESERVED dummy + retained prefix \
-             (≤ max_window_size) + last block (200 bytes); got {}",
+            "post-append history = retained prefix (≤ max_window_size) \
+             + last block (200 bytes); got {}",
             m.history.len(),
         );
         // Post-fix: drain RESETS prefix_start_index back to 1 (the
@@ -1263,10 +1262,10 @@ mod tests {
     #[test]
     fn skip_matching_dict_prime_handles_exactly_hash_read_size_bytes() {
         let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
-        // 8-byte real payload appends above the RESERVED dummy →
-        // history.len() = 8 + HISTORY_DRAIN_BASE, last_hashable =
-        // HISTORY_DRAIN_BASE, hashed range = [RESERVED..=RESERVED]
-        // (one position).
+        // 8-byte real payload appended to history → history.len() =
+        // 8 + HISTORY_DRAIN_BASE (= 8 under M8), last_hashable =
+        // HISTORY_DRAIN_BASE (= 0), hashed range = [0..=0] (one
+        // position).
         let payload: alloc::vec::Vec<u8> = (0..8u8).collect();
         m.accept_data(payload);
         m.skip_matching_with_hint(Some(false));
@@ -1421,9 +1420,9 @@ mod tests {
         // Third commit: real history (400) + new space (200) = 600 > 512.
         // Eviction MUST fire inside accept_data, dropping history
         // back to max_window_size (256) BEFORE the kernel runs.
-        // `history_len_for_eviction_accounting` returns REAL data
-        // length (excluding the RESERVED dummy), so pre/post compare
-        // cleanly in real-byte units.
+        // `history_len_for_eviction_accounting` returns the real-data
+        // length (history.len() minus HISTORY_DRAIN_BASE, which is 0
+        // under M8), so pre/post compare cleanly in real-byte units.
         let pre = m.history_len_for_eviction_accounting();
         m.accept_data((0..200u8).map(|i| i.wrapping_add(100)).collect());
         let post = m.history_len_for_eviction_accounting();

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -84,19 +84,17 @@ pub(crate) const FAST_INITIAL_REP: [u32; 2] = [1, 4];
 /// start and mirrors the value the old [`super::MatchGenerator`] used.
 pub(crate) const FAST_INITIAL_OFFSET_HIST: [u32; 3] = [1, 4, 8];
 
-/// Drain start offset used by eviction / drain paths. NOT a
-/// reserved-bytes count — set to 0 (M8): `history` holds real
-/// input bytes from position 0 onward, donor-parity layout, no
-/// dummy region. Sentinel-0 protection (hash table's empty-slot
-/// value `0` would otherwise be indistinguishable from a real
-/// match at position 0) is provided by
-/// [`INITIAL_PREFIX_START_INDEX`] = 1 via the kernel's
+/// Drain start offset used by eviction / drain paths. Set to 0:
+/// `history` holds real input bytes from position 0 onward,
+/// donor-parity layout, no dummy region. Sentinel-0 protection
+/// (hash table's empty-slot value `0` would otherwise be
+/// indistinguishable from a real match at position 0) is provided
+/// by [`INITIAL_PREFIX_START_INDEX`] = 1 via the kernel's
 /// `match_idx >= prefix_start_index` filter.
 ///
 /// Kept as a named constant so the drain math reads consistently
-/// against future changes; the name is legacy from the pre-M8
-/// "dummy-byte" layout.
-pub(crate) const RESERVED_PREFIX_BYTES: usize = 0;
+/// against future changes.
+pub(crate) const HISTORY_DRAIN_BASE: usize = 0;
 
 /// Donor's `prefixStartIndex` floor on fresh frames. Set to 1 (not 0)
 /// so the kernel's `match_idx >= prefix_start_index` filter rejects
@@ -116,7 +114,7 @@ const INITIAL_PREFIX_START_INDEX: u32 = 1;
 ///   current block live in this single contiguous buffer; the kernel's
 ///   `block_start` parameter separates the two.
 /// - `prefix_start_index` is donor's `prefixStartIndex` — the lowest
-///   position any match may reference. Pinned to `RESERVED_PREFIX_BYTES`
+///   position any match may reference. Pinned to `HISTORY_DRAIN_BASE`
 ///   at construction and after every drain (drain re-indexes the
 ///   retained tail).
 /// - `rep` carries the two-deep repcode state across blocks.
@@ -246,13 +244,13 @@ impl FastKernelMatcher {
             step_size >= 2,
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
         );
-        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
+        // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
         // Sentinel-0 protection comes from prefix_start_index =
         // INITIAL_PREFIX_START_INDEX = 1, which filters hash table
         // lookups returning the empty-slot value 0.
-        let history = alloc::vec![0u8; RESERVED_PREFIX_BYTES];
+        let history = alloc::vec![0u8; HISTORY_DRAIN_BASE];
         Self {
-            last_block_start: RESERVED_PREFIX_BYTES,
+            last_block_start: HISTORY_DRAIN_BASE,
             recycled_space: None,
             history,
             // Filter `match_idx >= prefix_start_index` rejects the
@@ -292,9 +290,9 @@ impl FastKernelMatcher {
             // `memset` (donor's `ZSTD_window_clear` cadence).
             self.hash_table.clear();
         }
-        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
+        // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
         self.history.clear();
-        self.history.resize(RESERVED_PREFIX_BYTES, 0);
+        self.history.resize(HISTORY_DRAIN_BASE, 0);
         // Sentinel-0 protection via prefix_start_index >= 1 filter
         // — see `with_params` for the full rationale.
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
@@ -305,7 +303,7 @@ impl FastKernelMatcher {
         self.step_size = step_size;
         self.max_window_size = 1usize << window_log;
         self.pending = None;
-        self.last_block_start = RESERVED_PREFIX_BYTES;
+        self.last_block_start = HISTORY_DRAIN_BASE;
         self.recycled_space = None;
     }
 
@@ -326,7 +324,7 @@ impl FastKernelMatcher {
     ///
     /// Three states:
     /// - Pre-`accept_data`: empty slice (the
-    ///   `RESERVED_PREFIX_BYTES`-seeded dummy means
+    ///   `HISTORY_DRAIN_BASE`-seeded dummy means
     ///   `history[last_block_start..]` is empty).
     /// - Between `accept_data` and processing: the pending buffer.
     /// - Post-processing: `history` slice of the just-processed
@@ -371,7 +369,7 @@ impl FastKernelMatcher {
         // reported window size (format-correctness risk).
         // Eviction operates on REAL data length (excluding the
         // no dummy at the head of history post-M8).
-        let real_len = self.history.len().saturating_sub(RESERVED_PREFIX_BYTES);
+        let real_len = self.history.len().saturating_sub(HISTORY_DRAIN_BASE);
         let new_real_total = real_len.saturating_add(space.len());
         let cap = self.max_window_size.saturating_mul(2);
         // Hard precondition: caller must split blocks into pieces no
@@ -429,12 +427,12 @@ impl FastKernelMatcher {
     ///    they'd be "dead history" — visible in the Vec but
     ///    unlookupable).
     fn drain_real_prefix(&mut self, drop_n: usize) {
-        let drain_end = RESERVED_PREFIX_BYTES + drop_n;
-        self.history.drain(RESERVED_PREFIX_BYTES..drain_end);
+        let drain_end = HISTORY_DRAIN_BASE + drop_n;
+        self.history.drain(HISTORY_DRAIN_BASE..drain_end);
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
         self.hash_table.clear();
         self.last_block_start = self.last_block_start.saturating_sub(drop_n);
-        self.prime_hash_table_for_range(RESERVED_PREFIX_BYTES);
+        self.prime_hash_table_for_range(HISTORY_DRAIN_BASE);
     }
 
     /// Internal: drain `self.pending` into `self.history`, applying
@@ -762,23 +760,23 @@ impl FastKernelMatcher {
     }
 
     /// Read-only view of REAL data length (excluding the
-    /// `RESERVED_PREFIX_BYTES` dummy at history's head) for the
+    /// `HISTORY_DRAIN_BASE` dummy at history's head) for the
     /// driver's eviction accounting (`commit_space` →
     /// `retire_dictionary_budget` flow). The driver compares
     /// pre/post values to derive a byte-delta. Returning REAL
     /// length keeps the delta meaningful (drain-of-N-real-bytes
     /// shows up as a clean N drop, not N±constant).
     pub(crate) fn history_len_for_eviction_accounting(&self) -> usize {
-        self.history.len().saturating_sub(RESERVED_PREFIX_BYTES)
+        self.history.len().saturating_sub(HISTORY_DRAIN_BASE)
     }
 
     /// Drop history bytes past `max_window_size` via
     /// [`Self::drain_real_prefix`] (rebases `prefix_start_index` to
-    /// `RESERVED_PREFIX_BYTES`, clears + rehashes the table).
+    /// `HISTORY_DRAIN_BASE`, clears + rehashes the table).
     /// Returns evicted byte count; idempotent when `real_len <=
     /// max_window_size`.
     pub(crate) fn trim_to_window(&mut self) -> usize {
-        let real_len = self.history.len().saturating_sub(RESERVED_PREFIX_BYTES);
+        let real_len = self.history.len().saturating_sub(HISTORY_DRAIN_BASE);
         if real_len <= self.max_window_size {
             return 0;
         }
@@ -858,11 +856,11 @@ mod tests {
         assert_eq!(m.rep, FAST_INITIAL_REP);
         assert_eq!(m.offset_hist, FAST_INITIAL_OFFSET_HIST);
         assert_eq!(m.max_window_size, 1usize << FAST_LEVEL_1_WINDOW_LOG);
-        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
+        // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
         // First input byte will live at position 0; sentinel-0
         // protection comes from the prefix filter, not from a
         // dummy region.
-        assert_eq!(m.history.len(), RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), HISTORY_DRAIN_BASE);
         // prefix_start_index = 1 makes position 0 unmatchable so
         // the hash table's empty-slot value 0 can't be confused
         // with a real match.
@@ -919,9 +917,9 @@ mod tests {
             2,
         );
 
-        // Post-reset: history empty (RESERVED_PREFIX_BYTES=0; no
+        // Post-reset: history empty (HISTORY_DRAIN_BASE=0; no
         // dummy only; prefix_start_index pinned to that baseline.
-        assert_eq!(m.history.len(), RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), HISTORY_DRAIN_BASE);
         assert_eq!(m.prefix_start_index, INITIAL_PREFIX_START_INDEX);
         assert_eq!(m.rep, FAST_INITIAL_REP);
         assert_eq!(m.offset_hist, FAST_INITIAL_OFFSET_HIST);
@@ -1002,7 +1000,7 @@ mod tests {
         assert!(m.pending.is_none());
         // History grew by exactly the block size (plus the
         // no dummy carried since construction — M8).
-        assert_eq!(m.history.len(), data.len() + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), data.len() + HISTORY_DRAIN_BASE);
         // `last_committed_space` post-processing reads from
         // history[last_block_start..] (donor / legacy MatchGenerator
         // parity for the frame compressor's raw-block emission
@@ -1029,9 +1027,9 @@ mod tests {
 
         assert_eq!(
             m.history.len(),
-            payload.len() + RESERVED_PREFIX_BYTES,
+            payload.len() + HISTORY_DRAIN_BASE,
             "skip_matching must append the pending buffer to history \
-             (above the RESERVED_PREFIX_BYTES dummy)",
+             (above the HISTORY_DRAIN_BASE dummy)",
         );
         assert_eq!(m.rep, pre_rep, "skip must not touch rep state");
         assert_eq!(
@@ -1107,7 +1105,7 @@ mod tests {
         );
         assert_eq!(
             m.history.len(),
-            block1.len() + block2.len() + RESERVED_PREFIX_BYTES,
+            block1.len() + block2.len() + HISTORY_DRAIN_BASE,
             "history must hold both blocks after two start_matching calls",
         );
     }
@@ -1134,7 +1132,7 @@ mod tests {
         m.skip_matching_with_hint(Some(false)); // dictionary-priming skip
 
         // Sanity: history grew, prefix_start_index unchanged.
-        assert_eq!(m.history.len(), dict_block.len() + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), dict_block.len() + HISTORY_DRAIN_BASE);
         assert_eq!(m.prefix_start_index, INITIAL_PREFIX_START_INDEX);
 
         // Block 2: 16 fresh bytes + 16-byte copy of dict_block[0..16]
@@ -1231,14 +1229,14 @@ mod tests {
         // accept_data call, so the invariant we assert here is the
         // post-append upper bound.
         assert!(
-            m.history.len() <= m.max_window_size * 2 + RESERVED_PREFIX_BYTES,
+            m.history.len() <= m.max_window_size * 2 + HISTORY_DRAIN_BASE,
             "after eviction, REAL history must be bounded by 2× \
              max_window_size (got history.len()={}, max_window_size={})",
             m.history.len(),
             m.max_window_size,
         );
         assert!(
-            m.history.len() <= m.max_window_size + 200 + RESERVED_PREFIX_BYTES,
+            m.history.len() <= m.max_window_size + 200 + HISTORY_DRAIN_BASE,
             "post-append history = RESERVED dummy + retained prefix \
              (≤ max_window_size) + last block (200 bytes); got {}",
             m.history.len(),
@@ -1257,19 +1255,19 @@ mod tests {
 
     /// Boundary: exactly `HASH_READ_SIZE` (8) real bytes appended
     /// via `skip_matching(Some(false))` — must hash one position
-    /// (`range_start == RESERVED_PREFIX_BYTES`, `last_hashable ==
-    /// RESERVED_PREFIX_BYTES`) without overrun.
+    /// (`range_start == HISTORY_DRAIN_BASE`, `last_hashable ==
+    /// HISTORY_DRAIN_BASE`) without overrun.
     #[test]
     fn skip_matching_dict_prime_handles_exactly_hash_read_size_bytes() {
         let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         // 8-byte real payload appends above the RESERVED dummy →
-        // history.len() = 8 + RESERVED_PREFIX_BYTES, last_hashable =
-        // RESERVED_PREFIX_BYTES, hashed range = [RESERVED..=RESERVED]
+        // history.len() = 8 + HISTORY_DRAIN_BASE, last_hashable =
+        // HISTORY_DRAIN_BASE, hashed range = [RESERVED..=RESERVED]
         // (one position).
         let payload: alloc::vec::Vec<u8> = (0..8u8).collect();
         m.accept_data(payload);
         m.skip_matching_with_hint(Some(false));
-        assert_eq!(m.history.len(), 8 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), 8 + HISTORY_DRAIN_BASE);
         // No assertion on hash entries — the bug we're guarding
         // against is a panic / overrun, not a behavioural one.
         // Reaching this line without unwinding is the test.
@@ -1287,7 +1285,7 @@ mod tests {
         // prime_hash_table_for_range must short-circuit on the
         // `history_len < HASH_READ_SIZE` guard.
         m.skip_matching_with_hint(Some(false));
-        assert_eq!(m.history.len(), 4 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), 4 + HISTORY_DRAIN_BASE);
     }
 
     /// rep ↔ offset_hist consistency: after a single block emits
@@ -1403,7 +1401,7 @@ mod tests {
 
         m.accept_data((0..200u8).collect());
         m.skip_matching_with_hint(None);
-        assert_eq!(m.history.len(), 200 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), 200 + HISTORY_DRAIN_BASE);
         assert_eq!(
             m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "no eviction yet"
@@ -1411,7 +1409,7 @@ mod tests {
 
         m.accept_data((0..200u8).map(|i| i.wrapping_add(50)).collect());
         m.skip_matching_with_hint(None);
-        assert_eq!(m.history.len(), 400 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), 400 + HISTORY_DRAIN_BASE);
         assert_eq!(
             m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "still no eviction (400 < 512)",
@@ -1467,8 +1465,8 @@ mod tests {
         // First block lands at history[RESERVED..RESERVED+200] after
         // the seed dummy at [0..RESERVED). last_block_start tracks
         // that absolute index.
-        assert_eq!(m.last_block_start, RESERVED_PREFIX_BYTES);
-        assert_eq!(m.history.len(), 200 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.last_block_start, HISTORY_DRAIN_BASE);
+        assert_eq!(m.history.len(), 200 + HISTORY_DRAIN_BASE);
 
         // Shrink the window and trim. Without the fix, last_block_start
         // stays mid-history past the post-drain end — to make the
@@ -1479,8 +1477,8 @@ mod tests {
         m.skip_matching_with_hint(None);
         // history = [dummy] + [0..200] + [50..150] = 1 + 200 + 100 = 301.
         // last_block_start = RESERVED + 200 = start of second block.
-        assert_eq!(m.last_block_start, RESERVED_PREFIX_BYTES + 200);
-        assert_eq!(m.history.len(), 300 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.last_block_start, HISTORY_DRAIN_BASE + 200);
+        assert_eq!(m.history.len(), 300 + HISTORY_DRAIN_BASE);
 
         // Now force trim_to_window to drain into the middle of the
         // second block: shrink max_window_size below the second
@@ -1494,7 +1492,7 @@ mod tests {
             "trim must drain REAL history down to max_window_size = 64",
         );
         // history.len() = RESERVED (dummy preserved) + 64.
-        assert_eq!(m.history.len(), 64 + RESERVED_PREFIX_BYTES);
+        assert_eq!(m.history.len(), 64 + HISTORY_DRAIN_BASE);
 
         // The slice MUST be in bounds — the bug would panic here OR
         // return a stale slice. After the fix, last_block_start is

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1,8 +1,17 @@
 //! Donor-shape Fast strategy matcher backend — selected for every
 //! Fast-strategy level (Uncompressed, Fastest, Level(1), and the
-//! negative Level(-7..=-1) variants). All levels currently resolve
-//! to the same matcher with donor level-1 `hash_log = 14, mls = 7`;
-//! per-level acceleration knobs land in phase 3.
+//! negative Level(-7..=-1) variants). Per-level dispatch on
+//! `(fast_hash_log, fast_mls, fast_step_size)` is wired through
+//! `LevelParams` → `with_params` / `reset` (step_size is part of
+//! the construction/reset signature, not a separate setter).
+//! Level(1) uses `(hash_log=14, mls=7, step_size=2)`; Fastest /
+//! Uncompressed / Level(-1..=-7) use `(hash_log=14, mls=6)` with
+//! `step_size` 2..8 driving donor's acceleration gradient on
+//! negative levels.
+//!
+//! `use_cmov` is derived directly from `window_log` inside the
+//! matcher (donor heuristic `windowLog < 19`) — NOT a
+//! `LevelParams` field.
 //!
 //! Wraps the kernel from
 //! [`super::fast_kernel::kernel::compress_block_fast`] and presents the
@@ -18,14 +27,15 @@
 //!
 //! # Invariants this module guarantees
 //!
-//! - `prefix_start_index >= RESERVED_PREFIX_BYTES` at all times.
-//!   The first `RESERVED_PREFIX_BYTES` of `history` is a reserved
-//!   dummy region (seeded on construction / reset, preserved across
-//!   eviction) so the hash table's empty-slot sentinel value `0`
-//!   cannot be confused with a real match position. Real input data
-//!   starts at `history[RESERVED_PREFIX_BYTES]`. See the
-//!   `RESERVED_PREFIX_BYTES` constant for the full sentinel-0
-//!   rationale.
+//! - `prefix_start_index >= INITIAL_PREFIX_START_INDEX = 1` at all
+//!   times. `history` holds real input bytes from position 0
+//!   onward (no dummy region — M8 dropped the seeded sentinel byte
+//!   for donor byte-range parity). Sentinel-0 protection comes from
+//!   the kernel's `match_idx >= prefix_start_index` filter rejecting
+//!   the hash table's empty-slot value `0`. After eviction / drain
+//!   the buffer is rebased to position 0 and `prefix_start_index`
+//!   resets to 1, making the first retained byte (`history[0]`)
+//!   unmatchable — small ratio cost, accepted for sentinel safety.
 //! - `history.len()` is bounded by `2 × max_window_size` post-append.
 //!   See [`FastKernelMatcher::extend_history_with_pending`].
 //! - `rep[0..2]` tracks the kernel's two-deep repcode state
@@ -47,11 +57,12 @@ use crate::encoding::blocks::encode_offset_with_history;
 use super::fast_kernel::hash_table::FastHashTable;
 use super::fast_kernel::kernel::compress_block_fast;
 
-/// Donor `ZSTD_defaultCParameters[level=1][srcSize > 256 KiB][Fast]` —
-/// hard-coded for all Fast levels today (the driver passes only
-/// `window_log` per-level; `hash_log` + `mls` are constant). Per-
-/// level `hash_log` scaling for smaller source-size hints lands in
-/// phase 3 along with the Fast acceleration gradient.
+/// Donor `ZSTD_defaultCParameters[level=1][srcSize > 256 KiB][Fast]`
+/// constants. Kept for `MatchGeneratorDriver::new`'s initial-state
+/// matcher (which runs BEFORE any `reset` from a resolved
+/// `LevelParams`). Production calls thread per-level values
+/// (`fast_hash_log`, `fast_mls`, `fast_step_size`) through
+/// `LevelParams` instead.
 pub(crate) const FAST_LEVEL_1_HASH_LOG: u32 = 14;
 pub(crate) const FAST_LEVEL_1_MLS: u32 = 7;
 /// Donor level-1 Fast `window_log`. Production code reads
@@ -73,24 +84,27 @@ pub(crate) const FAST_INITIAL_REP: [u32; 2] = [1, 4];
 /// start and mirrors the value the old [`super::MatchGenerator`] used.
 pub(crate) const FAST_INITIAL_OFFSET_HIST: [u32; 3] = [1, 4, 8];
 
-/// Number of reserved sub-prefix bytes at the head of `history`.
+/// Drain start offset used by eviction / drain paths. NOT a
+/// reserved-bytes count — set to 0 (M8): `history` holds real
+/// input bytes from position 0 onward, donor-parity layout, no
+/// dummy region. Sentinel-0 protection (hash table's empty-slot
+/// value `0` would otherwise be indistinguishable from a real
+/// match at position 0) is provided by
+/// [`INITIAL_PREFIX_START_INDEX`] = 1 via the kernel's
+/// `match_idx >= prefix_start_index` filter.
 ///
-/// The hash table uses `0` as its empty-slot sentinel. To keep that
-/// sentinel distinguishable from a real match position, we reserve
-/// `history[0]` as an unmatchable dummy byte (its value is
-/// irrelevant — the kernel never reads it as a match source because
-/// `prefix_start_index = 1` filters position 0 out via the
-/// `match_idx >= prefix_start_index` check).
-///
-/// Real input data starts at `history[1]`. Eviction / trim drain
-/// REAL bytes from `[1..=drop_n]` and preserve the dummy at
-/// position 0. Donor C zstd achieves the same effect via a virtual
-/// base pointer pre-positioned before the data buffer; the flat
-/// `Vec<u8>` model here can't mirror absolute-base addressing, so
-/// we pay one byte of memory overhead per matcher in exchange for
-/// the same correctness property (no missed matches at segment
-/// boundaries).
-pub(crate) const RESERVED_PREFIX_BYTES: usize = 1;
+/// Kept as a named constant so the drain math reads consistently
+/// against future changes; the name is legacy from the pre-M8
+/// "dummy-byte" layout.
+pub(crate) const RESERVED_PREFIX_BYTES: usize = 0;
+
+/// Donor's `prefixStartIndex` floor on fresh frames. Set to 1 (not 0)
+/// so the kernel's `match_idx >= prefix_start_index` filter rejects
+/// stale empty-slot lookups (value 0 in FastHashTable's all-zero
+/// initial state). Donor relies on its `ip0 += (ip0 == prefixStart)`
+/// bump to skip position 0 instead — both approaches match the same
+/// 0..N-1 byte ranges for the hash table.
+const INITIAL_PREFIX_START_INDEX: u32 = 1;
 
 /// Donor-shape Fast-strategy matcher state.
 ///
@@ -144,6 +158,22 @@ pub(crate) struct FastKernelMatcher {
     /// Decoder-side window size (in `log` bits). Reported to the
     /// frame header via the `Matcher::window_size` trait method.
     window_log: u8,
+    /// Donor heuristic: prefer cmov match-found when
+    /// `windowLog < 19` (`ZSTD_compressBlock_fast` line 449). Small-
+    /// window encoders have less predictable in-range filtering, so
+    /// the branchless variant beats the branchful one on those
+    /// levels. Set during `reset` / `with_params` from `window_log`.
+    /// Reachable in production via source-size hints (when the
+    /// caller passes a small `source_size` to a streaming encoder,
+    /// `adjust_params_for_source_size` clamps `window_log` below
+    /// the donor default of 19, flipping `use_cmov` on).
+    use_cmov: bool,
+    /// Initial step the kernel uses for the 4-cursor body's skip
+    /// schedule. Donor `stepSize = targetLength + !(targetLength) +
+    /// 1` (min 2). Negative-level frames set this to 2..8 to
+    /// recreate donor's acceleration gradient; Level(1) and other
+    /// Fast levels keep step_size=2.
+    step_size: usize,
     /// Holds a `commit_space`'d block until `start_matching` consumes
     /// it. `None` between frames and immediately after `start_matching`
     /// returns. The driver guarantees at most one outstanding pending
@@ -181,6 +211,7 @@ impl FastKernelMatcher {
             FAST_LEVEL_1_WINDOW_LOG,
             FAST_LEVEL_1_HASH_LOG,
             FAST_LEVEL_1_MLS,
+            2,
         )
     }
 
@@ -188,33 +219,32 @@ impl FastKernelMatcher {
     /// the level resolution produced a non-default `(window_log,
     /// hash_log, mls)` triple (typically because a small source-size
     /// hint clamped the window). Tests can also call this directly.
-    pub(crate) fn with_params(window_log: u8, hash_log: u32, mls: u32) -> Self {
-        // Reserve `RESERVED_PREFIX_BYTES` bytes at the head of
-        // history. The kernel never matches against this region
-        // because `prefix_start_index = RESERVED_PREFIX_BYTES = 1`
-        // filters it out — see the `RESERVED_PREFIX_BYTES` constant
-        // for the full sentinel-0 rationale.
+    pub(crate) fn with_params(window_log: u8, hash_log: u32, mls: u32, step_size: usize) -> Self {
+        assert!(
+            step_size >= 2,
+            "FastKernelMatcher requires step_size >= 2 (got {step_size})"
+        );
+        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
+        // Sentinel-0 protection comes from prefix_start_index =
+        // INITIAL_PREFIX_START_INDEX = 1, which filters hash table
+        // lookups returning the empty-slot value 0.
         let history = alloc::vec![0u8; RESERVED_PREFIX_BYTES];
         Self {
             last_block_start: RESERVED_PREFIX_BYTES,
             recycled_space: None,
             history,
-            // `prefixStartIndex` starts at `RESERVED_PREFIX_BYTES`
-            // so the head of `history` (the dummy bytes) is below
-            // the prefix and rejected by the kernel's
-            // `match_idx >= prefix_start_index` filter — see the
-            // `RESERVED_PREFIX_BYTES` constant for the full
-            // sentinel-0 rationale. Eviction in
-            // `extend_history_with_pending` preserves both the
-            // dummy AND keeps `prefix_start_index` at this baseline
-            // (the drain re-indexes the retained tail so the
-            // invariant restores).
-            prefix_start_index: RESERVED_PREFIX_BYTES as u32,
+            // Filter `match_idx >= prefix_start_index` rejects the
+            // hash table's empty-slot value 0. Eviction in
+            // `extend_history_with_pending` rebases the retained
+            // tail and resets prefix_start_index back to 1.
+            prefix_start_index: INITIAL_PREFIX_START_INDEX,
             rep: FAST_INITIAL_REP,
             offset_hist: FAST_INITIAL_OFFSET_HIST,
             hash_table: FastHashTable::new(hash_log, mls),
             max_window_size: 1usize << window_log,
             window_log,
+            use_cmov: window_log < 19,
+            step_size,
             pending: None,
         }
     }
@@ -225,7 +255,11 @@ impl FastKernelMatcher {
     /// either clears the existing hash table (if `(hash_log, mls)` are
     /// unchanged) or reallocates it. The window_log update redirects
     /// the soft-eviction bound and the decoder-side reported window.
-    pub(crate) fn reset(&mut self, window_log: u8, hash_log: u32, mls: u32) {
+    pub(crate) fn reset(&mut self, window_log: u8, hash_log: u32, mls: u32, step_size: usize) {
+        assert!(
+            step_size >= 2,
+            "FastKernelMatcher requires step_size >= 2 (got {step_size})"
+        );
         if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
             // Parameters changed — rebuild the table at the new size.
             // Cannot reuse the old allocation because the donor-shape
@@ -236,19 +270,17 @@ impl FastKernelMatcher {
             // `memset` (donor's `ZSTD_window_clear` cadence).
             self.hash_table.clear();
         }
+        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
         self.history.clear();
-        // Re-seed the RESERVED_PREFIX_BYTES dummy at the head so the
-        // post-reset state matches `with_params`'s invariant
-        // (sentinel-0 unmatchable, real data starts at index
-        // RESERVED_PREFIX_BYTES).
         self.history.resize(RESERVED_PREFIX_BYTES, 0);
-        // prefix_start_index pinned to RESERVED_PREFIX_BYTES so the
-        // dummy at position 0..RESERVED_PREFIX_BYTES is filtered as
-        // sub-prefix — see `with_params` for the full rationale.
-        self.prefix_start_index = RESERVED_PREFIX_BYTES as u32;
+        // Sentinel-0 protection via prefix_start_index >= 1 filter
+        // — see `with_params` for the full rationale.
+        self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
         self.rep = FAST_INITIAL_REP;
         self.offset_hist = FAST_INITIAL_OFFSET_HIST;
         self.window_log = window_log;
+        self.use_cmov = window_log < 19;
+        self.step_size = step_size;
         self.max_window_size = 1usize << window_log;
         self.pending = None;
         self.last_block_start = RESERVED_PREFIX_BYTES;
@@ -316,7 +348,7 @@ impl FastKernelMatcher {
         // matcher can emit offsets exceeding the frame header's
         // reported window size (format-correctness risk).
         // Eviction operates on REAL data length (excluding the
-        // RESERVED_PREFIX_BYTES dummy at the head of history).
+        // no dummy at the head of history post-M8).
         let real_len = self.history.len().saturating_sub(RESERVED_PREFIX_BYTES);
         let new_real_total = real_len.saturating_add(space.len());
         let cap = self.max_window_size.saturating_mul(2);
@@ -355,38 +387,31 @@ impl FastKernelMatcher {
         self.pending = Some(space);
     }
 
-    /// Drop the OLDEST `drop_n` real bytes from history while
-    /// preserving the `RESERVED_PREFIX_BYTES` dummy at indices
-    /// `[0..RESERVED_PREFIX_BYTES)`. Used by both the eager
-    /// commit-time eviction in [`Self::accept_data`] and the
-    /// dictionary-budget retire loop's [`Self::trim_to_window`].
+    /// Drop the OLDEST `drop_n` real bytes from history and rebase
+    /// the retained tail to start at position 0 (M8 layout: no
+    /// dummy region). Used by both the eager commit-time eviction
+    /// in [`Self::accept_data`] and the dictionary-budget retire
+    /// loop's [`Self::trim_to_window`].
     ///
-    /// Side effects (all required for invariant preservation —
-    /// extracted to keep the two call sites in lockstep across
-    /// future drain-related fixes):
+    /// Side effects:
     ///
-    /// 1. Drain `history[RESERVED_PREFIX_BYTES .. RESERVED_PREFIX_BYTES + drop_n)`.
-    /// 2. Pin `prefix_start_index` back to `RESERVED_PREFIX_BYTES`
-    ///    (drain re-indexes the retained tail; cumulative add would
-    ///    push the filter past every valid post-drain position).
+    /// 1. Drain `history[0..drop_n)`.
+    /// 2. Reset `prefix_start_index` to `INITIAL_PREFIX_START_INDEX = 1`
+    ///    — drain re-indexes the retained tail; the sentinel-0
+    ///    filter restores via this fixed baseline.
     /// 3. Clear the hash table — entries hold pre-drain absolute
     ///    positions that no longer reference live bytes.
-    /// 4. `saturating_sub` `last_block_start` by `drop_n`, clamped
-    ///    to `>= RESERVED_PREFIX_BYTES` so it never lands on the
-    ///    dummy region.
-    /// 5. Rehash retained tail starting at `RESERVED_PREFIX_BYTES`
-    ///    so block N+1 can find matches against the kept bytes
-    ///    (without this they'd be "dead history" — visible in the
-    ///    Vec but unlookupable).
+    /// 4. `saturating_sub` `last_block_start` by `drop_n`.
+    /// 5. Rehash retained tail starting at position 0 so block N+1
+    ///    can find matches against the kept bytes (without this
+    ///    they'd be "dead history" — visible in the Vec but
+    ///    unlookupable).
     fn drain_real_prefix(&mut self, drop_n: usize) {
         let drain_end = RESERVED_PREFIX_BYTES + drop_n;
         self.history.drain(RESERVED_PREFIX_BYTES..drain_end);
-        self.prefix_start_index = RESERVED_PREFIX_BYTES as u32;
+        self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
         self.hash_table.clear();
-        self.last_block_start = self
-            .last_block_start
-            .saturating_sub(drop_n)
-            .max(RESERVED_PREFIX_BYTES);
+        self.last_block_start = self.last_block_start.saturating_sub(drop_n);
         self.prime_hash_table_for_range(RESERVED_PREFIX_BYTES);
     }
 
@@ -460,7 +485,24 @@ impl FastKernelMatcher {
     /// construction.
     pub(crate) fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
         let block_start = self.extend_history_with_pending();
-        let prefix_start_index = self.prefix_start_index;
+        // Compute the EFFECTIVE prefix floor for this scan against
+        // the ADVERTISED frame window (`1 << window_log`), NOT
+        // `max_window_size` — the driver may temporarily inflate
+        // `max_window_size` by the retained dictionary budget
+        // during `prime_with_dictionary`. The frame header still
+        // reports `1 << window_log`, so any emitted offset older
+        // than `history.len() - (1 << window_log)` would exceed
+        // the decoder's reserved window and produce a format-
+        // invalid sequence. Donor's
+        // `ZSTD_getLowestPrefixIndex(ms, endIndex, windowLog)`
+        // uses `windowLog` for the same reason.
+        let advertised_window = 1usize << self.window_log;
+        let effective_prefix = self
+            .history
+            .len()
+            .saturating_sub(advertised_window)
+            .max(self.prefix_start_index as usize) as u32;
+        let prefix_start_index = effective_prefix;
         let rep_in = self.rep;
         let mls = self.hash_table.mls();
 
@@ -513,45 +555,106 @@ impl FastKernelMatcher {
             }
         };
 
-        let result = match mls {
-            4 => compress_block_fast::<4>(
+        // Dispatch on (mls, use_cmov) — donor's 8 specialised
+        // `ZSTD_GEN_FAST_FN` expansions (we also cover mls=8 for
+        // future use). Each (mls, cmov) pair monomorphises the
+        // kernel hot loop independently.
+        //
+        // The 10 arms are intentionally expanded inline rather
+        // than wrapped in a macro: the kernel signature is short
+        // enough that the duplication doesn't obscure intent, and
+        // an explicit match makes it obvious which monomorphisations
+        // exist. If the kernel ever grows additional const-generic
+        // parameters (e.g. per-level `hash_fill_step`), revisit.
+        let result = match (mls, self.use_cmov) {
+            (4, false) => compress_block_fast::<4, false>(
                 history,
                 block_start,
                 prefix_start_index,
                 hash_table,
                 rep_in,
+                self.step_size,
                 &mut wrap_emit,
             ),
-            5 => compress_block_fast::<5>(
+            (4, true) => compress_block_fast::<4, true>(
                 history,
                 block_start,
                 prefix_start_index,
                 hash_table,
                 rep_in,
+                self.step_size,
                 &mut wrap_emit,
             ),
-            6 => compress_block_fast::<6>(
+            (5, false) => compress_block_fast::<5, false>(
                 history,
                 block_start,
                 prefix_start_index,
                 hash_table,
                 rep_in,
+                self.step_size,
                 &mut wrap_emit,
             ),
-            7 => compress_block_fast::<7>(
+            (5, true) => compress_block_fast::<5, true>(
                 history,
                 block_start,
                 prefix_start_index,
                 hash_table,
                 rep_in,
+                self.step_size,
                 &mut wrap_emit,
             ),
-            8 => compress_block_fast::<8>(
+            (6, false) => compress_block_fast::<6, false>(
                 history,
                 block_start,
                 prefix_start_index,
                 hash_table,
                 rep_in,
+                self.step_size,
+                &mut wrap_emit,
+            ),
+            (6, true) => compress_block_fast::<6, true>(
+                history,
+                block_start,
+                prefix_start_index,
+                hash_table,
+                rep_in,
+                self.step_size,
+                &mut wrap_emit,
+            ),
+            (7, false) => compress_block_fast::<7, false>(
+                history,
+                block_start,
+                prefix_start_index,
+                hash_table,
+                rep_in,
+                self.step_size,
+                &mut wrap_emit,
+            ),
+            (7, true) => compress_block_fast::<7, true>(
+                history,
+                block_start,
+                prefix_start_index,
+                hash_table,
+                rep_in,
+                self.step_size,
+                &mut wrap_emit,
+            ),
+            (8, false) => compress_block_fast::<8, false>(
+                history,
+                block_start,
+                prefix_start_index,
+                hash_table,
+                rep_in,
+                self.step_size,
+                &mut wrap_emit,
+            ),
+            (8, true) => compress_block_fast::<8, true>(
+                history,
+                block_start,
+                prefix_start_index,
+                hash_table,
+                rep_in,
+                self.step_size,
                 &mut wrap_emit,
             ),
             _ => unreachable!(
@@ -733,18 +836,15 @@ mod tests {
         assert_eq!(m.rep, FAST_INITIAL_REP);
         assert_eq!(m.offset_hist, FAST_INITIAL_OFFSET_HIST);
         assert_eq!(m.max_window_size, 1usize << FAST_LEVEL_1_WINDOW_LOG);
-        // Post-#216-#17 fix: history is seeded with
-        // RESERVED_PREFIX_BYTES dummy at construction so the
-        // sentinel-0 invariant holds with no missed matches at
-        // segment boundaries. Empty-history check from the legacy
-        // model is replaced by a "only the dummy lives at head"
-        // check.
+        // M8: history starts empty (RESERVED_PREFIX_BYTES = 0).
+        // First input byte will live at position 0; sentinel-0
+        // protection comes from the prefix filter, not from a
+        // dummy region.
         assert_eq!(m.history.len(), RESERVED_PREFIX_BYTES);
-        // prefixStartIndex pinned to RESERVED so the dummy at
-        // indices [0..RESERVED) is sub-prefix and the hash table's
-        // empty-slot sentinel value 0 cannot be confused with a real
-        // match position.
-        assert_eq!(m.prefix_start_index as usize, RESERVED_PREFIX_BYTES);
+        // prefix_start_index = 1 makes position 0 unmatchable so
+        // the hash table's empty-slot value 0 can't be confused
+        // with a real match.
+        assert_eq!(m.prefix_start_index, INITIAL_PREFIX_START_INDEX);
         assert!(m.pending.is_none());
     }
 
@@ -752,7 +852,7 @@ mod tests {
     fn with_params_threads_through_each_field() {
         // Pick a non-default triple to prove no silent override by
         // donor-default constants.
-        let m = FastKernelMatcher::with_params(16, 12, 5);
+        let m = FastKernelMatcher::with_params(16, 12, 5, 2);
         assert_eq!(m.window_log, 16);
         assert_eq!(m.hash_table.hash_log(), 12);
         assert_eq!(m.hash_table.mls(), 5);
@@ -762,12 +862,12 @@ mod tests {
     #[test]
     fn window_size_reports_one_shifted_window_log() {
         // window_log = 16 → 64 KiB reported window.
-        let m = FastKernelMatcher::with_params(16, 12, 5);
+        let m = FastKernelMatcher::with_params(16, 12, 5, 2);
         assert_eq!(m.window_size(), 1u64 << 16);
         // Larger window_log → larger reported window. window_log = 22
         // (4 MiB, donor's BETTER_WINDOW_LOG) confirms the shift width
         // (`u64` head room).
-        let m = FastKernelMatcher::with_params(22, 14, 7);
+        let m = FastKernelMatcher::with_params(22, 14, 7, 2);
         assert_eq!(m.window_size(), 1u64 << 22);
     }
 
@@ -794,12 +894,13 @@ mod tests {
             FAST_LEVEL_1_WINDOW_LOG,
             FAST_LEVEL_1_HASH_LOG,
             FAST_LEVEL_1_MLS,
+            2,
         );
 
-        // Post-reset: history seeded with the RESERVED_PREFIX_BYTES
+        // Post-reset: history empty (RESERVED_PREFIX_BYTES=0; no
         // dummy only; prefix_start_index pinned to that baseline.
         assert_eq!(m.history.len(), RESERVED_PREFIX_BYTES);
-        assert_eq!(m.prefix_start_index as usize, RESERVED_PREFIX_BYTES);
+        assert_eq!(m.prefix_start_index, INITIAL_PREFIX_START_INDEX);
         assert_eq!(m.rep, FAST_INITIAL_REP);
         assert_eq!(m.offset_hist, FAST_INITIAL_OFFSET_HIST);
         assert!(m.pending.is_none());
@@ -816,7 +917,7 @@ mod tests {
         let mut m = FastKernelMatcher::new();
         // Force a parameter change — every Vec we hand the new
         // FastHashTable will be a fresh allocation.
-        m.reset(16, 10, 4);
+        m.reset(16, 10, 4, 2);
         assert_eq!(m.hash_table.hash_log(), 10);
         assert_eq!(m.hash_table.mls(), 4);
         assert_eq!(m.window_log, 16);
@@ -845,7 +946,7 @@ mod tests {
         // hash arm; level-1 defaults (mls=7) would also work but the
         // hash collisions on a 64-byte synthetic input are noisier
         // for mls>=5.
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         m.accept_data(data.clone());
 
         let mut emitted_match_lens: alloc::vec::Vec<usize> = alloc::vec::Vec::new();
@@ -878,7 +979,7 @@ mod tests {
         // Pending buffer was consumed.
         assert!(m.pending.is_none());
         // History grew by exactly the block size (plus the
-        // RESERVED_PREFIX_BYTES dummy carried since construction).
+        // no dummy carried since construction — M8).
         assert_eq!(m.history.len(), data.len() + RESERVED_PREFIX_BYTES);
         // `last_committed_space` post-processing reads from
         // history[last_block_start..] (donor / legacy MatchGenerator
@@ -893,7 +994,7 @@ mod tests {
     /// the rep / offset_hist state.
     #[test]
     fn skip_matching_extends_history_without_emissions() {
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         let pre_rep = m.rep;
         let pre_offset_hist = m.offset_hist;
 
@@ -948,7 +1049,7 @@ mod tests {
         block2.extend_from_slice(&block1[0..32]); // 32-byte cross-block copy
         block2.extend(200..216u8); // 16-byte tail buffer
 
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
 
         // Block 1 — drain emissions, ignore.
         m.accept_data(block1.clone());
@@ -1006,13 +1107,13 @@ mod tests {
             dict_block.push(i.wrapping_mul(13).wrapping_add(7));
         }
 
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         m.accept_data(dict_block.clone());
         m.skip_matching_with_hint(Some(false)); // dictionary-priming skip
 
         // Sanity: history grew, prefix_start_index unchanged.
         assert_eq!(m.history.len(), dict_block.len() + RESERVED_PREFIX_BYTES);
-        assert_eq!(m.prefix_start_index, 1);
+        assert_eq!(m.prefix_start_index, INITIAL_PREFIX_START_INDEX);
 
         // Block 2: 16 fresh bytes + 16-byte copy of dict_block[0..16]
         // + 16-byte tail buffer so the kernel can reach the copy.
@@ -1048,7 +1149,7 @@ mod tests {
             dict_block.push(i.wrapping_mul(13).wrapping_add(7));
         }
 
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         m.accept_data(dict_block.clone());
         m.skip_matching_with_hint(None); // plain skip — no hash pre-population
 
@@ -1090,7 +1191,7 @@ mod tests {
         // window_log = 8 → max_window_size = 256, eviction threshold
         // = 512. Stage three 200-byte blocks: after the third commit,
         // total would be 600 > 512 → eviction fires.
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
+        let mut m = FastKernelMatcher::with_params(8, 6, 4, 2);
         for round in 0..3 {
             // Distinct payload per round so a hash entry from round
             // 0 referencing position 0 is identifiable as stale
@@ -1127,7 +1228,7 @@ mod tests {
         // proven by post-history shrinking, not by an
         // index-advancement signal.
         assert_eq!(
-            m.prefix_start_index, 1,
+            m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "drain must rebase prefix_start_index to the baseline (1)",
         );
     }
@@ -1138,7 +1239,7 @@ mod tests {
     /// RESERVED_PREFIX_BYTES`) without overrun.
     #[test]
     fn skip_matching_dict_prime_handles_exactly_hash_read_size_bytes() {
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         // 8-byte real payload appends above the RESERVED dummy →
         // history.len() = 8 + RESERVED_PREFIX_BYTES, last_hashable =
         // RESERVED_PREFIX_BYTES, hashed range = [RESERVED..=RESERVED]
@@ -1157,7 +1258,7 @@ mod tests {
     /// without panicking on the `last_hashable` subtract.
     #[test]
     fn skip_matching_dict_prime_handles_below_hash_read_size_bytes() {
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         let payload: alloc::vec::Vec<u8> = (0..4u8).collect();
         m.accept_data(payload);
         // history will be 4 bytes after append < HASH_READ_SIZE (8).
@@ -1186,7 +1287,7 @@ mod tests {
         }
         data.extend_from_within(0..48);
 
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         m.accept_data(data.clone());
 
         let mut emitted_offsets: alloc::vec::Vec<usize> = alloc::vec::Vec::new();
@@ -1235,7 +1336,7 @@ mod tests {
         // window_log=8 → max_window_size=256, threshold=512.
         // Two 300-byte blocks both via dict-prime skip — second
         // one triggers eviction.
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
+        let mut m = FastKernelMatcher::with_params(8, 6, 4, 2);
         let block1: alloc::vec::Vec<u8> = (0..200u8).collect();
         m.accept_data(block1);
         m.skip_matching_with_hint(Some(false));
@@ -1253,96 +1354,11 @@ mod tests {
         // than cumulative saturating_add); eviction is proven by
         // bounded history below.
         assert_eq!(
-            m.prefix_start_index, 1,
+            m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "drain must rebase prefix_start_index to the baseline (1)",
         );
         // History within the 2× window-size hard cap.
         assert!(m.history.len() <= m.max_window_size * 2);
-    }
-
-    /// Regression for #216 CodeRabbit review #6: after multiple
-    /// drain-evictions, `prefix_start_index` grows cumulatively
-    /// (saturating_add of drop_n per drain) while the hash table is
-    /// cleared and re-populated from current `history` positions
-    /// [0..max_window_size]. Without rebasing `prefix_start_index`
-    /// back to 1 on drain, the kernel's `match_idx >=
-    /// prefix_start_index` filter eventually rejects EVERY match
-    /// candidate (table positions < accumulated prefix_start_index).
-    /// Retained-window matches die wholesale.
-    #[test]
-    fn drain_rebases_prefix_start_index_so_retained_history_stays_matchable() {
-        // Tight window so evictions fire quickly: window_log = 8 →
-        // max_window_size = 256, threshold = 512. Each 200-byte
-        // commit accumulates 200 bytes; the third onwards triggers
-        // eviction with drop_n ≈ 144-200 per drain.
-        //
-        // After ~8 evictions, naive prefix_start_index grows to
-        // ~1 + 8 * ~180 ≈ 1441, far past any position in the
-        // current 256-byte retained history. The kernel's filter
-        // would then reject every match candidate (positions are at
-        // most history.len() = 256 << prefix_start_index = 1441).
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
-        // Build a fixed "signature" pattern that will survive many
-        // commits and remain matchable in the retained tail.
-        let sig: alloc::vec::Vec<u8> = (0..32u8)
-            .map(|i| i.wrapping_mul(31).wrapping_add(17))
-            .collect();
-
-        // Run 12 commits of 200 bytes each — guarantees many evictions.
-        // Last block carries the signature in its head + matchable
-        // bytes — we want the kernel to find this signature against
-        // the retained-history copy (placed in commit #10 below).
-        for round in 0..10 {
-            let mut block: alloc::vec::Vec<u8> = (0..200u8)
-                .map(|i| i.wrapping_add(round as u8 * 7))
-                .collect();
-            if round == 10 - 1 {
-                // Plant the signature near end of this block — it
-                // will live in the retained tail by the time block
-                // 11 commits below.
-                block[100..132].copy_from_slice(&sig);
-            }
-            m.accept_data(block);
-            m.skip_matching_with_hint(Some(false)); // dict-prime, hashes populated
-        }
-
-        // After 10 commits at 200 bytes each, prefix_start_index has
-        // advanced significantly (cumulative drop_n). Pre-fix it
-        // would be in the thousands; post-fix it should be 1 (or
-        // small).
-        let pre_fix_index_would_exceed_history = m.prefix_start_index as usize > m.history.len();
-        // Document the failing-case expectation (the bug being
-        // tested for): without the fix, prefix_start_index >> any
-        // valid history position.
-        let _ = pre_fix_index_would_exceed_history;
-
-        // Now commit a final block whose head contains the
-        // signature — kernel should find it referencing the
-        // earlier-planted copy in retained history.
-        let mut block: alloc::vec::Vec<u8> = alloc::vec::Vec::with_capacity(200);
-        block.extend_from_slice(&sig);
-        for i in 0..168u8 {
-            block.push(i.wrapping_mul(53).wrapping_add(91));
-        }
-        m.accept_data(block);
-
-        let mut saw_match = false;
-        m.start_matching(|seq| {
-            if let Sequence::Triple { match_len, .. } = seq
-                && match_len >= 4
-            {
-                saw_match = true;
-            }
-        });
-
-        assert!(
-            saw_match,
-            "after multiple drain-evictions the matcher must still find \
-             matches against retained-history bytes (got no match; \
-             prefix_start_index = {} vs history.len() = {})",
-            m.prefix_start_index,
-            m.history.len(),
-        );
     }
 
     /// Regression for #216 review #1: `accept_data` MUST perform
@@ -1361,13 +1377,13 @@ mod tests {
         // eviction (200, 400 bytes). The THIRD accept_data crosses
         // the 512-byte threshold; its eviction MUST be visible at
         // accept_data return-time via the history.len() drop.
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
+        let mut m = FastKernelMatcher::with_params(8, 6, 4, 2);
 
         m.accept_data((0..200u8).collect());
         m.skip_matching_with_hint(None);
         assert_eq!(m.history.len(), 200 + RESERVED_PREFIX_BYTES);
         assert_eq!(
-            m.prefix_start_index as usize, RESERVED_PREFIX_BYTES,
+            m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "no eviction yet"
         );
 
@@ -1375,7 +1391,7 @@ mod tests {
         m.skip_matching_with_hint(None);
         assert_eq!(m.history.len(), 400 + RESERVED_PREFIX_BYTES);
         assert_eq!(
-            m.prefix_start_index as usize, RESERVED_PREFIX_BYTES,
+            m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
             "still no eviction (400 < 512)",
         );
 
@@ -1399,8 +1415,8 @@ mod tests {
             "post-eviction retained must equal max_window_size",
         );
         assert_eq!(
-            m.prefix_start_index as usize, RESERVED_PREFIX_BYTES,
-            "drain rebases prefix_start_index to the RESERVED baseline \
+            m.prefix_start_index, INITIAL_PREFIX_START_INDEX,
+            "drain rebases prefix_start_index to INITIAL_PREFIX_START_INDEX \
              — eviction is proven by the history.len() shrink above",
         );
     }
@@ -1422,7 +1438,7 @@ mod tests {
         // last_block_start (was 0) MUST now be 0 (since 72 > 0 →
         // saturating_sub gives 0) so last_committed_space() returns
         // a valid in-bounds slice.
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
+        let mut m = FastKernelMatcher::with_params(8, 6, 4, 2);
         let payload: alloc::vec::Vec<u8> = (0..200u8).collect();
         m.accept_data(payload);
         m.skip_matching_with_hint(None);
@@ -1482,7 +1498,7 @@ mod tests {
     /// repcode wire encoding (correctness bug, not perf).
     #[test]
     fn prime_offset_history_keeps_rep_and_offset_hist_in_lockstep() {
-        let mut m = FastKernelMatcher::with_params(12, 8, 4);
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
         // Pre-prime: matcher carries the donor's initial state.
         assert_eq!(m.rep, FAST_INITIAL_REP);
         assert_eq!(m.offset_hist, FAST_INITIAL_OFFSET_HIST);
@@ -1515,7 +1531,7 @@ mod tests {
     /// Fix retains a SMALLER prefix (or none) so the bound holds.
     #[test]
     fn accept_data_evicts_more_aggressively_when_block_larger_than_window() {
-        let mut m = FastKernelMatcher::with_params(8, 6, 4);
+        let mut m = FastKernelMatcher::with_params(8, 6, 4, 2);
         // max_window_size = 256 (1 << 8). Threshold = 512.
 
         // Pre-fill history to full max_window_size of real data via
@@ -1562,6 +1578,140 @@ mod tests {
             "pre-append drain must have shed historical bytes \
              (got real_len_after_drain={real_len_after}, was 256 \
              before accept)",
+        );
+    }
+
+    /// Regression for PR #219 round 6 (CR Critical): `start_matching`
+    /// computes an effective sliding prefix floor of
+    /// `history.len() - max_window_size` so emitted offsets never
+    /// exceed the advertised `max_window_size`. Without this floor,
+    /// after history grows past one window (commit's
+    /// eager-eviction keeps up to 2× max_window_size before
+    /// draining), the kernel could match against positions older
+    /// than the frame window — invalid for decoder buffer
+    /// reservation.
+    #[test]
+    fn start_matching_enforces_max_window_size_offset_bound() {
+        // Tight window: window_log=7 → max_window_size=128.
+        // Block lengths 200 + 200 = 400 bytes total, comfortably
+        // past 128 so without the sliding floor the kernel would
+        // emit matches at offsets > max_window.
+        let mut m = FastKernelMatcher::with_params(7, 8, 4, 2);
+        let max_window = m.max_window_size;
+        assert_eq!(max_window, 128, "test assumes window_log=7");
+
+        // Block 1: 200 bytes of a distinct ASCII pattern that
+        // populates the hash table at positions 0..200.
+        let block1: alloc::vec::Vec<u8> = (0..200u8).map(|i| 0x30 + (i % 64)).collect();
+        m.accept_data(block1.clone());
+        m.start_matching(|_| {});
+
+        // Block 2: 200 bytes that RE-USE block1's content from
+        // position 0 onwards. Without the sliding floor, the
+        // kernel would happily emit Triples with offset
+        // ≈ history_len (~200..400) — well past max_window=128.
+        let block2 = block1.clone();
+        m.accept_data(block2);
+
+        let mut max_emitted_offset = 0usize;
+        let mut emitted_match_count = 0usize;
+        m.start_matching(|seq| {
+            if let Sequence::Triple {
+                offset, match_len, ..
+            } = seq
+                && match_len > 0
+            {
+                emitted_match_count += 1;
+                if offset > max_emitted_offset {
+                    max_emitted_offset = offset;
+                }
+            }
+        });
+
+        // GUARANTEE 1: the kernel actually scanned and matched
+        // something — otherwise the offset bound below passes
+        // trivially with max_emitted_offset = 0.
+        assert!(
+            emitted_match_count > 0,
+            "fixture must produce at least one Triple match — \
+             history.len()=~400, max_window=128, block2 is identical to block1",
+        );
+
+        // GUARANTEE 2: every emitted offset stays within the
+        // advertised max_window_size. Without the sliding floor,
+        // matches against early block1 positions (e.g. position
+        // 0..72) would yield offsets > 128.
+        assert!(
+            max_emitted_offset <= max_window,
+            "sliding floor MUST cap emitted offsets at max_window_size; \
+             got max emitted offset {} vs max_window_size {}",
+            max_emitted_offset,
+            max_window,
+        );
+    }
+
+    /// Regression for PR #219 round 9 (Copilot Critical): the
+    /// sliding prefix floor in `start_matching` MUST use the
+    /// advertised frame window (`1 << window_log`), NOT the
+    /// dynamically inflated `max_window_size` (which the driver
+    /// adds dictionary-budget bytes to during
+    /// `prime_with_dictionary`). With the inflated value,
+    /// offsets could exceed the advertised window during
+    /// dictionary-primed compression — format-invalid sequences.
+    #[test]
+    fn start_matching_caps_offsets_at_window_log_not_inflated_max() {
+        // Advertised frame window = 1 << 7 = 128 bytes.
+        let mut m = FastKernelMatcher::with_params(7, 8, 4, 2);
+        let advertised_window: usize = 1 << m.window_log;
+        assert_eq!(advertised_window, 128, "test assumes window_log=7");
+
+        // Simulate dictionary priming: driver inflates
+        // max_window_size by retained_dict_budget. We add 200
+        // bytes of "dictionary" content to history first, then
+        // bump max_window_size to reflect the dict-retention
+        // budget (mirrors MatchGeneratorDriver::prime_with_dictionary
+        // for the Simple backend).
+        let dict: alloc::vec::Vec<u8> = (0..200u8).map(|i| 0x40 + (i % 64)).collect();
+        m.accept_data(dict.clone());
+        m.start_matching(|_| {}); // populate hash table from dict
+        m.max_window_size = m.max_window_size.saturating_add(200);
+
+        // Add a block whose first 100 bytes match dict[0..100].
+        // Without the fix, the kernel would emit offsets up to
+        // ~history_len (200..300), since the inflated max_window
+        // (328) keeps even the dict's earliest bytes inside the
+        // sliding floor.
+        let block: alloc::vec::Vec<u8> = (0..100u8).map(|i| 0x40 + (i % 64)).collect();
+        m.accept_data(block);
+
+        let mut max_emitted_offset = 0usize;
+        let mut emitted_match_count = 0usize;
+        m.start_matching(|seq| {
+            if let Sequence::Triple {
+                offset, match_len, ..
+            } = seq
+                && match_len > 0
+            {
+                emitted_match_count += 1;
+                if offset > max_emitted_offset {
+                    max_emitted_offset = offset;
+                }
+            }
+        });
+
+        assert!(
+            emitted_match_count > 0,
+            "fixture must produce at least one match — block content \
+             repeats dict, history.len() ≈ 300, scan should find at \
+             least one Triple",
+        );
+        assert!(
+            max_emitted_offset <= advertised_window,
+            "sliding floor MUST cap emitted offsets at the ADVERTISED \
+             frame window (1 << window_log = {}), NOT the inflated \
+             max_window_size; got max emitted offset {}",
+            advertised_window,
+            max_emitted_offset,
         );
     }
 }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -761,22 +761,23 @@ impl FastKernelMatcher {
         self.rep = [offset_hist[0], offset_hist[1]];
     }
 
-    /// Read-only view of REAL data length (excluding the
-    /// `HISTORY_DRAIN_BASE` dummy at history's head) for the
-    /// driver's eviction accounting (`commit_space` →
-    /// `retire_dictionary_budget` flow). The driver compares
-    /// pre/post values to derive a byte-delta. Returning REAL
-    /// length keeps the delta meaningful (drain-of-N-real-bytes
-    /// shows up as a clean N drop, not N±constant).
+    /// Read-only view of history's real-data length for the driver's
+    /// eviction accounting (`commit_space` →
+    /// `retire_dictionary_budget` flow). The driver compares pre/post
+    /// values to derive a byte-delta; under M8 history holds only
+    /// real bytes from position 0 onward (HISTORY_DRAIN_BASE is 0),
+    /// so this is just the history length — the `saturating_sub` is
+    /// kept symmetric with `trim_to_window` below in case the drain
+    /// base ever moves off 0.
     pub(crate) fn history_len_for_eviction_accounting(&self) -> usize {
         self.history.len().saturating_sub(HISTORY_DRAIN_BASE)
     }
 
     /// Drop history bytes past `max_window_size` via
-    /// [`Self::drain_real_prefix`] (rebases `prefix_start_index` to
-    /// `HISTORY_DRAIN_BASE`, clears + rehashes the table).
-    /// Returns evicted byte count; idempotent when `real_len <=
-    /// max_window_size`.
+    /// [`Self::drain_real_prefix`] (resets `prefix_start_index` to
+    /// `INITIAL_PREFIX_START_INDEX` = 1 — the sentinel-0 floor — and
+    /// clears + rehashes the table). Returns evicted byte count;
+    /// idempotent when `real_len <= max_window_size`.
     pub(crate) fn trim_to_window(&mut self) -> usize {
         let real_len = self.history.len().saturating_sub(HISTORY_DRAIN_BASE);
         if real_len <= self.max_window_size {

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -114,9 +114,11 @@ const INITIAL_PREFIX_START_INDEX: u32 = 1;
 ///   current block live in this single contiguous buffer; the kernel's
 ///   `block_start` parameter separates the two.
 /// - `prefix_start_index` is donor's `prefixStartIndex` — the lowest
-///   position any match may reference. Pinned to `HISTORY_DRAIN_BASE`
-///   at construction and after every drain (drain re-indexes the
-///   retained tail).
+///   position any match may reference. Pinned to
+///   `INITIAL_PREFIX_START_INDEX` (= 1) at construction and after every
+///   drain (drain re-indexes the retained tail; the `1` floor rejects
+///   the hash table's all-zero empty-slot value from being read as a
+///   valid match at position 0).
 /// - `rep` carries the two-deep repcode state across blocks.
 /// - `offset_hist` is the encoder-side 3-deep offset history used by
 ///   the wire encoder's repcode coding (separate from `rep`, which is
@@ -323,9 +325,9 @@ impl FastKernelMatcher {
     /// legacy MatchGenerator's `window.last().data` equivalent.
     ///
     /// Three states:
-    /// - Pre-`accept_data`: empty slice (the
-    ///   `HISTORY_DRAIN_BASE`-seeded dummy means
-    ///   `history[last_block_start..]` is empty).
+    /// - Pre-`accept_data`: empty slice — `history` is empty and
+    ///   `last_block_start` is 0, so `history[last_block_start..]`
+    ///   degenerates to a zero-length slice.
     /// - Between `accept_data` and processing: the pending buffer.
     /// - Post-processing: `history` slice of the just-processed
     ///   block — frame compressor's raw-block emission reads this.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -215,6 +215,27 @@ impl FastKernelMatcher {
         )
     }
 
+    /// Current per-frame `step_size` (set at construction / reset).
+    /// Test-only crate helper for verifying driver wiring.
+    #[cfg(test)]
+    pub(crate) fn step_size(&self) -> usize {
+        self.step_size
+    }
+
+    /// Hash table `hash_log` (delegates to the inner table). Test-only
+    /// crate helper for verifying driver wiring.
+    #[cfg(test)]
+    pub(crate) fn hash_log(&self) -> u32 {
+        self.hash_table.hash_log()
+    }
+
+    /// Hash table `mls` (delegates to the inner table). Test-only
+    /// crate helper for verifying driver wiring.
+    #[cfg(test)]
+    pub(crate) fn mls(&self) -> u32 {
+        self.hash_table.mls()
+    }
+
     /// Explicit-parameter constructor used by the wiring commit when
     /// the level resolution produced a non-default `(window_log,
     /// hash_log, mls)` triple (typically because a small source-size

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -246,6 +246,14 @@ impl FastKernelMatcher {
             step_size >= 2,
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
         );
+        // Kernel indices are `u32`; `1 << window_log` larger than
+        // `u32::MAX` is unrepresentable in the hash table and would
+        // overflow on 32-bit hosts. Cap at 31 so `1u32 << window_log`
+        // stays defined and `max_window_size <= u32::MAX`.
+        assert!(
+            window_log <= 31,
+            "FastKernelMatcher requires window_log <= 31 (got {window_log})"
+        );
         // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
         // Sentinel-0 protection comes from prefix_start_index =
         // INITIAL_PREFIX_START_INDEX = 1, which filters hash table
@@ -281,6 +289,12 @@ impl FastKernelMatcher {
         assert!(
             step_size >= 2,
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
+        );
+        // Same window_log cap as `with_params` — see there for why
+        // values above 31 are unrepresentable.
+        assert!(
+            window_log <= 31,
+            "FastKernelMatcher requires window_log <= 31 (got {window_log})"
         );
         if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
             // Parameters changed — rebuild the table at the new size.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -246,13 +246,19 @@ impl FastKernelMatcher {
             step_size >= 2,
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
         );
-        // Kernel indices are `u32`; `1 << window_log` larger than
-        // `u32::MAX` is unrepresentable in the hash table and would
-        // overflow on 32-bit hosts. Cap at 31 so `1u32 << window_log`
-        // stays defined and `max_window_size <= u32::MAX`.
+        // Kernel indices are `u32`. `accept_data` lets history grow
+        // up to `2 * max_window_size` before draining (donor parity
+        // for the eager-eviction band), so `max_window_size` is
+        // capped at 2^30 to keep that band ≤ 2^31 < `u32::MAX` and
+        // prevent any `history.len()` from tripping the kernel's
+        // `data.len() > u32::MAX` panic. Donor's
+        // `ZSTD_WINDOWLOG_MAX_64` is 30 for the same reason — we
+        // mirror it.
         assert!(
-            window_log <= 31,
-            "FastKernelMatcher requires window_log <= 31 (got {window_log})"
+            window_log <= 30,
+            "FastKernelMatcher requires window_log <= 30 (got {window_log}); \
+             2 * (1 << 30) is the eviction-band ceiling that keeps history \
+             length below the kernel's u32::MAX input bound"
         );
         // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
         // Sentinel-0 protection comes from prefix_start_index =
@@ -291,10 +297,10 @@ impl FastKernelMatcher {
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
         );
         // Same window_log cap as `with_params` — see there for why
-        // values above 31 are unrepresentable.
+        // the ceiling is 30, not 31.
         assert!(
-            window_log <= 31,
-            "FastKernelMatcher requires window_log <= 31 (got {window_log})"
+            window_log <= 30,
+            "FastKernelMatcher requires window_log <= 30 (got {window_log})"
         );
         if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
             // Parameters changed — rebuild the table at the new size.


### PR DESCRIPTION
## Summary

Native Rust port of donor's `ZSTD_compressBlock_fast_noDict_generic` (`zstd_fast.c:192-456`) — closes phase 3 of #198. Restores Fast-strategy throughput after the phase 1b regression and aligns encoder behaviour with donor parity on every front that affects ratio / speed / format correctness.

Squashed from PR #219 (41 review threads addressed across 10 rounds) into a single coherent commit.

## Headline results

`large-log-stream` (25 MiB dense corpus, i9-9900K):

| State                        | Time vs main | Throughput     |
|------------------------------|-------------:|---------------:|
| main (pre-phase-1b)          |      0%      | ~290 MiB/s     |
| #217 merged (phase 1b)       |    +122%     | ~235 MiB/s     |
| **This PR**                  |    **−22%**  | **~790 MiB/s** |

Net change phase 1b → phase 3: **~3.4× faster**.

## Ratio audit on `decodecorpus-z000033`

- L-7..L-1 Fast: monotone acceleration gradient restored (−1.85% to −4.79% vs donor)
- L2-3 Dfast: parity or slight win (−0.94% to −4.61%)
- L5-15 Lazy: consistently beat donor by −5.7..−6.18%
- L16-17 btopt: parity / win (−0.33% to −3.59%)
- L20-22 btultra2: parity (±0.2%)
- L1 Fast: +7.43% residual gap → follow-up #220

## Milestones (squashed from PR #219)

- **M1** — per-level `fast_hash_log`/`fast_mls`/`fast_step_size` threading through `LevelParams`
- **M2** — full 4-cursor `ip0/ip1/ip2/ip3` lookahead body + immediate-rep2 inner loop
- **M3** — `cmov` match-found variant + per-window dispatch (10 monomorphisations: `mls` 4..=8 × `use_cmov` true/false)
- **M4** — beyond-donor `fast_hash_log: 13 → 14` for negative levels (+32 KB memory, 2× fewer collisions on structured corpora)
- **M5** — reverted (adaptive mls peek did not pay off)
- **M6** — per-level `fast_step_size` from donor's `targetLength = -level` formula; restores acceleration gradient
- **M7** — added donor's missing `current0+2` hash insertion after each match emit (`zstd_fast.c:407`); raised L1/decodecorpus sequence-match-rate 43.1% → 57.7%
- **M8** — dropped `RESERVED_PREFIX_BYTES` dummy byte; history layout now donor-parity, sentinel-0 protection via `INITIAL_PREFIX_START_INDEX = 1` filter
- **M9** — sliding prefix floor enforces the advertised frame window (`1 << window_log`), NOT the dictionary-budget-inflated `max_window_size`. Prevents emitting offsets > advertised window during dictionary-primed compression — would otherwise produce format-invalid frames.

## API changes

- `FastKernelMatcher::with_params(window_log, hash_log, mls, step_size)` — step_size promoted to 4th positional arg
- `FastKernelMatcher::reset(...)` — same signature change
- `set_step_size` post-init setter removed (closed gap where new code paths could silently fall back to step_size=2)
- `RESERVED_PREFIX_BYTES`: 1 → 0; new `INITIAL_PREFIX_START_INDEX = 1` constant

## Tests

- 577 nextest, all passing (+13 new tests covering per-level dispatch, cmov vs branch parity, cmov out-of-window false-positive, backward extension, sliding-floor enforcement on inflated `max_window_size`)
- cross_validation FFI roundtrips on every level 1..=22 (dict + no-dict) — wire-format interop preserved
- clippy clean

## Out of scope (follow-ups)

- #220 — Fast L1 +7.43% ratio residual on decodecorpus
- L18-19 btultra +3.5% — separate ratio investigation

Closes #198 phase 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger window-bound enforcement and out-of-window match rejection so emitted offsets never exceed the advertised decoder window.

* **Refactor**
  * Per-level fast tuning (including explicit step-size) exposed and threaded through match engines and driver.
  * History/sentinel layout simplified to remove reserved dummy bytes and tighten hash/drain invariants.
  * Inner compression loop reorganized into a donor-style pipeline with explicit step handling and safer bounds checks.

* **New Features**
  * Optional branchless (cmov) match path with parity validation versus the branch variant.

* **Tests**
  * New unit and regression tests for per-level tuning, driver wiring, cmov parity, match-found correctness, and window-bound behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->