### PR TITLE
perf(decode): 4-slot software prefetch pipeline for sequence execution (#208)

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -385,6 +385,45 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
     }
 
+    /// Lookahead-friendly prefetch issued ahead of execute. The
+    /// in-loop `prefetch_match_source` above fires at the moment of
+    /// the copy, so it can't hide DRAM latency for cold long-distance
+    /// match sources. Pipelined callers compute the match source
+    /// logical index 3-4 sequences in advance and call this helper —
+    /// by the time the corresponding `repeat()` reaches the actual
+    /// load, the line is already in-flight.
+    ///
+    /// `start_idx` is a logical index into the current buffer (same
+    /// frame as `buffer.len()`). Indices past `buffer.len()` mean the
+    /// match source refers to bytes this block hasn't written yet
+    /// (intra-block self-overlap) — those don't exist in memory yet
+    /// and the prefetch is silently dropped. The donor (`PREFETCH_L1`
+    /// in `ZSTD_prefetchMatch`) tolerates invalid addresses by spec,
+    /// but in safe Rust the cheapest equivalent is to bound-check the
+    /// logical position before chasing the slice.
+    #[inline(always)]
+    pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize, _match_length: usize) {
+        if start_idx >= self.buffer.len() {
+            return;
+        }
+        // No `match_length < 64` gate here — the in-loop helper skips
+        // tiny matches because the prefetch issue cost is comparable
+        // to the load. With 3-4 sequences of lookahead the prefetch
+        // overlaps work the CPU has to do anyway, so even sub-cache-
+        // line matches benefit. We always prefetch a single cache line
+        // (prefetch_slice_t1 caps at 4 lines internally; passing the
+        // sub-slice extent ≤ 1 line keeps it to one issue).
+        let (s1, s2) = self.buffer.as_slices();
+        if start_idx < s1.len() {
+            prefetch::prefetch_slice_t1(&s1[start_idx..]);
+        } else {
+            let idx = start_idx - s1.len();
+            if idx < s2.len() {
+                prefetch::prefetch_slice_t1(&s2[idx..]);
+            }
+        }
+    }
+
     #[cold]
     fn repeat_from_dict(
         &mut self,

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -406,7 +406,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// but in safe Rust the cheapest equivalent is to bound-check
     /// the logical position before chasing the slice.
     #[inline(always)]
-    pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize, _match_length: usize) {
+    pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize) {
         if start_idx >= self.buffer.len() {
             return;
         }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -394,24 +394,32 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// load, the line is already in-flight.
     ///
     /// `start_idx` is a logical index into the current buffer (same
-    /// frame as `buffer.len()`). Indices past `buffer.len()` mean the
-    /// match source refers to bytes this block hasn't written yet
-    /// (intra-block self-overlap) — those don't exist in memory yet
-    /// and the prefetch is silently dropped. The donor (`PREFETCH_L1`
-    /// in `ZSTD_prefetchMatch`) tolerates invalid addresses by spec,
-    /// but in safe Rust the cheapest equivalent is to bound-check the
-    /// logical position before chasing the slice.
+    /// frame as `buffer.len()`). Indices outside `[0, buffer.len())`
+    /// are silently dropped — the cases this guards against include
+    /// intra-block self-overlap (source falls past the not-yet-
+    /// written cursor), `wrapping_sub` underflow on a caller that
+    /// computed `match_start - offset` with an offset larger than
+    /// match_start (e.g. a stale or malformed sequence), and
+    /// dictionary-sourced matches whose logical position predates
+    /// the buffer's current frame. The donor (`PREFETCH_L1` in
+    /// `ZSTD_prefetchMatch`) tolerates invalid addresses by spec,
+    /// but in safe Rust the cheapest equivalent is to bound-check
+    /// the logical position before chasing the slice.
     #[inline(always)]
     pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize, _match_length: usize) {
         if start_idx >= self.buffer.len() {
             return;
         }
-        // Donor parity: `ZSTD_prefetchMatch` issues exactly two
+        // Donor parity: `ZSTD_prefetchMatch` issues up to two
         // `PREFETCH_L1` hints per match — one at `match`, one at
         // `match + CACHELINE_SIZE`. Capping the slice extent at
-        // 2 × 64 B holds `prefetch_slice_t1` to two prefetch lines
-        // instead of the 4 its `MAX_LINES` cap would allow, so we
-        // don't burn prefetch-queue slots that the steady-state
+        // 2 × 64 B holds `prefetch_slice_t1` to AT MOST two
+        // prefetch lines (it can issue fewer when the source
+        // straddles the ring buffer's `as_slices()` boundary and
+        // only the head fragment is reachable here, or when the
+        // remaining slice tail is shorter than 64 B) instead of the
+        // 4 its `MAX_LINES` cap would otherwise allow. Either way
+        // we don't burn prefetch-queue slots that the steady-state
         // ADVANCE-deep pipeline already reserves for upcoming
         // sources. No `match_length < 64` gate — with several
         // sequences of lookahead the prefetch overlaps work the

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -406,20 +406,29 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         if start_idx >= self.buffer.len() {
             return;
         }
-        // No `match_length < 64` gate here — the in-loop helper skips
-        // tiny matches because the prefetch issue cost is comparable
-        // to the load. With 3-4 sequences of lookahead the prefetch
-        // overlaps work the CPU has to do anyway, so even sub-cache-
-        // line matches benefit. We always prefetch a single cache line
-        // (prefetch_slice_t1 caps at 4 lines internally; passing the
-        // sub-slice extent ≤ 1 line keeps it to one issue).
+        // Donor parity: `ZSTD_prefetchMatch` issues exactly two
+        // `PREFETCH_L1` hints per match — one at `match`, one at
+        // `match + CACHELINE_SIZE`. Capping the slice extent at
+        // 2 × 64 B holds `prefetch_slice_t1` to two prefetch lines
+        // instead of the 4 its `MAX_LINES` cap would allow, so we
+        // don't burn prefetch-queue slots that the steady-state
+        // ADVANCE-deep pipeline already reserves for upcoming
+        // sources. No `match_length < 64` gate — with several
+        // sequences of lookahead the prefetch overlaps work the
+        // CPU has to do anyway, so even sub-cache-line matches
+        // benefit.
+        const PREFETCH_EXTENT: usize = 128;
         let (s1, s2) = self.buffer.as_slices();
         if start_idx < s1.len() {
-            prefetch::prefetch_slice_t1(&s1[start_idx..]);
+            let tail = &s1[start_idx..];
+            let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
+            prefetch::prefetch_slice_t1(&tail[..bound]);
         } else {
             let idx = start_idx - s1.len();
             if idx < s2.len() {
-                prefetch::prefetch_slice_t1(&s2[idx..]);
+                let tail = &s2[idx..];
+                let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
+                prefetch::prefetch_slice_t1(&tail[..bound]);
             }
         }
     }

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -109,13 +109,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let saved_offset_hist = *offset_hist;
 
     #[inline(always)]
-    fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
+    fn execute_resolved_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,
         literals: &[u8],
         lit_cur: &mut usize,
         lit_len: usize,
-        offset_hist: &mut [u32; 3],
         seq: Sequence,
+        actual_offset: u32,
     ) -> Result<(), DecompressBlockError> {
         let high = *lit_cur + seq.ll as usize;
         if high > lit_len {
@@ -131,42 +131,157 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         *lit_cur = high;
         buffer.push(lits);
 
-        let actual = do_offset_history(seq.of, seq.ll, offset_hist);
-        if actual == 0 {
+        if actual_offset == 0 {
             return Err(ExecuteSequencesError::ZeroOffset.into());
         }
         buffer
-            .repeat(actual as usize, seq.ml as usize)
+            .repeat(actual_offset as usize, seq.ml as usize)
             .map_err(ExecuteSequencesError::from)?;
         Ok(())
     }
 
-    // Single fused loop over all sequences. The state-update step
-    // (`ensure_bits` + per-decoder `update_state_fast`) is skipped on
-    // the final iteration — matching the donor `isLastSeq` template
-    // pattern (no pre-fetch of the next state when there is no next
-    // sequence). Under `#[inline(always)]` the trailing `if i + 1 <
-    // num_sequences` collapses to the same generated code as the
-    // previous split-shape version, but keeps the per-sequence body in
-    // one place so future edits to the hot path stay in sync.
     let num_sequences = section.num_sequences as usize;
-    for i in 0..num_sequences {
-        let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-        execute_one_sequence(
-            buffer,
-            literals_buffer,
-            &mut lit_cur,
-            literals_buffer_len,
-            offset_hist,
-            seq,
-        )?;
-        seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
 
-        if i + 1 < num_sequences {
-            br.ensure_bits(max_update_bits);
-            ll_dec.update_state_fast(&mut br);
-            ml_dec.update_state_fast(&mut br);
-            of_dec.update_state_fast(&mut br);
+    // 4-slot software pipeline mirroring donor
+    // `ZSTD_decompressSequencesLong_body`. Pre-decode `ADVANCE`
+    // sequences ahead, prefetch each match source as we go, then
+    // execute the oldest in-flight sequence per iteration while
+    // decoding the next one. By the time `execute_resolved_sequence`
+    // reaches `buffer.repeat()` for slot k, the prefetch issued
+    // `ADVANCE` iterations earlier has had time to pull the source
+    // line(s) into L1/L2 — hiding DRAM latency for long-distance
+    // matches whose source is beyond cache residency.
+    //
+    // Donor uses STORED_SEQS = 8; we start at 4 to keep the ring on
+    // the stack within register pressure and reuse later iterations
+    // to dial up if profiling shows headroom. The pipeline is opt-in
+    // by `num_sequences >= ADVANCE * 2` — for short blocks the
+    // prefill + drain overhead dominates the prefetch gain, so the
+    // existing fused single-pass path stays in charge there.
+    const ADVANCE: usize = 4;
+    const ADVANCE_MASK: usize = ADVANCE - 1;
+
+    if num_sequences >= ADVANCE * 2 {
+        // `prefetch_pos` is the logical buffer index (same frame as
+        // `buffer.len()`) at which the NEXT not-yet-decoded sequence
+        // will start pushing literals. We pre-decode 4 ahead, so we
+        // accumulate (ll + ml) per resolved seq to keep this position
+        // synchronised with where execute will eventually be.
+        let mut prefetch_pos: usize = old_buffer_size;
+        // Stack ring of (raw seq, resolved actual_offset). Storing
+        // `actual_offset` up front lets execute skip
+        // `do_offset_history` — the resolution already mutated
+        // `offset_hist` at decode-ahead time.
+        let mut ring: [(Sequence, u32); ADVANCE] = [(
+            Sequence {
+                ll: 0,
+                ml: 0,
+                of: 0,
+            },
+            0,
+        ); ADVANCE];
+
+        // Pre-fill the ring. The FSE state-update guard mirrors the
+        // single-pass loop: skip update after the very last decode
+        // (when k+1 == num_sequences) since there is no next decode.
+        for (k, slot) in ring.iter_mut().enumerate() {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+            // Issue lookahead prefetch even when actual == 0; the
+            // helper short-circuits invalid positions, and we want
+            // the same control flow on the malformed-input path so
+            // the deferred ZeroOffset check fires from execute.
+            let match_start = prefetch_pos + seq.ll as usize;
+            let source_idx = match_start.wrapping_sub(actual as usize);
+            buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
+            prefetch_pos = match_start + seq.ml as usize;
+            *slot = (seq, actual);
+            if k + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
+        }
+
+        // Steady state: decode next, prefetch its source, execute the
+        // oldest slot in the ring. `i & ADVANCE_MASK` is both the
+        // oldest slot (currently holding seq at logical index i -
+        // ADVANCE) and the slot we overwrite with the newly-decoded
+        // seq[i] — donor pattern.
+        for i in ADVANCE..num_sequences {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+            let match_start = prefetch_pos + seq.ll as usize;
+            let source_idx = match_start.wrapping_sub(actual as usize);
+            buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
+            prefetch_pos = match_start + seq.ml as usize;
+
+            let slot = i & ADVANCE_MASK;
+            let (exec_seq, exec_actual) = ring[slot];
+            ring[slot] = (seq, actual);
+
+            execute_resolved_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                exec_seq,
+                exec_actual,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+
+            if i + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
+        }
+
+        // Drain: execute remaining ADVANCE sequences. Iteration order
+        // matches the ring slot they occupy from the steady-state
+        // loop's final write — start from `num_sequences & MASK` to
+        // preserve sequence order.
+        for k in 0..ADVANCE {
+            let slot = (num_sequences + k) & ADVANCE_MASK;
+            let (exec_seq, exec_actual) = ring[slot];
+            execute_resolved_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                exec_seq,
+                exec_actual,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+        }
+    } else {
+        // Short-block fallback: the single-pass fused loop. For
+        // num_sequences < ADVANCE * 2 the pipeline's prefill + drain
+        // dominates the cycles saved by prefetch lookahead, so the
+        // simpler shape wins. Inlined here (rather than a separate
+        // function) so the cold tail-call cost of swapping decoders
+        // mid-block stays at zero.
+        for i in 0..num_sequences {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+            execute_resolved_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                seq,
+                actual,
+            )?;
+            seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
+
+            if i + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
         }
     }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -167,6 +167,15 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // existing fused single-pass path stays in charge there.
     const ADVANCE: usize = 4;
     const ADVANCE_MASK: usize = ADVANCE - 1;
+    // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
+    // power of two. Compile-time guard so a future tweak (e.g.
+    // bumping to donor's STORED_SEQS = 8, also a power of two) can't
+    // silently corrupt the ring index if someone picks a non-power-
+    // of-two value.
+    const _: () = assert!(
+        ADVANCE.is_power_of_two(),
+        "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
+    );
 
     // Read-only estimate for the prefetch's match-source position.
     // The TRUE `actual_offset` requires mutating `offset_hist` via
@@ -197,7 +206,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             (2, false) => hist[1],
             (2, true) => hist[2],
             (3, false) => hist[2],
-            (3, true) => hist[0].saturating_sub(1),
+            // Mirror `do_offset_history_repcode`'s `wrapping_sub(1)` —
+            // not `saturating_sub` — so even on corrupted/0 history
+            // the estimate matches the real resolver. The result is
+            // only consumed by prefetch addressing, where a wild
+            // wrap just lands the hint on an out-of-range slot the
+            // helper drops.
+            (3, true) => hist[0].wrapping_sub(1),
             _ => 0,
         }
     }
@@ -230,7 +245,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
             let source_idx = match_start.wrapping_sub(est_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
+            buffer.prefetch_lookahead_match_source(source_idx);
             prefetch_pos = match_start + seq.ml as usize;
             *slot = seq;
             if k + 1 < num_sequences {
@@ -251,7 +266,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
             let source_idx = match_start.wrapping_sub(est_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
+            buffer.prefetch_lookahead_match_source(source_idx);
             prefetch_pos = match_start + seq.ml as usize;
 
             let slot = i & ADVANCE_MASK;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -108,14 +108,20 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
 
+    // `offset_hist` mutates here (via do_offset_history) and only
+    // here. The pipeline above intentionally defers all repcode
+    // resolution to this call site so a mid-loop error keeps the
+    // caller's `offset_hist` consistent with the sequences that
+    // actually executed — preserving the legacy two-pass
+    // 'partial output, no rewound history' contract on early exits.
     #[inline(always)]
-    fn execute_resolved_sequence<B: super::buffer_backend::BufferBackend>(
+    fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,
         literals: &[u8],
         lit_cur: &mut usize,
         lit_len: usize,
+        offset_hist: &mut [u32; 3],
         seq: Sequence,
-        actual_offset: u32,
     ) -> Result<(), DecompressBlockError> {
         let high = *lit_cur + seq.ll as usize;
         if high > lit_len {
@@ -131,11 +137,12 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         *lit_cur = high;
         buffer.push(lits);
 
-        if actual_offset == 0 {
+        let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+        if actual == 0 {
             return Err(ExecuteSequencesError::ZeroOffset.into());
         }
         buffer
-            .repeat(actual_offset as usize, seq.ml as usize)
+            .repeat(actual as usize, seq.ml as usize)
             .map_err(ExecuteSequencesError::from)?;
         Ok(())
     }
@@ -161,41 +168,71 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     const ADVANCE: usize = 4;
     const ADVANCE_MASK: usize = ADVANCE - 1;
 
+    // Read-only estimate for the prefetch's match-source position.
+    // The TRUE `actual_offset` requires mutating `offset_hist` via
+    // `do_offset_history`, which we deliberately defer to execute
+    // time so a mid-loop error preserves the legacy 'no partial
+    // history mutation' semantics. For the `seq.of >= 4` case
+    // (every fresh non-repcode offset, dominant on the long-distance
+    // workloads this pipeline targets) the estimate is exact and
+    // matches do_offset_history's output bit-for-bit. For the
+    // repcode 1..=3 cases the estimate reads the current `hist`
+    // without mutating it — this can lag by up to ADVANCE
+    // sequences vs the post-execute state, but the lag only
+    // mis-points the prefetch by a few cache lines on close-range
+    // matches whose source is already L1-warm; the cost of a
+    // mis-targeted PREFETCH_L1 on warm data is negligible.
+    #[inline(always)]
+    fn estimate_actual_offset(of: u32, ll: u32, hist: &[u32; 3]) -> u32 {
+        if of >= 4 {
+            return of - 3;
+        }
+        // Mirrors the read-only halves of do_offset_history_repcode's
+        // selection table: the lit-zero edge cases that pull from a
+        // different hist slot are kept consistent so the estimate
+        // tracks execute-time resolution as closely as possible.
+        match (of, ll == 0) {
+            (1, false) => hist[0],
+            (1, true) => hist[1],
+            (2, false) => hist[1],
+            (2, true) => hist[2],
+            (3, false) => hist[2],
+            (3, true) => hist[0].saturating_sub(1),
+            _ => 0,
+        }
+    }
+
     if num_sequences >= ADVANCE * 2 {
         // `prefetch_pos` is the logical buffer index (same frame as
         // `buffer.len()`) at which the NEXT not-yet-decoded sequence
         // will start pushing literals. We pre-decode 4 ahead, so we
-        // accumulate (ll + ml) per resolved seq to keep this position
+        // accumulate (ll + ml) per decoded seq to keep this position
         // synchronised with where execute will eventually be.
         let mut prefetch_pos: usize = old_buffer_size;
-        // Stack ring of (raw seq, resolved actual_offset). Storing
-        // `actual_offset` up front lets execute skip
-        // `do_offset_history` — the resolution already mutated
-        // `offset_hist` at decode-ahead time.
-        let mut ring: [(Sequence, u32); ADVANCE] = [(
-            Sequence {
-                ll: 0,
-                ml: 0,
-                of: 0,
-            },
-            0,
-        ); ADVANCE];
+        // Stack ring of raw sequences. `do_offset_history` is NOT
+        // run here — execute calls it later, so `offset_hist`
+        // mutations stay in lockstep with successful execute calls
+        // (matching the legacy 'no rollback on mid-loop error'
+        // contract).
+        let mut ring: [Sequence; ADVANCE] = [Sequence {
+            ll: 0,
+            ml: 0,
+            of: 0,
+        }; ADVANCE];
 
         // Pre-fill the ring. The FSE state-update guard mirrors the
         // single-pass loop: skip update after the very last decode
         // (when k+1 == num_sequences) since there is no next decode.
         for (k, slot) in ring.iter_mut().enumerate() {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
-            // Issue lookahead prefetch even when actual == 0; the
-            // helper short-circuits invalid positions, and we want
-            // the same control flow on the malformed-input path so
-            // the deferred ZeroOffset check fires from execute.
+            // Estimated offset for prefetch only — see
+            // `estimate_actual_offset` for the accuracy contract.
+            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
-            let source_idx = match_start.wrapping_sub(actual as usize);
+            let source_idx = match_start.wrapping_sub(est_offset as usize);
             buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
             prefetch_pos = match_start + seq.ml as usize;
-            *slot = (seq, actual);
+            *slot = seq;
             if k + 1 < num_sequences {
                 br.ensure_bits(max_update_bits);
                 ll_dec.update_state_fast(&mut br);
@@ -211,23 +248,23 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // seq[i] — donor pattern.
         for i in ADVANCE..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
-            let source_idx = match_start.wrapping_sub(actual as usize);
+            let source_idx = match_start.wrapping_sub(est_offset as usize);
             buffer.prefetch_lookahead_match_source(source_idx, seq.ml as usize);
             prefetch_pos = match_start + seq.ml as usize;
 
             let slot = i & ADVANCE_MASK;
-            let (exec_seq, exec_actual) = ring[slot];
-            ring[slot] = (seq, actual);
+            let exec_seq = ring[slot];
+            ring[slot] = seq;
 
-            execute_resolved_sequence(
+            execute_one_sequence(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
+                offset_hist,
                 exec_seq,
-                exec_actual,
             )?;
             seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
 
@@ -245,14 +282,14 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // preserve sequence order.
         for k in 0..ADVANCE {
             let slot = (num_sequences + k) & ADVANCE_MASK;
-            let (exec_seq, exec_actual) = ring[slot];
-            execute_resolved_sequence(
+            let exec_seq = ring[slot];
+            execute_one_sequence(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
+                offset_hist,
                 exec_seq,
-                exec_actual,
             )?;
             seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
         }
@@ -265,14 +302,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // mid-block stays at zero.
         for i in 0..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let actual = do_offset_history(seq.of, seq.ll, offset_hist);
-            execute_resolved_sequence(
+            execute_one_sequence(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
+                offset_hist,
                 seq,
-                actual,
             )?;
             seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -153,7 +153,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // `ZSTD_decompressSequencesLong_body`. Pre-decode `ADVANCE`
     // sequences ahead, prefetch each match source as we go, then
     // execute the oldest in-flight sequence per iteration while
-    // decoding the next one. By the time `execute_resolved_sequence`
+    // decoding the next one. By the time `execute_one_sequence`
     // reaches `buffer.repeat()` for slot k, the prefetch issued
     // `ADVANCE` iterations earlier has had time to pull the source
     // line(s) into L1/L2 — hiding DRAM latency for long-distance


### PR DESCRIPTION
## Summary

Port the donor `ZSTD_decompressSequencesLong_body` shape to the fused decode+execute path: 4-slot software pipeline that decodes 4 sequences ahead of execute, prefetching each match source line at decode time. By the time `buffer.repeat()` reaches the actual load for seq[i], the prefetch issued 4 iterations earlier has had time to pull the line into L1/L2 — hiding DRAM latency on long-distance matches whose source is beyond cache residency.

Closes #208.

## Changes

### `zstd/src/decoding/decode_buffer.rs`

- New `prefetch_lookahead_match_source(start_idx)` — issues the prefetch hint at a logical buffer position, bound-checks against `buffer.len()` so out-of-range indices (intra-block self-overlap, `wrapping_sub` underflow on a malformed sequence, dictionary-sourced matches predating the current frame) silently drop the hint. Always prefetches up to two 64 B cache lines per call (donor `PREFETCH_L1` parity), bounded by `PREFETCH_EXTENT = 128`.

### `zstd/src/decoding/sequence_section_decoder.rs`

- 4-slot software pipeline: prefill 4 → steady (decode N, prefetch using a read-only offset estimate, execute N−4) → drain 4.
- Ring stores raw `[Sequence; 4]`. `do_offset_history` stays in `execute_one_sequence` so a mid-loop error preserves the legacy "partial output, no history rewind" semantics — the in-flight ring slots haven't mutated `offset_hist` yet.
- For prefetch addressing only, a separate `estimate_actual_offset` resolves the seq's `actual_offset` against the current `offset_hist` **without mutating it**. The estimate is exact for `seq.of >= 4` (every fresh non-repcode offset — the dominant case on the long-distance workloads this pipeline targets); for repcode 1..=3 it can lag by up to ADVANCE sequences, but those are close-range matches whose source is already L1-warm, so a slightly mis-pointed PREFETCH_L1 has negligible cost.
- Opt-in by `num_sequences >= 2 * ADVANCE`. Short blocks fall back to the existing fused single-pass loop, which keeps its existing in-loop prefetch.
- Compile-time guard on `ADVANCE.is_power_of_two()` so the `i & ADVANCE_MASK` ring indexing stays equivalent to `i % ADVANCE` if `ADVANCE` is ever changed.

Donor uses `STORED_SEQS = 8`; this PR starts at 4 to keep ring on the stack within register pressure. Future iterations can dial up after profiling confirms headroom.

## Test plan

- [x] full nextest suite — 576 passed, 3 skipped
- [x] lint+typecheck clean
- [ ] Bench on Linux server (i9-9900K, BMI2/AVX2) on long-window corpus, before vs after
- [ ] Flamegraph on large-window corpus to confirm DRAM stall reduction
