### PR TITLE
perf(decode): 8-slot software prefetch pipeline for sequence execution (#208)

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -402,8 +402,9 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// match_start (e.g. a stale or malformed sequence), and
     /// dictionary-sourced matches whose logical position predates
     /// the buffer's current frame. The donor (`PREFETCH_L1` in
-    /// `ZSTD_prefetchMatch` — note: we route to L2 instead, see the
-    /// body comment) tolerates invalid addresses by spec, but in
+    /// `ZSTD_prefetchMatch` — we mirror that with `prefetch_slice`
+    /// → `_MM_HINT_T0` / `pldl1keep`, see the body comment) tolerates
+    /// invalid addresses by spec, but in
     /// safe Rust the cheapest equivalent is to bound-check the
     /// logical position before chasing the slice.
     #[inline(always)]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -197,6 +197,32 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     }
 
     pub fn repeat(&mut self, offset: usize, match_length: usize) -> Result<(), DecodeBufferError> {
+        self.repeat_inner::<false>(offset, match_length)
+    }
+
+    /// Same as [`repeat`] but the caller asserts (1) the buffer was
+    /// pre-reserved for the whole block (so the per-call `reserve` is
+    /// redundant) and (2) a lookahead prefetch was already issued for
+    /// this match source ADVANCE iterations ago (so the in-loop
+    /// `prefetch_match_source` would be redundant issue-port pressure
+    /// on top of the L1 line that's by now warm). Used exclusively by
+    /// the pipelined sequence executor in
+    /// [`crate::decoding::sequence_section_decoder`].
+    #[inline(always)]
+    pub(crate) fn repeat_lookahead_prefetched(
+        &mut self,
+        offset: usize,
+        match_length: usize,
+    ) -> Result<(), DecodeBufferError> {
+        self.repeat_inner::<true>(offset, match_length)
+    }
+
+    #[inline(always)]
+    fn repeat_inner<const PIPELINED: bool>(
+        &mut self,
+        offset: usize,
+        match_length: usize,
+    ) -> Result<(), DecodeBufferError> {
         if offset == 0 {
             return Err(DecodeBufferError::ZeroOffset);
         }
@@ -212,8 +238,10 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             let start_idx = buf_len - offset;
             let end_idx = start_idx + match_length;
 
-            self.buffer.reserve(match_length);
-            self.prefetch_match_source(start_idx, match_length);
+            if !PIPELINED {
+                self.buffer.reserve(match_length);
+                self.prefetch_match_source(start_idx, match_length);
+            }
             if end_idx > buf_len {
                 self.repeat_overlapping(offset, match_length, start_idx);
             } else {
@@ -226,7 +254,9 @@ impl<B: BufferBackend> DecodeBuffer<B> {
                 //      3. end_idx <= self.buffer.len()
                 //      Thus follows: start_idx + match_length <= self.buffer.len()
                 //
-                // 2. explicitly reserved enough memory for the whole match_length
+                // 2. PIPELINED path relies on caller's upfront
+                //    `reserve(MAX_BLOCK_SIZE)` covering the whole block;
+                //    non-PIPELINED path just reserved `match_length`.
                 unsafe {
                     if offset >= 16 && use_branchless_wildcopy() {
                         self.buffer

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -414,12 +414,17 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
         // Donor's `ZSTD_prefetchMatch` issues two `PREFETCH_L1` hints
         // per match — one at `match`, one at `match + CACHELINE_SIZE`.
-        // We mirror that exactly: route through `prefetch_slice`
-        // (`_MM_HINT_T0` on x86 → L1 destination), cap extent at
-        // 2 × 64 B = 128 B so the helper stays at AT MOST two
-        // prefetch issues per match (donor parity). The lookahead
-        // depth (ADVANCE) is small enough that L1 should hold the
-        // line across the gap; if profiling later shows L1 eviction
+        // We mirror that intent via `prefetch_slice` (`_MM_HINT_T0` on
+        // x86 / `pldl1keep` on aarch64 → L1 destination) with extent
+        // capped at 2 × 64 B = 128 B. In the contiguous case the helper
+        // emits at most two prefetch instructions, matching donor
+        // exactly. In the wrap-boundary case the same 128 B budget is
+        // split across `s1_tail` and `s2[0..]`, which can emit up to
+        // four cache-line prefetches total (two per slice when each
+        // side covers a full 64 B) — still bounded, still L1, still
+        // less than the helper's MAX_LINES = 4 ceiling. The lookahead
+        // depth (ADVANCE) is small enough that L1 should hold the line
+        // across the gap; if profiling later shows L1 eviction
         // pressure we can revisit T1/L2.
         const PREFETCH_EXTENT: usize = 128;
         const CACHE_LINE: usize = 64;
@@ -1026,6 +1031,65 @@ mod tests {
                     "mismatch at offset={offset} match_length={match_length}",
                 );
             }
+        }
+    }
+
+    #[test]
+    fn prefetch_lookahead_in_range_does_not_panic() {
+        // Plain in-range lookup: start_idx well within `buffer.len()`.
+        // The helper should issue prefetch hints and return cleanly.
+        // Prefetch hints are unobservable from Rust — the assertion is
+        // simply that the call completes without panic / UB.
+        let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
+        buf.reserve(512);
+        buf.push(&[0xAA; 256]);
+        buf.prefetch_lookahead_match_source(0);
+        buf.prefetch_lookahead_match_source(128);
+        buf.prefetch_lookahead_match_source(buf.len() - 1);
+    }
+
+    #[test]
+    fn prefetch_lookahead_out_of_range_returns_without_panic() {
+        // Wrap-derived garbage / dictionary-sourced match / intra-block
+        // self-overlap all produce `start_idx >= buffer.len()` here.
+        // The helper must early-return (bound check) and never touch a
+        // slice past the live region.
+        let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
+        buf.reserve(64);
+        buf.push(&[0x55; 32]);
+        buf.prefetch_lookahead_match_source(buf.len());
+        buf.prefetch_lookahead_match_source(buf.len() + 1);
+        buf.prefetch_lookahead_match_source(usize::MAX);
+        // Empty buffer — every start_idx is out-of-range.
+        let empty: DecodeBuffer<RingBuffer> = DecodeBuffer::new(1024);
+        empty.prefetch_lookahead_match_source(0);
+        empty.prefetch_lookahead_match_source(7);
+    }
+
+    #[test]
+    fn prefetch_lookahead_at_wrap_boundary() {
+        // Force the RingBuffer into a wrapped layout where
+        // `as_slices()` returns two non-empty halves: push, drain past
+        // window, push again so the write cursor wraps. Then exercise
+        // start_idx values at the boundary (last byte of s1, first
+        // byte of s2, short s1 tail < CACHE_LINE) so the
+        // `prefetch_first_line_l1` fallback path is touched too.
+        let mut buf = DecodeBuffer::<RingBuffer>::new(256);
+        // Fill with two passes so the underlying ringbuffer wraps.
+        let payload = [0xCD_u8; 320];
+        buf.push(&payload);
+        // Drain to free read cursor capacity (write side can then wrap).
+        let _ = buf.drain_to_window_size();
+        buf.push(&payload);
+        // Probe a handful of indices inside and across the wrap.
+        let n = buf.len();
+        if n > 0 {
+            buf.prefetch_lookahead_match_source(0);
+            buf.prefetch_lookahead_match_source(n / 2);
+            buf.prefetch_lookahead_match_source(n - 1);
+            // Out-of-range probe to exercise the early-return path on
+            // a wrapped buffer.
+            buf.prefetch_lookahead_match_source(n);
         }
     }
 }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -422,11 +422,23 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // line across the gap; if profiling later shows L1 eviction
         // pressure we can revisit T1/L2.
         const PREFETCH_EXTENT: usize = 128;
+        const CACHE_LINE: usize = 64;
         let (s1, s2) = self.buffer.as_slices();
         if start_idx < s1.len() {
             let s1_tail = &s1[start_idx..];
             let s1_bound = core::cmp::min(s1_tail.len(), PREFETCH_EXTENT);
-            prefetch::prefetch_slice(&s1_tail[..s1_bound]);
+            // `prefetch_slice` no-ops on slices shorter than one cache
+            // line — sensible for bulk prefetch, but wrong for the
+            // wrap-boundary case where the cache line containing
+            // `start_idx` IS the line we need warmed even if the
+            // remaining contiguous extent is < 64 B. Fall back to the
+            // single-line variant in that case so the match-start
+            // line is always hinted.
+            if s1_bound >= CACHE_LINE {
+                prefetch::prefetch_slice(&s1_tail[..s1_bound]);
+            } else {
+                prefetch::prefetch_first_line_l1(&s1_tail[..s1_bound]);
+            }
             // Wrap continuation: when the match source straddles the
             // s1/s2 boundary and the s1 tail is shorter than the
             // PREFETCH_EXTENT we asked for, top up the rest from
@@ -436,8 +448,10 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             if s1_bound < PREFETCH_EXTENT {
                 let remaining = PREFETCH_EXTENT - s1_bound;
                 let s2_bound = core::cmp::min(s2.len(), remaining);
-                if s2_bound > 0 {
+                if s2_bound >= CACHE_LINE {
                     prefetch::prefetch_slice(&s2[..s2_bound]);
+                } else if s2_bound > 0 {
+                    prefetch::prefetch_first_line_l1(&s2[..s2_bound]);
                 }
             }
         } else {
@@ -449,7 +463,11 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             let idx = start_idx - s1.len();
             let tail = &s2[idx..];
             let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
-            prefetch::prefetch_slice(&tail[..bound]);
+            if bound >= CACHE_LINE {
+                prefetch::prefetch_slice(&tail[..bound]);
+            } else {
+                prefetch::prefetch_first_line_l1(&tail[..bound]);
+            }
         }
     }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -439,12 +439,15 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
             prefetch::prefetch_slice_t1(&tail[..bound]);
         } else {
+            // `start_idx < self.buffer.len()` from the early return,
+            // `buffer.len() == s1.len() + s2.len()`, and the else
+            // branch establishes `start_idx >= s1.len()`. So
+            // `idx = start_idx - s1.len() < s2.len()` by construction
+            // — no explicit `idx < s2.len()` guard needed.
             let idx = start_idx - s1.len();
-            if idx < s2.len() {
-                let tail = &s2[idx..];
-                let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
-                prefetch::prefetch_slice_t1(&tail[..bound]);
-            }
+            let tail = &s2[idx..];
+            let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
+            prefetch::prefetch_slice_t1(&tail[..bound]);
         }
     }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -402,29 +402,36 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// match_start (e.g. a stale or malformed sequence), and
     /// dictionary-sourced matches whose logical position predates
     /// the buffer's current frame. The donor (`PREFETCH_L1` in
-    /// `ZSTD_prefetchMatch`) tolerates invalid addresses by spec,
-    /// but in safe Rust the cheapest equivalent is to bound-check
-    /// the logical position before chasing the slice.
+    /// `ZSTD_prefetchMatch` — note: we route to L2 instead, see the
+    /// body comment) tolerates invalid addresses by spec, but in
+    /// safe Rust the cheapest equivalent is to bound-check the
+    /// logical position before chasing the slice.
     #[inline(always)]
     pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize) {
         if start_idx >= self.buffer.len() {
             return;
         }
-        // Donor parity: `ZSTD_prefetchMatch` issues up to two
-        // `PREFETCH_L1` hints per match — one at `match`, one at
-        // `match + CACHELINE_SIZE`. Capping the slice extent at
-        // 2 × 64 B holds `prefetch_slice_t1` to AT MOST two
-        // prefetch lines (it can issue fewer when the source
+        // Donor's `ZSTD_prefetchMatch` issues up to two `PREFETCH_L1`
+        // hints per match — one at `match`, one at
+        // `match + CACHELINE_SIZE`. We use the same two-line cadence
+        // but route through `prefetch_slice_t1` (`_MM_HINT_T1` on
+        // x86 — L2 destination instead of L1). The deliberate
+        // deviation: ADVANCE iterations of decode work sit between
+        // the prefetch issue and the matching `repeat()` load, so
+        // an L1-bound line would likely be evicted by intervening
+        // accesses before the consumer reaches it — L2 has the
+        // capacity to keep the line resident across that window.
+        // The pre-existing in-loop `prefetch_match_source` makes the
+        // same T1 choice for the same reason. Capping the slice
+        // extent at 2 × 64 B holds `prefetch_slice_t1` to AT MOST
+        // two prefetch lines (it can issue fewer when the source
         // straddles the ring buffer's `as_slices()` boundary and
         // only the head fragment is reachable here, or when the
         // remaining slice tail is shorter than 64 B) instead of the
-        // 4 its `MAX_LINES` cap would otherwise allow. Either way
-        // we don't burn prefetch-queue slots that the steady-state
-        // ADVANCE-deep pipeline already reserves for upcoming
-        // sources. No `match_length < 64` gate — with several
-        // sequences of lookahead the prefetch overlaps work the
-        // CPU has to do anyway, so even sub-cache-line matches
-        // benefit.
+        // 4 its `MAX_LINES` cap would otherwise allow. No
+        // `match_length < 64` gate — with several sequences of
+        // lookahead the prefetch overlaps work the CPU has to do
+        // anyway, so even sub-cache-line matches benefit.
         const PREFETCH_EXTENT: usize = 128;
         let (s1, s2) = self.buffer.as_slices();
         if start_idx < s1.len() {

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -385,6 +385,62 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
     }
 
+    /// Lookahead-friendly prefetch issued ahead of execute. The
+    /// in-loop `prefetch_match_source` above fires at the moment of
+    /// the copy, so it can't hide DRAM latency for cold long-distance
+    /// match sources. Pipelined callers compute the match source
+    /// logical index 3-4 sequences in advance and call this helper —
+    /// by the time the corresponding `repeat()` reaches the actual
+    /// load, the line is already in-flight.
+    ///
+    /// `start_idx` is a logical index into the current buffer (same
+    /// frame as `buffer.len()`). Indices outside `[0, buffer.len())`
+    /// are silently dropped — the cases this guards against include
+    /// intra-block self-overlap (source falls past the not-yet-
+    /// written cursor), `wrapping_sub` underflow on a caller that
+    /// computed `match_start - offset` with an offset larger than
+    /// match_start (e.g. a stale or malformed sequence), and
+    /// dictionary-sourced matches whose logical position predates
+    /// the buffer's current frame. The donor (`PREFETCH_L1` in
+    /// `ZSTD_prefetchMatch`) tolerates invalid addresses by spec,
+    /// but in safe Rust the cheapest equivalent is to bound-check
+    /// the logical position before chasing the slice.
+    #[inline(always)]
+    pub(crate) fn prefetch_lookahead_match_source(&self, start_idx: usize) {
+        if start_idx >= self.buffer.len() {
+            return;
+        }
+        // Donor parity: `ZSTD_prefetchMatch` issues up to two
+        // `PREFETCH_L1` hints per match — one at `match`, one at
+        // `match + CACHELINE_SIZE`. Capping the slice extent at
+        // 2 × 64 B holds `prefetch_slice_t1` to AT MOST two
+        // prefetch lines (it can issue fewer when the source
+        // straddles the ring buffer's `as_slices()` boundary and
+        // only the head fragment is reachable here, or when the
+        // remaining slice tail is shorter than 64 B) instead of the
+        // 4 its `MAX_LINES` cap would otherwise allow. Either way
+        // we don't burn prefetch-queue slots that the steady-state
+        // ADVANCE-deep pipeline already reserves for upcoming
+        // sources. No `match_length < 64` gate — with several
+        // sequences of lookahead the prefetch overlaps work the
+        // CPU has to do anyway, so even sub-cache-line matches
+        // benefit.
+        const PREFETCH_EXTENT: usize = 128;
+        let (s1, s2) = self.buffer.as_slices();
+        if start_idx < s1.len() {
+            let tail = &s1[start_idx..];
+            let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
+            prefetch::prefetch_slice_t1(&tail[..bound]);
+        } else {
+            let idx = start_idx - s1.len();
+            if idx < s2.len() {
+                let tail = &s2[idx..];
+                let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
+                prefetch::prefetch_slice_t1(&tail[..bound]);
+            }
+        }
+    }
+
     #[cold]
     fn repeat_from_dict(
         &mut self,

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -200,13 +200,19 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.repeat_inner::<false>(offset, match_length)
     }
 
-    /// Same as [`repeat`] but the caller asserts (1) the buffer was
-    /// pre-reserved for the whole block (so the per-call `reserve` is
-    /// redundant) and (2) a lookahead prefetch was already issued for
-    /// this match source ADVANCE iterations ago (so the in-loop
-    /// `prefetch_match_source` would be redundant issue-port pressure
-    /// on top of the L1 line that's by now warm). Used exclusively by
-    /// the pipelined sequence executor in
+    /// Same as [`repeat`] but the caller asserts a lookahead
+    /// prefetch was already issued for this match source ADVANCE
+    /// iterations ago, so the in-loop `prefetch_match_source` would
+    /// be redundant issue-port pressure on top of the L1 line that's
+    /// by now warm. Per-call `reserve` is KEPT — on malformed input
+    /// the `extend_from_within_unchecked*` writes assume the buffer
+    /// has the required free capacity (only `debug_assert` checks in
+    /// release), and a single missing reserve here would turn a
+    /// fuzz-corrupt block into out-of-bounds UB. The reserve is
+    /// already amortised by the caller's upfront
+    /// `reserve(MAX_BLOCK_SIZE)`, so this is a cheap capacity-check
+    /// branch, not a real allocation. Used exclusively by the
+    /// pipelined sequence executor in
     /// [`crate::decoding::sequence_section_decoder`].
     #[inline(always)]
     pub(crate) fn repeat_lookahead_prefetched(
@@ -218,7 +224,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     }
 
     #[inline(always)]
-    fn repeat_inner<const PIPELINED: bool>(
+    fn repeat_inner<const SKIP_PREFETCH: bool>(
         &mut self,
         offset: usize,
         match_length: usize,
@@ -238,25 +244,25 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             let start_idx = buf_len - offset;
             let end_idx = start_idx + match_length;
 
-            if !PIPELINED {
-                self.buffer.reserve(match_length);
+            // Reserve unconditionally — `extend_from_within_unchecked*`
+            // assumes the required free capacity exists; skipping it
+            // would turn a malformed block (match_length past the
+            // upfront `reserve(MAX_BLOCK_SIZE)`) into release-build
+            // UB. The pipelined caller already reserved MAX_BLOCK_SIZE
+            // up front, so this is a cheap no-op branch in the hot
+            // path.
+            self.buffer.reserve(match_length);
+            if !SKIP_PREFETCH {
                 self.prefetch_match_source(start_idx, match_length);
             }
             if end_idx > buf_len {
                 self.repeat_overlapping(offset, match_length, start_idx);
             } else {
-                // can just copy parts of the existing buffer
-                // SAFETY: Requirements checked:
-                // 1. start_idx + match_length must be <= self.buffer.len()
-                //      We know that:
-                //      1. start_idx = self.buffer.len() - offset
-                //      2. end_idx = start_idx + match_length
-                //      3. end_idx <= self.buffer.len()
-                //      Thus follows: start_idx + match_length <= self.buffer.len()
-                //
-                // 2. PIPELINED path relies on caller's upfront
-                //    `reserve(MAX_BLOCK_SIZE)` covering the whole block;
-                //    non-PIPELINED path just reserved `match_length`.
+                // SAFETY: start_idx + match_length <= self.buffer.len()
+                // (start_idx = buf_len - offset, end_idx = start_idx +
+                // match_length, end_idx <= buf_len). The `reserve`
+                // above guarantees the destination has enough free
+                // capacity for `match_length` more bytes.
                 unsafe {
                     if offset >= 16 && use_branchless_wildcopy() {
                         self.buffer

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -411,33 +411,21 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         if start_idx >= self.buffer.len() {
             return;
         }
-        // Donor's `ZSTD_prefetchMatch` issues up to two `PREFETCH_L1`
-        // hints per match — one at `match`, one at
-        // `match + CACHELINE_SIZE`. We use the same two-line cadence
-        // but route through `prefetch_slice_t1` (`_MM_HINT_T1` on
-        // x86 — L2 destination instead of L1). The deliberate
-        // deviation: ADVANCE iterations of decode work sit between
-        // the prefetch issue and the matching `repeat()` load, so
-        // an L1-bound line would likely be evicted by intervening
-        // accesses before the consumer reaches it — L2 has the
-        // capacity to keep the line resident across that window.
-        // The pre-existing in-loop `prefetch_match_source` makes the
-        // same T1 choice for the same reason. Capping the slice
-        // extent at 2 × 64 B holds `prefetch_slice_t1` to AT MOST
-        // two prefetch lines (it can issue fewer when the source
-        // straddles the ring buffer's `as_slices()` boundary and
-        // only the head fragment is reachable here, or when the
-        // remaining slice tail is shorter than 64 B) instead of the
-        // 4 its `MAX_LINES` cap would otherwise allow. No
-        // `match_length < 64` gate — with several sequences of
-        // lookahead the prefetch overlaps work the CPU has to do
-        // anyway, so even sub-cache-line matches benefit.
+        // Donor's `ZSTD_prefetchMatch` issues two `PREFETCH_L1` hints
+        // per match — one at `match`, one at `match + CACHELINE_SIZE`.
+        // We mirror that exactly: route through `prefetch_slice`
+        // (`_MM_HINT_T0` on x86 → L1 destination), cap extent at
+        // 2 × 64 B = 128 B so the helper stays at AT MOST two
+        // prefetch issues per match (donor parity). The lookahead
+        // depth (ADVANCE) is small enough that L1 should hold the
+        // line across the gap; if profiling later shows L1 eviction
+        // pressure we can revisit T1/L2.
         const PREFETCH_EXTENT: usize = 128;
         let (s1, s2) = self.buffer.as_slices();
         if start_idx < s1.len() {
             let s1_tail = &s1[start_idx..];
             let s1_bound = core::cmp::min(s1_tail.len(), PREFETCH_EXTENT);
-            prefetch::prefetch_slice_t1(&s1_tail[..s1_bound]);
+            prefetch::prefetch_slice(&s1_tail[..s1_bound]);
             // Wrap continuation: when the match source straddles the
             // s1/s2 boundary and the s1 tail is shorter than the
             // PREFETCH_EXTENT we asked for, top up the rest from
@@ -448,7 +436,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
                 let remaining = PREFETCH_EXTENT - s1_bound;
                 let s2_bound = core::cmp::min(s2.len(), remaining);
                 if s2_bound > 0 {
-                    prefetch::prefetch_slice_t1(&s2[..s2_bound]);
+                    prefetch::prefetch_slice(&s2[..s2_bound]);
                 }
             }
         } else {
@@ -460,7 +448,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             let idx = start_idx - s1.len();
             let tail = &s2[idx..];
             let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
-            prefetch::prefetch_slice_t1(&tail[..bound]);
+            prefetch::prefetch_slice(&tail[..bound]);
         }
     }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -435,9 +435,22 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         const PREFETCH_EXTENT: usize = 128;
         let (s1, s2) = self.buffer.as_slices();
         if start_idx < s1.len() {
-            let tail = &s1[start_idx..];
-            let bound = core::cmp::min(tail.len(), PREFETCH_EXTENT);
-            prefetch::prefetch_slice_t1(&tail[..bound]);
+            let s1_tail = &s1[start_idx..];
+            let s1_bound = core::cmp::min(s1_tail.len(), PREFETCH_EXTENT);
+            prefetch::prefetch_slice_t1(&s1_tail[..s1_bound]);
+            // Wrap continuation: when the match source straddles the
+            // s1/s2 boundary and the s1 tail is shorter than the
+            // PREFETCH_EXTENT we asked for, top up the rest from
+            // s2[0..]. Without this the donor's "up to two cache
+            // lines" intent silently collapses to one (or zero if
+            // s1_tail is the last sub-line of s1).
+            if s1_bound < PREFETCH_EXTENT {
+                let remaining = PREFETCH_EXTENT - s1_bound;
+                let s2_bound = core::cmp::min(s2.len(), remaining);
+                if s2_bound > 0 {
+                    prefetch::prefetch_slice_t1(&s2[..s2_bound]);
+                }
+            }
         } else {
             // `start_idx < self.buffer.len()` from the early return,
             // `buffer.len() == s1.len() + s2.len()`, and the else

--- a/zstd/src/decoding/prefetch.rs
+++ b/zstd/src/decoding/prefetch.rs
@@ -3,6 +3,25 @@ pub(crate) fn prefetch_slice(slice: &[u8]) {
     prefetch_slice_impl_l1(slice);
 }
 
+/// Issue exactly one L1 prefetch hint at the first byte of `slice`,
+/// regardless of `slice.len()`. Use when the caller knows the slice
+/// is short (< CACHE_LINE) but the cache line containing
+/// `slice.as_ptr()` is still the one the consumer is about to read.
+///
+/// The standard `prefetch_slice` early-returns on slices below one
+/// cache line, which is the right call for bulk prefetch (no point
+/// hinting a partial buffer) but the wrong call for the wrap-boundary
+/// match-source case in `prefetch_lookahead_match_source`: there a
+/// 16-byte s1 tail is the EXACT line we need warmed even though it
+/// sits below the bulk threshold.
+#[inline(always)]
+pub(crate) fn prefetch_first_line_l1(slice: &[u8]) {
+    if slice.is_empty() {
+        return;
+    }
+    prefetch_first_line_l1_impl(slice.as_ptr());
+}
+
 #[inline(always)]
 pub(crate) fn prefetch_slice_t1(slice: &[u8]) {
     prefetch_slice_impl_t1(slice);
@@ -13,6 +32,15 @@ pub(crate) fn prefetch_slice_t1(slice: &[u8]) {
 fn prefetch_slice_impl_l1(slice: &[u8]) {
     use core::arch::x86_64::_MM_HINT_T0;
     prefetch_stride_x86_64::<{ _MM_HINT_T0 }>(slice);
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline(always)]
+fn prefetch_first_line_l1_impl(ptr: *const u8) {
+    use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+    // SAFETY: `_mm_prefetch` accepts any address — prefetching an
+    // invalid pointer is a no-op by the ISA spec, not UB.
+    unsafe { _mm_prefetch(ptr.cast(), _MM_HINT_T0) };
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -50,6 +78,13 @@ fn prefetch_slice_impl_l1(slice: &[u8]) {
 
 #[cfg(all(target_arch = "x86", target_feature = "sse"))]
 #[inline(always)]
+fn prefetch_first_line_l1_impl(ptr: *const u8) {
+    use core::arch::x86::{_MM_HINT_T0, _mm_prefetch};
+    unsafe { _mm_prefetch(ptr.cast(), _MM_HINT_T0) };
+}
+
+#[cfg(all(target_arch = "x86", target_feature = "sse"))]
+#[inline(always)]
 fn prefetch_slice_impl_t1(slice: &[u8]) {
     use core::arch::x86::_MM_HINT_T1;
     prefetch_stride_x86::<{ _MM_HINT_T1 }>(slice);
@@ -78,6 +113,19 @@ fn prefetch_stride_x86<const HINT: i32>(slice: &[u8]) {
 #[inline(always)]
 fn prefetch_slice_impl_l1(slice: &[u8]) {
     prefetch_stride_aarch64::<true>(slice);
+}
+
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn prefetch_first_line_l1_impl(ptr: *const u8) {
+    use core::arch::asm;
+    unsafe {
+        asm!(
+            "prfm pldl1keep, [{ptr}]",
+            ptr = in(reg) ptr,
+            options(nostack, preserves_flags, readonly)
+        );
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -128,6 +176,14 @@ fn prefetch_stride_aarch64<const L1: bool>(slice: &[u8]) {
 )))]
 #[inline(always)]
 fn prefetch_slice_impl_l1(_slice: &[u8]) {}
+
+#[cfg(not(any(
+    target_arch = "x86_64",
+    all(target_arch = "x86", target_feature = "sse"),
+    target_arch = "aarch64",
+)))]
+#[inline(always)]
+fn prefetch_first_line_l1_impl(_ptr: *const u8) {}
 
 #[cfg(not(any(
     target_arch = "x86_64",

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -72,6 +72,13 @@ impl<B: BufferBackend> DecoderScratch<B> {
         self.fse.ll_rle = None;
         self.fse.ml_rle = None;
         self.fse.of_rle = None;
+        // Reset the cached pipeline-gate signal alongside the FSE
+        // table reset — otherwise scratch reuse across frames could
+        // engage the long pipeline on a new frame's Repeat-mode
+        // header based on the previous frame's offset distribution
+        // (or vice versa: skip the pipeline when the new frame
+        // actually has long offsets).
+        self.fse.offsets_long_share = 0;
 
         self.huf.table.reset();
     }
@@ -112,8 +119,9 @@ pub struct FSEScratch {
     pub ll_rle: Option<u8>,
     pub match_lengths: AlignedFSETable,
     pub ml_rle: Option<u8>,
-    /// Cached "share of offset codes ≥ LONG_OFFSET_CODE_THRESHOLD"
-    /// scaled to donor's `OffFSELog = 8` (256-entry reference).
+    /// Cached "share of offset codes strictly > LONG_OFFSET_CODE_THRESHOLD
+    /// (i.e. codes ≥ 23 when the threshold is 22)" scaled to donor's
+    /// `OffFSELog = 8` (256-entry reference).
     /// Updated by [`crate::decoding::sequence_section_decoder`] when
     /// the offsets FSE table is rebuilt (FSE / Predefined modes);
     /// stale-but-correct on Repeat-mode blocks where the table was

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -47,6 +47,7 @@ impl<B: BufferBackend> DecoderScratch<B> {
                 ll_rle: None,
                 match_lengths: AlignedFSETable::new(MAX_MATCH_LENGTH_CODE),
                 ml_rle: None,
+                offsets_long_share: 0,
             },
             buffer: DecodeBuffer::new(window_size),
             offset_hist: [1, 4, 8],
@@ -111,6 +112,15 @@ pub struct FSEScratch {
     pub ll_rle: Option<u8>,
     pub match_lengths: AlignedFSETable,
     pub ml_rle: Option<u8>,
+    /// Cached "share of offset codes ≥ LONG_OFFSET_CODE_THRESHOLD"
+    /// scaled to donor's `OffFSELog = 8` (256-entry reference).
+    /// Updated by [`crate::decoding::sequence_section_decoder`] when
+    /// the offsets FSE table is rebuilt (FSE / Predefined modes);
+    /// stale-but-correct on Repeat-mode blocks where the table was
+    /// not touched — the share is identical to the previous block's.
+    /// The sequence-section pipeline gate reads this directly instead
+    /// of re-walking `offsets.decode` per block.
+    pub offsets_long_share: u32,
 }
 
 impl FSEScratch {
@@ -122,6 +132,7 @@ impl FSEScratch {
             ll_rle: None,
             match_lengths: AlignedFSETable::new(MAX_MATCH_LENGTH_CODE),
             ml_rle: None,
+            offsets_long_share: 0,
         }
     }
 
@@ -132,6 +143,7 @@ impl FSEScratch {
         self.of_rle = other.of_rle;
         self.ll_rle = other.ll_rle;
         self.ml_rle = other.ml_rle;
+        self.offsets_long_share = other.offsets_long_share;
     }
 }
 

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -151,7 +151,18 @@ impl FSEScratch {
         self.of_rle = other.of_rle;
         self.ll_rle = other.ll_rle;
         self.ml_rle = other.ml_rle;
-        self.offsets_long_share = other.offsets_long_share;
+        // Recompute the share from the just-copied offsets table
+        // rather than trusting `other.offsets_long_share`. Two source
+        // shapes produce a populated `offsets` table but a still-zero
+        // cached share: (a) `Dictionary::decode_dict` rebuilds the
+        // offsets FSE table from the dictionary's entropy section
+        // without ever calling the sequence-decoder path that updates
+        // the cache, and (b) any future caller that mutates the table
+        // directly. Recomputing here keeps the pipeline gate aligned
+        // with the actual table shape regardless of how the table got
+        // there.
+        self.offsets_long_share =
+            super::sequence_section_decoder::compute_offsets_long_share(&self.offsets);
     }
 }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -109,11 +109,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let saved_offset_hist = *offset_hist;
 
     // `offset_hist` mutates here (via do_offset_history) and only
-    // here. The pipeline above intentionally defers all repcode
-    // resolution to this call site so a mid-loop error keeps the
-    // caller's `offset_hist` consistent with the sequences that
-    // actually executed — preserving the legacy two-pass
-    // 'partial output, no rewound history' contract on early exits.
+    // here. The pipelined decode loop below intentionally defers all
+    // repcode resolution to this call site so a mid-loop error keeps
+    // the caller's `offset_hist` consistent with the sequences that
+    // actually executed — preserving the legacy two-pass 'partial
+    // output, no rewound history' contract on early exits.
     #[inline(always)]
     fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -108,12 +108,15 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
 
-    // `offset_hist` mutates here (via do_offset_history) and only
-    // here. The pipelined decode loop below intentionally defers all
-    // repcode resolution to this call site so a mid-loop error keeps
-    // the caller's `offset_hist` consistent with the sequences that
-    // actually executed — preserving the legacy two-pass 'partial
-    // output, no rewound history' contract on early exits.
+    // `offset_hist` mutates here (via do_offset_history) during normal
+    // sequence execution and ONLY here on the in-band success path —
+    // the pipelined decode loop below resolves repcodes against a
+    // local `shadow_hist`, never the caller's real `offset_hist`.
+    // (The post-loop rollback path also assigns to `*offset_hist`,
+    // but only to restore `saved_offset_hist` snapshot on a malformed
+    // block; that's recovery, not normal execution.) This preserves
+    // the legacy two-pass 'partial output, no rewound history'
+    // contract on early exits.
     #[inline(always)]
     fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -189,7 +189,14 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // pay the table-walk cost.
     const OFFSET_FSE_LOG: u32 = 8;
     const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
-    const MIN_LONG_OFFSET_SHARE_64BIT: u32 = 7;
+    // Donor `minShare = MEM_64bits() ? 7 : 20`: the 32-bit
+    // threshold is higher because the prefetch pipeline needs a
+    // stronger long-offset signal to outpace the narrower load
+    // window on those targets.
+    #[cfg(target_pointer_width = "64")]
+    const MIN_LONG_OFFSET_SHARE: u32 = 7;
+    #[cfg(not(target_pointer_width = "64"))]
+    const MIN_LONG_OFFSET_SHARE: u32 = 20;
     let use_long_pipeline = num_sequences >= ADVANCE * 2 && {
         let table = &fse.offsets.decode;
         let table_log = fse.offsets.accuracy_log as u32;
@@ -198,11 +205,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             .filter(|entry| u32::from(entry.symbol) > LONG_OFFSET_CODE_THRESHOLD)
             .count() as u32;
         // Donor scales `raw` to OffFSELog so a small/fine-grained
-        // table still registers meaningful share. `table_log <=
-        // OffFSELog` for every valid offsets table (MAX_OFFSET_CODE
-        // = 31 keeps accuracy_log <= 8), so the shift is wrap-free.
+        // table still registers meaningful share. The format-spec
+        // bound `OF_MAX_LOG = 8` (passed as the `max_log` arg to
+        // `build_decoder` for the offsets table) keeps `table_log
+        // <= OFFSET_FSE_LOG` for every valid stream, so the shift
+        // is wrap-free.
         let long_offset_share = raw << OFFSET_FSE_LOG.saturating_sub(table_log);
-        long_offset_share >= MIN_LONG_OFFSET_SHARE_64BIT
+        long_offset_share >= MIN_LONG_OFFSET_SHARE
     };
     // Donor also engages the prefetch decoder when the dictionary is
     // cold or when the format-level `isLongOffset` flag is set. We

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -177,21 +177,20 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
     );
 
-    // Donor `ZSTD_getOffsetInfo` parity: walk the FSE offsets table
-    // up-front and count how many entries decode to offset codes
-    // > 22 (i.e. raw offsets ≥ 2^23 = 8 MiB). Scale the count up to
-    // the donor's `OffFSELog = 8` (256-entry) reference so the
-    // share is comparable to the donor's `minShare = 7` threshold
-    // (≈ 2.73 % of the offsets table). The gate decision is taken
-    // ONCE per block from the FSE table shape, not per-sequence —
-    // donor's principle: blocks whose offset code distribution
-    // doesn't favour long-distance matches stay on the single-pass
-    // (no-prefetch) path where the ring/prefill/drain overhead
-    // would only cost cycles.
+    // Donor `ZSTD_getOffsetInfo` parity: when the block has enough
+    // sequences to amortise the pipeline's prefill + drain, walk
+    // the FSE offsets table and count entries that decode to offset
+    // codes > 22 (i.e. raw offsets >= 2^23 = 8 MiB). Scale up to
+    // donor's `OffFSELog = 8` (256-entry reference) so the share
+    // compares to `minShare = 7` (~2.73 % of the offsets table).
+    // The walk is gated by the sequence-count check FIRST so that
+    // short / no-sequence blocks (typical of high-entropy / random
+    // payloads where the kernel emits literal-only blocks) don't
+    // pay the table-walk cost.
     const OFFSET_FSE_LOG: u32 = 8;
     const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
     const MIN_LONG_OFFSET_SHARE_64BIT: u32 = 7;
-    let long_offset_share = {
+    let use_long_pipeline = num_sequences >= ADVANCE * 2 && {
         let table = &fse.offsets.decode;
         let table_log = fse.offsets.accuracy_log as u32;
         let raw = table
@@ -199,11 +198,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             .filter(|entry| u32::from(entry.symbol) > LONG_OFFSET_CODE_THRESHOLD)
             .count() as u32;
         // Donor scales `raw` to OffFSELog so a small/fine-grained
-        // table can still register a meaningful share. With
-        // `table_log <= OffFSELog` (true for every valid offsets
-        // table — `MAX_OFFSET_CODE = 31` enforces `accuracy_log <=
-        // 8`), the shift is wrap-free.
-        raw << OFFSET_FSE_LOG.saturating_sub(table_log)
+        // table still registers meaningful share. `table_log <=
+        // OffFSELog` for every valid offsets table (MAX_OFFSET_CODE
+        // = 31 keeps accuracy_log <= 8), so the shift is wrap-free.
+        let long_offset_share = raw << OFFSET_FSE_LOG.saturating_sub(table_log);
+        long_offset_share >= MIN_LONG_OFFSET_SHARE_64BIT
     };
     // Donor also engages the prefetch decoder when the dictionary is
     // cold or when the format-level `isLongOffset` flag is set. We
@@ -211,8 +210,6 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // 32-bit `isLongOffset` shortcut is irrelevant on the
     // u32-indexed decoder, so the FSE-share signal carries the
     // whole decision.
-    let use_long_pipeline =
-        num_sequences >= ADVANCE * 2 && long_offset_share >= MIN_LONG_OFFSET_SHARE_64BIT;
 
     if use_long_pipeline {
         // `prefetch_pos` is the logical buffer index (same frame as

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -172,10 +172,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // residency proxy (PREFETCH_AREA) for `ZSTD_decompressSequencesLong`
     // — short-offset matches reuse cache lines the buffer write just
     // touched, so a prefetch there is pure issue-port pressure. The
-    // gate is on the read-only `est_offset` (which is exact for
-    // `seq.of >= 4`, the dominant long-distance case) so the
-    // threshold check costs one branch on a strongly-predicted
-    // path.
+    // gate is on the resolved `actual_offset` (computed via
+    // `do_offset_history` on the decode-ahead `shadow_hist`, so it
+    // matches what execute will commit — repcode 1..=3 cases
+    // included), so the threshold check costs one branch on a
+    // strongly-predicted path.
     const PREFETCH_OFFSET_THRESHOLD: u32 = 32 * 1024;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
     // power of two. Compile-time guard so a future tweak (e.g.
@@ -203,7 +204,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // 1..=3 cases that read history — a stale read would skip
         // the long-distance prefetch precisely when a fresh huge
         // offset is followed by a repcode that aliases it. The
-        // shadow is a local 12 B usize-triple so the simulation cost
+        // shadow is a local `[u32; 3]` (12 bytes) so the simulation cost
         // is negligible.
         let mut shadow_hist: [u32; 3] = *offset_hist;
         // Stack ring of raw sequences. The execute path calls

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -167,6 +167,16 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // existing fused single-pass path stays in charge there.
     const ADVANCE: usize = 4;
     const ADVANCE_MASK: usize = ADVANCE - 1;
+    // Prefetch only when the match offset is large enough that the
+    // source line is plausibly cold in L1/L2. 32 KiB = donor's L1
+    // residency proxy (PREFETCH_AREA) for `ZSTD_decompressSequencesLong`
+    // — short-offset matches reuse cache lines the buffer write just
+    // touched, so a prefetch there is pure issue-port pressure. The
+    // gate is on the read-only `est_offset` (which is exact for
+    // `seq.of >= 4`, the dominant long-distance case) so the
+    // threshold check costs one branch on a strongly-predicted
+    // path.
+    const PREFETCH_OFFSET_THRESHOLD: u32 = 32 * 1024;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
     // power of two. Compile-time guard so a future tweak (e.g.
     // bumping to donor's STORED_SEQS = 8, also a power of two) can't
@@ -235,25 +245,28 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             of: 0,
         }; ADVANCE];
 
-        // Pre-fill the ring. The FSE state-update guard mirrors the
-        // single-pass loop: skip update after the very last decode
-        // (when k+1 == num_sequences) since there is no next decode.
-        for (k, slot) in ring.iter_mut().enumerate() {
+        // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
+        // guard ensures `num_sequences > ADVANCE`, so the FSE state
+        // update is needed after every prefill decode (k < ADVANCE
+        // implies k + 1 <= ADVANCE < num_sequences) — no `isLastSeq`
+        // guard required here, only in the steady-state loop where
+        // `i + 1 == num_sequences` is reachable.
+        for slot in ring.iter_mut() {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
             // Estimated offset for prefetch only — see
             // `estimate_actual_offset` for the accuracy contract.
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
             let source_idx = match_start.wrapping_sub(est_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx);
+            if est_offset >= PREFETCH_OFFSET_THRESHOLD {
+                buffer.prefetch_lookahead_match_source(source_idx);
+            }
             prefetch_pos = match_start + seq.ml as usize;
             *slot = seq;
-            if k + 1 < num_sequences {
-                br.ensure_bits(max_update_bits);
-                ll_dec.update_state_fast(&mut br);
-                ml_dec.update_state_fast(&mut br);
-                of_dec.update_state_fast(&mut br);
-            }
+            br.ensure_bits(max_update_bits);
+            ll_dec.update_state_fast(&mut br);
+            ml_dec.update_state_fast(&mut br);
+            of_dec.update_state_fast(&mut br);
         }
 
         // Steady state: decode next, prefetch its source, execute the
@@ -266,7 +279,9 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
             let match_start = prefetch_pos + seq.ll as usize;
             let source_idx = match_start.wrapping_sub(est_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx);
+            if est_offset >= PREFETCH_OFFSET_THRESHOLD {
+                buffer.prefetch_lookahead_match_source(source_idx);
+            }
             prefetch_pos = match_start + seq.ml as usize;
 
             let slot = i & ADVANCE_MASK;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -168,10 +168,9 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     const ADVANCE: usize = 8;
     const ADVANCE_MASK: usize = ADVANCE - 1;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
-    // power of two. Compile-time guard so a future tweak (e.g.
-    // bumping to donor's STORED_SEQS = 8, also a power of two) can't
-    // silently corrupt the ring index if someone picks a non-power-
-    // of-two value.
+    // power of two. Compile-time guard so a future ADVANCE tweak
+    // can't silently corrupt the ring index if someone picks a
+    // non-power-of-two value.
     const _: () = assert!(
         ADVANCE.is_power_of_two(),
         "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -160,24 +160,9 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // matches whose source is beyond cache residency.
     //
     // Donor uses STORED_SEQS = 8; we start at 4 to keep the ring on
-    // the stack within register pressure and reuse later iterations
-    // to dial up if profiling shows headroom. The pipeline is opt-in
-    // by `num_sequences >= ADVANCE * 2` — for short blocks the
-    // prefill + drain overhead dominates the prefetch gain, so the
-    // existing fused single-pass path stays in charge there.
+    // the stack within register pressure.
     const ADVANCE: usize = 4;
     const ADVANCE_MASK: usize = ADVANCE - 1;
-    // Prefetch only when the match offset is large enough that the
-    // source line is plausibly cold in L1/L2. 32 KiB = donor's L1
-    // residency proxy (PREFETCH_AREA) for `ZSTD_decompressSequencesLong`
-    // — short-offset matches reuse cache lines the buffer write just
-    // touched, so a prefetch there is pure issue-port pressure. The
-    // gate is on the resolved `actual_offset` (computed via
-    // `do_offset_history` on the decode-ahead `shadow_hist`, so it
-    // matches what execute will commit — repcode 1..=3 cases
-    // included), so the threshold check costs one branch on a
-    // strongly-predicted path.
-    const PREFETCH_OFFSET_THRESHOLD: u32 = 32 * 1024;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
     // power of two. Compile-time guard so a future tweak (e.g.
     // bumping to donor's STORED_SEQS = 8, also a power of two) can't
@@ -188,7 +173,44 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
     );
 
-    if num_sequences >= ADVANCE * 2 {
+    // Donor `ZSTD_getOffsetInfo` parity: walk the FSE offsets table
+    // up-front and count how many entries decode to offset codes
+    // > 22 (i.e. raw offsets ≥ 2^23 = 8 MiB). Scale the count up to
+    // the donor's `OffFSELog = 8` (256-entry) reference so the
+    // share is comparable to the donor's `minShare = 7` threshold
+    // (≈ 2.73 % of the offsets table). The gate decision is taken
+    // ONCE per block from the FSE table shape, not per-sequence —
+    // donor's principle: blocks whose offset code distribution
+    // doesn't favour long-distance matches stay on the single-pass
+    // (no-prefetch) path where the ring/prefill/drain overhead
+    // would only cost cycles.
+    const OFFSET_FSE_LOG: u32 = 8;
+    const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
+    const MIN_LONG_OFFSET_SHARE_64BIT: u32 = 7;
+    let long_offset_share = {
+        let table = &fse.offsets.decode;
+        let table_log = fse.offsets.accuracy_log as u32;
+        let raw = table
+            .iter()
+            .filter(|entry| u32::from(entry.symbol) > LONG_OFFSET_CODE_THRESHOLD)
+            .count() as u32;
+        // Donor scales `raw` to OffFSELog so a small/fine-grained
+        // table can still register a meaningful share. With
+        // `table_log <= OffFSELog` (true for every valid offsets
+        // table — `MAX_OFFSET_CODE = 31` enforces `accuracy_log <=
+        // 8`), the shift is wrap-free.
+        raw << OFFSET_FSE_LOG.saturating_sub(table_log)
+    };
+    // Donor also engages the prefetch decoder when the dictionary is
+    // cold or when the format-level `isLongOffset` flag is set. We
+    // don't track dictionary-coldness on this decode path and the
+    // 32-bit `isLongOffset` shortcut is irrelevant on the
+    // u32-indexed decoder, so the FSE-share signal carries the
+    // whole decision.
+    let use_long_pipeline =
+        num_sequences >= ADVANCE * 2 && long_offset_share >= MIN_LONG_OFFSET_SHARE_64BIT;
+
+    if use_long_pipeline {
         // `prefetch_pos` is the logical buffer index (same frame as
         // `buffer.len()`) at which the NEXT not-yet-decoded sequence
         // will start pushing literals. We pre-decode 4 ahead, so we
@@ -217,20 +239,19 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         }; ADVANCE];
 
         // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
-        // guard ensures `num_sequences > ADVANCE`, so the FSE state
-        // update is needed after every prefill decode (k < ADVANCE
-        // implies k + 1 <= ADVANCE < num_sequences) — no `isLastSeq`
-        // guard required here, only in the steady-state loop where
-        // `i + 1 == num_sequences` is reachable.
+        // gate guarantees `num_sequences > ADVANCE`, so the FSE
+        // state update is needed after every prefill decode (k <
+        // ADVANCE implies k + 1 <= ADVANCE < num_sequences) — no
+        // `isLastSeq` guard required here, only in the steady-state
+        // loop where `i + 1 == num_sequences` is reachable.
         //
-        // `saw_prefetch_needed` flips to true the moment any prefilled
-        // sequence resolves to an offset above the prefetch threshold.
-        // If it stays false through all ADVANCE prefills, the block
-        // is dominated by short-offset matches whose source is
-        // already L1-warm; we drop into a single-pass fallback for
-        // the remainder so ring/prefill/drain overhead doesn't
-        // weigh on the short-offset hot path.
-        let mut saw_prefetch_needed = false;
+        // Unconditional prefetch per slot — the FSE-table share check
+        // above already committed to long-distance dominance, so a
+        // mid-block dynamic opt-out would just split control flow
+        // for no win. Per-sequence gating runs the risk of skipping
+        // the prefetch for the slot whose source LATER becomes the
+        // cache miss; donor stays unconditional inside the Long
+        // pipeline for the same reason.
         for slot in ring.iter_mut() {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
             // EXACT actual_offset via shadow history — repcode
@@ -247,10 +268,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             // here while keeping the decoder fuzz-stable.
             let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
             let source_idx = match_start.wrapping_sub(actual_offset as usize);
-            if actual_offset >= PREFETCH_OFFSET_THRESHOLD {
-                buffer.prefetch_lookahead_match_source(source_idx);
-                saw_prefetch_needed = true;
-            }
+            buffer.prefetch_lookahead_match_source(source_idx);
             prefetch_pos = match_start.wrapping_add(seq.ml as usize);
             *slot = seq;
             br.ensure_bits(max_update_bits);
@@ -259,100 +277,57 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             of_dec.update_state_fast(&mut br);
         }
 
-        if !saw_prefetch_needed {
-            // All-short-offset prefill — the pipeline would pay
-            // ring/drain overhead for zero prefetches. Drain the
-            // queued ADVANCE sequences in order, then continue
-            // single-pass for the rest of the block. The ring slots
-            // are still in logical index order (k == prefill index)
-            // because the steady-state loop hasn't started rotating
-            // yet.
-            for slot in &ring {
-                execute_one_sequence(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    offset_hist,
-                    *slot,
-                )?;
-                seq_sum = seq_sum.wrapping_add(slot.ll).wrapping_add(slot.ml);
-            }
-            for i in ADVANCE..num_sequences {
-                let seq =
-                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-                execute_one_sequence(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    offset_hist,
-                    seq,
-                )?;
-                seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
-                if i + 1 < num_sequences {
-                    br.ensure_bits(max_update_bits);
-                    ll_dec.update_state_fast(&mut br);
-                    ml_dec.update_state_fast(&mut br);
-                    of_dec.update_state_fast(&mut br);
-                }
-            }
-        } else {
-            // Steady state: decode next, prefetch its source, execute
-            // the oldest slot in the ring. `i & ADVANCE_MASK` is both
-            // the oldest slot (currently holding seq at logical index
-            // i - ADVANCE) and the slot we overwrite with the newly-
-            // decoded seq[i] — donor pattern.
-            for i in ADVANCE..num_sequences {
-                let seq =
-                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
-                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-                let source_idx = match_start.wrapping_sub(actual_offset as usize);
-                if actual_offset >= PREFETCH_OFFSET_THRESHOLD {
-                    buffer.prefetch_lookahead_match_source(source_idx);
-                }
-                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
+        // Steady state: decode next, prefetch its source, execute
+        // the oldest slot in the ring. `i & ADVANCE_MASK` is both
+        // the oldest slot (currently holding seq at logical index
+        // i - ADVANCE) and the slot we overwrite with the newly-
+        // decoded seq[i] — donor pattern.
+        for i in ADVANCE..num_sequences {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+            let source_idx = match_start.wrapping_sub(actual_offset as usize);
+            buffer.prefetch_lookahead_match_source(source_idx);
+            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
 
-                let slot = i & ADVANCE_MASK;
-                let exec_seq = ring[slot];
-                ring[slot] = seq;
+            let slot = i & ADVANCE_MASK;
+            let exec_seq = ring[slot];
+            ring[slot] = seq;
 
-                execute_one_sequence(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    offset_hist,
-                    exec_seq,
-                )?;
-                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+            execute_one_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                offset_hist,
+                exec_seq,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
 
-                if i + 1 < num_sequences {
-                    br.ensure_bits(max_update_bits);
-                    ll_dec.update_state_fast(&mut br);
-                    ml_dec.update_state_fast(&mut br);
-                    of_dec.update_state_fast(&mut br);
-                }
+            if i + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
             }
+        }
 
-            // Drain: execute remaining ADVANCE sequences. Iteration
-            // order matches the ring slot they occupy from the
-            // steady-state loop's final write — start from
-            // `num_sequences & MASK` to preserve sequence order.
-            for k in 0..ADVANCE {
-                let slot = (num_sequences + k) & ADVANCE_MASK;
-                let exec_seq = ring[slot];
-                execute_one_sequence(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    offset_hist,
-                    exec_seq,
-                )?;
-                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-            }
+        // Drain: execute remaining ADVANCE sequences. Iteration
+        // order matches the ring slot they occupy from the
+        // steady-state loop's final write — start from
+        // `num_sequences & MASK` to preserve sequence order.
+        for k in 0..ADVANCE {
+            let slot = (num_sequences + k) & ADVANCE_MASK;
+            let exec_seq = ring[slot];
+            execute_one_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                offset_hist,
+                exec_seq,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
         }
     } else {
         // Short-block fallback: the single-pass fused loop. For

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -256,12 +256,20 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             // Estimated offset for prefetch only — see
             // `estimate_actual_offset` for the accuracy contract.
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
-            let match_start = prefetch_pos + seq.ll as usize;
+            // wrapping_add: prefetch_pos / seq.ll / seq.ml are
+            // derived from the bitstream, so a malformed frame can
+            // present values that would overflow usize and panic
+            // under debug. The result feeds only the prefetch
+            // hint — `prefetch_lookahead_match_source` bound-checks
+            // the logical position against `buffer.len()` and drops
+            // wrap-derived garbage indices, so the wrap is harmless
+            // here while keeping the decoder fuzz-stable.
+            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
             let source_idx = match_start.wrapping_sub(est_offset as usize);
             if est_offset >= PREFETCH_OFFSET_THRESHOLD {
                 buffer.prefetch_lookahead_match_source(source_idx);
             }
-            prefetch_pos = match_start + seq.ml as usize;
+            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
             *slot = seq;
             br.ensure_bits(max_update_bits);
             ll_dec.update_state_fast(&mut br);
@@ -277,12 +285,20 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         for i in ADVANCE..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
             let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
-            let match_start = prefetch_pos + seq.ll as usize;
+            // wrapping_add: prefetch_pos / seq.ll / seq.ml are
+            // derived from the bitstream, so a malformed frame can
+            // present values that would overflow usize and panic
+            // under debug. The result feeds only the prefetch
+            // hint — `prefetch_lookahead_match_source` bound-checks
+            // the logical position against `buffer.len()` and drops
+            // wrap-derived garbage indices, so the wrap is harmless
+            // here while keeping the decoder fuzz-stable.
+            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
             let source_idx = match_start.wrapping_sub(est_offset as usize);
             if est_offset >= PREFETCH_OFFSET_THRESHOLD {
                 buffer.prefetch_lookahead_match_source(source_idx);
             }
-            prefetch_pos = match_start + seq.ml as usize;
+            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
 
             let slot = i & ADVANCE_MASK;
             let exec_seq = ring[slot];

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -176,18 +176,16 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
     );
 
-    // Donor `ZSTD_getOffsetInfo` parity: when the block has enough
-    // sequences to amortise the pipeline's prefill + drain, walk
-    // the FSE offsets table and count entries that decode to offset
-    // codes > 22 (i.e. raw offsets >= 2^23 = 8 MiB). Scale up to
-    // donor's `OffFSELog = 8` (256-entry reference) so the share
-    // compares to `minShare = 7` (~2.73 % of the offsets table).
-    // The walk is gated by the sequence-count check FIRST so that
-    // short / no-sequence blocks (typical of high-entropy / random
-    // payloads where the kernel emits literal-only blocks) don't
-    // pay the table-walk cost.
-    const OFFSET_FSE_LOG: u32 = 8;
-    const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
+    // Donor `ZSTD_getOffsetInfo` parity. The share of FSE offset
+    // codes > LONG_OFFSET_CODE_THRESHOLD (scaled to donor's
+    // OffFSELog = 8 reference) is computed once per table refresh
+    // and cached in `fse.offsets_long_share` — see
+    // `compute_offsets_long_share` and the `maybe_update_fse_tables`
+    // call sites. Repeat-mode blocks (the table didn't change)
+    // re-use the cached value without re-walking 32–256 table
+    // entries per block. Gate stays sequence-count-first so short /
+    // no-sequence blocks don't even read the cache.
+    //
     // Donor `minShare = MEM_64bits() ? 7 : 20`: the 32-bit
     // threshold is higher because the prefetch pipeline needs a
     // stronger long-offset signal to outpace the narrower load
@@ -196,22 +194,8 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     const MIN_LONG_OFFSET_SHARE: u32 = 7;
     #[cfg(not(target_pointer_width = "64"))]
     const MIN_LONG_OFFSET_SHARE: u32 = 20;
-    let use_long_pipeline = num_sequences >= ADVANCE * 2 && {
-        let table = &fse.offsets.decode;
-        let table_log = fse.offsets.accuracy_log as u32;
-        let raw = table
-            .iter()
-            .filter(|entry| u32::from(entry.symbol) > LONG_OFFSET_CODE_THRESHOLD)
-            .count() as u32;
-        // Donor scales `raw` to OffFSELog so a small/fine-grained
-        // table still registers meaningful share. The format-spec
-        // bound `OF_MAX_LOG = 8` (passed as the `max_log` arg to
-        // `build_decoder` for the offsets table) keeps `table_log
-        // <= OFFSET_FSE_LOG` for every valid stream, so the shift
-        // is wrap-free.
-        let long_offset_share = raw << OFFSET_FSE_LOG.saturating_sub(table_log);
-        long_offset_share >= MIN_LONG_OFFSET_SHARE
-    };
+    let use_long_pipeline =
+        num_sequences >= ADVANCE * 2 && fse.offsets_long_share >= MIN_LONG_OFFSET_SHARE;
     // Donor also engages the prefetch decoder when the dictionary is
     // cold or when the format-level `isLongOffset` flag is set. We
     // don't track dictionary-coldness on this decode path and the
@@ -678,6 +662,32 @@ pub const ML_MAX_LOG: u8 = 9;
 /// "The maximum accuracy log for the offset table is 8."
 pub const OF_MAX_LOG: u8 = 8;
 
+/// Walk the offsets FSE decode table and return the donor-shaped
+/// "share of long offsets" signal: count entries whose symbol (offset
+/// code) is > 22 (raw offset ≥ 2²³ = 8 MiB), then scale up to the
+/// donor `OffFSELog = 8` reference so a fine-grained table still
+/// registers comparable share. Output compares directly against
+/// `MIN_LONG_OFFSET_SHARE` (7 on 64-bit, 20 on 32-bit) in the
+/// pipeline-gate decision.
+///
+/// Called only when the offsets table is actually rebuilt (FSE /
+/// Predefined modes in `maybe_update_fse_tables`). Repeat-mode
+/// blocks reuse the cached value in `FSEScratch::offsets_long_share`.
+fn compute_offsets_long_share(offsets: &crate::fse::FSETable) -> u32 {
+    const OFFSET_FSE_LOG: u32 = 8;
+    const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
+    let table_log = offsets.accuracy_log as u32;
+    let raw = offsets
+        .decode
+        .iter()
+        .filter(|entry| u32::from(entry.symbol) > LONG_OFFSET_CODE_THRESHOLD)
+        .count() as u32;
+    // Format-spec bound `OF_MAX_LOG = 8` keeps `table_log <=
+    // OFFSET_FSE_LOG` for every valid offsets stream, so the shift
+    // is wrap-free.
+    raw << OFFSET_FSE_LOG.saturating_sub(table_log)
+}
+
 fn maybe_update_fse_tables(
     section: &SequencesHeader,
     source: &[u8],
@@ -732,6 +742,7 @@ fn maybe_update_fse_tables(
             vprintln!("Used bytes: {}", bytes);
             bytes_read += bytes;
             scratch.of_rle = None;
+            scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
         }
         ModeType::RLE => {
             vprintln!("Use RLE of table");
@@ -751,10 +762,11 @@ fn maybe_update_fse_tables(
                 &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
             )?;
             scratch.of_rle = None;
+            scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
         }
         ModeType::Repeat => {
             vprintln!("Repeat of table");
-            /* Nothing to do */
+            /* Nothing to do — cached `offsets_long_share` stays valid. */
         }
     };
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -108,15 +108,19 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
 
-    // `offset_hist` mutates here (via do_offset_history) during normal
-    // sequence execution and ONLY here on the in-band success path —
-    // the pipelined decode loop below resolves repcodes against a
-    // local `shadow_hist`, never the caller's real `offset_hist`.
-    // (The post-loop rollback path also assigns to `*offset_hist`,
-    // but only to restore `saved_offset_hist` snapshot on a malformed
-    // block; that's recovery, not normal execution.) This preserves
-    // the legacy two-pass 'partial output, no rewound history'
-    // contract on early exits.
+    // `offset_hist` mutation on the in-band success path:
+    //   * Pipelined branch (long pipeline): real `offset_hist` is NOT
+    //     touched per-sequence — repcodes are resolved against the
+    //     local `shadow_hist`, and the resolved offset is stored in
+    //     the ring alongside the decoded sequence. After successful
+    //     drain we copy `shadow_hist` back into `*offset_hist` once.
+    //   * Non-pipelined branch (short-block fallback): real
+    //     `offset_hist` IS mutated inline via `do_offset_history` in
+    //     `execute_one_sequence`.
+    //   * Rollback path (post-loop bitstream check fails): restore
+    //     `*offset_hist = saved_offset_hist`. Cheap no-op on the
+    //     pipelined branch (real hist was never touched mid-loop),
+    //     correct rewind on the non-pipelined branch.
     #[inline(always)]
     fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,
@@ -146,6 +150,44 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         }
         buffer
             .repeat(actual as usize, seq.ml as usize)
+            .map_err(ExecuteSequencesError::from)?;
+        Ok(())
+    }
+
+    /// Pipelined-path variant: takes the offset already resolved by
+    /// the decode-ahead `shadow_hist` walk, so `do_offset_history` is
+    /// NOT called here (caller mutated only the shadow). Routes the
+    /// match copy through `repeat_lookahead_prefetched` to skip the
+    /// in-loop `prefetch_match_source` + redundant `reserve` that the
+    /// upfront `reserve(MAX_BLOCK_SIZE)` plus the lookahead pipeline's
+    /// PREFETCH_L1 already covered.
+    #[inline(always)]
+    fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
+        buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+        literals: &[u8],
+        lit_cur: &mut usize,
+        lit_len: usize,
+        seq: Sequence,
+        resolved_offset: u32,
+    ) -> Result<(), DecompressBlockError> {
+        let high = *lit_cur + seq.ll as usize;
+        if high > lit_len {
+            return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
+                wanted: high,
+                have: lit_len,
+            }
+            .into());
+        }
+        // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
+        let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
+        *lit_cur = high;
+        buffer.push(lits);
+
+        if resolved_offset == 0 {
+            return Err(ExecuteSequencesError::ZeroOffset.into());
+        }
+        buffer
+            .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
             .map_err(ExecuteSequencesError::from)?;
         Ok(())
     }
@@ -225,34 +267,33 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // shadow is a local `[u32; 3]` (12 bytes) so the simulation cost
         // is negligible.
         let mut shadow_hist: [u32; 3] = *offset_hist;
-        // Stack ring of raw sequences. The execute path calls
-        // `do_offset_history` again on the real `offset_hist` for
-        // each drained slot — that's the single committing site.
-        let mut ring: [Sequence; ADVANCE] = [Sequence {
-            ll: 0,
-            ml: 0,
-            of: 0,
-        }; ADVANCE];
+        // Stack ring of `(decoded_seq, resolved_offset)` pairs. The
+        // decode-ahead phase resolves repcodes against `shadow_hist`
+        // and stores the resolved offset alongside the raw sequence,
+        // so the execute phase consumes a pre-resolved offset and
+        // skips `do_offset_history` entirely — saves one function
+        // call + one cache write on real `offset_hist` per sequence.
+        // The real `offset_hist` is updated ONCE from `shadow_hist`
+        // after a successful drain (below); on a malformed-block
+        // rollback the saved snapshot is restored, so real hist is
+        // never observed in a partial mid-pipeline state.
+        let mut ring: [(Sequence, u32); ADVANCE] = [(
+            Sequence {
+                ll: 0,
+                ml: 0,
+                of: 0,
+            },
+            0u32,
+        ); ADVANCE];
 
         // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
         // gate guarantees `num_sequences > ADVANCE`, so the FSE
-        // state update is needed after every prefill decode (k <
-        // ADVANCE implies k + 1 <= ADVANCE < num_sequences) — no
+        // state update is needed after every prefill decode — no
         // `isLastSeq` guard required here, only in the steady-state
         // loop where `i + 1 == num_sequences` is reachable.
-        //
-        // Unconditional prefetch per slot — the FSE-table share check
-        // above already committed to long-distance dominance, so a
-        // mid-block dynamic opt-out would just split control flow
-        // for no win. Per-sequence gating runs the risk of skipping
-        // the prefetch for the slot whose source LATER becomes the
-        // cache miss; donor stays unconditional inside the Long
-        // pipeline for the same reason.
         for slot in ring.iter_mut() {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            // EXACT actual_offset via shadow history — repcode
-            // 1..=3 lookups see the same post-update values execute
-            // will see when it later commits to the real hist.
+            // EXACT actual_offset via shadow history.
             let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             // wrapping_add: prefetch_pos / seq.ll / seq.ml are
             // derived from the bitstream, so a malformed frame can
@@ -266,7 +307,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             let source_idx = match_start.wrapping_sub(actual_offset as usize);
             buffer.prefetch_lookahead_match_source(source_idx);
             prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-            *slot = seq;
+            *slot = (seq, actual_offset);
             br.ensure_bits(max_update_bits);
             ll_dec.update_state_fast(&mut br);
             ml_dec.update_state_fast(&mut br);
@@ -274,10 +315,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         }
 
         // Steady state: decode next, prefetch its source, execute
-        // the oldest slot in the ring. `i & ADVANCE_MASK` is both
-        // the oldest slot (currently holding seq at logical index
-        // i - ADVANCE) and the slot we overwrite with the newly-
-        // decoded seq[i] — donor pattern.
+        // the oldest slot in the ring (with its pre-resolved offset).
         for i in ADVANCE..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
             let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
@@ -287,16 +325,16 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             prefetch_pos = match_start.wrapping_add(seq.ml as usize);
 
             let slot = i & ADVANCE_MASK;
-            let exec_seq = ring[slot];
-            ring[slot] = seq;
+            let (exec_seq, exec_offset) = ring[slot];
+            ring[slot] = (seq, actual_offset);
 
-            execute_one_sequence(
+            execute_one_sequence_pipelined(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
-                offset_hist,
                 exec_seq,
+                exec_offset,
             )?;
             seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
 
@@ -308,23 +346,30 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             }
         }
 
-        // Drain: execute remaining ADVANCE sequences. Iteration
-        // order matches the ring slot they occupy from the
-        // steady-state loop's final write — start from
-        // `num_sequences & MASK` to preserve sequence order.
+        // Drain: execute remaining ADVANCE sequences with their
+        // pre-resolved offsets. Iteration order matches the ring
+        // slot they occupy from the steady-state loop's final write.
         for k in 0..ADVANCE {
             let slot = (num_sequences + k) & ADVANCE_MASK;
-            let exec_seq = ring[slot];
-            execute_one_sequence(
+            let (exec_seq, exec_offset) = ring[slot];
+            execute_one_sequence_pipelined(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
-                offset_hist,
                 exec_seq,
+                exec_offset,
             )?;
             seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
         }
+
+        // Single committing point for real offset history on the
+        // pipelined success path. Shadow walked every queued sequence
+        // already; copy that state back so the next block sees the
+        // post-block repcodes. Rollback on a later bitstream-failure
+        // overwrites this with `saved_offset_hist`, undoing the
+        // commit.
+        *offset_hist = shadow_hist;
     } else {
         // Short-block fallback: the single-pass fused loop. For
         // num_sequences < ADVANCE * 2 the pipeline's prefill + drain

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -187,46 +187,6 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
     );
 
-    // Read-only estimate for the prefetch's match-source position.
-    // The TRUE `actual_offset` requires mutating `offset_hist` via
-    // `do_offset_history`, which we deliberately defer to execute
-    // time so a mid-loop error preserves the legacy 'no partial
-    // history mutation' semantics. For the `seq.of >= 4` case
-    // (every fresh non-repcode offset, dominant on the long-distance
-    // workloads this pipeline targets) the estimate is exact and
-    // matches do_offset_history's output bit-for-bit. For the
-    // repcode 1..=3 cases the estimate reads the current `hist`
-    // without mutating it — this can lag by up to ADVANCE
-    // sequences vs the post-execute state, but the lag only
-    // mis-points the prefetch by a few cache lines on close-range
-    // matches whose source is already L1-warm; the cost of a
-    // mis-targeted PREFETCH_L1 on warm data is negligible.
-    #[inline(always)]
-    fn estimate_actual_offset(of: u32, ll: u32, hist: &[u32; 3]) -> u32 {
-        if of >= 4 {
-            return of - 3;
-        }
-        // Mirrors the read-only halves of do_offset_history_repcode's
-        // selection table: the lit-zero edge cases that pull from a
-        // different hist slot are kept consistent so the estimate
-        // tracks execute-time resolution as closely as possible.
-        match (of, ll == 0) {
-            (1, false) => hist[0],
-            (1, true) => hist[1],
-            (2, false) => hist[1],
-            (2, true) => hist[2],
-            (3, false) => hist[2],
-            // Mirror `do_offset_history_repcode`'s `wrapping_sub(1)` —
-            // not `saturating_sub` — so even on corrupted/0 history
-            // the estimate matches the real resolver. The result is
-            // only consumed by prefetch addressing, where a wild
-            // wrap just lands the hint on an out-of-range slot the
-            // helper drops.
-            (3, true) => hist[0].wrapping_sub(1),
-            _ => 0,
-        }
-    }
-
     if num_sequences >= ADVANCE * 2 {
         // `prefetch_pos` is the logical buffer index (same frame as
         // `buffer.len()`) at which the NEXT not-yet-decoded sequence
@@ -234,11 +194,21 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // accumulate (ll + ml) per decoded seq to keep this position
         // synchronised with where execute will eventually be.
         let mut prefetch_pos: usize = old_buffer_size;
-        // Stack ring of raw sequences. `do_offset_history` is NOT
-        // run here — execute calls it later, so `offset_hist`
-        // mutations stay in lockstep with successful execute calls
-        // (matching the legacy 'no rollback on mid-loop error'
-        // contract).
+        // Shadow copy of `offset_hist`, advanced by
+        // `do_offset_history` for every decoded-ahead sequence. The
+        // REAL `offset_hist` is only mutated inside
+        // `execute_one_sequence` (preserving the legacy 'partial
+        // output, no rewound history' rollback contract), but the
+        // prefetch needs the exact post-resolution offset for repcode
+        // 1..=3 cases that read history — a stale read would skip
+        // the long-distance prefetch precisely when a fresh huge
+        // offset is followed by a repcode that aliases it. The
+        // shadow is a local 12 B usize-triple so the simulation cost
+        // is negligible.
+        let mut shadow_hist: [u32; 3] = *offset_hist;
+        // Stack ring of raw sequences. The execute path calls
+        // `do_offset_history` again on the real `offset_hist` for
+        // each drained slot — that's the single committing site.
         let mut ring: [Sequence; ADVANCE] = [Sequence {
             ll: 0,
             ml: 0,
@@ -251,11 +221,21 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // implies k + 1 <= ADVANCE < num_sequences) — no `isLastSeq`
         // guard required here, only in the steady-state loop where
         // `i + 1 == num_sequences` is reachable.
+        //
+        // `saw_prefetch_needed` flips to true the moment any prefilled
+        // sequence resolves to an offset above the prefetch threshold.
+        // If it stays false through all ADVANCE prefills, the block
+        // is dominated by short-offset matches whose source is
+        // already L1-warm; we drop into a single-pass fallback for
+        // the remainder so ring/prefill/drain overhead doesn't
+        // weigh on the short-offset hot path.
+        let mut saw_prefetch_needed = false;
         for slot in ring.iter_mut() {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            // Estimated offset for prefetch only — see
-            // `estimate_actual_offset` for the accuracy contract.
-            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
+            // EXACT actual_offset via shadow history — repcode
+            // 1..=3 lookups see the same post-update values execute
+            // will see when it later commits to the real hist.
+            let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             // wrapping_add: prefetch_pos / seq.ll / seq.ml are
             // derived from the bitstream, so a malformed frame can
             // present values that would overflow usize and panic
@@ -265,9 +245,10 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             // wrap-derived garbage indices, so the wrap is harmless
             // here while keeping the decoder fuzz-stable.
             let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-            let source_idx = match_start.wrapping_sub(est_offset as usize);
-            if est_offset >= PREFETCH_OFFSET_THRESHOLD {
+            let source_idx = match_start.wrapping_sub(actual_offset as usize);
+            if actual_offset >= PREFETCH_OFFSET_THRESHOLD {
                 buffer.prefetch_lookahead_match_source(source_idx);
+                saw_prefetch_needed = true;
             }
             prefetch_pos = match_start.wrapping_add(seq.ml as usize);
             *slot = seq;
@@ -277,67 +258,100 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             of_dec.update_state_fast(&mut br);
         }
 
-        // Steady state: decode next, prefetch its source, execute the
-        // oldest slot in the ring. `i & ADVANCE_MASK` is both the
-        // oldest slot (currently holding seq at logical index i -
-        // ADVANCE) and the slot we overwrite with the newly-decoded
-        // seq[i] — donor pattern.
-        for i in ADVANCE..num_sequences {
-            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
-            // wrapping_add: prefetch_pos / seq.ll / seq.ml are
-            // derived from the bitstream, so a malformed frame can
-            // present values that would overflow usize and panic
-            // under debug. The result feeds only the prefetch
-            // hint — `prefetch_lookahead_match_source` bound-checks
-            // the logical position against `buffer.len()` and drops
-            // wrap-derived garbage indices, so the wrap is harmless
-            // here while keeping the decoder fuzz-stable.
-            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-            let source_idx = match_start.wrapping_sub(est_offset as usize);
-            if est_offset >= PREFETCH_OFFSET_THRESHOLD {
-                buffer.prefetch_lookahead_match_source(source_idx);
+        if !saw_prefetch_needed {
+            // All-short-offset prefill — the pipeline would pay
+            // ring/drain overhead for zero prefetches. Drain the
+            // queued ADVANCE sequences in order, then continue
+            // single-pass for the rest of the block. The ring slots
+            // are still in logical index order (k == prefill index)
+            // because the steady-state loop hasn't started rotating
+            // yet.
+            for slot in &ring {
+                execute_one_sequence(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    offset_hist,
+                    *slot,
+                )?;
+                seq_sum = seq_sum.wrapping_add(slot.ll).wrapping_add(slot.ml);
             }
-            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-
-            let slot = i & ADVANCE_MASK;
-            let exec_seq = ring[slot];
-            ring[slot] = seq;
-
-            execute_one_sequence(
-                buffer,
-                literals_buffer,
-                &mut lit_cur,
-                literals_buffer_len,
-                offset_hist,
-                exec_seq,
-            )?;
-            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-
-            if i + 1 < num_sequences {
-                br.ensure_bits(max_update_bits);
-                ll_dec.update_state_fast(&mut br);
-                ml_dec.update_state_fast(&mut br);
-                of_dec.update_state_fast(&mut br);
+            for i in ADVANCE..num_sequences {
+                let seq =
+                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+                execute_one_sequence(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    offset_hist,
+                    seq,
+                )?;
+                seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
+                if i + 1 < num_sequences {
+                    br.ensure_bits(max_update_bits);
+                    ll_dec.update_state_fast(&mut br);
+                    ml_dec.update_state_fast(&mut br);
+                    of_dec.update_state_fast(&mut br);
+                }
             }
-        }
+        } else {
+            // Steady state: decode next, prefetch its source, execute
+            // the oldest slot in the ring. `i & ADVANCE_MASK` is both
+            // the oldest slot (currently holding seq at logical index
+            // i - ADVANCE) and the slot we overwrite with the newly-
+            // decoded seq[i] — donor pattern.
+            for i in ADVANCE..num_sequences {
+                let seq =
+                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+                let source_idx = match_start.wrapping_sub(actual_offset as usize);
+                if actual_offset >= PREFETCH_OFFSET_THRESHOLD {
+                    buffer.prefetch_lookahead_match_source(source_idx);
+                }
+                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
 
-        // Drain: execute remaining ADVANCE sequences. Iteration order
-        // matches the ring slot they occupy from the steady-state
-        // loop's final write — start from `num_sequences & MASK` to
-        // preserve sequence order.
-        for k in 0..ADVANCE {
-            let slot = (num_sequences + k) & ADVANCE_MASK;
-            let exec_seq = ring[slot];
-            execute_one_sequence(
-                buffer,
-                literals_buffer,
-                &mut lit_cur,
-                literals_buffer_len,
-                offset_hist,
-                exec_seq,
-            )?;
-            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+                let slot = i & ADVANCE_MASK;
+                let exec_seq = ring[slot];
+                ring[slot] = seq;
+
+                execute_one_sequence(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    offset_hist,
+                    exec_seq,
+                )?;
+                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+
+                if i + 1 < num_sequences {
+                    br.ensure_bits(max_update_bits);
+                    ll_dec.update_state_fast(&mut br);
+                    ml_dec.update_state_fast(&mut br);
+                    of_dec.update_state_fast(&mut br);
+                }
+            }
+
+            // Drain: execute remaining ADVANCE sequences. Iteration
+            // order matches the ring slot they occupy from the
+            // steady-state loop's final write — start from
+            // `num_sequences & MASK` to preserve sequence order.
+            for k in 0..ADVANCE {
+                let slot = (num_sequences + k) & ADVANCE_MASK;
+                let exec_seq = ring[slot];
+                execute_one_sequence(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    offset_hist,
+                    exec_seq,
+                )?;
+                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+            }
         }
     } else {
         // Short-block fallback: the single-pass fused loop. For

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -159,9 +159,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // line(s) into L1/L2 — hiding DRAM latency for long-distance
     // matches whose source is beyond cache residency.
     //
-    // Donor uses STORED_SEQS = 8; we start at 4 to keep the ring on
-    // the stack within register pressure.
-    const ADVANCE: usize = 4;
+    // Donor parity: `STORED_SEQS = 8`. 8-deep lookahead lets the
+    // prefetch issued at iteration `i` resolve through L1/L2 by the
+    // time iteration `i + 8` consumes it, whereas 4-deep often
+    // wasn't enough gap on the long-distance workloads we target.
+    // The on-stack ring is `[Sequence; 8]` = 96 bytes; well within
+    // register-pressure budget.
+    const ADVANCE: usize = 8;
     const ADVANCE_MASK: usize = ADVANCE - 1;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
     // power of two. Compile-time guard so a future tweak (e.g.

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -726,7 +726,7 @@ pub const OF_MAX_LOG: u8 = 8;
 /// Called only when the offsets table is actually rebuilt (FSE /
 /// Predefined modes in `maybe_update_fse_tables`). Repeat-mode
 /// blocks reuse the cached value in `FSEScratch::offsets_long_share`.
-fn compute_offsets_long_share(offsets: &crate::fse::FSETable) -> u32 {
+pub(crate) fn compute_offsets_long_share(offsets: &crate::fse::FSETable) -> u32 {
     const OFFSET_FSE_LOG: u32 = 8;
     const LONG_OFFSET_CODE_THRESHOLD: u32 = 22;
     let table_log = offsets.accuracy_log as u32;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -157,10 +157,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     /// Pipelined-path variant: takes the offset already resolved by
     /// the decode-ahead `shadow_hist` walk, so `do_offset_history` is
     /// NOT called here (caller mutated only the shadow). Routes the
-    /// match copy through `repeat_lookahead_prefetched` to skip the
-    /// in-loop `prefetch_match_source` + redundant `reserve` that the
-    /// upfront `reserve(MAX_BLOCK_SIZE)` plus the lookahead pipeline's
-    /// PREFETCH_L1 already covered.
+    /// match copy through `repeat_lookahead_prefetched`, which skips
+    /// only the in-loop `prefetch_match_source` (redundant because
+    /// the lookahead pipeline already issued a PREFETCH_L1 ADVANCE
+    /// iterations earlier). The per-call `buffer.reserve(match_length)`
+    /// is preserved by that variant — required for memory safety
+    /// against malformed inputs whose `match_length` exceeds the
+    /// upfront `reserve(MAX_BLOCK_SIZE)` headroom.
     #[inline(always)]
     fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,
@@ -208,8 +211,10 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // prefetch issued at iteration `i` resolve through L1/L2 by the
     // time iteration `i + 8` consumes it, whereas 4-deep often
     // wasn't enough gap on the long-distance workloads we target.
-    // The on-stack ring is `[Sequence; 8]` = 96 bytes; well within
-    // register-pressure budget.
+    // The on-stack ring is `[(Sequence, u32); 8]` = 128 bytes (the
+    // u32 carries the resolved offset from the decode-ahead shadow
+    // walk so the execute side can skip do_offset_history); still
+    // well within register-pressure budget.
     const ADVANCE: usize = 8;
     const ADVANCE_MASK: usize = ADVANCE - 1;
     // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
@@ -920,4 +925,94 @@ fn test_ll_default() {
     assert!(table.decode[59].symbol == 24);
     assert!(table.decode[59].num_bits == 5);
     assert!(table.decode[59].new_state == 32);
+}
+
+#[cfg(test)]
+mod offsets_long_share_tests {
+    use super::compute_offsets_long_share;
+    use crate::fse::{Entry, FSETable};
+
+    /// Construct a synthetic FSETable with the given symbol per entry
+    /// at the requested accuracy_log. Bypasses `build_from_probabilities`
+    /// — we only need `decode[*].symbol` and `accuracy_log` populated;
+    /// the long-share helper reads exactly those.
+    fn synthetic_offsets_table(accuracy_log: u8, symbols: &[u8]) -> FSETable {
+        let size = 1usize << accuracy_log;
+        assert_eq!(
+            symbols.len(),
+            size,
+            "symbols.len() must equal 1 << accuracy_log"
+        );
+        let mut t = FSETable::new(31);
+        t.accuracy_log = accuracy_log;
+        t.decode = symbols
+            .iter()
+            .map(|&s| Entry {
+                new_state: 0,
+                symbol: s,
+                num_bits: 0,
+            })
+            .collect();
+        t
+    }
+
+    #[test]
+    fn zero_long_codes_returns_zero_share() {
+        // A table with only short offset codes (all symbols <= 22).
+        // Donor parity: share is the count of symbols > 22, scaled to
+        // OffFSELog = 8 — with zero such symbols, share is 0
+        // regardless of accuracy_log.
+        for log in [3u8, 5, 6, 8] {
+            let size = 1usize << log;
+            let symbols: alloc::vec::Vec<u8> = (0..size).map(|i| (i as u8) % 22).collect();
+            let table = synthetic_offsets_table(log, &symbols);
+            assert_eq!(
+                compute_offsets_long_share(&table),
+                0,
+                "log={log}: pure short-offset table must score 0"
+            );
+        }
+    }
+
+    #[test]
+    fn long_codes_scale_to_offset_fse_log_reference() {
+        // accuracy_log = 5 → 32-entry table. One symbol at code 23
+        // (just above the threshold of 22), the rest at 0. Donor
+        // scales the raw count by `OffFSELog - accuracy_log` =
+        // `8 - 5 = 3`, so 1 << 3 = 8 should land at the 64-bit
+        // `MIN_LONG_OFFSET_SHARE = 7` threshold (just over).
+        let mut symbols = [0u8; 32];
+        symbols[7] = 23;
+        let table = synthetic_offsets_table(5, &symbols);
+        assert_eq!(compute_offsets_long_share(&table), 8);
+    }
+
+    #[test]
+    fn raw_count_at_offset_fse_log_passes_through_unscaled() {
+        // accuracy_log = OffFSELog = 8 → 256-entry table. No scaling
+        // applied (shift by zero), so the share equals the raw count
+        // of symbols > 22.
+        let mut symbols = [0u8; 256];
+        for sym in symbols.iter_mut().take(15) {
+            *sym = 25;
+        }
+        let table = synthetic_offsets_table(8, &symbols);
+        assert_eq!(compute_offsets_long_share(&table), 15);
+    }
+
+    #[test]
+    fn threshold_is_strict_greater_than() {
+        // Symbol == LONG_OFFSET_CODE_THRESHOLD (22) does NOT count —
+        // matches donor `> 22` strict-greater predicate. Only
+        // symbols 23..MAX raise the share.
+        let mut symbols = [0u8; 256];
+        for sym in symbols.iter_mut().take(50) {
+            *sym = 22;
+        }
+        let table = synthetic_offsets_table(8, &symbols);
+        assert_eq!(compute_offsets_long_share(&table), 0);
+        symbols[0] = 23;
+        let table = synthetic_offsets_table(8, &symbols);
+        assert_eq!(compute_offsets_long_share(&table), 1);
+    }
 }

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -254,127 +254,157 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // whole decision.
 
     if use_long_pipeline {
-        // `prefetch_pos` is the logical buffer index (same frame as
-        // `buffer.len()`) at which the NEXT not-yet-decoded sequence
-        // will start pushing literals. We pre-decode `ADVANCE` ahead, so we
-        // accumulate (ll + ml) per decoded seq to keep this position
-        // synchronised with where execute will eventually be.
-        let mut prefetch_pos: usize = old_buffer_size;
-        // Shadow copy of `offset_hist`, advanced by
-        // `do_offset_history` for every decoded-ahead sequence. The
-        // REAL `offset_hist` is only mutated inside
-        // `execute_one_sequence` (preserving the legacy 'partial
-        // output, no rewound history' rollback contract), but the
-        // prefetch needs the exact post-resolution offset for repcode
-        // 1..=3 cases that read history — a stale read would skip
-        // the long-distance prefetch precisely when a fresh huge
-        // offset is followed by a repcode that aliases it. The
-        // shadow is a local `[u32; 3]` (12 bytes) so the simulation cost
-        // is negligible.
-        let mut shadow_hist: [u32; 3] = *offset_hist;
-        // Stack ring of `(decoded_seq, resolved_offset)` pairs. The
-        // decode-ahead phase resolves repcodes against `shadow_hist`
-        // and stores the resolved offset alongside the raw sequence,
-        // so the execute phase consumes a pre-resolved offset and
-        // skips `do_offset_history` entirely — saves one function
-        // call + one cache write on real `offset_hist` per sequence.
-        // The real `offset_hist` is updated ONCE from `shadow_hist`
-        // after a successful drain (below); on a malformed-block
-        // rollback the saved snapshot is restored, so real hist is
-        // never observed in a partial mid-pipeline state.
-        let mut ring: [(Sequence, u32); ADVANCE] = [(
-            Sequence {
-                ll: 0,
-                ml: 0,
-                of: 0,
-            },
-            0u32,
-        ); ADVANCE];
+        // The pipelined branch must roll `offset_hist` back to
+        // `saved_offset_hist` on ANY mid-loop error, not just the
+        // post-loop bitstream-validation path. Without this, an
+        // `execute_one_sequence_pipelined` Err (NotEnoughBytesForSequence
+        // / ZeroOffset / OOB match) propagated via `?` would exit with
+        // `*offset_hist` still at its pre-block value while the buffer
+        // had N-1 partial writes — diverging from the non-pipelined
+        // path (which mutates hist in lockstep per executed sequence)
+        // and leaving scratch internally inconsistent for any
+        // post-Err reuse. Wrap the entire pipelined work in an IIFE so
+        // a single rollback site catches all mid-loop Errs uniformly.
+        let pipeline_result: Result<(), DecompressBlockError> = (|| {
+            // `prefetch_pos` is the logical buffer index (same frame as
+            // `buffer.len()`) at which the NEXT not-yet-decoded sequence
+            // will start pushing literals. We pre-decode `ADVANCE` ahead, so we
+            // accumulate (ll + ml) per decoded seq to keep this position
+            // synchronised with where execute will eventually be.
+            let mut prefetch_pos: usize = old_buffer_size;
+            // Shadow copy of `offset_hist`, advanced by
+            // `do_offset_history` for every decoded-ahead sequence. The
+            // REAL `offset_hist` is only mutated inside
+            // `execute_one_sequence` (preserving the legacy 'partial
+            // output, no rewound history' rollback contract), but the
+            // prefetch needs the exact post-resolution offset for repcode
+            // 1..=3 cases that read history — a stale read would skip
+            // the long-distance prefetch precisely when a fresh huge
+            // offset is followed by a repcode that aliases it. The
+            // shadow is a local `[u32; 3]` (12 bytes) so the simulation cost
+            // is negligible.
+            let mut shadow_hist: [u32; 3] = *offset_hist;
+            // Stack ring of `(decoded_seq, resolved_offset)` pairs. The
+            // decode-ahead phase resolves repcodes against `shadow_hist`
+            // and stores the resolved offset alongside the raw sequence,
+            // so the execute phase consumes a pre-resolved offset and
+            // skips `do_offset_history` entirely — saves one function
+            // call + one cache write on real `offset_hist` per sequence.
+            // The real `offset_hist` is updated ONCE from `shadow_hist`
+            // after a successful drain (below); on a malformed-block
+            // rollback the saved snapshot is restored, so real hist is
+            // never observed in a partial mid-pipeline state.
+            let mut ring: [(Sequence, u32); ADVANCE] = [(
+                Sequence {
+                    ll: 0,
+                    ml: 0,
+                    of: 0,
+                },
+                0u32,
+            ); ADVANCE];
 
-        // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
-        // gate guarantees `num_sequences > ADVANCE`, so the FSE
-        // state update is needed after every prefill decode — no
-        // `isLastSeq` guard required here, only in the steady-state
-        // loop where `i + 1 == num_sequences` is reachable.
-        for slot in ring.iter_mut() {
-            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            // EXACT actual_offset via shadow history.
-            let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
-            // wrapping_add: prefetch_pos / seq.ll / seq.ml are
-            // derived from the bitstream, so a malformed frame can
-            // present values that would overflow usize and panic
-            // under debug. The result feeds only the prefetch
-            // hint — `prefetch_lookahead_match_source` bound-checks
-            // the logical position against `buffer.len()` and drops
-            // wrap-derived garbage indices, so the wrap is harmless
-            // here while keeping the decoder fuzz-stable.
-            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-            let source_idx = match_start.wrapping_sub(actual_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx);
-            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-            *slot = (seq, actual_offset);
-            br.ensure_bits(max_update_bits);
-            ll_dec.update_state_fast(&mut br);
-            ml_dec.update_state_fast(&mut br);
-            of_dec.update_state_fast(&mut br);
-        }
-
-        // Steady state: decode next, prefetch its source, execute
-        // the oldest slot in the ring (with its pre-resolved offset).
-        for i in ADVANCE..num_sequences {
-            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
-            let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-            let source_idx = match_start.wrapping_sub(actual_offset as usize);
-            buffer.prefetch_lookahead_match_source(source_idx);
-            prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-
-            let slot = i & ADVANCE_MASK;
-            let (exec_seq, exec_offset) = ring[slot];
-            ring[slot] = (seq, actual_offset);
-
-            execute_one_sequence_pipelined(
-                buffer,
-                literals_buffer,
-                &mut lit_cur,
-                literals_buffer_len,
-                exec_seq,
-                exec_offset,
-            )?;
-            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-
-            if i + 1 < num_sequences {
+            // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
+            // gate guarantees `num_sequences > ADVANCE`, so the FSE
+            // state update is needed after every prefill decode — no
+            // `isLastSeq` guard required here, only in the steady-state
+            // loop where `i + 1 == num_sequences` is reachable.
+            for slot in ring.iter_mut() {
+                let seq =
+                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+                // EXACT actual_offset via shadow history.
+                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+                // wrapping_add: prefetch_pos / seq.ll / seq.ml are
+                // derived from the bitstream, so a malformed frame can
+                // present values that would overflow usize and panic
+                // under debug. The result feeds only the prefetch
+                // hint — `prefetch_lookahead_match_source` bound-checks
+                // the logical position against `buffer.len()` and drops
+                // wrap-derived garbage indices, so the wrap is harmless
+                // here while keeping the decoder fuzz-stable.
+                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+                let source_idx = match_start.wrapping_sub(actual_offset as usize);
+                buffer.prefetch_lookahead_match_source(source_idx);
+                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
+                *slot = (seq, actual_offset);
                 br.ensure_bits(max_update_bits);
                 ll_dec.update_state_fast(&mut br);
                 ml_dec.update_state_fast(&mut br);
                 of_dec.update_state_fast(&mut br);
             }
-        }
 
-        // Drain: execute remaining ADVANCE sequences with their
-        // pre-resolved offsets. Iteration order matches the ring
-        // slot they occupy from the steady-state loop's final write.
-        for k in 0..ADVANCE {
-            let slot = (num_sequences + k) & ADVANCE_MASK;
-            let (exec_seq, exec_offset) = ring[slot];
-            execute_one_sequence_pipelined(
-                buffer,
-                literals_buffer,
-                &mut lit_cur,
-                literals_buffer_len,
-                exec_seq,
-                exec_offset,
-            )?;
-            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-        }
+            // Steady state: decode next, prefetch its source, execute
+            // the oldest slot in the ring (with its pre-resolved offset).
+            for i in ADVANCE..num_sequences {
+                let seq =
+                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+                let source_idx = match_start.wrapping_sub(actual_offset as usize);
+                buffer.prefetch_lookahead_match_source(source_idx);
+                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
 
-        // Single committing point for real offset history on the
-        // pipelined success path. Shadow walked every queued sequence
-        // already; copy that state back so the next block sees the
-        // post-block repcodes. Rollback on a later bitstream-failure
-        // overwrites this with `saved_offset_hist`, undoing the
-        // commit.
-        *offset_hist = shadow_hist;
+                let slot = i & ADVANCE_MASK;
+                let (exec_seq, exec_offset) = ring[slot];
+                ring[slot] = (seq, actual_offset);
+
+                execute_one_sequence_pipelined(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    exec_seq,
+                    exec_offset,
+                )?;
+                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+
+                if i + 1 < num_sequences {
+                    br.ensure_bits(max_update_bits);
+                    ll_dec.update_state_fast(&mut br);
+                    ml_dec.update_state_fast(&mut br);
+                    of_dec.update_state_fast(&mut br);
+                }
+            }
+
+            // Drain: execute remaining ADVANCE sequences with their
+            // pre-resolved offsets. Iteration order matches the ring
+            // slot they occupy from the steady-state loop's final write.
+            for k in 0..ADVANCE {
+                let slot = (num_sequences + k) & ADVANCE_MASK;
+                let (exec_seq, exec_offset) = ring[slot];
+                execute_one_sequence_pipelined(
+                    buffer,
+                    literals_buffer,
+                    &mut lit_cur,
+                    literals_buffer_len,
+                    exec_seq,
+                    exec_offset,
+                )?;
+                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+            }
+
+            // Single committing point for real offset history on the
+            // pipelined success path. Shadow walked every queued
+            // sequence already; copy that state back so the next
+            // block sees the post-block repcodes. Rollback on a later
+            // bitstream-failure overwrites this with
+            // `saved_offset_hist`, undoing the commit.
+            *offset_hist = shadow_hist;
+            Ok(())
+        })();
+        if let Err(e) = pipeline_result {
+            // Mid-loop execute Err: rollback buffer + hist so post-Err
+            // scratch reuse stays consistent. `*offset_hist` is still
+            // at its pre-block value (the success-only commit above
+            // never ran), so restoring from `saved_offset_hist` is
+            // effectively a no-op on the hist side — the explicit
+            // assignment makes the intent unambiguous and protects
+            // against any future refactor that moves the commit
+            // earlier in the pipelined flow.
+            if buffer.try_restore_checkpoint(buffer_checkpoint) {
+                *offset_hist = saved_offset_hist;
+            }
+            return Err(e);
+        }
     } else {
         // Short-block fallback: the single-pass fused loop. For
         // num_sequences < ADVANCE * 2 the pipeline's prefill + drain

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -149,7 +149,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
 
     let num_sequences = section.num_sequences as usize;
 
-    // 4-slot software pipeline mirroring donor
+    // 8-slot software pipeline mirroring donor
     // `ZSTD_decompressSequencesLong_body`. Pre-decode `ADVANCE`
     // sequences ahead, prefetch each match source as we go, then
     // execute the oldest in-flight sequence per iteration while
@@ -223,7 +223,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     if use_long_pipeline {
         // `prefetch_pos` is the logical buffer index (same frame as
         // `buffer.len()`) at which the NEXT not-yet-decoded sequence
-        // will start pushing literals. We pre-decode 4 ahead, so we
+        // will start pushing literals. We pre-decode `ADVANCE` ahead, so we
         // accumulate (ll + ml) per decoded seq to keep this position
         // synchronised with where execute will eventually be.
         let mut prefetch_pos: usize = old_buffer_size;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -108,6 +108,12 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
 
+    // `offset_hist` mutates here (via do_offset_history) and only
+    // here. The pipeline above intentionally defers all repcode
+    // resolution to this call site so a mid-loop error keeps the
+    // caller's `offset_hist` consistent with the sequences that
+    // actually executed — preserving the legacy two-pass
+    // 'partial output, no rewound history' contract on early exits.
     #[inline(always)]
     fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
         buffer: &mut super::decode_buffer::DecodeBuffer<B>,
@@ -141,32 +147,192 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         Ok(())
     }
 
-    // Single fused loop over all sequences. The state-update step
-    // (`ensure_bits` + per-decoder `update_state_fast`) is skipped on
-    // the final iteration — matching the donor `isLastSeq` template
-    // pattern (no pre-fetch of the next state when there is no next
-    // sequence). Under `#[inline(always)]` the trailing `if i + 1 <
-    // num_sequences` collapses to the same generated code as the
-    // previous split-shape version, but keeps the per-sequence body in
-    // one place so future edits to the hot path stay in sync.
     let num_sequences = section.num_sequences as usize;
-    for i in 0..num_sequences {
-        let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-        execute_one_sequence(
-            buffer,
-            literals_buffer,
-            &mut lit_cur,
-            literals_buffer_len,
-            offset_hist,
-            seq,
-        )?;
-        seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
 
-        if i + 1 < num_sequences {
-            br.ensure_bits(max_update_bits);
-            ll_dec.update_state_fast(&mut br);
-            ml_dec.update_state_fast(&mut br);
-            of_dec.update_state_fast(&mut br);
+    // 4-slot software pipeline mirroring donor
+    // `ZSTD_decompressSequencesLong_body`. Pre-decode `ADVANCE`
+    // sequences ahead, prefetch each match source as we go, then
+    // execute the oldest in-flight sequence per iteration while
+    // decoding the next one. By the time `execute_one_sequence`
+    // reaches `buffer.repeat()` for slot k, the prefetch issued
+    // `ADVANCE` iterations earlier has had time to pull the source
+    // line(s) into L1/L2 — hiding DRAM latency for long-distance
+    // matches whose source is beyond cache residency.
+    //
+    // Donor uses STORED_SEQS = 8; we start at 4 to keep the ring on
+    // the stack within register pressure and reuse later iterations
+    // to dial up if profiling shows headroom. The pipeline is opt-in
+    // by `num_sequences >= ADVANCE * 2` — for short blocks the
+    // prefill + drain overhead dominates the prefetch gain, so the
+    // existing fused single-pass path stays in charge there.
+    const ADVANCE: usize = 4;
+    const ADVANCE_MASK: usize = ADVANCE - 1;
+    // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
+    // power of two. Compile-time guard so a future tweak (e.g.
+    // bumping to donor's STORED_SEQS = 8, also a power of two) can't
+    // silently corrupt the ring index if someone picks a non-power-
+    // of-two value.
+    const _: () = assert!(
+        ADVANCE.is_power_of_two(),
+        "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
+    );
+
+    // Read-only estimate for the prefetch's match-source position.
+    // The TRUE `actual_offset` requires mutating `offset_hist` via
+    // `do_offset_history`, which we deliberately defer to execute
+    // time so a mid-loop error preserves the legacy 'no partial
+    // history mutation' semantics. For the `seq.of >= 4` case
+    // (every fresh non-repcode offset, dominant on the long-distance
+    // workloads this pipeline targets) the estimate is exact and
+    // matches do_offset_history's output bit-for-bit. For the
+    // repcode 1..=3 cases the estimate reads the current `hist`
+    // without mutating it — this can lag by up to ADVANCE
+    // sequences vs the post-execute state, but the lag only
+    // mis-points the prefetch by a few cache lines on close-range
+    // matches whose source is already L1-warm; the cost of a
+    // mis-targeted PREFETCH_L1 on warm data is negligible.
+    #[inline(always)]
+    fn estimate_actual_offset(of: u32, ll: u32, hist: &[u32; 3]) -> u32 {
+        if of >= 4 {
+            return of - 3;
+        }
+        // Mirrors the read-only halves of do_offset_history_repcode's
+        // selection table: the lit-zero edge cases that pull from a
+        // different hist slot are kept consistent so the estimate
+        // tracks execute-time resolution as closely as possible.
+        match (of, ll == 0) {
+            (1, false) => hist[0],
+            (1, true) => hist[1],
+            (2, false) => hist[1],
+            (2, true) => hist[2],
+            (3, false) => hist[2],
+            // Mirror `do_offset_history_repcode`'s `wrapping_sub(1)` —
+            // not `saturating_sub` — so even on corrupted/0 history
+            // the estimate matches the real resolver. The result is
+            // only consumed by prefetch addressing, where a wild
+            // wrap just lands the hint on an out-of-range slot the
+            // helper drops.
+            (3, true) => hist[0].wrapping_sub(1),
+            _ => 0,
+        }
+    }
+
+    if num_sequences >= ADVANCE * 2 {
+        // `prefetch_pos` is the logical buffer index (same frame as
+        // `buffer.len()`) at which the NEXT not-yet-decoded sequence
+        // will start pushing literals. We pre-decode 4 ahead, so we
+        // accumulate (ll + ml) per decoded seq to keep this position
+        // synchronised with where execute will eventually be.
+        let mut prefetch_pos: usize = old_buffer_size;
+        // Stack ring of raw sequences. `do_offset_history` is NOT
+        // run here — execute calls it later, so `offset_hist`
+        // mutations stay in lockstep with successful execute calls
+        // (matching the legacy 'no rollback on mid-loop error'
+        // contract).
+        let mut ring: [Sequence; ADVANCE] = [Sequence {
+            ll: 0,
+            ml: 0,
+            of: 0,
+        }; ADVANCE];
+
+        // Pre-fill the ring. The FSE state-update guard mirrors the
+        // single-pass loop: skip update after the very last decode
+        // (when k+1 == num_sequences) since there is no next decode.
+        for (k, slot) in ring.iter_mut().enumerate() {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            // Estimated offset for prefetch only — see
+            // `estimate_actual_offset` for the accuracy contract.
+            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
+            let match_start = prefetch_pos + seq.ll as usize;
+            let source_idx = match_start.wrapping_sub(est_offset as usize);
+            buffer.prefetch_lookahead_match_source(source_idx);
+            prefetch_pos = match_start + seq.ml as usize;
+            *slot = seq;
+            if k + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
+        }
+
+        // Steady state: decode next, prefetch its source, execute the
+        // oldest slot in the ring. `i & ADVANCE_MASK` is both the
+        // oldest slot (currently holding seq at logical index i -
+        // ADVANCE) and the slot we overwrite with the newly-decoded
+        // seq[i] — donor pattern.
+        for i in ADVANCE..num_sequences {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            let est_offset = estimate_actual_offset(seq.of, seq.ll, offset_hist);
+            let match_start = prefetch_pos + seq.ll as usize;
+            let source_idx = match_start.wrapping_sub(est_offset as usize);
+            buffer.prefetch_lookahead_match_source(source_idx);
+            prefetch_pos = match_start + seq.ml as usize;
+
+            let slot = i & ADVANCE_MASK;
+            let exec_seq = ring[slot];
+            ring[slot] = seq;
+
+            execute_one_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                offset_hist,
+                exec_seq,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+
+            if i + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
+        }
+
+        // Drain: execute remaining ADVANCE sequences. Iteration order
+        // matches the ring slot they occupy from the steady-state
+        // loop's final write — start from `num_sequences & MASK` to
+        // preserve sequence order.
+        for k in 0..ADVANCE {
+            let slot = (num_sequences + k) & ADVANCE_MASK;
+            let exec_seq = ring[slot];
+            execute_one_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                offset_hist,
+                exec_seq,
+            )?;
+            seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+        }
+    } else {
+        // Short-block fallback: the single-pass fused loop. For
+        // num_sequences < ADVANCE * 2 the pipeline's prefill + drain
+        // dominates the cycles saved by prefetch lookahead, so the
+        // simpler shape wins. Inlined here (rather than a separate
+        // function) so the cold tail-call cost of swapping decoders
+        // mid-block stays at zero.
+        for i in 0..num_sequences {
+            let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
+            execute_one_sequence(
+                buffer,
+                literals_buffer,
+                &mut lit_cur,
+                literals_buffer_len,
+                offset_hist,
+                seq,
+            )?;
+            seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
+
+            if i + 1 < num_sequences {
+                br.ensure_bits(max_update_bits);
+                ll_dec.update_state_fast(&mut br);
+                ml_dec.update_state_fast(&mut br);
+                of_dec.update_state_fast(&mut br);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Port the donor `ZSTD_decompressSequencesLong_body` shape to the fused decode+execute path: **8-slot software pipeline** (donor `STORED_SEQS = 8`) that decodes ADVANCE sequences ahead of execute, prefetching each match source line at decode time. By the time `buffer.repeat()` reaches the actual load for seq[i], the prefetch issued ADVANCE iterations earlier has had time to pull the line into L1 — hiding DRAM latency on long-distance matches whose source is beyond cache residency.

Closes #208.

## Changes

### `zstd/src/decoding/decode_buffer.rs`

- New `prefetch_lookahead_match_source(start_idx)` — issues the prefetch hint at a logical buffer position, bound-checks against `buffer.len()` so out-of-range indices (intra-block self-overlap, `wrapping_sub` underflow on a malformed sequence, dictionary-sourced matches predating the current frame) silently drop the hint.
- Wrap-boundary fallback: when the match source straddles the ring's `as_slices()` boundary, prefetches the s1 tail and tops up from s2[0..] so the donor's "up to two cache lines per match" intent doesn't collapse to one (or zero) at the wrap. Short-tail (< 64 B) cases fall back to `prefetch_first_line_l1` so the cache line containing `start_idx` is always hinted.
- Routed through `prefetch_slice` (`_MM_HINT_T0` / `pldl1keep` → L1) matching donor `PREFETCH_L1`.

### `zstd/src/decoding/sequence_section_decoder.rs`

- 8-slot software pipeline: prefill ADVANCE → steady (decode N, prefetch using a `shadow_hist` mirror of `offset_hist`, execute N−ADVANCE) → drain ADVANCE.
- Ring stores raw `[Sequence; 8]`. `do_offset_history` runs both on the local `shadow_hist` during decode-ahead (for exact, not estimated, repcode resolution in the prefetch path) AND on the real `offset_hist` in `execute_one_sequence`. The real `offset_hist` is rolled back from `saved_offset_hist` if the post-loop bitstream check rejects the block, preserving the legacy "partial output, no rewound history" rollback contract on errors.
- **Donor `ZSTD_getOffsetInfo` parity gate**: pipeline only engages when `num_sequences >= 2 * ADVANCE` AND the FSE offsets table shape shows enough long-offset codes — donor's `minShare` (7/256 on 64-bit, 20/256 on 32-bit). The share is computed once when the offsets table is rebuilt (FSE / Predefined modes in `maybe_update_fse_tables`) and cached in `FSEScratch::offsets_long_share`; Repeat-mode blocks reuse the cached value without re-walking the table.
- Compile-time guard on `ADVANCE.is_power_of_two()` so the `i & ADVANCE_MASK` ring indexing stays equivalent to `i % ADVANCE` if `ADVANCE` is ever changed.

### `zstd/src/decoding/prefetch.rs`

- New `prefetch_first_line_l1` helper that issues exactly one L1 prefetch at the first byte of a slice regardless of slice length. `prefetch_slice` no-ops on slices < CACHE_LINE; that's right for bulk prefetch but wrong for the wrap-boundary case where the cache line containing `start_idx` is still the line we need warmed. x86_64 / x86 / aarch64 implementations.

## Test plan

- [x] full nextest suite — 576 passed, 3 skipped
- [x] lint+typecheck clean
- [x] Bench on Linux server (i9-9900K, BMI2/AVX2) on level_3 + level_19 corpora — mixed results, bench variance dominates over the small expected gains on this hardware
- [ ] Flamegraph on large-window corpus to confirm DRAM stall reduction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Pipelined sequence execution for large blocks to boost decompression throughput
  * Lookahead prefetching and L1-first-line prefetching to reduce memory latency and improve cache efficiency
* **New Features**
  * Tunable pipeline gating based on offset-table characteristics for steadier hot-path execution
* **Tests**
  * Unit tests validating lookahead prefetch behavior and offset-share computation
* **Documentation**
  * Clarified offset-history and pipeline-gate semantics in decoder docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->