### PR TITLE
feat(frame): magicless frame format support (#26)

### DIFF
--- a/zstd/src/decoding/frame.rs
+++ b/zstd/src/decoding/frame.rs
@@ -3,27 +3,48 @@ use crate::decoding::errors::{FrameDescriptorError, FrameHeaderError, ReadFrameH
 use crate::io::Read;
 
 /// Read a single serialized frame from the reader and return a tuple containing the parsed frame and the number of bytes read.
-pub fn read_frame_header(mut r: impl Read) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
+///
+/// Reads the 4-byte magic number prefix; errors with
+/// `BadMagicNumber` if it doesn't match. For magicless streams
+/// (donor `ZSTD_f_zstd1_magicless`), call
+/// [`read_frame_header_with_format`] with `magicless = true`.
+#[allow(dead_code)] // Public surface used by downstream consumers; internal call sites use the _with_format variant.
+pub fn read_frame_header(r: impl Read) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
+    read_frame_header_with_format(r, false)
+}
+
+/// Read a single serialized frame header. When `magicless` is
+/// `true`, the 4-byte magic prefix is NOT consumed and skippable-
+/// frame detection is bypassed — the caller MUST know out-of-band
+/// that the stream is magicless. Donor parity:
+/// `ZSTD_f_zstd1_magicless` via `ZSTD_d_format`.
+pub fn read_frame_header_with_format(
+    mut r: impl Read,
+    magicless: bool,
+) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
     use ReadFrameHeaderError as err;
     let mut buf = [0u8; 4];
 
-    r.read_exact(&mut buf).map_err(err::MagicNumberReadError)?;
-    let mut bytes_read = 4;
-    let magic_num = u32::from_le_bytes(buf);
+    let mut bytes_read = 0;
+    if !magicless {
+        r.read_exact(&mut buf).map_err(err::MagicNumberReadError)?;
+        bytes_read = 4;
+        let magic_num = u32::from_le_bytes(buf);
 
-    // Skippable frames have a magic number in this interval
-    if (0x184D2A50..=0x184D2A5F).contains(&magic_num) {
-        r.read_exact(&mut buf)
-            .map_err(err::FrameDescriptorReadError)?;
-        let skip_size = u32::from_le_bytes(buf);
-        return Err(ReadFrameHeaderError::SkipFrame {
-            magic_number: magic_num,
-            length: skip_size,
-        });
-    }
+        // Skippable frames have a magic number in this interval
+        if (0x184D2A50..=0x184D2A5F).contains(&magic_num) {
+            r.read_exact(&mut buf)
+                .map_err(err::FrameDescriptorReadError)?;
+            let skip_size = u32::from_le_bytes(buf);
+            return Err(ReadFrameHeaderError::SkipFrame {
+                magic_number: magic_num,
+                length: skip_size,
+            });
+        }
 
-    if magic_num != MAGIC_NUM {
-        return Err(ReadFrameHeaderError::BadMagicNumber(magic_num));
+        if magic_num != MAGIC_NUM {
+            return Err(ReadFrameHeaderError::BadMagicNumber(magic_num));
+        }
     }
 
     r.read_exact(&mut buf[0..1])

--- a/zstd/src/decoding/frame.rs
+++ b/zstd/src/decoding/frame.rs
@@ -8,8 +8,12 @@ use crate::io::Read;
 /// `BadMagicNumber` if it doesn't match. For magicless streams
 /// (donor `ZSTD_f_zstd1_magicless`), call
 /// [`read_frame_header_with_format`] with `magicless = true`.
-#[allow(dead_code)] // Public surface used by downstream consumers; internal call sites use the _with_format variant.
-pub fn read_frame_header(r: impl Read) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
+// Test-only convenience wrapper: production decoder paths now
+// route through `read_frame_header_with_format`. Used by the
+// in-crate `tests/` modules to keep their existing call sites
+// simple.
+#[cfg(test)]
+pub(crate) fn read_frame_header(r: impl Read) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
     read_frame_header_with_format(r, false)
 }
 

--- a/zstd/src/decoding/frame.rs
+++ b/zstd/src/decoding/frame.rs
@@ -2,16 +2,12 @@ use crate::common::{MAGIC_NUM, MAX_WINDOW_SIZE, MIN_WINDOW_SIZE};
 use crate::decoding::errors::{FrameDescriptorError, FrameHeaderError, ReadFrameHeaderError};
 use crate::io::Read;
 
-/// Read a single serialized frame from the reader and return a tuple containing the parsed frame and the number of bytes read.
-///
-/// Reads the 4-byte magic number prefix; errors with
-/// `BadMagicNumber` if it doesn't match. For magicless streams
-/// (donor `ZSTD_f_zstd1_magicless`), call
-/// [`read_frame_header_with_format`] with `magicless = true`.
-// Test-only convenience wrapper: production decoder paths now
-// route through `read_frame_header_with_format`. Used by the
-// in-crate `tests/` modules to keep their existing call sites
-// simple.
+/// Test-only convenience wrapper around
+/// [`read_frame_header_with_format`] with `magicless = false`.
+/// Production decoder paths route through
+/// `read_frame_header_with_format` directly so that the magicless
+/// bit is threaded explicitly; this wrapper keeps the existing
+/// in-crate `tests/` call sites simple.
 #[cfg(test)]
 pub(crate) fn read_frame_header(r: impl Read) -> Result<(FrameHeader, u8), ReadFrameHeaderError> {
     read_frame_header_with_format(r, false)

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -257,20 +257,14 @@ pub enum BlockDecodingStrategy {
 
 impl FrameDecoderState {
     /// Read the frame header from `source` and create a new decoder
-    /// state. Crate-internal — `FrameDecoderState` itself is not
-    /// re-exported; downstream reaches this only through
-    /// `FrameDecoder::init`.
+    /// Construct a new frame decoder state, reading the frame header
+    /// from `source`. When `magicless` is `true`, the 4-byte magic
+    /// number prefix is NOT consumed (donor `ZSTD_f_zstd1_magicless`).
+    /// Crate-internal — reached only via `FrameDecoder::init` /
+    /// `FrameDecoder::init_with_dict_handle`.
     ///
     /// Pre-allocates the decode buffer to `window_size` so the first
     /// block does not trigger incremental growth from zero capacity.
-    #[allow(dead_code)] // Crate-internal; reached via new_with_format from FrameDecoder.
-    pub(crate) fn new(source: impl Read) -> Result<FrameDecoderState, FrameDecoderError> {
-        Self::new_with_format(source, false)
-    }
-
-    /// Same as [`Self::new`] but with explicit magicless setting.
-    /// When `magicless` is `true`, the frame header is read WITHOUT
-    /// expecting a magic-number prefix (donor `ZSTD_f_zstd1_magicless`).
     pub(crate) fn new_with_format(
         source: impl Read,
         magicless: bool,
@@ -301,20 +295,15 @@ impl FrameDecoderState {
     }
 
     /// Reset this state for a new frame read from `source`, reusing
-    /// existing allocations. Crate-internal — reached via
-    /// `FrameDecoder::reset`.
+    /// existing allocations. When `magicless` is `true`, the frame
+    /// header is read WITHOUT expecting a magic-number prefix
+    /// (donor `ZSTD_f_zstd1_magicless`). Crate-internal — reached
+    /// only via `FrameDecoder::reset`.
     ///
-    /// `DecodeBuffer::reset` reserves `window_size` internally, so no
-    /// additional frame-level reservation is needed here. Further buffer
-    /// growth during decoding is performed on demand by the active block path.
-    #[allow(dead_code)] // Crate-internal; reached via reset_with_format from FrameDecoder.
-    pub(crate) fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
-        self.reset_with_format(source, false)
-    }
-
-    /// Same as [`Self::reset`] but with explicit magicless setting
-    /// (donor `ZSTD_f_zstd1_magicless`). The caller plumbs the
-    /// matcher's `magicless` flag through here.
+    /// `DecodeBuffer::reset` reserves `window_size` internally, so
+    /// no additional frame-level reservation is needed here.
+    /// Further buffer growth during decoding is performed on demand
+    /// by the active block path.
     pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -80,6 +80,10 @@ pub struct FrameDecoder {
     shared_dicts: BTreeMap<u32, DictionaryHandle>,
     #[cfg(not(target_has_atomic = "ptr"))]
     shared_dicts: (),
+    /// `ZSTD_f_zstd1_magicless` — when true, [`init`] / [`reset`]
+    /// expect frames without the 4-byte magic number prefix.
+    /// Default false (standard zstd format).
+    magicless: bool,
 }
 
 /// Backend-tagged decode scratch — chosen at frame-reset time based
@@ -256,8 +260,19 @@ impl FrameDecoderState {
     ///
     /// Pre-allocates the decode buffer to `window_size` so the first block
     /// does not trigger incremental growth from zero capacity.
+    #[allow(dead_code)] // Public API; internal sites use new_with_format.
     pub fn new(source: impl Read) -> Result<FrameDecoderState, FrameDecoderError> {
-        let (frame, header_size) = frame::read_frame_header(source)?;
+        Self::new_with_format(source, false)
+    }
+
+    /// Same as [`Self::new`] but with explicit magicless setting.
+    /// When `magicless` is `true`, the frame header is read WITHOUT
+    /// expecting a magic-number prefix (donor `ZSTD_f_zstd1_magicless`).
+    pub fn new_with_format(
+        source: impl Read,
+        magicless: bool,
+    ) -> Result<FrameDecoderState, FrameDecoderError> {
+        let (frame, header_size) = frame::read_frame_header_with_format(source, magicless)?;
         let window_size = frame.window_size()?;
 
         if window_size > MAXIMUM_ALLOWED_WINDOW_SIZE {
@@ -287,8 +302,20 @@ impl FrameDecoderState {
     /// `DecodeBuffer::reset` reserves `window_size` internally, so no
     /// additional frame-level reservation is needed here. Further buffer
     /// growth during decoding is performed on demand by the active block path.
+    #[allow(dead_code)] // Public API; internal sites use reset_with_format.
     pub fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
-        let (frame_header, header_size) = frame::read_frame_header(source)?;
+        self.reset_with_format(source, false)
+    }
+
+    /// Same as [`Self::reset`] but with explicit magicless setting
+    /// (donor `ZSTD_f_zstd1_magicless`). The caller plumbs the
+    /// matcher's `magicless` flag through here.
+    pub fn reset_with_format(
+        &mut self,
+        source: impl Read,
+        magicless: bool,
+    ) -> Result<(), FrameDecoderError> {
+        let (frame_header, header_size) = frame::read_frame_header_with_format(source, magicless)?;
         let window_size = frame_header.window_size()?;
 
         if window_size > MAXIMUM_ALLOWED_WINDOW_SIZE {
@@ -327,7 +354,19 @@ impl FrameDecoder {
             shared_dicts: BTreeMap::new(),
             #[cfg(not(target_has_atomic = "ptr"))]
             shared_dicts: (),
+            magicless: false,
         }
+    }
+
+    /// Enable or disable magicless frame format
+    /// (`ZSTD_f_zstd1_magicless`). When set to `true`, subsequent
+    /// [`init`] / [`reset`] calls expect the frame header to begin
+    /// directly with the frame-header descriptor — no 4-byte magic
+    /// number prefix. Default false. Must match the encoder's
+    /// magicless setting; the format is unambiguous only when the
+    /// caller knows it out-of-band.
+    pub fn set_magicless(&mut self, magicless: bool) {
+        self.magicless = magicless;
     }
 
     #[cfg(target_has_atomic = "ptr")]
@@ -398,13 +437,14 @@ impl FrameDecoder {
     /// equivalent to init()
     pub fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        let magicless = self.magicless;
         let dict_id = match &mut self.state {
             Some(s) => {
-                s.reset(source)?;
+                s.reset_with_format(source, magicless)?;
                 s.frame_header.dictionary_id()
             }
             None => {
-                self.state = Some(FrameDecoderState::new(source)?);
+                self.state = Some(FrameDecoderState::new_with_format(source, magicless)?);
                 self.state
                     .as_ref()
                     .and_then(|state| state.frame_header.dictionary_id())
@@ -459,13 +499,14 @@ impl FrameDecoder {
     ) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
         Self::validate_registered_dictionary(dict.as_dict())?;
+        let magicless = self.magicless;
         let state = match &mut self.state {
             Some(s) => {
-                s.reset(source)?;
+                s.reset_with_format(source, magicless)?;
                 s
             }
             None => {
-                self.state = Some(FrameDecoderState::new(source)?);
+                self.state = Some(FrameDecoderState::new_with_format(source, magicless)?);
                 self.state.as_mut().unwrap()
             }
         };

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -357,6 +357,16 @@ impl FrameDecoder {
     /// number prefix. Default false. Must match the encoder's
     /// magicless setting; the format is unambiguous only when the
     /// caller knows it out-of-band.
+    ///
+    /// Note: magicless mode also disables skippable-frame detection.
+    /// The `0x184D2A50..=0x184D2A5F` skippable-frame magic range is
+    /// only recognised when the 4-byte magic prefix is consumed, so
+    /// `decode_all` / `init` / `reset` will treat a skippable frame
+    /// at the head of a magicless stream as a malformed frame header
+    /// (bad descriptor / window-size error) instead of skipping it.
+    /// Mixed-format streams that interleave skippable frames must be
+    /// pre-split by the caller; `set_magicless(true)` is only safe
+    /// when the entire stream is known to be magicless zstd frames.
     pub fn set_magicless(&mut self, magicless: bool) {
         self.magicless = magicless;
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -256,15 +256,13 @@ pub enum BlockDecodingStrategy {
 }
 
 impl FrameDecoderState {
-    /// Read the frame header from `source` and create a new decoder
     /// Construct a new frame decoder state, reading the frame header
     /// from `source`. When `magicless` is `true`, the 4-byte magic
     /// number prefix is NOT consumed (donor `ZSTD_f_zstd1_magicless`).
     /// Crate-internal — reached only via `FrameDecoder::init` /
-    /// `FrameDecoder::init_with_dict_handle`.
-    ///
-    /// Pre-allocates the decode buffer to `window_size` so the first
-    /// block does not trigger incremental growth from zero capacity.
+    /// `FrameDecoder::init_with_dict_handle`. Pre-allocates the
+    /// decode buffer to `window_size` so the first block does not
+    /// trigger incremental growth from zero capacity.
     pub(crate) fn new_with_format(
         source: impl Read,
         magicless: bool,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -256,19 +256,22 @@ pub enum BlockDecodingStrategy {
 }
 
 impl FrameDecoderState {
-    /// Read the frame header from `source` and create a new decoder state.
+    /// Read the frame header from `source` and create a new decoder
+    /// state. Crate-internal — `FrameDecoderState` itself is not
+    /// re-exported; downstream reaches this only through
+    /// `FrameDecoder::init`.
     ///
-    /// Pre-allocates the decode buffer to `window_size` so the first block
-    /// does not trigger incremental growth from zero capacity.
-    #[allow(dead_code)] // Public API; internal sites use new_with_format.
-    pub fn new(source: impl Read) -> Result<FrameDecoderState, FrameDecoderError> {
+    /// Pre-allocates the decode buffer to `window_size` so the first
+    /// block does not trigger incremental growth from zero capacity.
+    #[allow(dead_code)] // Crate-internal; reached via new_with_format from FrameDecoder.
+    pub(crate) fn new(source: impl Read) -> Result<FrameDecoderState, FrameDecoderError> {
         Self::new_with_format(source, false)
     }
 
     /// Same as [`Self::new`] but with explicit magicless setting.
     /// When `magicless` is `true`, the frame header is read WITHOUT
     /// expecting a magic-number prefix (donor `ZSTD_f_zstd1_magicless`).
-    pub fn new_with_format(
+    pub(crate) fn new_with_format(
         source: impl Read,
         magicless: bool,
     ) -> Result<FrameDecoderState, FrameDecoderError> {
@@ -297,20 +300,22 @@ impl FrameDecoderState {
         })
     }
 
-    /// Reset this state for a new frame read from `source`, reusing existing allocations.
+    /// Reset this state for a new frame read from `source`, reusing
+    /// existing allocations. Crate-internal — reached via
+    /// `FrameDecoder::reset`.
     ///
     /// `DecodeBuffer::reset` reserves `window_size` internally, so no
     /// additional frame-level reservation is needed here. Further buffer
     /// growth during decoding is performed on demand by the active block path.
-    #[allow(dead_code)] // Public API; internal sites use reset_with_format.
-    pub fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
+    #[allow(dead_code)] // Crate-internal; reached via reset_with_format from FrameDecoder.
+    pub(crate) fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
         self.reset_with_format(source, false)
     }
 
     /// Same as [`Self::reset`] but with explicit magicless setting
     /// (donor `ZSTD_f_zstd1_magicless`). The caller plumbs the
     /// matcher's `magicless` flag through here.
-    pub fn reset_with_format(
+    pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,
         magicless: bool,

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -44,6 +44,12 @@ pub struct FrameCompressor<R: Read, W: Write, M: Matcher> {
     dictionary_entropy_cache: Option<CachedDictionaryEntropy>,
     source_size_hint: Option<u64>,
     state: CompressState<M>,
+    /// When true, emitted frames omit the 4-byte magic number prefix
+    /// (`ZSTD_f_zstd1_magicless`). Default false. The caller is
+    /// responsible for ensuring the decoder is configured for the
+    /// matching format — wire-format only round-trips with a
+    /// magicless-aware decoder.
+    magicless: bool,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
 }
@@ -430,6 +436,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                     compression_level,
                 ),
             },
+            magicless: false,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
         }
@@ -456,9 +463,20 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 ),
             },
             compression_level,
+            magicless: false,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
         }
+    }
+
+    /// Enable or disable magicless frame format (`ZSTD_f_zstd1_magicless`).
+    ///
+    /// When set to `true`, emitted frames omit the 4-byte magic number
+    /// prefix. The matching decoder must be configured to expect a
+    /// magicless stream — wire-format only round-trips with a
+    /// magicless-aware decoder.
+    pub fn set_magicless(&mut self, magicless: bool) {
+        self.magicless = magicless;
     }
 
     /// Before calling [FrameCompressor::compress] you need to set the source.
@@ -756,6 +774,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             } else {
                 Some(window_size)
             },
+            magicless: self.magicless,
         };
         // Write the frame header and compressed blocks separately to avoid
         // shifting the entire `all_blocks` buffer to prepend the header.
@@ -2279,6 +2298,53 @@ mod tests {
             new_tag, initial_tag,
             "test fixture invariant: chosen levels must resolve to \
              different StrategyTag variants",
+        );
+    }
+
+    /// Magicless mode (`ZSTD_f_zstd1_magicless`): encoded frame
+    /// MUST NOT start with the 4-byte magic prefix, AND must
+    /// round-trip through a magicless-aware decoder.
+    #[test]
+    fn magicless_frame_omits_magic_and_roundtrips() {
+        use crate::common::MAGIC_NUM;
+        let input: alloc::vec::Vec<u8> = (0..512u32).map(|i| (i ^ 0xA5) as u8).collect();
+
+        // Encode with magicless = true.
+        let mut output: Vec<u8> = Vec::new();
+        let mut compressor = FrameCompressor::new(super::CompressionLevel::Default);
+        compressor.set_magicless(true);
+        compressor.set_source(input.as_slice());
+        compressor.set_drain(&mut output);
+        compressor.compress();
+
+        // 1. Encoded output must NOT begin with the zstd magic number.
+        assert!(
+            !output.starts_with(&MAGIC_NUM.to_le_bytes()),
+            "magicless frame must omit the 4-byte magic prefix",
+        );
+
+        // 2. A magicless-aware decoder must round-trip the payload.
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        decoder.set_magicless(true);
+        let mut cursor: &[u8] = output.as_slice();
+        decoder.init(&mut cursor).expect("magicless init");
+        decoder
+            .decode_blocks(&mut cursor, crate::decoding::BlockDecodingStrategy::All)
+            .expect("decode_blocks");
+        let mut decoded: Vec<u8> = Vec::new();
+        decoder
+            .collect_to_writer(&mut decoded)
+            .expect("collect_to_writer");
+        assert_eq!(decoded, input, "magicless roundtrip must preserve bytes");
+
+        // 3. A standard (magicful) decoder MUST fail on a magicless
+        //    frame — the first 4 bytes are the frame-header descriptor
+        //    + window/dictionary/FCS metadata, not the magic.
+        let mut std_decoder = crate::decoding::FrameDecoder::new();
+        let std_init = std_decoder.init(output.as_slice());
+        assert!(
+            std_init.is_err(),
+            "standard decoder must reject a magicless frame (got Ok)",
         );
     }
 }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2338,13 +2338,22 @@ mod tests {
         assert_eq!(decoded, input, "magicless roundtrip must preserve bytes");
 
         // 3. A standard (magicful) decoder MUST fail on a magicless
-        //    frame — the first 4 bytes are the frame-header descriptor
-        //    + window/dictionary/FCS metadata, not the magic.
+        //    frame with the specific `BadMagicNumber` variant — the
+        //    first 4 bytes are the frame-header descriptor + window /
+        //    dictionary / FCS metadata, not the magic. Asserting the
+        //    specific variant prevents regressions from being masked
+        //    by unrelated failures.
+        use crate::decoding::errors::{FrameDecoderError, ReadFrameHeaderError};
         let mut std_decoder = crate::decoding::FrameDecoder::new();
         let std_init = std_decoder.init(output.as_slice());
-        assert!(
-            std_init.is_err(),
-            "standard decoder must reject a magicless frame (got Ok)",
-        );
+        match std_init {
+            Err(FrameDecoderError::ReadFrameHeaderError(ReadFrameHeaderError::BadMagicNumber(
+                _,
+            ))) => {}
+            other => panic!(
+                "standard decoder must reject a magicless frame with \
+                 ReadFrameHeaderError::BadMagicNumber, got {other:?}",
+            ),
+        }
     }
 }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2337,22 +2337,26 @@ mod tests {
             .expect("collect_to_writer");
         assert_eq!(decoded, input, "magicless roundtrip must preserve bytes");
 
-        // 3. A standard (magicful) decoder MUST fail on a magicless
-        //    frame with the specific `BadMagicNumber` variant — the
-        //    first 4 bytes are the frame-header descriptor + window /
-        //    dictionary / FCS metadata, not the magic. Asserting the
-        //    specific variant prevents regressions from being masked
-        //    by unrelated failures.
+        // 3. A standard (magicful) decoder MUST reject a magicless
+        //    frame at the header-read step — the first 4 bytes are
+        //    the frame-header descriptor + window / dictionary / FCS
+        //    metadata, not the magic. We accept either
+        //    `BadMagicNumber` (typical case: first 4 bytes don't
+        //    match `MAGIC_NUM` and don't fall in the skippable-frame
+        //    magic range) or `SkipFrame` (rare: the first 4 bytes
+        //    coincidentally land in `0x184D2A50..=0x184D2A5F`). Both
+        //    prove the standard decoder did not treat the bytes as a
+        //    real magicful frame.
         use crate::decoding::errors::{FrameDecoderError, ReadFrameHeaderError};
         let mut std_decoder = crate::decoding::FrameDecoder::new();
         let std_init = std_decoder.init(output.as_slice());
         match std_init {
-            Err(FrameDecoderError::ReadFrameHeaderError(ReadFrameHeaderError::BadMagicNumber(
-                _,
-            ))) => {}
+            Err(FrameDecoderError::ReadFrameHeaderError(
+                ReadFrameHeaderError::BadMagicNumber(_) | ReadFrameHeaderError::SkipFrame { .. },
+            )) => {}
             other => panic!(
                 "standard decoder must reject a magicless frame with \
-                 ReadFrameHeaderError::BadMagicNumber, got {other:?}",
+                 ReadFrameHeaderError::BadMagicNumber or SkipFrame, got {other:?}",
             ),
         }
     }

--- a/zstd/src/encoding/frame_header.rs
+++ b/zstd/src/encoding/frame_header.rs
@@ -25,6 +25,11 @@ pub struct FrameHeader {
     /// and less than 3.75TB. Encoders should not generate a frame that requires a window size larger than
     /// 8mb.
     pub window_size: Option<u64>,
+    /// If true, the 4-byte magic number prefix is omitted from the
+    /// serialized output. The caller MUST know out-of-band that the
+    /// stream is magicless and use a magicless-aware decoder.
+    /// Donor parity: `ZSTD_f_zstd1_magicless` (see `ZSTD_d_format`).
+    pub magicless: bool,
 }
 
 impl FrameHeader {
@@ -34,8 +39,10 @@ impl FrameHeader {
     pub fn serialize(self, output: &mut Vec<u8>) {
         vprintln!("Serializing frame with header: {self:?}");
         // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header
-        // Magic Number:
-        output.extend_from_slice(&MAGIC_NUM.to_le_bytes());
+        // Magic Number (omitted in magicless mode — `ZSTD_f_zstd1_magicless`):
+        if !self.magicless {
+            output.extend_from_slice(&MAGIC_NUM.to_le_bytes());
+        }
 
         // `Frame_Header_Descriptor`:
         output.push(self.descriptor());
@@ -182,6 +189,7 @@ mod tests {
             content_checksum: false,
             dictionary_id: None,
             window_size: None,
+            magicless: false,
         };
         let descriptor = header.descriptor();
         let decoded_descriptor = FrameDescriptor(descriptor);
@@ -198,6 +206,7 @@ mod tests {
             content_checksum: false,
             dictionary_id: None,
             window_size: None,
+            magicless: false,
         };
 
         let mut serialized_header = Vec::new();
@@ -216,6 +225,7 @@ mod tests {
             content_checksum: false,
             dictionary_id: None,
             window_size: Some(1),
+            magicless: false,
         };
 
         let mut serialized_header = Vec::new();
@@ -231,6 +241,7 @@ mod tests {
             content_checksum: false,
             dictionary_id: None,
             window_size: None,
+            magicless: false,
         };
 
         let mut serialized_header = Vec::new();

--- a/zstd/src/encoding/frame_header.rs
+++ b/zstd/src/encoding/frame_header.rs
@@ -7,7 +7,14 @@ use alloc::vec::Vec;
 /// A header for a single Zstandard frame.
 ///
 /// <https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header>
-#[derive(Debug)]
+///
+/// Marked `#[non_exhaustive]`: external constructors MUST use the
+/// functional update syntax (`..FrameHeader::default()`) so future
+/// additions don't break source compatibility for downstream
+/// callers that don't need the new field. Within-crate constructors
+/// continue to provide every field explicitly.
+#[derive(Debug, Default)]
+#[non_exhaustive]
 pub struct FrameHeader {
     /// Optionally, the original (uncompressed) size of the data within the frame in bytes.
     /// If not present, `window_size` must be set.

--- a/zstd/src/encoding/frame_header.rs
+++ b/zstd/src/encoding/frame_header.rs
@@ -8,13 +8,11 @@ use alloc::vec::Vec;
 ///
 /// <https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header>
 ///
-/// Marked `#[non_exhaustive]`: external constructors MUST use the
-/// functional update syntax (`..FrameHeader::default()`) so future
-/// additions don't break source compatibility for downstream
-/// callers that don't need the new field. Within-crate constructors
-/// continue to provide every field explicitly.
+/// The containing module is `pub(crate)`, so this struct is not
+/// externally constructible. The `Default` derive is kept as a
+/// convenience for tests and for internal callers that only need
+/// to override specific fields.
 #[derive(Debug, Default)]
-#[non_exhaustive]
 pub struct FrameHeader {
     /// Optionally, the original (uncompressed) size of the data within the frame in bytes.
     /// If not present, `window_size` must be set.

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -33,6 +33,9 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     frame_started: bool,
     pledged_content_size: Option<u64>,
     bytes_consumed: u64,
+    /// `ZSTD_f_zstd1_magicless` — omit the 4-byte magic number prefix.
+    /// Default false. See [`Self::set_magicless`].
+    magicless: bool,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
 }
@@ -78,9 +81,19 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             frame_started: false,
             pledged_content_size: None,
             bytes_consumed: 0,
+            magicless: false,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
         }
+    }
+
+    /// Enable or disable magicless frame format (`ZSTD_f_zstd1_magicless`).
+    ///
+    /// When set to `true`, the frame header serialized by this encoder
+    /// omits the 4-byte magic number prefix. Must be called BEFORE the
+    /// first write — has no effect on already-started frames.
+    pub fn set_magicless(&mut self, magicless: bool) {
+        self.magicless = magicless;
     }
 
     /// Pledge the total uncompressed content size for this frame.
@@ -275,6 +288,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             } else {
                 Some(window_size)
             },
+            magicless: self.magicless,
         };
         let mut encoded_header = Vec::new();
         header.serialize(&mut encoded_header);

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -784,6 +784,58 @@ mod tests {
         }
     }
 
+    /// Pre-write `set_magicless(true)` → emitted frame omits the
+    /// magic prefix AND round-trips through a magicless-aware
+    /// decoder.
+    #[test]
+    fn streaming_encoder_set_magicless_before_write_omits_magic_and_roundtrips() {
+        use crate::common::MAGIC_NUM;
+        let payload = b"streaming-magicless-roundtrip-".repeat(64);
+
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Fastest);
+        encoder
+            .set_magicless(true)
+            .expect("set_magicless pre-write");
+        encoder.write_all(&payload).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        assert!(
+            !compressed.starts_with(&MAGIC_NUM.to_le_bytes()),
+            "magicless frame must omit the 4-byte magic prefix",
+        );
+
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        decoder.set_magicless(true);
+        let mut cursor: &[u8] = compressed.as_slice();
+        decoder.init(&mut cursor).expect("magicless init");
+        decoder
+            .decode_blocks(&mut cursor, crate::decoding::BlockDecodingStrategy::All)
+            .expect("decode_blocks");
+        let mut decoded: Vec<u8> = Vec::new();
+        decoder
+            .collect_to_writer(&mut decoded)
+            .expect("collect_to_writer");
+        assert_eq!(decoded, payload);
+    }
+
+    /// `set_magicless` after the first write MUST return an error
+    /// (the frame header has already been emitted, flipping the flag
+    /// can't affect the current frame). Mirrors
+    /// `set_pledged_content_size` / `set_source_size_hint` semantics.
+    #[test]
+    fn streaming_encoder_set_magicless_after_first_write_errors() {
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Fastest);
+        encoder.write_all(b"first-block").unwrap();
+        let err = encoder
+            .set_magicless(true)
+            .expect_err("set_magicless after first write must error");
+        assert_eq!(
+            err.kind(),
+            crate::io::ErrorKind::InvalidInput,
+            "expected InvalidInput when setting magicless after frame_started, got {err:?}",
+        );
+    }
+
     #[test]
     fn streaming_encoder_roundtrip_multiple_writes() {
         let payload = b"streaming-encoder-roundtrip-".repeat(1024);

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -91,9 +91,18 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
     ///
     /// When set to `true`, the frame header serialized by this encoder
     /// omits the 4-byte magic number prefix. Must be called BEFORE the
-    /// first write — has no effect on already-started frames.
-    pub fn set_magicless(&mut self, magicless: bool) {
+    /// first [`write`](Write::write) call; calling it after the frame
+    /// header has already been emitted returns an error so the caller
+    /// can't be misled into thinking they produced a magicless stream.
+    pub fn set_magicless(&mut self, magicless: bool) -> Result<(), Error> {
+        self.ensure_open()?;
+        if self.frame_started {
+            return Err(invalid_input_error(
+                "magicless format must be set before the first write",
+            ));
+        }
         self.magicless = magicless;
+        Ok(())
     }
 
     /// Pledge the total uncompressed content size for this frame.


### PR DESCRIPTION
## Summary

Implements donor's `ZSTD_f_zstd1_magicless` format variant — frames emitted/parsed without the 4-byte magic number prefix. Used by embedded protocols where the frame boundary is known from context, saving 4 bytes per frame.

## Encoder side

- New `magicless: bool` field on `FrameHeader` (default `false`). When `true`, `FrameHeader::serialize` skips the magic write.
- New `FrameCompressor::set_magicless(bool)` setter.
- New `StreamingEncoder::set_magicless(bool)` setter (must be called before first write).

## Decoder side

- New `read_frame_header_with_format(r, magicless)` in `decoding/frame.rs` — existing `read_frame_header` is retained as a test-only `#[cfg(test)]` wrapper (`magicless = false`); production paths call `read_frame_header_with_format` directly.
- `FrameDecoderState::new_with_format` / `reset_with_format` thread the flag through.
- `FrameDecoder::set_magicless(bool)` setter; existing `init` / `reset` / `reset_with_dict_handle` paths consult the stored flag.
- Standard (magicful) decoder still rejects magicless frames with `BadMagicNumber` — matches donor semantics where the format is unambiguous only when the caller knows it out-of-band.

## Test

`magicless_frame_omits_magic_and_roundtrips`:

1. Encode 512 bytes with `set_magicless(true)`.
2. Assert the output does NOT begin with the 4-byte zstd magic number.
3. Magicless-aware decoder round-trips the payload byte-for-byte.
4. Standard decoder MUST fail on a magicless frame.

## Test plan

- [x] Encoder: `set_magicless(true)` omits magic prefix
- [x] Decoder: `set_magicless(true)` accepts magicless frame
- [x] Roundtrip: encode → decode preserves bytes exactly
- [x] Standard decoder rejects magicless frame (no silent corruption)
- [x] All 574 nextest tests pass
- [x] clippy clean

Closes #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for encoding and decoding "magicless" Zstd frames (omits the standard 4‑byte magic prefix).
  * Compressors, streaming encoders, and decoders can be configured to enable/disable magicless framing.
  * Streaming encoders must enable magicless before the first write; magicless-aware decoders can round‑trip magicless data while standard decoders reject it.

* **Tests**
  * Added tests verifying magicless encoding, round‑trip decoding, and error on late configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
