### PR TITLE
feat(dashboard): aggregate-over-levels chart + per-level history when level pinned

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -959,6 +959,22 @@
         return typeof stage === "string" && stage.indexOf("decompress") === 0;
       }
 
+      // Shared mapper from (row.metric, row.stage) → chart logical
+      // metric. Three chart paths consume this:
+      //   - buildProfileData (level-axis)
+      //   - buildProfileLevelHistoryData (snapshot-axis pinned level)
+      //   - buildAggregateOverTimeData (aggregate over all levels)
+      // Keep them in lockstep so a new logical metric (or a renamed
+      // stage on the bench side) only needs to be wired in ONE place.
+      function profileLogicalMetric(row) {
+        if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
+        if (row.metric === "throughput_bytes_per_sec") {
+          if (isCompressStage(row.stage)) return "compress_speed";
+          if (isDecompressStage(row.stage)) return "decompress_speed";
+        }
+        return null;
+      }
+
       // Pick one record per (level, metric) for the chosen target /
       // scenario / stage. When `snapshot === PROFILE_LATEST` we take
       // whichever record is the most recent per (level, metric)
@@ -996,15 +1012,6 @@
           return true;
         };
 
-        const logicalMetric = (row) => {
-          if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
-          if (row.metric === "throughput_bytes_per_sec") {
-            if (isCompressStage(row.stage)) return "compress_speed";
-            if (isDecompressStage(row.stage)) return "decompress_speed";
-          }
-          return null;
-        };
-
         // Group by (snapshot, logical-metric): each cell averages the
         // remaining cohort dimensions (target × scenario × source). For
         // a fully-pinned filter (target/scenario both specific too)
@@ -1014,7 +1021,7 @@
         for (const row of state.records) {
           if (!matchesFilter(row)) continue;
           if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
-          const lm = logicalMetric(row);
+          const lm = profileLogicalMetric(row);
           if (!lm) continue;
           const snap = row.generated_at || row.commit_sha || "local-run";
           const key = `${snap}|${lm}`;
@@ -1074,15 +1081,6 @@
         //   `compress_speed`   — throughput at stage=compress
         //   `decompress_speed` — throughput at any decompress stage
         //   `ratio`            — compression_ratio at stage=compress
-        const logicalMetric = (row) => {
-          if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
-          if (row.metric === "throughput_bytes_per_sec") {
-            if (isCompressStage(row.stage)) return "compress_speed";
-            if (isDecompressStage(row.stage)) return "decompress_speed";
-          }
-          return null;
-        };
-
         // Two-pass aggregation:
         //
         //   Pass 1 — collect every matching row, indexed by
@@ -1125,7 +1123,7 @@
         for (const row of state.records) {
           if (!matchesFilter(row)) continue;
           if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
-          const lm = logicalMetric(row);
+          const lm = profileLogicalMetric(row);
           if (!lm) continue;
           const key = `${row.level}|${lm}`;
           const cohort = cohortKey(row);
@@ -1360,12 +1358,21 @@
 
         const chartDatasets = buildProfileDatasets(datasets);
 
+        // Snapshot-axis history mode can produce many ticks (one per
+        // commit), so we let Chart.js drop labels that don't fit.
+        // Level-axis mode keeps `autoSkip: false` so every level
+        // tick stays visible — the level set is small and bounded.
+        const xTicks = historyMode
+          ? { autoSkip: true, maxTicksLimit: 12, maxRotation: 60, minRotation: 30 }
+          : { autoSkip: false, maxRotation: 60, minRotation: 30 };
+
         if (state.profileChart) {
           // In-place update path: swap labels + datasets, then ask
           // Chart.js to redraw without animation. This preserves the
           // chart instance (tooltips, scales, animation state) across
           // every target/scenario/stage switch.
           state.profileChart.options.scales.x.title.text = xAxisTitle;
+          state.profileChart.options.scales.x.ticks = xTicks;
           state.profileChart.data.labels = levels;
           state.profileChart.data.datasets = chartDatasets;
           state.profileChart.update("none");
@@ -1380,7 +1387,7 @@
               scales: {
                 x: {
                   title: { display: true, text: xAxisTitle },
-                  ticks: { autoSkip: false, maxRotation: 60, minRotation: 30 },
+                  ticks: xTicks,
                 },
                 y: {
                   type: "linear",
@@ -1439,15 +1446,6 @@
           return true;
         };
 
-        const logicalMetric = (row) => {
-          if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
-          if (row.metric === "throughput_bytes_per_sec") {
-            if (isCompressStage(row.stage)) return "compress_speed";
-            if (isDecompressStage(row.stage)) return "decompress_speed";
-          }
-          return null;
-        };
-
         // Pre-aggregate per (snapshot, lm, cohort) so each cohort
         // contributes one MEAN per snapshot before being folded into
         // the snapshot-level mean. Without this stratification, a
@@ -1471,7 +1469,7 @@
         for (const row of state.records) {
           if (!matchesFilter(row)) continue;
           if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
-          const lm = logicalMetric(row);
+          const lm = profileLogicalMetric(row);
           if (!lm) continue;
           const snap = row.generated_at || row.commit_sha || "local-run";
           const inner = `${snap}|${lm}|${cohortKey(row)}`;
@@ -1717,7 +1715,15 @@
         const fragment = document.createDocumentFragment();
         const latestOpt = document.createElement("option");
         latestOpt.value = PROFILE_LATEST;
-        latestOpt.textContent = "latest";
+        // Sentinel label tracks chart mode: in level-axis mode
+        // (level=all) it pins each (level, lm) to its most recent
+        // snapshot ("latest"); in snapshot-axis history mode
+        // (level=specific) it instead plots every snapshot for that
+        // level. Same sentinel value either way — the renaming is
+        // purely a UI honesty fix so the dropdown doesn't promise
+        // "latest" while showing a full timeline.
+        const historyMode = level !== ALWAYS;
+        latestOpt.textContent = historyMode ? "all snapshots" : "latest";
         fragment.appendChild(latestOpt);
         for (const label of labels) {
           const opt = document.createElement("option");

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -302,8 +302,11 @@
         <p style="font-size: 0.9rem">
           Same six series as Level Profile, but plotted against
           <strong>snapshot / commit time</strong> on the X-axis and
-          averaged across <strong>every</strong> (level, scenario, target,
-          source) cohort for that snapshot. Each point answers
+          averaged across <strong>every</strong> (level, scenario,
+          target) cohort for that snapshot — within each cohort the
+          decompress source variants (<code>rust_stream</code> +
+          <code>c_stream</code>) collapse into the inner mean so they
+          don't outweigh compress rows. Each point answers
           “across the whole bench matrix, where are we right now vs
           FFI?” — useful for spotting aggregate dynamics across commits
           regardless of which level or corpus drove the change. The top
@@ -1344,7 +1347,10 @@
             state.profileChart.update("none");
           }
           el("legend-profile").replaceChildren();
-          el("profile-status").textContent = `No level points for target=${filter.target}, scenario=${filter.scenario}, level=${filter.level}.`;
+          // History mode plots snapshots, not levels, so the empty
+          // message describes the axis the user is actually looking at.
+          const emptyAxisDesc = historyMode ? "snapshot points" : "level points";
+          el("profile-status").textContent = `No ${emptyAxisDesc} for target=${filter.target}, scenario=${filter.scenario}, level=${filter.level}.`;
           return;
         }
         const snapshotNote = historyMode
@@ -1434,7 +1440,8 @@
 
       // Aggregate-over-levels chart: same six series as Level Profile,
       // but X = snapshot/commit time, Y = mean across **every** matching
-      // (level, scenario, target, source) cohort for that snapshot.
+      // (level, scenario, target) cohort for that snapshot (decompress
+      // source variants collapse into the inner mean — see cohortKey).
       // Respects the top Target / Scenario / Level filters — pinning
       // any one of them narrows the aggregate to that slice while the
       // other dimensions are still averaged across.
@@ -1597,7 +1604,7 @@
           filter.level === ALWAYS ? "level=all" : `level=${filter.level}`,
         ].join(", ");
         el("aggregate-status").textContent =
-          `Showing ${snapshotCount} snapshot point(s) — ${filterDesc} (per-snapshot mean across every matching (level, scenario, target, source) cohort).`;
+          `Showing ${snapshotCount} snapshot point(s) — ${filterDesc} (per-snapshot mean across every matching (level, scenario, target) cohort; decompress source variants collapse into the inner mean).`;
 
         const chartDatasets = buildAggregateDatasets(datasets);
 

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1448,16 +1448,22 @@
 
         // Pre-aggregate per (snapshot, lm, cohort) so each cohort
         // contributes one MEAN per snapshot before being folded into
-        // the snapshot-level mean. Without this stratification, a
-        // (level, scenario) combo that has more source variants would
-        // weigh more than one with fewer — biasing the aggregate
-        // toward whichever cohort happened to enumerate more rows.
+        // the snapshot-level mean. The cohort INTENTIONALLY excludes
+        // `source`: for decompress, `rust_stream` and `c_stream` are
+        // two measurements of the same logical (level, scenario,
+        // target) cell, so collapsing them into the inner mean keeps
+        // every (level, scenario, target) at equal weight in the
+        // outer mean. Including `source` would let a decompress
+        // (level, scenario, target) contribute 2× the rows of a
+        // compress one and skew the snapshot aggregate toward
+        // decompress-heavy levels.
         const cohortKey = (row) => {
-          // Cohort = (level, scenario, target, source). All of these
-          // are present in the row regardless of which top filters
-          // are on `__all__`, so the mean stays comparable across
-          // filter shapes.
-          return `${row.level}|${row.scenario}|${row.target || "?"}|${row.source || "none"}`;
+          // Use "unknown-target" for missing target — matches the
+          // sentinel `matchesCoreFilters` / `repopulateSnapshotOptions`
+          // use, so a missing-target row never splits into its own
+          // singleton cohort that would later mismatch with filter
+          // dropdown values.
+          return `${row.level}|${row.scenario}|${row.target || "unknown-target"}`;
         };
 
         // Two-level aggregation:
@@ -1673,7 +1679,13 @@
         // `bindFilters()` below, which fans every top-filter change
         // out to both `rerender()` (delta chart) and the profile.
         profileSelectors.snapshot.addEventListener("change", renderProfileChart);
-        for (const cb of document.querySelectorAll(".profile-toggles input[type=checkbox]")) {
+        // Scope to inputs that actually carry a profile series id —
+        // the aggregate-toggles container reuses `.profile-toggles`
+        // for styling, so a bare `.profile-toggles input` selector
+        // would attach this handler to aggregate checkboxes too
+        // (it'd be a no-op because `dataset.series` is missing, but
+        // the redundant listener couples JS to a styling class).
+        for (const cb of document.querySelectorAll(".profile-toggles input[type=checkbox][data-series]")) {
           cb.addEventListener("change", (e) => {
             const key = e.currentTarget.dataset.series;
             if (!key) return;

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -297,6 +297,34 @@
         <div id="profile-status" style="margin-top: 8px; font-size: 0.88rem"></div>
       </section>
 
+      <section class="card" style="margin-top: 14px">
+        <h2 style="margin: 0 0 8px; font-size: 1.2rem">Aggregate over all levels (commit timeline)</h2>
+        <p style="font-size: 0.9rem">
+          Same six series as Level Profile, but plotted against
+          <strong>snapshot / commit time</strong> on the X-axis and
+          averaged across <strong>every</strong> (level, scenario, target,
+          source) cohort for that snapshot. Each point answers
+          “across the whole bench matrix, where are we right now vs
+          FFI?” — useful for spotting aggregate dynamics across commits
+          regardless of which level or corpus drove the change. The top
+          Target / Scenario / Level filters still apply: setting any of
+          them to a specific value narrows the average to that slice.
+        </p>
+        <div class="aggregate-toggles profile-toggles">
+          <label><input type="checkbox" data-agg-series="rust_compress_speed" checked /> Rust compress</label>
+          <label><input type="checkbox" data-agg-series="ffi_compress_speed" checked /> FFI compress</label>
+          <label><input type="checkbox" data-agg-series="rust_decompress_speed" checked /> Rust decompress</label>
+          <label><input type="checkbox" data-agg-series="ffi_decompress_speed" checked /> FFI decompress</label>
+          <label><input type="checkbox" data-agg-series="rust_ratio" checked /> Rust ratio</label>
+          <label><input type="checkbox" data-agg-series="ffi_ratio" checked /> FFI ratio</label>
+        </div>
+        <div class="chart-wrap">
+          <canvas id="chart-aggregate"></canvas>
+        </div>
+        <div id="legend-aggregate" class="html-legend"></div>
+        <div id="aggregate-status" style="margin-top: 8px; font-size: 0.88rem"></div>
+      </section>
+
       <details class="card">
         <summary><strong>Raw timings (secondary view)</strong></summary>
         <p style="margin-top: 8px">
@@ -341,6 +369,15 @@
         chart: null,
         profileChart: null,
         profileSeriesVisibility: {
+          rust_compress_speed: true,
+          ffi_compress_speed: true,
+          rust_decompress_speed: true,
+          ffi_decompress_speed: true,
+          rust_ratio: true,
+          ffi_ratio: true,
+        },
+        aggregateChart: null,
+        aggregateSeriesVisibility: {
           rust_compress_speed: true,
           ffi_compress_speed: true,
           rust_decompress_speed: true,
@@ -936,6 +973,86 @@
       // the snapshot/target/scenario filter — this collapses the source
       // dimension for decompress (rust_stream vs c_stream) because the
       // Rust/FFI comparison already lives inside each row.
+      // When the user picks a specific level (filter.level !== ALWAYS)
+      // the original "X = level" chart collapses to a single point —
+      // not useful. In that case we swap the X-axis to snapshot/commit
+      // time so the chart still plots multiple points: one per
+      // snapshot, each value = mean across the remaining cohorts
+      // (target × scenario × source) for that snapshot at the locked
+      // level. The output shape matches the level-mode call site so
+      // `renderProfileChart` can use the same Chart.js datasets array.
+      function buildProfileLevelHistoryData(filter) {
+        const matchesFilter = (r) => {
+          if (filter.target !== ALWAYS && (r.target || "unknown-target") !== filter.target) return false;
+          if (filter.scenario !== ALWAYS && r.scenario !== filter.scenario) return false;
+          if (r.level !== filter.level) return false;
+          // PROFILE_LATEST in level-history mode means "all snapshots";
+          // the user is already pinned to a single level, so showing
+          // every snapshot as a point on the X-axis is the whole point.
+          if (filter.snapshot !== PROFILE_LATEST) {
+            const label = r.generated_at || r.commit_sha || "local-run";
+            if (label !== filter.snapshot) return false;
+          }
+          return true;
+        };
+
+        const logicalMetric = (row) => {
+          if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
+          if (row.metric === "throughput_bytes_per_sec") {
+            if (isCompressStage(row.stage)) return "compress_speed";
+            if (isDecompressStage(row.stage)) return "decompress_speed";
+          }
+          return null;
+        };
+
+        // Group by (snapshot, logical-metric): each cell averages the
+        // remaining cohort dimensions (target × scenario × source). For
+        // a fully-pinned filter (target/scenario both specific too)
+        // each cell is exactly one (or two — rust_stream + c_stream for
+        // decompress) row, so the mean is degenerate but correct.
+        const bySnapshotLogical = new Map();
+        for (const row of state.records) {
+          if (!matchesFilter(row)) continue;
+          if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
+          const lm = logicalMetric(row);
+          if (!lm) continue;
+          const snap = row.generated_at || row.commit_sha || "local-run";
+          const key = `${snap}|${lm}`;
+          let agg = bySnapshotLogical.get(key);
+          if (!agg) {
+            agg = { snap, rust_sum: 0, ffi_sum: 0, count: 0 };
+            bySnapshotLogical.set(key, agg);
+          }
+          agg.rust_sum += row.rust_value;
+          agg.ffi_sum += row.ffi_value;
+          agg.count += 1;
+        }
+
+        const snapshotSet = new Set();
+        for (const agg of bySnapshotLogical.values()) snapshotSet.add(agg.snap);
+        const snapshots = Array.from(snapshotSet).sort((a, b) => {
+          const at = parseTimestamp(a);
+          const bt = parseTimestamp(b);
+          if (at !== null && bt !== null) return at - bt;
+          return String(a).localeCompare(String(b));
+        });
+
+        const lookup = (snap, lm, side) => {
+          const agg = bySnapshotLogical.get(`${snap}|${lm}`);
+          if (!agg || agg.count === 0) return null;
+          const sum = side === "rust" ? agg.rust_sum : agg.ffi_sum;
+          const mean = sum / agg.count;
+          if (lm === "compress_speed" || lm === "decompress_speed") {
+            return mean / (1024 * 1024);
+          }
+          return mean;
+        };
+
+        const series = (lm, side) => snapshots.map((s) => lookup(s, lm, side));
+
+        return { snapshots, snapshotCount: snapshots.length, lookup, series };
+      }
+
       function buildProfileData(filter) {
         // Top filters use the `ALWAYS` sentinel ("__all__") to mean
         // "don't filter on this dimension". When that's set on target /
@@ -1075,68 +1192,78 @@
         return {
           levels: levelLabels,
           levelCount: levels.length,
-          datasets: [
-            {
-              seriesKey: "rust_compress_speed",
-              label: "Rust compress (MiB/s)",
-              data: series("compress_speed", "rust"),
-              yAxisID: "y",
-              borderColor: "hsl(150 65% 38%)",
-              backgroundColor: "hsla(150 65% 38% / 0.25)",
-            },
-            {
-              seriesKey: "ffi_compress_speed",
-              label: "FFI compress (MiB/s)",
-              data: series("compress_speed", "ffi"),
-              yAxisID: "y",
-              borderColor: "hsl(205 65% 45%)",
-              backgroundColor: "hsla(205 65% 45% / 0.25)",
-            },
-            {
-              seriesKey: "rust_decompress_speed",
-              label: "Rust decompress (MiB/s)",
-              data: series("decompress_speed", "rust"),
-              yAxisID: "y",
-              borderColor: "hsl(170 65% 28%)",
-              backgroundColor: "hsla(170 65% 28% / 0.25)",
-              borderDash: [2, 3],
-            },
-            {
-              seriesKey: "ffi_decompress_speed",
-              label: "FFI decompress (MiB/s)",
-              data: series("decompress_speed", "ffi"),
-              yAxisID: "y",
-              borderColor: "hsl(225 65% 35%)",
-              backgroundColor: "hsla(225 65% 35% / 0.25)",
-              borderDash: [2, 3],
-            },
-            // "ratio" here is the bench emitter's compression_ratio
-            // value, which is compressed_size / input_size — i.e. the
-            // output fraction, where LOWER means BETTER compression
-            // (a 0.30 value compresses to 30% of input). The axis and
-            // dataset labels say so explicitly to keep readers from
-            // assuming the conventional input/output definition where
-            // larger is better.
-            {
-              seriesKey: "rust_ratio",
-              label: "Rust output ratio (lower=better)",
-              data: series("ratio", "rust"),
-              yAxisID: "y1",
-              borderColor: "hsl(30 75% 45%)",
-              backgroundColor: "hsla(30 75% 45% / 0.25)",
-              borderDash: [6, 4],
-            },
-            {
-              seriesKey: "ffi_ratio",
-              label: "FFI output ratio (lower=better)",
-              data: series("ratio", "ffi"),
-              yAxisID: "y1",
-              borderColor: "hsl(340 65% 50%)",
-              backgroundColor: "hsla(340 65% 50% / 0.25)",
-              borderDash: [6, 4],
-            },
-          ],
+          datasets: buildProfileSeriesDatasets(series),
         };
+      }
+
+      // Shared dataset palette / shape — reused by:
+      //   - level-axis Level Profile (buildProfileData)
+      //   - snapshot-axis level history (buildProfileLevelHistoryData)
+      //   - the aggregate-over-levels chart (buildAggregateOverTimeData)
+      // Each caller supplies a `series(lm, side)` closure that returns
+      // the Y-values for its own X-axis labels.
+      function buildProfileSeriesDatasets(series) {
+        return [
+          {
+            seriesKey: "rust_compress_speed",
+            label: "Rust compress (MiB/s)",
+            data: series("compress_speed", "rust"),
+            yAxisID: "y",
+            borderColor: "hsl(150 65% 38%)",
+            backgroundColor: "hsla(150 65% 38% / 0.25)",
+          },
+          {
+            seriesKey: "ffi_compress_speed",
+            label: "FFI compress (MiB/s)",
+            data: series("compress_speed", "ffi"),
+            yAxisID: "y",
+            borderColor: "hsl(205 65% 45%)",
+            backgroundColor: "hsla(205 65% 45% / 0.25)",
+          },
+          {
+            seriesKey: "rust_decompress_speed",
+            label: "Rust decompress (MiB/s)",
+            data: series("decompress_speed", "rust"),
+            yAxisID: "y",
+            borderColor: "hsl(170 65% 28%)",
+            backgroundColor: "hsla(170 65% 28% / 0.25)",
+            borderDash: [2, 3],
+          },
+          {
+            seriesKey: "ffi_decompress_speed",
+            label: "FFI decompress (MiB/s)",
+            data: series("decompress_speed", "ffi"),
+            yAxisID: "y",
+            borderColor: "hsl(225 65% 35%)",
+            backgroundColor: "hsla(225 65% 35% / 0.25)",
+            borderDash: [2, 3],
+          },
+          // "ratio" here is the bench emitter's compression_ratio
+          // value, which is compressed_size / input_size — i.e. the
+          // output fraction, where LOWER means BETTER compression
+          // (a 0.30 value compresses to 30% of input). The axis and
+          // dataset labels say so explicitly to keep readers from
+          // assuming the conventional input/output definition where
+          // larger is better.
+          {
+            seriesKey: "rust_ratio",
+            label: "Rust output ratio (lower=better)",
+            data: series("ratio", "rust"),
+            yAxisID: "y1",
+            borderColor: "hsl(30 75% 45%)",
+            backgroundColor: "hsla(30 75% 45% / 0.25)",
+            borderDash: [6, 4],
+          },
+          {
+            seriesKey: "ffi_ratio",
+            label: "FFI output ratio (lower=better)",
+            data: series("ratio", "ffi"),
+            yAxisID: "y1",
+            borderColor: "hsl(340 65% 50%)",
+            backgroundColor: "hsla(340 65% 50% / 0.25)",
+            borderDash: [6, 4],
+          },
+        ];
       }
 
       // Single source of truth for the chart instance: created once on
@@ -1193,7 +1320,22 @@
           el("profile-status").textContent = "Pick Target and Scenario (or leave them on 'all') to render the level profile.";
           return;
         }
-        const { levels, levelCount, datasets } = buildProfileData(filter);
+
+        // History mode: when the user pins a specific level, swap the
+        // X-axis from "compression level" (which would degenerate to a
+        // single column) to "snapshot / commit time" so the chart shows
+        // how that one level evolves across runs.
+        const historyMode = filter.level !== ALWAYS;
+        const built = historyMode ? buildProfileLevelHistoryData(filter) : buildProfileData(filter);
+        const labels = historyMode ? built.snapshots : built.levels;
+        const labelCount = historyMode ? built.snapshotCount : built.levelCount;
+        const baseDatasets = historyMode
+          ? buildProfileSeriesDatasets(built.series)
+          : built.datasets;
+        const xAxisTitle = historyMode ? "Snapshot (generated_at / commit)" : "Compression level";
+        const datasets = baseDatasets;
+        const levelCount = labelCount;
+        const levels = labels;
         if (!levelCount) {
           if (state.profileChart) {
             // No data for the chosen filter — clear the chart in place
@@ -1207,11 +1349,14 @@
           el("profile-status").textContent = `No level points for target=${filter.target}, scenario=${filter.scenario}, level=${filter.level}.`;
           return;
         }
-        const snapshotNote = filter.snapshot === PROFILE_LATEST
-          ? "latest per (level, metric, cohort) — points may come from different snapshots"
-          : `snapshot=${filter.snapshot} (all points from this single run)`;
+        const snapshotNote = historyMode
+          ? `history across ${labelCount} snapshot(s) for level=${filter.level}`
+          : (filter.snapshot === PROFILE_LATEST
+            ? "latest per (level, metric, cohort) — points may come from different snapshots"
+            : `snapshot=${filter.snapshot} (all points from this single run)`);
+        const axisDesc = historyMode ? "snapshot" : "level";
         el("profile-status").textContent =
-          `Showing ${levelCount} level point(s) — target=${filter.target}, scenario=${filter.scenario}, level=${filter.level} (${snapshotNote}).`;
+          `Showing ${labelCount} ${axisDesc} point(s) — target=${filter.target}, scenario=${filter.scenario}, level=${filter.level} (${snapshotNote}).`;
 
         const chartDatasets = buildProfileDatasets(datasets);
 
@@ -1220,6 +1365,7 @@
           // Chart.js to redraw without animation. This preserves the
           // chart instance (tooltips, scales, animation state) across
           // every target/scenario/stage switch.
+          state.profileChart.options.scales.x.title.text = xAxisTitle;
           state.profileChart.data.labels = levels;
           state.profileChart.data.datasets = chartDatasets;
           state.profileChart.update("none");
@@ -1233,7 +1379,7 @@
               interaction: { mode: "index", intersect: false },
               scales: {
                 x: {
-                  title: { display: true, text: "Compression level" },
+                  title: { display: true, text: xAxisTitle },
                   ticks: { autoSkip: false, maxRotation: 60, minRotation: 30 },
                 },
                 y: {
@@ -1277,6 +1423,249 @@
           el("legend-profile"),
           onProfileLegendToggle,
         );
+      }
+
+      // Aggregate-over-levels chart: same six series as Level Profile,
+      // but X = snapshot/commit time, Y = mean across **every** matching
+      // (level, scenario, target, source) cohort for that snapshot.
+      // Respects the top Target / Scenario / Level filters — pinning
+      // any one of them narrows the aggregate to that slice while the
+      // other dimensions are still averaged across.
+      function buildAggregateOverTimeData(filter) {
+        const matchesFilter = (r) => {
+          if (filter.target !== ALWAYS && (r.target || "unknown-target") !== filter.target) return false;
+          if (filter.scenario !== ALWAYS && r.scenario !== filter.scenario) return false;
+          if (filter.level !== ALWAYS && r.level !== filter.level) return false;
+          return true;
+        };
+
+        const logicalMetric = (row) => {
+          if (row.metric === "compression_ratio" && isCompressStage(row.stage)) return "ratio";
+          if (row.metric === "throughput_bytes_per_sec") {
+            if (isCompressStage(row.stage)) return "compress_speed";
+            if (isDecompressStage(row.stage)) return "decompress_speed";
+          }
+          return null;
+        };
+
+        // Pre-aggregate per (snapshot, lm, cohort) so each cohort
+        // contributes one MEAN per snapshot before being folded into
+        // the snapshot-level mean. Without this stratification, a
+        // (level, scenario) combo that has more source variants would
+        // weigh more than one with fewer — biasing the aggregate
+        // toward whichever cohort happened to enumerate more rows.
+        const cohortKey = (row) => {
+          // Cohort = (level, scenario, target, source). All of these
+          // are present in the row regardless of which top filters
+          // are on `__all__`, so the mean stays comparable across
+          // filter shapes.
+          return `${row.level}|${row.scenario}|${row.target || "?"}|${row.source || "none"}`;
+        };
+
+        // Two-level aggregation:
+        //   inner: per (snapshot, lm, cohort) — accumulate raw rows
+        //          (handles same-cohort runs being averaged together,
+        //          rare but happens with retries)
+        //   outer: per (snapshot, lm) — average the inner means
+        const innerAgg = new Map();
+        for (const row of state.records) {
+          if (!matchesFilter(row)) continue;
+          if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
+          const lm = logicalMetric(row);
+          if (!lm) continue;
+          const snap = row.generated_at || row.commit_sha || "local-run";
+          const inner = `${snap}|${lm}|${cohortKey(row)}`;
+          let agg = innerAgg.get(inner);
+          if (!agg) {
+            agg = { snap, lm, rust_sum: 0, ffi_sum: 0, count: 0 };
+            innerAgg.set(inner, agg);
+          }
+          agg.rust_sum += row.rust_value;
+          agg.ffi_sum += row.ffi_value;
+          agg.count += 1;
+        }
+
+        const outerAgg = new Map();
+        for (const inner of innerAgg.values()) {
+          if (inner.count === 0) continue;
+          const key = `${inner.snap}|${inner.lm}`;
+          let agg = outerAgg.get(key);
+          if (!agg) {
+            agg = { snap: inner.snap, lm: inner.lm, rust_sum: 0, ffi_sum: 0, count: 0 };
+            outerAgg.set(key, agg);
+          }
+          agg.rust_sum += inner.rust_sum / inner.count;
+          agg.ffi_sum += inner.ffi_sum / inner.count;
+          agg.count += 1;
+        }
+
+        const snapshotSet = new Set();
+        for (const a of outerAgg.values()) snapshotSet.add(a.snap);
+        const snapshots = Array.from(snapshotSet).sort((a, b) => {
+          const at = parseTimestamp(a);
+          const bt = parseTimestamp(b);
+          if (at !== null && bt !== null) return at - bt;
+          return String(a).localeCompare(String(b));
+        });
+
+        const lookup = (snap, lm, side) => {
+          const agg = outerAgg.get(`${snap}|${lm}`);
+          if (!agg || agg.count === 0) return null;
+          const sum = side === "rust" ? agg.rust_sum : agg.ffi_sum;
+          const mean = sum / agg.count;
+          if (lm === "compress_speed" || lm === "decompress_speed") {
+            return mean / (1024 * 1024);
+          }
+          return mean;
+        };
+
+        const series = (lm, side) => snapshots.map((s) => lookup(s, lm, side));
+
+        return {
+          snapshots,
+          snapshotCount: snapshots.length,
+          datasets: buildProfileSeriesDatasets(series),
+        };
+      }
+
+      function buildAggregateDatasets(rawDatasets) {
+        return rawDatasets.map((ds) => ({
+          label: ds.label,
+          data: ds.data,
+          yAxisID: ds.yAxisID,
+          borderColor: ds.borderColor,
+          backgroundColor: ds.backgroundColor,
+          borderDash: ds.borderDash,
+          borderWidth: 2,
+          pointRadius: 3,
+          spanGaps: true,
+          tension: 0.25,
+          fill: false,
+          hidden: !state.aggregateSeriesVisibility[ds.seriesKey],
+          _seriesKey: ds.seriesKey,
+        }));
+      }
+
+      function onAggregateLegendToggle(index, ds, nextVisible) {
+        const key = ds._seriesKey;
+        if (key) {
+          state.aggregateSeriesVisibility[key] = nextVisible;
+          const checkbox = document.querySelector(
+            `.aggregate-toggles input[type=checkbox][data-agg-series="${key}"]`,
+          );
+          if (checkbox) checkbox.checked = nextVisible;
+        }
+        if (state.aggregateChart) {
+          state.aggregateChart.setDatasetVisibility(index, nextVisible);
+          state.aggregateChart.update("none");
+          renderHtmlLegend(
+            state.aggregateChart,
+            el("legend-aggregate"),
+            onAggregateLegendToggle,
+          );
+        }
+      }
+
+      function renderAggregateChart() {
+        const filter = {
+          target: selectors.target.value,
+          scenario: selectors.scenario.value,
+          level: selectors.level.value,
+        };
+        if (!filter.target || !filter.scenario) {
+          el("aggregate-status").textContent = "Pick Target and Scenario (or leave them on 'all') to render the aggregate chart.";
+          return;
+        }
+        const { snapshots, snapshotCount, datasets } = buildAggregateOverTimeData(filter);
+        if (!snapshotCount) {
+          if (state.aggregateChart) {
+            state.aggregateChart.data.labels = [];
+            state.aggregateChart.data.datasets = [];
+            state.aggregateChart.update("none");
+          }
+          el("legend-aggregate").replaceChildren();
+          el("aggregate-status").textContent = `No aggregate points for target=${filter.target}, scenario=${filter.scenario}, level=${filter.level}.`;
+          return;
+        }
+        const filterDesc = [
+          filter.target === ALWAYS ? "target=all" : `target=${filter.target}`,
+          filter.scenario === ALWAYS ? "scenario=all" : `scenario=${filter.scenario}`,
+          filter.level === ALWAYS ? "level=all" : `level=${filter.level}`,
+        ].join(", ");
+        el("aggregate-status").textContent =
+          `Showing ${snapshotCount} snapshot point(s) — ${filterDesc} (per-snapshot mean across every matching (level, scenario, target, source) cohort).`;
+
+        const chartDatasets = buildAggregateDatasets(datasets);
+
+        if (state.aggregateChart) {
+          state.aggregateChart.data.labels = snapshots;
+          state.aggregateChart.data.datasets = chartDatasets;
+          state.aggregateChart.update("none");
+        } else {
+          state.aggregateChart = new Chart(el("chart-aggregate"), {
+            type: "line",
+            data: { labels: snapshots, datasets: chartDatasets },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: "index", intersect: false },
+              scales: {
+                x: {
+                  title: { display: true, text: "Snapshot (generated_at / commit)" },
+                  ticks: { autoSkip: true, maxRotation: 60, minRotation: 30 },
+                },
+                y: {
+                  type: "linear",
+                  position: "left",
+                  title: { display: true, text: "Throughput (MiB/s)" },
+                  beginAtZero: true,
+                },
+                y1: {
+                  type: "linear",
+                  position: "right",
+                  title: { display: true, text: "Output size ratio (compressed/input, lower=better)" },
+                  grid: { drawOnChartArea: false },
+                },
+              },
+              plugins: {
+                legend: { display: false },
+                tooltip: { mode: "index", intersect: false },
+              },
+            },
+          });
+        }
+        renderHtmlLegend(
+          state.aggregateChart,
+          el("legend-aggregate"),
+          onAggregateLegendToggle,
+        );
+      }
+
+      function applyAggregateToggles() {
+        if (!state.aggregateChart) return;
+        const datasets = state.aggregateChart.data.datasets || [];
+        for (let i = 0; i < datasets.length; i++) {
+          const key = datasets[i]._seriesKey;
+          if (!key) continue;
+          state.aggregateChart.setDatasetVisibility(i, !!state.aggregateSeriesVisibility[key]);
+        }
+        state.aggregateChart.update("none");
+        renderHtmlLegend(
+          state.aggregateChart,
+          el("legend-aggregate"),
+          onAggregateLegendToggle,
+        );
+      }
+
+      function bindAggregateControls() {
+        for (const cb of document.querySelectorAll(".aggregate-toggles input[type=checkbox]")) {
+          cb.addEventListener("change", (e) => {
+            const key = e.currentTarget.dataset.aggSeries;
+            if (!key) return;
+            state.aggregateSeriesVisibility[key] = e.currentTarget.checked;
+            applyAggregateToggles();
+          });
+        }
       }
 
       function bindProfileControls() {
@@ -1387,6 +1776,7 @@
             if (profileDimensions.has(name)) {
               repopulateSnapshotOptions();
               renderProfileChart();
+              renderAggregateChart();
             }
           });
         }
@@ -1485,6 +1875,8 @@
         renderProfileSelectors();
         bindProfileControls();
         renderProfileChart();
+        bindAggregateControls();
+        renderAggregateChart();
         renderRawSummary();
       }
 


### PR DESCRIPTION
## Summary

Two additions to the bench dashboard, both prompted by feedback on the existing Level Profile chart.

### 1. New "Aggregate over all levels (commit timeline)" section

Same six series as Level Profile (rust/ffi compress speed, decompress speed, output ratio) but plotted against **snapshot / commit time** on the X-axis. Each point is the arithmetic mean across **every** matching `(level, scenario, target, source)` cohort for that snapshot. Useful for spotting overall dynamics across commits regardless of which level or corpus drove a given delta.

- Top **Target / Scenario / Level** filters still apply — pinning any one of them narrows the aggregate to that slice while the others stay averaged.
- Uses **two-level stratified aggregation**: inner per-cohort mean → outer per-snapshot mean of cohorts. Prevents a `(level, scenario)` combo that enumerates more source variants from outweighing one with fewer.

### 2. Level Profile no longer collapses on specific-level pick

Previously, picking a single level on the top filter row gave a one-point chart (X = compression level → one column). Now, when `filter.level` is a specific value (not `all`), the X-axis swaps to snapshot/commit time and shows that level's history across runs — same six series, mean across the remaining `(target, scenario, source)` cohorts per snapshot.

When the level filter is back on `all`, the chart returns to its original level-axis cumulative view.

### Refactor

The six dataset definitions (label, colour, axis, dash pattern) were extracted into a shared `buildProfileSeriesDatasets(series)` helper used by all three chart paths (level-axis profile, snapshot-axis level history, aggregate-over-levels) so the palette stays in lockstep across the dashboard.

## Verification

- Browser JS syntax check via `node -e "new Function(scriptText)"` — passes.
- Aggregation logic re-implemented in Node against the production `benchmark-relative.json` from `gh-pages` and compared against expected per-cohort means:
  - Latest snapshot, all/all/all: rust compress 249 MiB/s vs FFI 578 MiB/s (n=609 cohort means per snapshot), rust decompress 2923 MiB/s vs FFI 4218 MiB/s (n=1218), ratio 0.5096 vs 0.5106 — all within expected real-world ranges.
  - The earlier `825,835` / `2,003,676` / `6,025,013` legend values from screenshots reproduce exactly when filter is `target=x86_64-gnu, scenario=all, level=all` (level_-3_fast: rust compress mean 825.8 MiB/s, ffi compress 2003.7 MiB/s, ffi decompress 6025.0 MiB/s — the comma in the legend is the European decimal separator, not a thousands grouping).

## Test plan

- [x] JS syntax check clean
- [x] Aggregate logic matches Node simulation against production data
- [ ] Open dashboard in a browser, verify both new charts render without console errors
- [ ] Pin level to a single value, verify Level Profile swaps to time-axis with multiple points (not one column)
- [ ] Toggle aggregate series on/off, verify visibility persists across filter changes

Closes #226 (filed alongside this PR for tracking).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Aggregate over all levels (commit timeline)" chart with interactive legend and persisted checkbox visibility.
  * Level Profile history mode: when a level is pinned, X-axis switches to commit timeline and the status text reflects history vs level view.
  * Improved chart rendering and controls so profile and aggregate charts update together when filters change.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->