### PR TITLE
perf(fast): donor-parity hot-path cleanups in Fast kernel + inline short-literal append (#220 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,17 @@ Behind the `dict_builder` feature flag, the `dictionary` module can:
 <details>
 <summary>Internal: compression strategy backends</summary>
 
-| Level range | Backend |
-|-------------|---------|
-| 1           | `Simple` matcher |
-| 2-3         | `Dfast` |
-| 4           | `Row` matcher |
-| 5-15        | `HashChain` with lazy / lazy2 tuning |
+| Level range | Strategy | Backend |
+|-------------|----------|---------|
+| 1-2         | `Fast`   | `Simple` matcher |
+| 3-4         | `Dfast`  | `Dfast` two-tier hash |
+| 5           | `Greedy` | `Row` matcher (`lazy_depth=0`) |
+| 6-15        | `Lazy` / `Lazy2` | `HashChain` with `lazy_depth=1` or `2` |
 | 16-17       | `btopt`-style price parser on top of hash-chain candidates |
 | 18-19       | `btultra`-style price parser profile |
 | 20-22       | `btultra2`-style dual-profile pass (choose lower-cost parse) |
 
-The `greedy` family is not implemented as a dedicated strategy yet — its target ratios are covered by adjacent levels.
+The level → strategy column matches donor `ZSTD_defaultCParameters[0]` at `zstd/lib/compress/clevels.h:25-50` (srcSize > 256 KiB tier). Donor routes `greedy`/`lazy`/`lazy2` through its row-based matchfinder when `windowLog > 14`; we route `Greedy` through the row matcher (matches donor) but `Lazy`/`Lazy2` through the hash-chain matcher — an intentional architectural difference, not an oversight.
 
 </details>
 

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -70,6 +70,11 @@ critical-section = ["dep:critical-section"]
 bench_internals = []
 fuzz_exports = []
 std = []
+# Diagnostic tracing of the Fast kernel's inner loop — per-iteration state
+# dumps gated at compile time so production builds carry zero cost. Runtime
+# activation via `STRUCTURED_ZSTD_KERNEL_TRACE=1` env var. Used by the
+# `trace_fast_kernel` example for #220 ratio-divergence investigation.
+kernel_trace = ["std"]
 
 # Internal feature, only used when building as part of libstd, not part of the
 # stable interface of this crate.

--- a/zstd/examples/donor_compress_z000033.rs
+++ b/zstd/examples/donor_compress_z000033.rs
@@ -1,0 +1,50 @@
+//! One-shot diagnostic: invoke FFI `ZSTD_compress` on z000033 at level 1.
+//! Donor's `zstd_fast.c` has been patched with `fprintf(stderr, "D_...")`
+//! traces gated by `DONOR_TRACE_FAST=1` env var. Run this binary with
+//! both `DONOR_TRACE_FAST=1` set and stderr redirected to a file to
+//! capture donor's actual cursor trace.
+//!
+//! Build: cargo build --release -p structured-zstd --example donor_compress_z000033
+//! Run:   DONOR_TRACE_FAST=1 ./target/release/examples/donor_compress_z000033 \
+//!          > /dev/null 2> /tmp/donor_trace.log
+
+use std::env;
+use std::fs;
+
+use zstd::zstd_safe::zstd_sys;
+
+fn main() {
+    let corpus_path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "zstd/decodecorpus_files/z000033".to_string());
+    let bytes = fs::read(&corpus_path).expect("read corpus");
+    eprintln!(
+        "DONOR_TRACE_START corpus={} size={} level=1",
+        corpus_path,
+        bytes.len()
+    );
+
+    let dst_cap = unsafe { zstd_sys::ZSTD_compressBound(bytes.len()) };
+    let mut dst: Vec<u8> = vec![0u8; dst_cap];
+
+    let rc = unsafe {
+        zstd_sys::ZSTD_compress(
+            dst.as_mut_ptr() as *mut core::ffi::c_void,
+            dst_cap,
+            bytes.as_ptr() as *const core::ffi::c_void,
+            bytes.len(),
+            1,
+        )
+    };
+    assert_eq!(
+        unsafe { zstd_sys::ZSTD_isError(rc) },
+        0,
+        "ZSTD_compress failed"
+    );
+
+    eprintln!(
+        "DONOR_TRACE_END ffi_bytes={} input_bytes={}",
+        rc,
+        bytes.len()
+    );
+}

--- a/zstd/examples/donor_cparams_check.rs
+++ b/zstd/examples/donor_cparams_check.rs
@@ -1,0 +1,26 @@
+//! One-shot diagnostic: ask donor what cParams it selects for our exact
+//! (level, srcSize, dictSize) tuple. Confirms whether donor's L1 path
+//! uses mls=7 vs mls=4/6 for the 1MB decodecorpus-z000033 fixture.
+//!
+//! Build: cargo build --release -p structured-zstd --example donor_cparams_check
+//! Run:   ./target/release/examples/donor_cparams_check
+
+use zstd::zstd_safe::zstd_sys;
+
+fn main() {
+    let src_size = 1022035u64; // bytes in zstd/decodecorpus_files/z000033
+    let level = 1i32;
+    let dict_size = 0usize;
+
+    // SAFETY: standard libzstd query.
+    let cp = unsafe { zstd_sys::ZSTD_getCParams(level, src_size, dict_size) };
+
+    println!("L{level} srcSize={src_size} dictSize={dict_size}:");
+    println!("  windowLog = {}", cp.windowLog);
+    println!("  chainLog  = {}", cp.chainLog);
+    println!("  hashLog   = {}", cp.hashLog);
+    println!("  searchLog = {}", cp.searchLog);
+    println!("  minMatch  = {} (mls)", cp.minMatch);
+    println!("  targetLength = {}", cp.targetLength);
+    println!("  strategy  = {}", cp.strategy as u32);
+}

--- a/zstd/examples/trace_fast_kernel.rs
+++ b/zstd/examples/trace_fast_kernel.rs
@@ -1,0 +1,59 @@
+//! Trace driver for #220 Fast L1 ratio gap investigation.
+//!
+//! Loads `decodecorpus_files/z000033`, runs production encoder at
+//! `CompressionLevel::Fastest` (Level 1 → Fast strategy), prints the
+//! kernel inner-loop trace from `compress_block_fast` to stderr.
+//!
+//! Build: `cargo build --release --features kernel_trace --example trace_fast_kernel`
+//! Run:   `STRUCTURED_ZSTD_KERNEL_TRACE=1 ./target/release/examples/trace_fast_kernel > /dev/null 2> trace.log`
+//!
+//! The trace records every outer-iter state, every hash-table put, and
+//! every match-found event. Diff vs donor's expected sequence (manually
+//! computed from `zstd_fast.c:266-348`) to pinpoint the first
+//! divergence in block 0.
+//!
+//! Caps trace output at the first 2000 lines via `STRUCTURED_ZSTD_KERNEL_TRACE_HEAD`
+//! env var (defaults to 2000) so the log stays diffable. Set to 0 to
+//! disable the cap and dump every iteration.
+
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+
+use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+
+fn main() {
+    let corpus_path = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "zstd/decodecorpus_files/z000033".to_string());
+    let bytes = fs::read(&corpus_path).expect("read corpus");
+    eprintln!(
+        "TRACE_START corpus={} size={} level=Fastest",
+        corpus_path,
+        bytes.len()
+    );
+
+    // Drive the production encoder. Sequence emissions land via the
+    // standard FrameCompressor → MatchGeneratorDriver → FastKernelMatcher
+    // → compress_block_fast path, hitting every ktrace! site.
+    // CRITICAL: use Level(1), NOT CompressionLevel::Fastest. They look
+    // synonymous from the docs ("Fastest is roughly equivalent to Zstd
+    // compression level 1") but `Fastest` overrides `LEVEL_TABLE[0]`'s
+    // `fast_mls = 7` to `fast_mls = 6` for an even-faster preset. The
+    // canonical L1 Fast strategy (which `compare_ffi` benches and the
+    // donor `ZSTD_compress_usingCDict(level=1)` both use) is mls=7 via
+    // `LEVEL_TABLE[0]` unchanged → reach it via `Level(1)`.
+    let compressed = compress_to_vec(&bytes[..], CompressionLevel::Level(1));
+
+    eprintln!(
+        "TRACE_END rust_bytes={} input_bytes={}",
+        compressed.len(),
+        bytes.len()
+    );
+
+    // Write the compressed output to stdout so the binary can also be
+    // used as a one-shot compressor for ad-hoc verification.
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    out.write_all(&compressed).expect("write compressed");
+}

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -160,22 +160,32 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     /// dwarfs the actual byte write at FSE flush cadence (~54K
     /// flushes per compress on the L1 fast path). The direct
     /// unaligned store path matches donor's hot loop cycle-for-cycle.
+    ///
+    /// # Safety
+    ///
+    /// Caller MUST guarantee that `output.capacity() >= output.len() +
+    /// 8` BEFORE calling this method (typically via a prior
+    /// [`Self::reserve_output`]). Violating the precondition produces a
+    /// 8-byte out-of-bounds write to whatever memory follows the
+    /// `Vec`'s allocation — undefined behaviour. The accompanying
+    /// `debug_assert!` catches misuse in test/debug builds but does
+    /// NOT survive `cargo build --release`, hence the `unsafe`
+    /// signature.
     #[inline(always)]
-    pub fn flush_bulk(&mut self) {
+    pub unsafe fn flush_bulk(&mut self) {
         let nb_bytes = self.bits_in_partial >> 3;
         let bytes = self.partial.to_le_bytes();
-        // SAFETY: caller's `reserve_output` guarantees `capacity >=
-        // len + 8` (the per-burst budget bound documented on the
-        // FSE encoder side). We write 8 bytes starting at `len`,
-        // then commit only `nb_bytes` — the remaining `8 - nb_bytes`
-        // bytes stay within capacity but past `len`, and the next
-        // flush_bulk overwrites them.
         let output = self.output.as_mut();
         let len = output.len();
         debug_assert!(
             output.capacity() >= len + 8,
             "flush_bulk requires 8 bytes of spare capacity; caller forgot reserve_output",
         );
+        // SAFETY: the function-level Safety contract requires
+        // `output.capacity() >= len + 8`. We write 8 bytes starting at
+        // `len`, then commit only `nb_bytes` — the remaining `8 -
+        // nb_bytes` bytes stay within capacity but past `len`, and
+        // the next flush_bulk overwrites them.
         unsafe {
             let dst = output.as_mut_ptr().add(len);
             core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, 8);

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -280,7 +280,17 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         self.output
             .as_mut()
             .extend_from_slice(&self.partial.to_le_bytes()[..full_bytes]);
-        self.partial >>= full_bytes * 8;
+        // `full_bytes == 8` (full accumulator) means a raw
+        // `partial >>= 64` would be UB on `u64`. This SAFE function is
+        // reachable indirectly via `with_aligned_output_mut`,
+        // `change_bits`, and `append_bytes`, so the state IS reachable
+        // — zero explicitly when the whole word is consumed instead of
+        // shifting.
+        if full_bytes == 8 {
+            self.partial = 0;
+        } else {
+            self.partial >>= full_bytes * 8;
+        }
         self.bits_in_partial -= full_bytes * 8;
         self.bit_idx += full_bytes * 8;
     }

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -111,6 +111,68 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         self.bit_idx += data.len() * 8;
     }
 
+    /// Pre-reserve additional capacity in the output buffer so the
+    /// donor-faithful FSE fast path can do `flush_bulk` writes without
+    /// triggering `Vec::extend_from_slice`'s grow-on-realloc branch.
+    /// `additional` is the number of bytes the upcoming bursts will
+    /// emit (caller's bit budget / 8, rounded up).
+    #[inline]
+    pub fn reserve_output(&mut self, additional: usize) {
+        self.output.as_mut().reserve(additional);
+    }
+
+    /// Donor `BIT_addBitsFast` (`bitstream.h:193-200`): always accumulate
+    /// `bits` into the bottom of `partial`, no overflow check. Caller
+    /// guarantees `num_bits + bits_in_partial <= 64` (no overflow) AND
+    /// `bits >> num_bits == 0` (value is "clean" — no junk in high
+    /// bits that would corrupt the packed stream).
+    ///
+    /// Used by the donor-faithful FSE sequence encoder which knows its
+    /// per-sequence bit budget at compile time and inserts explicit
+    /// [`Self::flush_bulk`] calls between bursts — saving the
+    /// per-call branch + spill that `write_bits_64`'s overflow check
+    /// pays.
+    #[inline(always)]
+    pub fn write_bits_64_no_check(&mut self, bits: u64, num_bits: usize) {
+        debug_assert!(
+            num_bits + self.bits_in_partial <= 64,
+            "write_bits_64_no_check would overflow partial: would push to {} bits",
+            num_bits + self.bits_in_partial,
+        );
+        debug_assert!(
+            num_bits == 64 || bits >> num_bits == 0,
+            "value has dirty high bits beyond num_bits={num_bits}",
+        );
+        self.partial |= bits << self.bits_in_partial;
+        self.bits_in_partial += num_bits;
+    }
+
+    /// Donor `BIT_flushBitsFast` (`bitstream.h:202-214`): write full
+    /// bytes from `partial` to output, shift container down to keep
+    /// the leftover `< 8` bits at the bottom for the next add. No
+    /// overflow check on the output buffer — caller pre-reserves
+    /// sufficient capacity.
+    ///
+    /// Pairs with [`Self::write_bits_64_no_check`] in the FSE
+    /// sequence encoder's hot loop: a single flush_bulk after each
+    /// sequence keeps the budget under 64 bits + 7-bit tail.
+    #[inline(always)]
+    pub fn flush_bulk(&mut self) {
+        let nb_bytes = self.bits_in_partial >> 3;
+        // Donor `MEM_writeLEST` analogue. We can't do an unconditional
+        // 8-byte unaligned write without `Vec::reserve`; instead push
+        // the exact `nb_bytes` to extend the Vec by that much. LLVM
+        // typically lowers `extend_from_slice` of a fixed-size byte
+        // slice to a single store + len bump when capacity is large
+        // enough (the caller's pre-reserve guarantees this on the
+        // hot path).
+        let bytes = self.partial.to_le_bytes();
+        self.output.as_mut().extend_from_slice(&bytes[..nb_bytes]);
+        self.partial >>= nb_bytes * 8;
+        self.bits_in_partial &= 7;
+        self.bit_idx += nb_bytes * 8;
+    }
+
     /// Bridge for the donor-faithful Huffman encoder (`HufCStream`) so
     /// it can write bytes directly into our backing `Vec<u8>` without
     /// going through the `BitWriter`'s partial-bit accumulator. The

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -122,10 +122,26 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     }
 
     /// Donor `BIT_addBitsFast` (`bitstream.h:193-200`): always accumulate
-    /// `bits` into the bottom of `partial`, no overflow check. Caller
-    /// guarantees `num_bits + bits_in_partial <= 64` (no overflow) AND
-    /// `bits >> num_bits == 0` (value is "clean" — no junk in high
-    /// bits that would corrupt the packed stream).
+    /// `bits` into the bottom of `partial`, no overflow check.
+    ///
+    /// # Safety
+    ///
+    /// Caller MUST guarantee BOTH preconditions BEFORE calling:
+    ///
+    /// 1. `num_bits + bits_in_partial <= 64` — accumulator must not
+    ///    overflow. A violation triggers `<< num_bits` shift overflow
+    ///    (undefined in Rust for shift ≥ 64) and corrupts the bit
+    ///    stream silently.
+    /// 2. `num_bits == 64 || bits >> num_bits == 0` — value must be
+    ///    clean of high junk past `num_bits`. Dirty high bits leak
+    ///    into the packed stream at the next OR.
+    ///
+    /// The `debug_assert!`s below catch both in test/debug builds but
+    /// do NOT survive `cargo build --release`, hence the `unsafe`
+    /// signature. The function does not perform any memory-unsafe
+    /// operation, but a violation produces a silently-corrupted
+    /// output stream that decoders cannot recover — equivalent in
+    /// blast radius to undefined behaviour for the consumer.
     ///
     /// Used by the donor-faithful FSE sequence encoder which knows its
     /// per-sequence bit budget at compile time and inserts explicit
@@ -133,7 +149,7 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     /// per-call branch + spill that `write_bits_64`'s overflow check
     /// pays.
     #[inline(always)]
-    pub fn write_bits_64_no_check(&mut self, bits: u64, num_bits: usize) {
+    pub unsafe fn write_bits_64_no_check(&mut self, bits: u64, num_bits: usize) {
         debug_assert!(
             num_bits + self.bits_in_partial <= 64,
             "write_bits_64_no_check would overflow partial: would push to {} bits",
@@ -220,9 +236,13 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         let result = f(self.output.as_mut());
         let new_len = self.output.as_mut().len();
         // Closure may only APPEND bytes (HufCStream's contract).
-        // Detect accidental truncation early — that would corrupt
-        // bit_idx into a phantom future bit.
-        debug_assert!(new_len >= prev_len, "closure must not shrink output");
+        // Promoted to `assert!` (release-active) — a shrink here
+        // would underflow `(new_len - prev_len) * 8` in release
+        // and corrupt `bit_idx` into a phantom future bit, which
+        // propagates silently through downstream `change_bits`
+        // callers. This is a correctness invariant, not a debug
+        // aid.
+        assert!(new_len >= prev_len, "closure must not shrink output");
         self.bit_idx += (new_len - prev_len) * 8;
         result
     }

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -111,6 +111,37 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         self.bit_idx += data.len() * 8;
     }
 
+    /// Bridge for the donor-faithful Huffman encoder (`HufCStream`) so
+    /// it can write bytes directly into our backing `Vec<u8>` without
+    /// going through the `BitWriter`'s partial-bit accumulator. The
+    /// closure receives full mutable access to the underlying `Vec`;
+    /// any bytes it appends are integrated into `bit_idx` afterward.
+    ///
+    /// MUST be called only when the writer is byte-aligned
+    /// (`bits_in_partial` a multiple of 8); the assertion mirrors
+    /// `append_bytes`. Internally calls `flush()` first so the
+    /// closure sees a Vec whose `len()` reflects every bit written so
+    /// far.
+    pub fn with_aligned_output_mut<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut Vec<u8>) -> R,
+    {
+        assert!(
+            self.bits_in_partial.is_multiple_of(8),
+            "with_aligned_output_mut requires byte-aligned writer state",
+        );
+        self.flush();
+        let prev_len = self.output.as_mut().len();
+        let result = f(self.output.as_mut());
+        let new_len = self.output.as_mut().len();
+        // Closure may only APPEND bytes (HufCStream's contract).
+        // Detect accidental truncation early — that would corrupt
+        // bit_idx into a phantom future bit.
+        debug_assert!(new_len >= prev_len, "closure must not shrink output");
+        self.bit_idx += (new_len - prev_len) * 8;
+        result
+    }
+
     /// Flush temporary internal buffers to the output buffer. Only works if this is currently byte aligned
     pub fn flush(&mut self) {
         assert!(self.bits_in_partial.is_multiple_of(8));

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -147,27 +147,40 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         self.bits_in_partial += num_bits;
     }
 
-    /// Donor `BIT_flushBitsFast` (`bitstream.h:202-214`): write full
-    /// bytes from `partial` to output, shift container down to keep
-    /// the leftover `< 8` bits at the bottom for the next add. No
-    /// overflow check on the output buffer — caller pre-reserves
-    /// sufficient capacity.
+    /// Donor `BIT_flushBitsFast` (`bitstream.h:202-214`): write the
+    /// full 8 bytes of `partial` directly to the output buffer via a
+    /// single `MEM_writeLEST` (unaligned 8-byte LE store), then
+    /// advance the Vec's `len` by only `nb_bytes` so the scratch
+    /// bytes past the commit point get overwritten by the next
+    /// flush. No overflow check — caller must have pre-reserved at
+    /// least 8 bytes of spare capacity via [`Self::reserve_output`].
     ///
-    /// Pairs with [`Self::write_bits_64_no_check`] in the FSE
-    /// sequence encoder's hot loop: a single flush_bulk after each
-    /// sequence keeps the budget under 64 bits + 7-bit tail.
+    /// `extend_from_slice` for tiny (0..=7-byte) tails was previously
+    /// hot — its per-call capacity check + memcpy dispatch cost
+    /// dwarfs the actual byte write at FSE flush cadence (~54K
+    /// flushes per compress on the L1 fast path). The direct
+    /// unaligned store path matches donor's hot loop cycle-for-cycle.
     #[inline(always)]
     pub fn flush_bulk(&mut self) {
         let nb_bytes = self.bits_in_partial >> 3;
-        // Donor `MEM_writeLEST` analogue. We can't do an unconditional
-        // 8-byte unaligned write without `Vec::reserve`; instead push
-        // the exact `nb_bytes` to extend the Vec by that much. LLVM
-        // typically lowers `extend_from_slice` of a fixed-size byte
-        // slice to a single store + len bump when capacity is large
-        // enough (the caller's pre-reserve guarantees this on the
-        // hot path).
         let bytes = self.partial.to_le_bytes();
-        self.output.as_mut().extend_from_slice(&bytes[..nb_bytes]);
+        // SAFETY: caller's `reserve_output` guarantees `capacity >=
+        // len + 8` (the per-burst budget bound documented on the
+        // FSE encoder side). We write 8 bytes starting at `len`,
+        // then commit only `nb_bytes` — the remaining `8 - nb_bytes`
+        // bytes stay within capacity but past `len`, and the next
+        // flush_bulk overwrites them.
+        let output = self.output.as_mut();
+        let len = output.len();
+        debug_assert!(
+            output.capacity() >= len + 8,
+            "flush_bulk requires 8 bytes of spare capacity; caller forgot reserve_output",
+        );
+        unsafe {
+            let dst = output.as_mut_ptr().add(len);
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, 8);
+            output.set_len(len + nb_bytes);
+        }
         self.partial >>= nb_bytes * 8;
         self.bits_in_partial &= 7;
         self.bit_idx += nb_bytes * 8;

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -128,10 +128,13 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     ///
     /// Caller MUST guarantee BOTH preconditions BEFORE calling:
     ///
-    /// 1. `num_bits + bits_in_partial <= 64` — accumulator must not
-    ///    overflow. A violation triggers `<< num_bits` shift overflow
-    ///    (undefined in Rust for shift ≥ 64) and corrupts the bit
-    ///    stream silently.
+    /// 1. `num_bits + bits_in_partial <= 64` AND **not both 64**, i.e.
+    ///    if `bits_in_partial == 64` then `num_bits` MUST be 0 — and
+    ///    the explicit `num_bits == 0` early-return below handles that
+    ///    case without ever evaluating `bits << bits_in_partial`. The
+    ///    point of the precondition: any other combination would either
+    ///    shift-by-64 (undefined for `u64 << 64` in Rust) or overflow
+    ///    `bits_in_partial` past 64.
     /// 2. `num_bits == 64 || bits >> num_bits == 0` — value must be
     ///    clean of high junk past `num_bits`. Dirty high bits leak
     ///    into the packed stream at the next OR.
@@ -150,10 +153,25 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     /// pays.
     #[inline(always)]
     pub unsafe fn write_bits_64_no_check(&mut self, bits: u64, num_bits: usize) {
+        // num_bits == 0 short-circuit: matches donor `BIT_addBits` no-op
+        // semantics AND guards the `bits << self.bits_in_partial` below
+        // from a `<< 64` undefined-behaviour evaluation when the
+        // accumulator is already full (`bits_in_partial == 64`). Callers
+        // that legitimately drain a full container (e.g. the FSE encoder
+        // hitting a state-diff burst boundary) can call this with
+        // `num_bits = 0` as a no-op without tripping UB.
+        if num_bits == 0 {
+            return;
+        }
         debug_assert!(
             num_bits + self.bits_in_partial <= 64,
             "write_bits_64_no_check would overflow partial: would push to {} bits",
             num_bits + self.bits_in_partial,
+        );
+        debug_assert!(
+            self.bits_in_partial < 64,
+            "write_bits_64_no_check called with full accumulator and num_bits>0; \
+             caller must flush_bulk before adding more bits",
         );
         debug_assert!(
             num_bits == 64 || bits >> num_bits == 0,
@@ -207,7 +225,15 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
             core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, 8);
             output.set_len(len + nb_bytes);
         }
-        self.partial >>= nb_bytes * 8;
+        // `nb_bytes == 8` means the accumulator was full (64 bits). A
+        // raw `partial >>= 64` is UB on `u64`, so we zero explicitly.
+        // Donor's `BIT_flushBitsFast` writes a fresh 8 bytes the next
+        // round so the post-flush state must be clean either way.
+        if nb_bytes == 8 {
+            self.partial = 0;
+        } else {
+            self.partial >>= nb_bytes * 8;
+        }
         self.bits_in_partial &= 7;
         self.bit_idx += nb_bytes * 8;
     }

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -56,7 +56,7 @@ mod ringbuffer;
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
-mod simd_copy;
+pub(crate) mod simd_copy;
 
 #[cfg(feature = "bench_internals")]
 pub(crate) use self::simd_copy::copy_bytes_overshooting_for_bench;

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -499,23 +499,40 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
     } else {
         encode_seqnum(sequences.len(), &mut writer);
 
-        // Choose the tables
-        let ll_mode = choose_table(
+        // Single-pass histogram of ll/ml/of codes across all sequences.
+        // Previously did three separate `sequences.iter().map(...)`
+        // passes; folded into one loop here saves the per-element
+        // closure overhead (profile #220 round 3: `Map::fold` +
+        // `call_mut` accounted for ~5% of total bench CPU).
+        let mut ll_counts = [0usize; 256];
+        let mut ml_counts = [0usize; 256];
+        let mut of_counts = [0usize; 256];
+        for seq in sequences.iter() {
+            ll_counts[encode_literal_length(seq.ll).0 as usize] += 1;
+            ml_counts[encode_match_len(seq.ml).0 as usize] += 1;
+            of_counts[encode_offset(seq.of).0 as usize] += 1;
+        }
+        let total = sequences.len();
+
+        let ll_mode = choose_table_from_counts(
             state.fse_tables.ll_previous.as_ref(),
             state.fse_tables.ll_default_ref(),
-            sequences.iter().map(|seq| encode_literal_length(seq.ll).0),
+            &ll_counts,
+            total,
             9,
         );
-        let ml_mode = choose_table(
+        let ml_mode = choose_table_from_counts(
             state.fse_tables.ml_previous.as_ref(),
             state.fse_tables.ml_default_ref(),
-            sequences.iter().map(|seq| encode_match_len(seq.ml).0),
+            &ml_counts,
+            total,
             9,
         );
-        let of_mode = choose_table(
+        let of_mode = choose_table_from_counts(
             state.fse_tables.of_previous.as_ref(),
             state.fse_tables.of_default_ref(),
-            sequences.iter().map(|seq| encode_offset(seq.of).0),
+            &of_counts,
+            total,
             8,
         );
 
@@ -1351,7 +1368,23 @@ fn choose_table<'a>(
         counts[symbol as usize] += 1;
         total += 1;
     }
+    choose_table_from_counts(previous, default_table, &counts, total, max_log)
+}
 
+/// Same decision logic as [`choose_table`] but takes pre-computed
+/// symbol counts and total directly. Hot-path callers in
+/// `compress_literals_and_sequences` use this overload to avoid
+/// re-iterating the sequence vec three times (one pass per
+/// ll/ml/of stream); the iterator form is kept for the cost
+/// estimator's call sites where the data is already in iterator
+/// form.
+fn choose_table_from_counts<'a>(
+    previous: Option<&'a PreviousFseTable>,
+    default_table: &'a FSETable,
+    counts: &[usize; 256],
+    total: usize,
+    max_log: u8,
+) -> FseTableMode<'a> {
     if total == 0 {
         return FseTableMode::Predefined(default_table);
     }

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -1419,15 +1419,15 @@ fn choose_table_from_counts<'a>(
     let new_total_cost = new_table.as_ref().map(|table| {
         table
             .table_header_bits()
-            .saturating_add(entropy_cost(&counts, max_symbol, total))
+            .saturating_add(entropy_cost(counts, max_symbol, total))
     });
 
-    let predefined_cost = cross_entropy_cost(&counts, max_symbol, default_table);
+    let predefined_cost = cross_entropy_cost(counts, max_symbol, default_table);
 
     let previous_cost = previous.and_then(|previous| {
         previous
             .as_table(default_table)
-            .and_then(|table| fse_bit_cost(&counts, max_symbol, table))
+            .and_then(|table| fse_bit_cost(counts, max_symbol, table))
     });
 
     enum Choice {

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -346,6 +346,55 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     state.block_scratch = scratch;
 }
 
+/// Append `lits` to `dst` using inline byte / u64 ops for short
+/// slices, avoiding the libc memmove call overhead that
+/// `Vec::extend_from_slice` lowers to for runtime-sized
+/// `ptr::copy_nonoverlapping`. Fast L1 emits literal runs of 1-10
+/// bytes typically — at thousands of sequences per block, the per-
+/// emit libc call dominated the hot path (flamegraph: 60 % of CPU
+/// in `__memmove_avx_unaligned_erms` chain).
+///
+/// Route through `simd_copy::copy_bytes_overshooting` with src.1 ==
+/// dst.1 == lit_len (no overshoot READ; we don't know how much
+/// readable slack the caller's slice has). For lit_len ≤ 32 that
+/// drops into the byte-by-byte / overlapping-u64 path, fully
+/// inlineable. Larger runs fall through `extend_from_slice` —
+/// they're rare and libc memmove amortises across the longer copy.
+#[inline]
+fn append_literals(dst: &mut Vec<u8>, lits: &[u8]) {
+    let lit_len = lits.len();
+    if lit_len == 0 {
+        return;
+    }
+    if lit_len <= 32 {
+        // Caller pre-reserved `src_len` (the whole block); the sum
+        // of all literal runs is ≤ src_len, so the unused tail
+        // always has ≥ `lit_len` capacity.
+        debug_assert!(
+            dst.capacity() - dst.len() >= lit_len,
+            "append_literals requires `dst` to have at least `lit_len` reserved capacity \
+             past `dst.len()` — caller failed to reserve before the emit loop",
+        );
+        let cur_len = dst.len();
+        let dst_ptr = unsafe { dst.as_mut_ptr().add(cur_len) };
+        // SAFETY: `lits` is a valid slice (so reading `lit_len`
+        // bytes from `lits.as_ptr()` is in-bounds); `dst_ptr` has
+        // `lit_len` bytes of reserved capacity (debug_assert above).
+        // copy_bytes_overshooting writes EXACTLY `lit_len` bytes when
+        // `min(src.1, dst.1) == lit_len`.
+        unsafe {
+            crate::decoding::simd_copy::copy_bytes_overshooting(
+                (lits.as_ptr(), lit_len),
+                (dst_ptr, lit_len),
+                lit_len,
+            );
+            dst.set_len(cur_len + lit_len);
+        }
+    } else {
+        dst.extend_from_slice(lits);
+    }
+}
+
 fn collect_block_parts<M: Matcher>(state: &mut CompressState<M>, parts: &mut EncodedBlockParts) {
     let src_len = state.matcher.get_last_space().len();
     parts.literals.clear();
@@ -365,14 +414,14 @@ fn collect_block_parts<M: Matcher>(state: &mut CompressState<M>, parts: &mut Enc
             .reserve_exact(sequence_capacity - parts.sequences.len());
     }
     state.matcher.start_matching(|seq| match seq {
-        Sequence::Literals { literals } => parts.literals.extend_from_slice(literals),
+        Sequence::Literals { literals } => append_literals(&mut parts.literals, literals),
         Sequence::Triple {
             literals,
             offset,
             match_len,
         } => {
             let ll = literals.len() as u32;
-            parts.literals.extend_from_slice(literals);
+            append_literals(&mut parts.literals, literals);
             parts.sequences.push(RawSequence {
                 ll,
                 ml: match_len as u32,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -1601,29 +1601,43 @@ fn encode_sequences(
             // State diffs burst: max 30 bits (10+10+9 worst case for
             // acc_log ≤ 9 ll/ml + acc_log ≤ 8 of) + ≤ 7 leftover from
             // prior flush = ≤ 37 bits total — well under 64.
+            //
+            // SAFETY (for every `write_bits_64_no_check` below):
+            // - the prior `flush_bulk` left `bits_in_partial ≤ 7`;
+            // - each FSE state diff has `next.num_bits ≤ acc_log ≤ 10`;
+            //   three diffs back-to-back add ≤ 30 bits → total ≤ 37,
+            //   well below the 64-bit accumulator cap.
+            // - `diff = state.index - next.baseline` cannot exceed
+            //   `(1 << num_bits) - 1`, so `diff >> num_bits == 0`.
+            // `reserve_output(sequences.len() * 12 + 64)` above
+            // pre-allocated enough spare capacity to cover every
+            // per-sequence flush in this loop (≤ 16 bytes per
+            // sequence, plus the 32-byte slack on top of the 64-byte
+            // header reserve).
             if let (Some(table), Some(state)) = (of_table, of_state) {
                 let next = table.next_state(of_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                unsafe {
+                    writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                }
                 of_state = Some(next);
             }
             if let (Some(table), Some(state)) = (ml_table, ml_state) {
                 let next = table.next_state(ml_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                unsafe {
+                    writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                }
                 ml_state = Some(next);
             }
             if let (Some(table), Some(state)) = (ll_table, ll_state) {
                 let next = table.next_state(ll_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                unsafe {
+                    writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
+                }
                 ll_state = Some(next);
             }
-            // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
-            // pre-allocated enough spare capacity to cover every
-            // per-sequence flush in this loop (≤ 16 bytes per
-            // sequence, plus the 32-byte slack on top of the 64-byte
-            // header reserve).
             unsafe {
                 writer.flush_bulk();
             }
@@ -1638,25 +1652,25 @@ fn encode_sequences(
             // donor's `MEM_32bits()` flush-between-each-component
             // shape on the 32-bit build (which has the same 64-bit
             // container constraint).
-            writer.write_bits_64_no_check(ll_add_bits as u64, ll_num_bits);
-            writer.write_bits_64_no_check(ml_add_bits as u64, ml_num_bits);
+            //
+            // SAFETY: `encode_literal_length` / `encode_match_len`
+            // bound `*_num_bits ≤ 16` and return a clean `*_add_bits`
+            // (low `num_bits` bits only). `encode_offset` bounds
+            // `of_num_bits ≤ ilog2(of)`, capped at the encoder's
+            // `window_log` ≤ 30; the conditional flush_bulk above
+            // drains the partial when of_num_bits crosses the 24-bit
+            // threshold where the sum could exceed 64.
+            unsafe {
+                writer.write_bits_64_no_check(ll_add_bits as u64, ll_num_bits);
+                writer.write_bits_64_no_check(ml_add_bits as u64, ml_num_bits);
+            }
             if of_num_bits > 24 {
-                // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
-                // pre-allocated enough spare capacity to cover every
-                // per-sequence flush in this loop (≤ 16 bytes per
-                // sequence, plus the 32-byte slack on top of the 64-byte
-                // header reserve).
                 unsafe {
                     writer.flush_bulk();
                 }
             }
-            writer.write_bits_64_no_check(of_add_bits as u64, of_num_bits);
-            // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
-            // pre-allocated enough spare capacity to cover every
-            // per-sequence flush in this loop (≤ 16 bytes per
-            // sequence, plus the 32-byte slack on top of the 64-byte
-            // header reserve).
             unsafe {
+                writer.write_bits_64_no_check(of_add_bits as u64, of_num_bits);
                 writer.flush_bulk();
             }
         }

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -369,13 +369,15 @@ fn append_literals(dst: &mut Vec<u8>, lits: &[u8]) {
     if lit_len <= 32 {
         // Production callers (`collect_block_parts`) pre-reserve
         // `src_len` of spare capacity, so the sum of all literal
-        // runs across a block fits without grow. But this function
-        // is `pub(crate)` and stays a SAFE fn, so we must enforce
-        // the precondition in release too — otherwise a future
-        // caller skipping the pre-reserve would get an immediate
-        // 32-byte OOB write into whatever follows the `Vec`'s
-        // allocation. The branch is cold on the production hot
-        // path (debug_assert in tests confirms it stays untaken).
+        // runs across a block fits without grow. But this is a SAFE
+        // fn (module-private; callers in this same file are the
+        // only ones today, but the safety net still must hold), so
+        // we enforce the precondition in release too — otherwise a
+        // future caller skipping the pre-reserve would get an
+        // immediate 32-byte OOB write into whatever follows the
+        // `Vec`'s allocation. The branch is cold on the production
+        // hot path (debug_assert in tests confirms it stays
+        // untaken).
         let cur_len = dst.len();
         if dst.capacity() - cur_len < lit_len {
             dst.reserve(lit_len);

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -1587,7 +1587,11 @@ fn encode_sequences(
         // 0..=63. Before the first unchecked-add burst we drain to
         // < 8 leftover so the per-burst budget math (state diffs ≤
         // 30 + leftover ≤ 8 = 38 < 64) holds invariantly.
-        writer.flush_bulk();
+        // SAFETY: `reserve_output` above guarantees capacity ≥
+        // current_len + sequences.len() * 12 + 64 ≥ current_len + 8.
+        unsafe {
+            writer.flush_bulk();
+        }
         for sequence in (0..=sequences.len() - 2).rev() {
             let sequence = sequences[sequence];
             let (ll_code, ll_add_bits, ll_num_bits) = encode_literal_length(sequence.ll);
@@ -1615,15 +1619,46 @@ fn encode_sequences(
                 writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
                 ll_state = Some(next);
             }
-            writer.flush_bulk();
+            // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
+            // pre-allocated enough spare capacity to cover every
+            // per-sequence flush in this loop (≤ 16 bytes per
+            // sequence, plus the 32-byte slack on top of the 64-byte
+            // header reserve).
+            unsafe {
+                writer.flush_bulk();
+            }
 
-            // Extras burst: max 16+16+24 = 56 bits + ≤ 7 leftover =
-            // 63 bits, just under 64. Order matches donor's
-            // ZSTD_encodeSequences_body: ll first, ml second, of last.
+            // Extras burst: ll (≤16) + ml (≤16) + of (≤ window_log,
+            // up to 30 for our max window_log). With ≤ 7 leftover from
+            // the prior flush_bulk, total ll+ml+of+partial can exceed
+            // 64 once of_num_bits > 25. Donor handles this via
+            // `longOffsets` mode that splits high offsets across two
+            // BIT_addBits calls; we instead drain the partial after ml
+            // and write of into a fresh container. The branch matches
+            // donor's `MEM_32bits()` flush-between-each-component
+            // shape on the 32-bit build (which has the same 64-bit
+            // container constraint).
             writer.write_bits_64_no_check(ll_add_bits as u64, ll_num_bits);
             writer.write_bits_64_no_check(ml_add_bits as u64, ml_num_bits);
+            if of_num_bits > 24 {
+                // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
+                // pre-allocated enough spare capacity to cover every
+                // per-sequence flush in this loop (≤ 16 bytes per
+                // sequence, plus the 32-byte slack on top of the 64-byte
+                // header reserve).
+                unsafe {
+                    writer.flush_bulk();
+                }
+            }
             writer.write_bits_64_no_check(of_add_bits as u64, of_num_bits);
-            writer.flush_bulk();
+            // SAFETY: `reserve_output(sequences.len() * 12 + 64)` above
+            // pre-allocated enough spare capacity to cover every
+            // per-sequence flush in this loop (≤ 16 bytes per
+            // sequence, plus the 32-byte slack on top of the 64-byte
+            // header reserve).
+            unsafe {
+                writer.flush_bulk();
+            }
         }
     }
     if let (Some(state), Some(table)) = (ml_state, ml_table) {

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -1564,36 +1564,66 @@ fn encode_sequences(
     writer.write_bits(ml_add_bits, ml_num_bits);
     writer.write_bits(of_add_bits, of_num_bits);
 
-    // encode backwards so the decoder reads the first sequence first
+    // Donor-faithful sequence loop: write state diffs + extras via
+    // unchecked fast-path adds with explicit `flush_bulk` calls at
+    // safe burst boundaries. Per-sequence bit budget:
+    //   state diffs: of (<=8) + ml (<=9) + ll (<=9) = 26 bits → one
+    //                burst between flushes.
+    //   extras:      ll (<=16) + ml (<=16) + of (<=24) = 56 bits →
+    //                one burst between flushes.
+    //
+    // Total per sequence: 82 bits ⇒ at least 2 flushes (one per burst).
+    // Mirrors donor `ZSTD_encodeSequences_body`
+    // (`zstd_compress_sequences.c:303-360`) which uses BIT_addBitsFast
+    // + BIT_flushBitsFast at the same burst boundaries.
+    //
+    // Pre-reserve output capacity for the worst-case sequence section
+    // size (~10 bytes/sequence + 32 byte slack) so the per-flush
+    // `extend_from_slice` never triggers a Vec realloc.
     if sequences.len() > 1 {
+        writer.reserve_output(sequences.len() * 12 + 64);
+        // Pre-loop flush: the safe `write_bits` calls above for the
+        // final sequence's add_bits leave `bits_in_partial` in
+        // 0..=63. Before the first unchecked-add burst we drain to
+        // < 8 leftover so the per-burst budget math (state diffs ≤
+        // 30 + leftover ≤ 8 = 38 < 64) holds invariantly.
+        writer.flush_bulk();
         for sequence in (0..=sequences.len() - 2).rev() {
             let sequence = sequences[sequence];
             let (ll_code, ll_add_bits, ll_num_bits) = encode_literal_length(sequence.ll);
             let (of_code, of_add_bits, of_num_bits) = encode_offset(sequence.of);
             let (ml_code, ml_add_bits, ml_num_bits) = encode_match_len(sequence.ml);
 
+            // State diffs burst: max 30 bits (10+10+9 worst case for
+            // acc_log ≤ 9 ll/ml + acc_log ≤ 8 of) + ≤ 7 leftover from
+            // prior flush = ≤ 37 bits total — well under 64.
             if let (Some(table), Some(state)) = (of_table, of_state) {
                 let next = table.next_state(of_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits(diff as u64, next.num_bits as usize);
+                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
                 of_state = Some(next);
             }
             if let (Some(table), Some(state)) = (ml_table, ml_state) {
                 let next = table.next_state(ml_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits(diff as u64, next.num_bits as usize);
+                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
                 ml_state = Some(next);
             }
             if let (Some(table), Some(state)) = (ll_table, ll_state) {
                 let next = table.next_state(ll_code, state.index);
                 let diff = state.index - next.baseline;
-                writer.write_bits(diff as u64, next.num_bits as usize);
+                writer.write_bits_64_no_check(diff as u64, next.num_bits as usize);
                 ll_state = Some(next);
             }
+            writer.flush_bulk();
 
-            writer.write_bits(ll_add_bits, ll_num_bits);
-            writer.write_bits(ml_add_bits, ml_num_bits);
-            writer.write_bits(of_add_bits, of_num_bits);
+            // Extras burst: max 16+16+24 = 56 bits + ≤ 7 leftover =
+            // 63 bits, just under 64. Order matches donor's
+            // ZSTD_encodeSequences_body: ll first, ml second, of last.
+            writer.write_bits_64_no_check(ll_add_bits as u64, ll_num_bits);
+            writer.write_bits_64_no_check(ml_add_bits as u64, ml_num_bits);
+            writer.write_bits_64_no_check(of_add_bits as u64, of_num_bits);
+            writer.flush_bulk();
         }
     }
     if let (Some(state), Some(table)) = (ml_state, ml_table) {

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -367,20 +367,25 @@ fn append_literals(dst: &mut Vec<u8>, lits: &[u8]) {
         return;
     }
     if lit_len <= 32 {
-        // Caller pre-reserved `src_len` (the whole block); the sum
-        // of all literal runs is ≤ src_len, so the unused tail
-        // always has ≥ `lit_len` capacity.
-        debug_assert!(
-            dst.capacity() - dst.len() >= lit_len,
-            "append_literals requires `dst` to have at least `lit_len` reserved capacity \
-             past `dst.len()` — caller failed to reserve before the emit loop",
-        );
+        // Production callers (`collect_block_parts`) pre-reserve
+        // `src_len` of spare capacity, so the sum of all literal
+        // runs across a block fits without grow. But this function
+        // is `pub(crate)` and stays a SAFE fn, so we must enforce
+        // the precondition in release too — otherwise a future
+        // caller skipping the pre-reserve would get an immediate
+        // 32-byte OOB write into whatever follows the `Vec`'s
+        // allocation. The branch is cold on the production hot
+        // path (debug_assert in tests confirms it stays untaken).
         let cur_len = dst.len();
+        if dst.capacity() - cur_len < lit_len {
+            dst.reserve(lit_len);
+        }
         let dst_ptr = unsafe { dst.as_mut_ptr().add(cur_len) };
         // SAFETY: `lits` is a valid slice (so reading `lit_len`
-        // bytes from `lits.as_ptr()` is in-bounds); `dst_ptr` has
-        // `lit_len` bytes of reserved capacity (debug_assert above).
-        // copy_bytes_overshooting writes EXACTLY `lit_len` bytes when
+        // bytes from `lits.as_ptr()` is in-bounds); the
+        // `dst.reserve(lit_len)` above guarantees `dst_ptr` has
+        // `lit_len` bytes of spare capacity. copy_bytes_overshooting
+        // writes EXACTLY `lit_len` bytes when
         // `min(src.1, dst.1) == lit_len`.
         unsafe {
             crate::decoding::simd_copy::copy_bytes_overshooting(

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -296,12 +296,12 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // Lvl  Strategy       wlog  fast_hlog  fast_mls  fast_step  lazy  HC config                                   row config
     // ---  -------------- ----  ---------  --------  ---------  ----  ------------------------------------------  ----------
     /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 20, fast_hash_log: 16, fast_mls: 6, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
+    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
     /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
     /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
     /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
     /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
@@ -4183,9 +4183,9 @@ fn driver_switches_backends_and_initializes_dfast_via_reset() {
 }
 
 #[test]
-fn driver_level4_selects_row_backend() {
+fn driver_level5_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
     // Greedy-specific routing assertion: the `BackendTag::Row` arm of
     // `MatchGeneratorDriver::compress_block` has a
@@ -4406,7 +4406,7 @@ fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (u
 /// repcode lookup fails the test instead of being masked by
 /// first-slice matches.
 #[test]
-fn driver_level4_greedy_tail_rep_only_reachable() {
+fn driver_level5_greedy_tail_rep_only_reachable() {
     // Period-4 first slice locks rep1 = 4 into `offset_hist` by the
     // time the parse reaches the slice tail. Second slice is exactly
     // 5 bytes ( = `GREEDY_MIN_LOOKAHEAD`) so the outer loop runs
@@ -4422,7 +4422,7 @@ fn driver_level4_greedy_tail_rep_only_reachable() {
     let first: &[u8] = b"ABCDABCDABCDABCD"; // 16 bytes — strict period 4
     let second: &[u8] = b"ABCDA"; // 5 bytes — exact GREEDY_MIN_LOOKAHEAD
     let mut driver = MatchGeneratorDriver::new(16, 2);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
 
     let mut first_space = driver.get_next_space();
     first_space[..first.len()].copy_from_slice(first);
@@ -4588,9 +4588,10 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
     }
 
     check(CompressionLevel::Level(1), StrategyTag::Fast);
-    check(CompressionLevel::Level(2), StrategyTag::Dfast);
+    check(CompressionLevel::Level(2), StrategyTag::Fast);
     check(CompressionLevel::Level(3), StrategyTag::Dfast);
-    check(CompressionLevel::Level(4), StrategyTag::Greedy);
+    check(CompressionLevel::Level(4), StrategyTag::Dfast);
+    check(CompressionLevel::Level(5), StrategyTag::Greedy);
     check(CompressionLevel::Level(7), StrategyTag::Lazy);
     check(CompressionLevel::Level(15), StrategyTag::Lazy);
     check(CompressionLevel::Level(16), StrategyTag::BtOpt);
@@ -5515,7 +5516,7 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
 fn driver_small_source_hint_shrinks_dfast_hash_tables() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
 
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"abcabcabcabc");
     space.truncate(12);
@@ -5532,7 +5533,7 @@ fn driver_small_source_hint_shrinks_dfast_hash_tables() {
     );
 
     driver.set_source_size_hint(1024);
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"xyzxyzxyzxyz");
     space.truncate(12);
@@ -5569,7 +5570,7 @@ fn driver_small_source_hint_shrinks_dfast_hash_tables() {
 fn driver_small_source_hint_shrinks_row_hash_tables() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
 
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"abcabcabcabc");
     space.truncate(12);
@@ -5579,7 +5580,7 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     assert_eq!(full_rows, 1 << (ROW_HASH_BITS - ROW_LOG));
 
     driver.set_source_size_hint(1024);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"xyzxyzxyzxyz");
     space.truncate(12);
@@ -5785,7 +5786,7 @@ fn row_skip_matching_with_incompressible_hint_uses_sparse_prefix() {
 fn driver_unhinted_level2_keeps_default_dfast_hash_table_size() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
 
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"abcabcabcabc");
     space.truncate(12);
@@ -6064,7 +6065,11 @@ fn hc_prime_with_dictionary_disables_btultra2_seed_pass() {
 #[test]
 fn dfast_prime_with_dictionary_preserves_history_for_first_full_block() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(2));
+    // Use Level(4) — Dfast with `use_fast_loop=false`. Level(3) is
+    // also Dfast but flips `use_fast_loop=true`, which routes through
+    // a different scan path that bails early on the tiny 8-byte
+    // dict + 8-byte block scenario this test exercises.
+    driver.reset(CompressionLevel::Level(4));
 
     driver.prime_with_dictionary(b"abcdefgh", [1, 4, 8]);
 
@@ -6148,7 +6153,7 @@ fn prime_with_dictionary_counts_only_committed_tail_budget() {
 #[test]
 fn dfast_prime_with_dictionary_counts_four_byte_tail_budget() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
 
     let before = driver.dfast_matcher().max_window_size;
     // One full slice plus a 4-byte tail. Dfast can still use this tail through
@@ -6198,7 +6203,7 @@ fn row_prime_with_dictionary_preserves_history_for_first_full_block() {
 #[test]
 fn row_prime_with_dictionary_subtracts_uncommitted_tail_budget() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
 
     let base_window = driver.row_matcher().max_window_size;
     // Slice size is 8. The trailing byte cannot be committed (<4 tail),
@@ -6215,7 +6220,7 @@ fn row_prime_with_dictionary_subtracts_uncommitted_tail_budget() {
 #[test]
 fn prime_with_dictionary_budget_shrinks_after_row_eviction() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     // Keep live window tiny so dictionary-primed slices are evicted quickly.
     driver.row_matcher_mut().max_window_size = 8;
     driver.reported_window_size = 8;
@@ -6255,7 +6260,7 @@ fn prime_with_dictionary_budget_shrinks_after_row_eviction() {
 #[test]
 fn row_get_last_space_then_reset_to_fastest_drops_row_variant() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
 
     let mut space = driver.get_next_space();
@@ -6282,7 +6287,7 @@ fn row_get_last_space_then_reset_to_fastest_drops_row_variant() {
 #[test]
 fn driver_reset_from_row_backend_recycles_row_buffers_into_pool() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(4));
+    driver.reset(CompressionLevel::Level(5));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
 
     let mut space = driver.get_next_space();
@@ -7100,7 +7105,7 @@ fn prime_with_dictionary_budget_shrinks_after_simple_eviction() {
 #[test]
 fn prime_with_dictionary_budget_shrinks_after_dfast_eviction() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
     // Use a small live window in this regression so dictionary-primed slices are
     // evicted quickly and budget retirement can be asserted deterministically.
     driver.dfast_matcher_mut().max_window_size = 8;
@@ -7677,7 +7682,7 @@ fn dfast_commit_space_eviction_uses_window_size_delta() {
     use crate::encoding::CompressionLevel;
 
     let mut driver = MatchGeneratorDriver::new(10, 1);
-    driver.reset(CompressionLevel::Level(2));
+    driver.reset(CompressionLevel::Level(3));
     assert!(matches!(driver.storage, MatcherStorage::Dfast(_)));
 
     // Override the level-derived window with a tiny one so the

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -112,10 +112,15 @@ const CMOV_DUMMY: [u8; 4] = [0x12, 0x34, 0x56, 0x78];
 ///
 /// - `ip` MUST point to ≥ 4 readable bytes (the kernel only calls
 ///   this when ip0..ip3 stay within `iend - HASH_READ_SIZE`).
-/// - `base` MUST be the start of the same buffer that `data_len`
-///   describes, i.e. `base[0..data_len]` is a valid byte range.
-/// - `ip_pos` MUST equal the byte offset of `ip` within the buffer
-///   `base` points at: `ip == base.add(ip_pos)`.
+/// - `base` MUST be the start of the same buffer the kernel scans.
+///   For an in-window `match_idx >= prefix_start_index`,
+///   `base.add(match_idx as usize)` MUST yield ≥ 4 readable bytes
+///   (i.e. `match_idx + 4 <= data_len`). The kernel maintains this
+///   invariant by only inserting hash-table entries for positions
+///   strictly below `ilimit = data_len - HASH_READ_SIZE`, so every
+///   in-range `match_idx` returned by the table is automatically
+///   ≥ 4 bytes from the buffer end. See the comment block inside
+///   the function body for the full derivation.
 #[inline(always)]
 unsafe fn match_found<const USE_CMOV: bool>(
     ip: *const u8,
@@ -223,15 +228,22 @@ pub(crate) struct FastBlockResult {
 /// - `block_start`: byte offset of the current block's first byte
 ///   within `data`. The kernel hashes/searches only positions in
 ///   `[block_start, data.len())`, but matches may reach back into the
-///   prefix all the way to `prefix_start_index`.
-/// - `prefix_start_index`: lowest position that match candidates may
-///   reference. Donor computes this from `windowLog`; for a flat
-///   single-block kernel this is typically `0` or `block_start -
-///   window_size`, clamped to ≥ 0.
+///   prefix all the way to `bounds.prefix_start_index`.
+/// - `bounds: PrefixBounds`: bundle of two donor-derived absolute
+///   floors (kept together so the kernel signature stays inside the
+///   clippy 7-argument cap). See [`PrefixBounds`] field docs for the
+///   exact semantics:
+///   - `prefix_start_index`: sentinel-aware match-table filter (rejects
+///     the all-zero empty-slot value at position 0).
+///   - `window_low`: donor `windowLow`-equivalent absolute floor used
+///     by the prologue's `max_rep` computation and the backward-extension
+///     `match_pos > window_low` bound.
 /// - `hash_table`: the encoder's `FastHashTable`. Mutated in place;
 ///   entries are absolute indices into `data`.
 /// - `rep`: incoming `[rep_offset1, rep_offset2]` from the previous
 ///   block. Returned updated in `FastBlockResult.rep`.
+/// - `step_size`: donor `stepSize = targetLength + !(targetLength) + 1`
+///   (min 2). Drives the initial step in the 4-cursor skip schedule.
 /// - `handle_sequence`: closure that the kernel invokes once per
 ///   emitted `Sequence` — equivalent to donor's `ZSTD_storeSeq`.
 ///

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -260,6 +260,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     data: &[u8],
     block_start: usize,
     prefix_start_index: u32,
+    window_low: u32,
     hash_table: &mut FastHashTable,
     rep: [u32; 2],
     step_size: usize,
@@ -370,7 +371,17 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     let mut offset_saved1: u32 = 0;
     let mut offset_saved2: u32 = 0;
     {
-        let max_rep = (ip0 as u32).saturating_sub(prefix_start_index);
+        // Donor (`zstd_fast.c:240-244`): `maxRep = curr - windowLow`.
+        // `windowLow` is the absolute floor of in-window positions
+        // (= 0 at block 0). It is NOT `prefixStartIndex` — donor's
+        // `prefixStartIndex == windowLow` in the canonical fast path,
+        // but our `prefix_start_index` carries the sentinel-1 floor
+        // for hash-filter purposes. Using `prefix_start_index` here
+        // would zero `rep_offset1 = 1` at block 0 (ip0=1 →
+        // max_rep=0; 1>0), disabling rep-at-ip2 for the entire first
+        // block — see the `block_zero_prologue_preserves_default_rep_offset_one`
+        // regression test in `fast_matcher.rs`.
+        let max_rep = (ip0 as u32).saturating_sub(window_low);
         if rep_offset2 > max_rep {
             offset_saved2 = rep_offset2;
             rep_offset2 = 0;
@@ -486,8 +497,15 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 let mut new_ip = ip2;
                 let mut match0 = new_ip - rep_offset1 as usize;
                 let mut m_len: usize = 4;
+                // Donor bound: `match0 > prefixStart` ≡
+                // `match_pos > windowLow` (donor's prefixStart and
+                // windowLow are the same pointer in the no-dict
+                // fast path). We use `window_low` here rather than
+                // the sentinel-aware `prefix_start_index` so the
+                // backward step can reach position 1 (impossible
+                // under the sentinel) at block 0.
                 if new_ip > anchor
-                    && match0 > prefix_start_index as usize
+                    && match0 > window_low as usize
                     && data[new_ip - 1] == data[match0 - 1]
                 {
                     new_ip -= 1;
@@ -651,10 +669,14 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         };
 
         // Backward extension — only for explicit matches; rep path
-        // already handled the 1-byte backward step above.
+        // already handled the 1-byte backward step above. Donor's
+        // bound is `match0 > prefixStart` ≡ `match_pos > windowLow`;
+        // we mirror it via `window_low` (NOT `prefix_start_index`,
+        // which is sentinel-floored at 1 for hash-filter purposes
+        // only).
         if !is_rep {
             while match_ip > anchor
-                && match_pos > prefix_start_index as usize
+                && match_pos > window_low as usize
                 && data[match_ip - 1] == data[match_pos - 1]
             {
                 match_ip -= 1;
@@ -839,8 +861,8 @@ mod tests {
             }
         };
         let result = match mls {
-            4 => compress_block_fast::<4, false>(data, 0, 0, &mut table, [0, 0], 2, &mut handle),
-            5 => compress_block_fast::<5, false>(data, 0, 0, &mut table, [0, 0], 2, &mut handle),
+            4 => compress_block_fast::<4, false>(data, 0, 0, 0, &mut table, [0, 0], 2, &mut handle),
+            5 => compress_block_fast::<5, false>(data, 0, 0, 0, &mut table, [0, 0], 2, &mut handle),
             _ => panic!("test helper only supports mls=4 and mls=5"),
         };
         // Accounting invariant: literals + matches + tail == input.
@@ -920,7 +942,8 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let result = compress_block_fast::<4, false>(data, 0, 0, &mut table, rep, 2, &mut handle);
+        let result =
+            compress_block_fast::<4, false>(data, 0, 0, 0, &mut table, rep, 2, &mut handle);
         let acct: usize = tuples
             .iter()
             .map(|(lits, _off, mlen)| lits.len() + mlen)
@@ -1051,7 +1074,7 @@ mod tests {
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
         // prefix_start_index=5 blocks index 0.
-        let _ = compress_block_fast::<4, false>(&data, 0, 5, &mut table, [0, 0], 2, &mut handle);
+        let _ = compress_block_fast::<4, false>(&data, 0, 5, 5, &mut table, [0, 0], 2, &mut handle);
 
         // Walk emitted sequences in order, tracking the running
         // `anchor` cursor (which equals the start of the current
@@ -1130,7 +1153,8 @@ mod tests {
         // prefix_start_index = 50 — match_idx=5 is below the floor and
         // must be rejected by the donor-parity prefix filter in
         // `match_found`.
-        let _ = compress_block_fast::<4, false>(&data, 50, 50, &mut table, [0, 0], 2, &mut handle);
+        let _ =
+            compress_block_fast::<4, false>(&data, 50, 50, 50, &mut table, [0, 0], 2, &mut handle);
 
         // Either zero emissions (stale rejected, no other match found
         // in the limited scan window) or a Triple whose offset
@@ -1209,7 +1233,7 @@ mod tests {
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
         let result =
-            compress_block_fast::<4, false>(&data, 0, 0, &mut table, [huge, 7], 2, &mut handle);
+            compress_block_fast::<4, false>(&data, 0, 0, 0, &mut table, [huge, 7], 2, &mut handle);
         assert_eq!(
             result.rep[0], huge,
             "out-of-range rep_offset1 must be restored verbatim across the block",
@@ -1252,11 +1276,20 @@ mod tests {
                 }
             };
             if use_cmov {
-                let _ =
-                    compress_block_fast::<4, true>(&data, 0, 0, &mut table, [0, 0], 2, &mut handle);
+                let _ = compress_block_fast::<4, true>(
+                    &data,
+                    0,
+                    0,
+                    0,
+                    &mut table,
+                    [0, 0],
+                    2,
+                    &mut handle,
+                );
             } else {
                 let _ = compress_block_fast::<4, false>(
                     &data,
+                    0,
                     0,
                     0,
                     &mut table,

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -73,25 +73,34 @@ unsafe fn match_found<const USE_CMOV: bool>(
     base: *const u8,
     match_idx: u32,
     prefix_start_index: u32,
-    ip_pos: usize,
-    data_len: usize,
 ) -> bool {
-    // Bounds filters (well-predicted "not taken" on the hot path)
-    // stay as explicit branches — these protect against stale entries
-    // pointing past the buffer end and forward-pointing matches.
+    // Donor-parity hot-path: the ONLY filter on the branch variant is
+    // `match_idx < prefix_start_index` (rejects stale entries below
+    // the current window). Two safety invariants make additional
+    // bounds checks redundant:
+    //
+    // 1. `match_pos + 4 <= data_len`: hash table entries are only
+    //    written for positions visited by the scan, which by
+    //    construction stay strictly below `ilimit = data_len -
+    //    HASH_READ_SIZE = data_len - 8`. So any in-window
+    //    `match_idx >= prefix_start_index` satisfies `match_pos + 4
+    //    < data_len`. The `prefix_start_index >= INITIAL_PREFIX_START_INDEX
+    //    = 1` rule at the matcher boundary rejects the stale-zero
+    //    initial entry that would otherwise alias to position 0.
+    //
+    // 2. `match_pos < ip_pos`: hash writes precede probes in donor's
+    //    flow (writeback `hashTable[hash0] = current0` happens before
+    //    `matchFound(...)` reads matchIdx). Since `current0 < ip0` at
+    //    every shift step, `matchIdx <= current0_prev < ip0_now`.
+    //
+    // Donor `ZSTD_match4Found_branch` (`zstd_fast.c:128-141`) takes
+    // the same invariants and emits exactly one prefix filter + one
+    // 4-byte equality compare. The previous defensive bounds checks
+    // we carried here added two extra branches per match probe —
+    // and the kernel invokes `match_found` TWICE per inner-loop
+    // iteration, so the savings compound to ~4 branches/iter
+    // dropped on the hot path.
     let match_pos = match_idx as usize;
-    // `match_pos + 4` would wrap on 32-bit targets when `match_idx`
-    // approaches `u32::MAX`, allowing an OOB `read32` through.
-    // `checked_add` keeps the unsafe read fully guarded: `None` means
-    // overflow → reject; `Some(end)` mirrors the original predicate
-    // (`end > data_len` rejects). On 64-bit the optimizer collapses
-    // this to the same codegen as the previous form.
-    if match_pos.checked_add(4).is_none_or(|end| end > data_len) {
-        return false;
-    }
-    if match_pos >= ip_pos {
-        return false;
-    }
 
     if USE_CMOV {
         // Donor cmov variant (`ZSTD_match4Found_cmov`): pick either
@@ -445,20 +454,19 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             },
         }
         let found: Option<MatchFound> = loop {
-            // Repcode probe at ip2 (donor line 268). Load rval
-            // first so it stays consistent even if writeback below
-            // races. SAFETY: ip2 < ilimit ⇒ ≥ 4 readable bytes at
-            // ip2; ip2 ≥ rep_offset1 when rep_offset1 is non-zero
-            // because the save/restore prologue zeroed any
-            // rep_offset that exceeded the prefix-distance.
-            let rval = if rep_offset1 > 0 {
-                unsafe { read32(base.add(ip2 - rep_offset1 as usize)) }
-            } else {
-                // Sentinel — the equality check below can't pass
-                // when rep_offset1 == 0 anyway because the
-                // `rep_offset1 > 0` guard short-circuits.
-                0
-            };
+            // Repcode probe at ip2 (donor line 268). Unconditional
+            // load — donor `MEM_read32(ip2 - rep_offset1)` always
+            // reads, no `rep_offset1 > 0` short-circuit. Safe even
+            // when rep_offset1 == 0 because `ip2 - 0 = ip2`, which
+            // reads the same 4 bytes as the equality target below
+            // (so the comparison degrades to `read32(ip2) ==
+            // read32(ip2)` and the rep branch is correctly suppressed
+            // by the `rep_offset1 > 0` guard inside the `if`).
+            // SAFETY: ip2 < ilimit ⇒ ≥ 4 readable bytes at ip2; if
+            // rep_offset1 > 0 the save/restore prologue ensures
+            // `ip2 - rep_offset1 >= prefix_start_index >= 1`, so the
+            // backward read stays in-bounds.
+            let rval = unsafe { read32(base.add(ip2 - rep_offset1 as usize)) };
 
             // Writeback hash for ip0 (donor line 272). Donor writes
             // BEFORE the rep probe so the hash table reflects ip0
@@ -502,14 +510,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
 
             // First explicit-match probe at ip0 (donor line 292).
             if unsafe {
-                match_found::<USE_CMOV>(
-                    base.add(ip0),
-                    base,
-                    match_idx,
-                    prefix_start_index,
-                    ip0,
-                    iend_addr,
-                )
+                match_found::<USE_CMOV>(base.add(ip0), base, match_idx, prefix_start_index)
             } {
                 // Safe writeback for hash1 (ip1 = ip0 + 1, before
                 // search resumption). Donor line 296.
@@ -539,14 +540,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             // Second explicit-match probe at the shifted ip0
             // (donor line 317).
             if unsafe {
-                match_found::<USE_CMOV>(
-                    base.add(ip0),
-                    base,
-                    match_idx,
-                    prefix_start_index,
-                    ip0,
-                    iend_addr,
-                )
+                match_found::<USE_CMOV>(base.add(ip0), base, match_idx, prefix_start_index)
             } {
                 // Conditional writeback: only safe if `step <= 4`
                 // (donor lines 319-324) — otherwise ip1 might fall
@@ -630,6 +624,19 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 current0: _,
             } => {
                 let match_pos = match_idx as usize;
+                // Donor invariant: hash table writes for ip_pos
+                // happen BEFORE the probe reads `match_idx` (see the
+                // writeback at the top of the do-while body), so the
+                // returned `match_idx` is always strictly less than
+                // `new_ip` (it was a hash slot occupant from a prior
+                // shift step where `current0_prev < ip0_now`).
+                // Donor `ZSTD_match4Found_branch` relies on the same
+                // invariant — neither side adds a release-time check.
+                debug_assert!(
+                    match_pos < new_ip,
+                    "kernel invariant violated: match_pos ({match_pos}) >= new_ip ({new_ip}); \
+                     hash table holds forward-pointing entry — driver/test broke writeback ordering"
+                );
                 let offset = new_ip - match_pos;
                 // Rotate the rep stack ahead of backward extension
                 // — donor stores the offset BEFORE the backward
@@ -1090,21 +1097,26 @@ mod tests {
     /// gigantic offset → emit a Triple with a meaningless backward
     /// reference.
     ///
-    /// Engineered scenario: uniform data so the raw-cmp at any two
-    /// positions always succeeds; pre-populate the hash slot that
-    /// ip0=1 will probe with a forward-pointing stale index (150);
-    /// without the `match_pos < ip_pos` filter the very first
-    /// iteration would emit `Triple { offset = 1 - 150 = u_wrap, ... }`.
-    /// Test asserts every emitted Triple has an offset ≤ data.len()
-    /// — only achievable when the stale forward index is rejected.
+    /// Stale hash entries below `prefix_start_index` must be rejected
+    /// by the donor-parity prefix filter in `match_found`. Engineered
+    /// scenario: pre-populate the hash slot for ip0 with a low stale
+    /// index (5) that points into the supposedly-out-of-window region;
+    /// run with `prefix_start_index = 50` so the kernel must skip
+    /// that candidate. The kernel's own writeback at the iteration
+    /// start would still leave the stale value usable if the prefix
+    /// filter didn't fire — uniform data ensures any survived
+    /// candidate would emit a non-zero match.
     #[test]
-    fn match_found_rejects_stale_forward_entry() {
+    fn match_found_rejects_stale_entry_below_prefix_floor() {
         let data = vec![0u8; 200];
         let mut table = FastHashTable::new(8, 4);
-        // SAFETY: data has ≥ 4 readable bytes at index 1.
-        let h = unsafe { table.hash_ptr::<4>(data.as_ptr().add(1)) };
+        // Force the explicit-match probe at ip0=50 (first iter once
+        // ip0 is bumped from prefix_start_index=50) to see the stale
+        // index 5.
+        // SAFETY: data has ≥ 4 readable bytes at index 50.
+        let h = unsafe { table.hash_ptr::<4>(data.as_ptr().add(50)) };
         // SAFETY: h came from hash_ptr on this same table.
-        unsafe { table.put(h, 150) };
+        unsafe { table.put(h, 5) };
 
         let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
         let mut handle = |seq: Sequence<'_>| match seq {
@@ -1115,8 +1127,15 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let _ = compress_block_fast::<4, false>(&data, 0, 0, &mut table, [0, 0], 2, &mut handle);
+        // prefix_start_index = 50 — match_idx=5 is below the floor and
+        // must be rejected by the donor-parity prefix filter in
+        // `match_found`.
+        let _ = compress_block_fast::<4, false>(&data, 50, 50, &mut table, [0, 0], 2, &mut handle);
 
+        // Either zero emissions (stale rejected, no other match found
+        // in the limited scan window) or a Triple whose offset
+        // references a position >= prefix_start_index = 50, never a
+        // 1-byte-from-stale-5 offset.
         for (_, off, m) in &tuples {
             if *m > 0 {
                 assert!(
@@ -1284,12 +1303,12 @@ mod tests {
         let base = data.as_ptr();
         let ip_pos = 16usize;
         let ip = unsafe { base.add(ip_pos) };
-        let branch_result = unsafe { match_found::<false>(ip, base, 4, 10, ip_pos, data.len()) };
+        let branch_result = unsafe { match_found::<false>(ip, base, 4, 10) };
         assert!(
             !branch_result,
             "branch variant must reject out-of-window match_idx"
         );
-        let cmov_result = unsafe { match_found::<true>(ip, base, 4, 10, ip_pos, data.len()) };
+        let cmov_result = unsafe { match_found::<true>(ip, base, 4, 10) };
         assert!(
             !cmov_result,
             "cmov variant must reject out-of-window match_idx even when \

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -53,15 +53,23 @@ pub(crate) fn kernel_trace_enabled() -> bool {
     }
 }
 
-/// Donor `kSearchStrength` — the step-skip accelerator advances the
-/// per-iteration step every `1 << (kSearchStrength - 1) = 32` bytes
-/// when no matches are found, so incompressible regions skip ahead
-/// faster than the linear 1-byte advance.
-const SEARCH_STRENGTH: usize = 6;
+/// Donor `kSearchStrength` — defined in `zstd_compress_internal.h:32`
+/// as `#define kSearchStrength 8`. The step-skip accelerator advances
+/// the per-iteration step every `1 << (kSearchStrength - 1) = 128`
+/// bytes when no matches are found, so incompressible regions skip
+/// ahead faster than the linear 1-byte advance.
+///
+/// Issue #220 fix: previously had `SEARCH_STRENGTH = 6` (`K_STEP_INCR
+/// = 32`), causing our step doubling to fire 4× more frequently than
+/// donor — by ip0=1280 our step was ~40 while donor's was 12. This
+/// drove the +7.43% ratio gap on decodecorpus-z000033 at Level(1)
+/// Fast: cursor skipped too many positions, missing matches donor
+/// found via finer-grained probing.
+const SEARCH_STRENGTH: usize = 8;
 
-/// Donor `kStepIncr = 1 << (kSearchStrength - 1)` — every this-many
-/// bytes of no-match scanning, the per-iteration `step` is bumped
-/// by 1 (donor's `step++` at `zstd_fast.c:343`). Drives the
+/// Donor `kStepIncr = 1 << (kSearchStrength - 1) = 128` — every this-
+/// many bytes of no-match scanning, the per-iteration `step` is
+/// bumped by 1 (donor's `step++` at `zstd_fast.c:343`). Drives the
 /// incompressible-region step acceleration.
 const K_STEP_INCR: usize = 1 << (SEARCH_STRENGTH - 1);
 

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -304,17 +304,41 @@ pub(crate) struct FastBlockResult {
 /// wrapping the kernel's output would have to special-case "did
 /// the kernel already emit the tail" per branch, which is exactly
 /// the inconsistency this contract removes.
+/// Donor `prefixStartIndex` + `windowLow` bundled into a single
+/// argument so the kernel signature stays within the 7-arg clippy
+/// budget. Both fields are u32 absolute positions in the flat
+/// history buffer; see [`compress_block_fast`] doc for which path
+/// uses which.
+#[derive(Clone, Copy)]
+pub(crate) struct PrefixBounds {
+    /// Sentinel-aware floor for the hash-table `match_idx` filter
+    /// (`match_found::<USE_CMOV>` rejects `match_idx <
+    /// prefix_start_index`). Caller is expected to maintain
+    /// `prefix_start_index >= 1` so the all-zero empty-slot value
+    /// can't be confused with a valid match at position 0.
+    pub prefix_start_index: u32,
+    /// Donor `windowLow` analogue — the absolute floor of in-window
+    /// positions, equals 0 at block 0 / pre-eviction blocks and
+    /// advances as the window slides. Drives the prologue's
+    /// `max_rep = ip0 - window_low` computation AND the backward-
+    /// extension `match_pos > window_low` bound (both paths donor
+    /// expresses against `prefixStart` directly, NOT against a
+    /// sentinel-1 floor).
+    pub window_low: u32,
+}
+
 #[inline(always)]
 pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     data: &[u8],
     block_start: usize,
-    prefix_start_index: u32,
-    window_low: u32,
+    bounds: PrefixBounds,
     hash_table: &mut FastHashTable,
     rep: [u32; 2],
     step_size: usize,
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
 ) -> FastBlockResult {
+    let prefix_start_index = bounds.prefix_start_index;
+    let window_low = bounds.window_low;
     // Donor's `stepSize = targetLength + !(targetLength) + 1`
     // (min 2). Callers must pass >= 2; values larger than 2 drive
     // the kernel's acceleration gradient on negative levels.
@@ -959,8 +983,30 @@ mod tests {
             }
         };
         let result = match mls {
-            4 => compress_block_fast::<4, false>(data, 0, 0, 0, &mut table, [0, 0], 2, &mut handle),
-            5 => compress_block_fast::<5, false>(data, 0, 0, 0, &mut table, [0, 0], 2, &mut handle),
+            4 => compress_block_fast::<4, false>(
+                data,
+                0,
+                PrefixBounds {
+                    prefix_start_index: 0,
+                    window_low: 0,
+                },
+                &mut table,
+                [0, 0],
+                2,
+                &mut handle,
+            ),
+            5 => compress_block_fast::<5, false>(
+                data,
+                0,
+                PrefixBounds {
+                    prefix_start_index: 0,
+                    window_low: 0,
+                },
+                &mut table,
+                [0, 0],
+                2,
+                &mut handle,
+            ),
             _ => panic!("test helper only supports mls=4 and mls=5"),
         };
         // Accounting invariant: literals + matches + tail == input.
@@ -1040,8 +1086,18 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let result =
-            compress_block_fast::<4, false>(data, 0, 0, 0, &mut table, rep, 2, &mut handle);
+        let result = compress_block_fast::<4, false>(
+            data,
+            0,
+            PrefixBounds {
+                prefix_start_index: 0,
+                window_low: 0,
+            },
+            &mut table,
+            rep,
+            2,
+            &mut handle,
+        );
         let acct: usize = tuples
             .iter()
             .map(|(lits, _off, mlen)| lits.len() + mlen)
@@ -1172,7 +1228,18 @@ mod tests {
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
         // prefix_start_index=5 blocks index 0.
-        let _ = compress_block_fast::<4, false>(&data, 0, 5, 5, &mut table, [0, 0], 2, &mut handle);
+        let _ = compress_block_fast::<4, false>(
+            &data,
+            0,
+            PrefixBounds {
+                prefix_start_index: 5,
+                window_low: 5,
+            },
+            &mut table,
+            [0, 0],
+            2,
+            &mut handle,
+        );
 
         // Walk emitted sequences in order, tracking the running
         // `anchor` cursor (which equals the start of the current
@@ -1251,8 +1318,18 @@ mod tests {
         // prefix_start_index = 50 — match_idx=5 is below the floor and
         // must be rejected by the donor-parity prefix filter in
         // `match_found`.
-        let _ =
-            compress_block_fast::<4, false>(&data, 50, 50, 50, &mut table, [0, 0], 2, &mut handle);
+        let _ = compress_block_fast::<4, false>(
+            &data,
+            50,
+            PrefixBounds {
+                prefix_start_index: 50,
+                window_low: 50,
+            },
+            &mut table,
+            [0, 0],
+            2,
+            &mut handle,
+        );
 
         // Either zero emissions (stale rejected, no other match found
         // in the limited scan window) or a Triple whose offset
@@ -1330,8 +1407,18 @@ mod tests {
             } => tuples.push((literals.to_vec(), offset, match_len)),
             Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
         };
-        let result =
-            compress_block_fast::<4, false>(&data, 0, 0, 0, &mut table, [huge, 7], 2, &mut handle);
+        let result = compress_block_fast::<4, false>(
+            &data,
+            0,
+            PrefixBounds {
+                prefix_start_index: 0,
+                window_low: 0,
+            },
+            &mut table,
+            [huge, 7],
+            2,
+            &mut handle,
+        );
         assert_eq!(
             result.rep[0], huge,
             "out-of-range rep_offset1 must be restored verbatim across the block",
@@ -1377,8 +1464,10 @@ mod tests {
                 let _ = compress_block_fast::<4, true>(
                     &data,
                     0,
-                    0,
-                    0,
+                    PrefixBounds {
+                        prefix_start_index: 0,
+                        window_low: 0,
+                    },
                     &mut table,
                     [0, 0],
                     2,
@@ -1388,8 +1477,10 @@ mod tests {
                 let _ = compress_block_fast::<4, false>(
                     &data,
                     0,
-                    0,
-                    0,
+                    PrefixBounds {
+                        prefix_start_index: 0,
+                        window_low: 0,
+                    },
                     &mut table,
                     [0, 0],
                     2,

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -987,7 +987,12 @@ mod tests {
                 data,
                 0,
                 PrefixBounds {
-                    prefix_start_index: 0,
+                    // Match production contract:
+                    // `prefix_start_index >= 1` rejects the hash table
+                    // empty-slot value `0` so a fresh-table probe
+                    // cannot be mistaken for a position-0 match (the
+                    // sentinel-1 floor documented on FastKernelMatcher).
+                    prefix_start_index: 1,
                     window_low: 0,
                 },
                 &mut table,
@@ -999,7 +1004,12 @@ mod tests {
                 data,
                 0,
                 PrefixBounds {
-                    prefix_start_index: 0,
+                    // Match production contract:
+                    // `prefix_start_index >= 1` rejects the hash table
+                    // empty-slot value `0` so a fresh-table probe
+                    // cannot be mistaken for a position-0 match (the
+                    // sentinel-1 floor documented on FastKernelMatcher).
+                    prefix_start_index: 1,
                     window_low: 0,
                 },
                 &mut table,
@@ -1090,7 +1100,10 @@ mod tests {
             data,
             0,
             PrefixBounds {
-                prefix_start_index: 0,
+                // Match production contract:
+                // `prefix_start_index >= 1` rejects the hash table
+                // empty-slot value `0`.
+                prefix_start_index: 1,
                 window_low: 0,
             },
             &mut table,
@@ -1411,7 +1424,10 @@ mod tests {
             &data,
             0,
             PrefixBounds {
-                prefix_start_index: 0,
+                // Match production contract:
+                // `prefix_start_index >= 1` rejects the hash table
+                // empty-slot value `0`.
+                prefix_start_index: 1,
                 window_low: 0,
             },
             &mut table,
@@ -1465,7 +1481,10 @@ mod tests {
                     &data,
                     0,
                     PrefixBounds {
-                        prefix_start_index: 0,
+                        // Match production contract:
+                        // `prefix_start_index >= 1` rejects the hash
+                        // table empty-slot value `0`.
+                        prefix_start_index: 1,
                         window_low: 0,
                     },
                     &mut table,
@@ -1478,7 +1497,10 @@ mod tests {
                     &data,
                     0,
                     PrefixBounds {
-                        prefix_start_index: 0,
+                        // Match production contract:
+                        // `prefix_start_index >= 1` rejects the hash
+                        // table empty-slot value `0`.
+                        prefix_start_index: 1,
                         window_low: 0,
                     },
                     &mut table,

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -12,6 +12,47 @@ use super::count::count_forward;
 use super::hash_table::FastHashTable;
 use crate::encoding::Sequence;
 
+/// Per-iteration diagnostic tracing of the Fast kernel inner loop.
+///
+/// Compile-time gated by `--features kernel_trace`; runtime-gated by
+/// `STRUCTURED_ZSTD_KERNEL_TRACE` env var (any non-empty value).
+/// Production builds carry ZERO cost — the macro expands to a no-op
+/// when the feature is off, so the hot loop never even sees the
+/// `if std::env::var(..)` check.
+///
+/// Used by `examples/trace_fast_kernel.rs` to diff our kernel's
+/// state against donor `zstd_fast.c:266-348` reasoning at every iter
+/// in the first block of decodecorpus-z000033 (issue #220 ratio gap).
+#[cfg(feature = "kernel_trace")]
+macro_rules! ktrace {
+    ($($arg:tt)*) => {
+        if crate::encoding::simple::fast_kernel::kernel::kernel_trace_enabled() {
+            ::std::eprintln!($($arg)*);
+        }
+    };
+}
+#[cfg(not(feature = "kernel_trace"))]
+macro_rules! ktrace {
+    ($($arg:tt)*) => {};
+}
+
+#[cfg(feature = "kernel_trace")]
+pub(crate) fn kernel_trace_enabled() -> bool {
+    use core::sync::atomic::{AtomicU8, Ordering};
+    static CACHED: AtomicU8 = AtomicU8::new(0); // 0=unknown, 1=off, 2=on
+    match CACHED.load(Ordering::Relaxed) {
+        1 => false,
+        2 => true,
+        _ => {
+            let on = std::env::var("STRUCTURED_ZSTD_KERNEL_TRACE")
+                .map(|v| !v.is_empty())
+                .unwrap_or(false);
+            CACHED.store(if on { 2 } else { 1 }, Ordering::Relaxed);
+            on
+        }
+    }
+}
+
 /// Donor `kSearchStrength` — the step-skip accelerator advances the
 /// per-iteration step every `1 << (kSearchStrength - 1) = 32` bytes
 /// when no matches are found, so incompressible regions skip ahead
@@ -406,6 +447,18 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
     // with hash precomputation, repcode-at-ip2 probe, two explicit-
     // match probes (at ip0 then at the shifted ip0), and a step-
     // doubling cadence.
+    ktrace!(
+        "ENTER block_start={} ip0_initial={} ilimit={} window_low={} prefix={} rep1={} rep2={} step={} mls={}",
+        block_start,
+        ip0,
+        ilimit,
+        window_low,
+        prefix_start_index,
+        rep_offset1,
+        rep_offset2,
+        step_size,
+        MLS,
+    );
     'restart: while ip0 < ilimit {
         // _start: setup. ip0 already positioned; derive ip1/ip2/ip3
         // from current step. If even ip3 is past ilimit, the loop
@@ -433,6 +486,19 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         let mut hash0 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
         let mut hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip1)) };
         let mut match_idx = unsafe { hash_table.get(hash0) };
+        ktrace!(
+            "OUTER ip0={} ip1={} ip2={} ip3={} step={} hash0={} hash1={} match_idx={} rep1={} rep2={}",
+            ip0,
+            ip1,
+            ip2,
+            ip3,
+            step,
+            hash0,
+            hash1,
+            match_idx,
+            rep_offset1,
+            rep_offset2
+        );
 
         // Inner do-while body. On any match, break out with the
         // `MatchFound` enum carrying the match coordinates; the
@@ -484,6 +550,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             // even if the iteration's match comes from rep at ip2.
             // SAFETY: hash0 from hash_ptr ⇒ in-bounds; ip0 ≤ u32::MAX
             // by the entry-point cap.
+            ktrace!("PUT hash0={} pos={} (iter-start)", hash0, ip0);
             unsafe { hash_table.put(hash0, ip0 as u32) };
 
             // Repcode-at-ip2 check.
@@ -515,7 +582,15 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // Safe writeback for hash1 — ip1 is BEFORE ip2 (the
                 // match site), so its position won't conflict with
                 // the match's forward extension. Donor lines 286-287.
+                ktrace!("PUT hash1={} pos={} (rep-emit post)", hash1, ip1);
                 unsafe { hash_table.put(hash1, ip1 as u32) };
+                ktrace!(
+                    "MATCH rep new_ip={} match0={} m_len={} offset={}",
+                    new_ip,
+                    match0,
+                    m_len,
+                    rep_offset1
+                );
                 break Some(MatchFound::Rep {
                     new_ip,
                     match0,
@@ -527,12 +602,20 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             }
 
             // First explicit-match probe at ip0 (donor line 292).
+            ktrace!("PROBE1 ip0={} match_idx={}", ip0, match_idx);
             if unsafe {
                 match_found::<USE_CMOV>(base.add(ip0), base, match_idx, prefix_start_index)
             } {
                 // Safe writeback for hash1 (ip1 = ip0 + 1, before
                 // search resumption). Donor line 296.
+                ktrace!("PUT hash1={} pos={} (explicit1 post)", hash1, ip1);
                 unsafe { hash_table.put(hash1, ip1 as u32) };
+                ktrace!(
+                    "MATCH explicit1 ip0={} match_idx={} offset={}",
+                    ip0,
+                    match_idx,
+                    ip0 as i64 - match_idx as i64
+                );
                 break Some(MatchFound::Explicit {
                     new_ip: ip0,
                     match_idx,
@@ -553,10 +636,12 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             ip2 = ip3;
 
             // Writeback for new ip0. Donor lines 314-315.
+            ktrace!("PUT hash0={} pos={} (post-shift1)", hash0, ip0);
             unsafe { hash_table.put(hash0, ip0 as u32) };
 
             // Second explicit-match probe at the shifted ip0
             // (donor line 317).
+            ktrace!("PROBE2 ip0={} match_idx={}", ip0, match_idx);
             if unsafe {
                 match_found::<USE_CMOV>(base.add(ip0), base, match_idx, prefix_start_index)
             } {
@@ -564,13 +649,18 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // (donor lines 319-324) — otherwise ip1 might fall
                 // past the match start when we resume scanning.
                 if step <= 4 {
+                    ktrace!("PUT hash1={} pos={} (explicit2 post, step<=4)", hash1, ip1);
                     unsafe { hash_table.put(hash1, ip1 as u32) };
                 }
+                ktrace!(
+                    "MATCH explicit2 ip0={} match_idx={} offset={}",
+                    ip0,
+                    match_idx,
+                    ip0 as i64 - match_idx as i64
+                );
                 break Some(MatchFound::Explicit {
                     new_ip: ip0,
                     match_idx,
-                    // After the shift + writeback at line 488,
-                    // current0 == shifted ip0.
                     current0: ip0,
                 });
             }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1850,17 +1850,19 @@ mod tests {
     ///
     /// Symptom assertion: on a `[0x01, 0x42 × 199]` fixture, donor's
     /// rep-at-ip2 fires at iter 1 (ip2=3, both `read32` reads see
-    /// `[42,42,42,42]`), emitting `Triple{literals=[0x01], offset=1,
-    /// match_len=~198}`. The buggy path skips rep, walks the cursor
-    /// via explicit-match shifts until matchIdx coincides at ip0=3
-    /// (iter 2 of inner loop, slot for `h([42,42,42,42])` was written
-    /// at ip0=2 in iter 1), then emits `Triple{literals=[0x01,
-    /// 0x42, 0x42], offset=1, ...}` — TWO extra literal bytes.
+    /// `[42,42,42,42]`). The donor emit sequence is:
+    /// `new_ip = ip2 = 3`, `match0 = ip2 - rep_offset1 = 2`, then the
+    /// one-byte backward extension absorbs `data[2] == data[1]`
+    /// (both `0x42`), giving `new_ip = 2, match_len ≈ 198`. Literal
+    /// prefix is `data[0..new_ip] = [0x01, 0x42]` → length 2.
     ///
-    /// The `literals.len() == 1` assertion is the bug discriminator:
-    /// uniform-byte data lets the explicit-match path eventually find
-    /// offset=1 too, so a check on offset alone passes both paths;
-    /// only the LITERAL PREFIX LENGTH reveals which path fired first.
+    /// The buggy path skips rep, walks the cursor via explicit-match
+    /// shifts until matchIdx coincides further into the run, and
+    /// emits a different literal prefix length. Asserting both
+    /// `offset == 1` AND `literals.len() == 2` pins down the
+    /// rep-at-ip2 path exactly — the explicit-match catch-up on
+    /// uniform-byte data also finds offset=1 via slot collision, so
+    /// an offset-only check passes both fixed and buggy paths.
     #[test]
     fn block_zero_prologue_preserves_default_rep_offset_one() {
         let mut data = alloc::vec::Vec::with_capacity(200);
@@ -1885,15 +1887,20 @@ mod tests {
             }
         });
 
-        // The narrowest assertion that's stable under hash-slot
-        // collisions on uniform-byte inputs: the first emit MUST
-        // reference offset=1. With the prologue bug, the explicit-
-        // match path catches up via slot collision and still emits
-        // offset=1 (matching this assertion on simple fixtures), so
-        // the unit test only documents the contract — the real
-        // ratio-regression discriminator is the compare_ffi run on
-        // decodecorpus, where the cascade from the disabled rep
-        // probe shows up as ~36 missing matches in block 0.
+        // Both `offset` AND `literals.len()` are asserted — together
+        // they pin down EXACTLY which inner-loop path emitted the
+        // first match. With the prologue bug (rep-at-ip2 disabled
+        // because `max_rep` was computed against `prefix_start_index`
+        // instead of `window_low`), the explicit-match path catches
+        // up via hash-slot collision at ip0=3 and STILL emits
+        // offset=1 — so an offset-only check would pass both fixed
+        // and buggy paths on this uniform-byte fixture. The literal
+        // prefix length is the actual discriminator: the rep-at-ip2
+        // path consumes only the leading `0x01` literal (1 byte),
+        // while the explicit-match catch-up walks past two more
+        // `0x42` bytes before firing (3 bytes total). Asserting both
+        // values keeps the regression locked to the exact path the
+        // fix was meant to preserve.
         assert_eq!(
             first_offset,
             Some(1),
@@ -1903,6 +1910,14 @@ mod tests {
              window_low=0 at block 0, NOT against the sentinel \
              prefix=1)",
         );
-        let _ = first_literals_len;
+        assert_eq!(
+            first_literals_len,
+            Some(2),
+            "first emit must have a 2-byte literal prefix \
+             ([0x01, 0x42]) — the rep-at-ip2 probe lands at ip2=3, \
+             then the one-byte backward extension drops new_ip to 2, \
+             so literals = data[0..2]. A different prefix length \
+             would indicate the explicit-match catch-up fired instead",
+        );
     }
 }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -561,12 +561,27 @@ impl FastKernelMatcher {
         // `ZSTD_getLowestPrefixIndex(ms, endIndex, windowLog)`
         // uses `windowLog` for the same reason.
         let advertised_window = 1usize << self.window_log;
-        let effective_prefix = self
-            .history
-            .len()
-            .saturating_sub(advertised_window)
-            .max(self.prefix_start_index as usize) as u32;
-        let prefix_start_index = effective_prefix;
+        // Donor's `windowLow` analogue: the absolute floor of in-window
+        // positions. Equals 0 at block 0 (no prior input retained) and
+        // advances as the window slides. Drives the prologue's
+        // `max_rep = ip0 - window_low` computation AND the backward-
+        // extension `match_pos > window_low` bound — both paths that
+        // donor expresses against `prefixStart` directly (NOT against
+        // a sentinel-1 floor).
+        let window_low = self.history.len().saturating_sub(advertised_window) as u32;
+        // Sentinel-aware prefix for the hash-table filter — match_idx
+        // == 0 (an uninitialized FastHashTable slot) must be rejected
+        // by `match_found`, so we floor at `INITIAL_PREFIX_START_INDEX
+        // = 1` when window_low is 0 (block 0 / pre-eviction blocks).
+        // For later blocks (window_low >= 1) the two values coincide.
+        //
+        // This SPLIT is the donor-parity fix for issue #220: using
+        // `prefix_start_index = 1` for the prologue's max_rep gave
+        // `max_rep = 0` at ip0=1, zeroing donor's default
+        // `rep_offset1 = 1` and disabling rep-at-ip2 for the entire
+        // first block. With `window_low = 0` we match donor exactly
+        // (`max_rep = 1`, rep_offset1 survives).
+        let prefix_start_index = window_low.max(self.prefix_start_index);
         let rep_in = self.rep;
         let mls = self.hash_table.mls();
 
@@ -635,6 +650,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -644,6 +660,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -653,6 +670,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -662,6 +680,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -671,6 +690,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -680,6 +700,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -689,6 +710,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -698,6 +720,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -707,6 +730,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -716,6 +740,7 @@ impl FastKernelMatcher {
                 history,
                 block_start,
                 prefix_start_index,
+                window_low,
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -1777,5 +1802,75 @@ mod tests {
             advertised_window,
             max_emitted_offset,
         );
+    }
+
+    /// Regression: at block 0 the kernel's prologue must NOT zero
+    /// `rep_offset1 = 1` (donor's default initial rep state). Donor
+    /// computes `max_rep = ip0 - windowLow` where `windowLow = 0` at
+    /// block 0, giving `max_rep = 1` at ip0=1 → `rep_offset1 = 1`
+    /// survives (`1 > 1` is false).
+    ///
+    /// Buggy prologue uses `max_rep = ip0 - prefix_start_index` with
+    /// `prefix_start_index = 1` (sentinel-0 floor for hash-table
+    /// filtering), giving `max_rep = 0` at ip0=1 → `rep_offset1 = 1 >
+    /// 0` → stashed → rep-at-ip2 probe disabled for the ENTIRE first
+    /// block.
+    ///
+    /// Symptom assertion: on a `[0x01, 0x42 × 199]` fixture, donor's
+    /// rep-at-ip2 fires at iter 1 (ip2=3, both `read32` reads see
+    /// `[42,42,42,42]`), emitting `Triple{literals=[0x01], offset=1,
+    /// match_len=~198}`. The buggy path skips rep, walks the cursor
+    /// via explicit-match shifts until matchIdx coincides at ip0=3
+    /// (iter 2 of inner loop, slot for `h([42,42,42,42])` was written
+    /// at ip0=2 in iter 1), then emits `Triple{literals=[0x01,
+    /// 0x42, 0x42], offset=1, ...}` — TWO extra literal bytes.
+    ///
+    /// The `literals.len() == 1` assertion is the bug discriminator:
+    /// uniform-byte data lets the explicit-match path eventually find
+    /// offset=1 too, so a check on offset alone passes both paths;
+    /// only the LITERAL PREFIX LENGTH reveals which path fired first.
+    #[test]
+    fn block_zero_prologue_preserves_default_rep_offset_one() {
+        let mut data = alloc::vec::Vec::with_capacity(200);
+        data.push(0x01);
+        data.resize(200, 0x42);
+
+        let mut m = FastKernelMatcher::with_params(12, 8, 4, 2);
+        m.accept_data(data.clone());
+
+        let mut first_literals_len: Option<usize> = None;
+        let mut first_offset: Option<usize> = None;
+        m.start_matching(|seq| {
+            if first_literals_len.is_some() {
+                return;
+            }
+            if let Sequence::Triple {
+                literals, offset, ..
+            } = seq
+            {
+                first_literals_len = Some(literals.len());
+                first_offset = Some(offset);
+            }
+        });
+
+        // The narrowest assertion that's stable under hash-slot
+        // collisions on uniform-byte inputs: the first emit MUST
+        // reference offset=1. With the prologue bug, the explicit-
+        // match path catches up via slot collision and still emits
+        // offset=1 (matching this assertion on simple fixtures), so
+        // the unit test only documents the contract — the real
+        // ratio-regression discriminator is the compare_ffi run on
+        // decodecorpus, where the cascade from the disabled rep
+        // probe shows up as ~36 missing matches in block 0.
+        assert_eq!(
+            first_offset,
+            Some(1),
+            "first emit must reference offset=1 — donor's default \
+             rep_offset1=1 fires on rep-at-ip2 at iter 1, and the \
+             prologue MUST NOT zero it (max_rep computed against \
+             window_low=0 at block 0, NOT against the sentinel \
+             prefix=1)",
+        );
+        let _ = first_literals_len;
     }
 }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -102,6 +102,14 @@ pub(crate) const HISTORY_DRAIN_BASE: usize = 0;
 /// initial state). Donor relies on its `ip0 += (ip0 == prefixStart)`
 /// bump to skip position 0 instead — both approaches match the same
 /// 0..N-1 byte ranges for the hash table.
+///
+/// Tradeoff: this rejects legitimate position-0 matches donor would
+/// emit (rare — requires `read32(ip0)` to coincidentally equal
+/// `read32(base)`), but cross-block isolation under
+/// `skip_matching_with_hint(None)` depends on the sentinel — the
+/// `skip_matching_with_none_hint_skips_hash_population` test
+/// exercises that contract. Lowering to 0 breaks the test; the
+/// position-0 emit rate is too small to be worth that breakage.
 const INITIAL_PREFIX_START_INDEX: u32 = 1;
 
 /// Donor-shape Fast-strategy matcher state.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1760,7 +1760,19 @@ mod tests {
         // bump max_window_size to reflect the dict-retention
         // budget (mirrors MatchGeneratorDriver::prime_with_dictionary
         // for the Simple backend).
-        let dict: alloc::vec::Vec<u8> = (0..200u8).map(|i| 0x40 + (i % 64)).collect();
+        //
+        // Pattern period 4 (`(i % 4)`) — dense enough that the donor-
+        // parity `kSearchStrength = 8` (K_STEP_INCR = 128) step
+        // doubling, which skips positions under step=3 in dict scan,
+        // still leaves matches hittable from block2: every position
+        // divisible by 4 inside the [in-window, hashed] subset writes
+        // the same hash slot, so the slot at block2's first probe
+        // contains a recent in-window dict position. Period 64 (the
+        // original fixture) only had matches at positions {0, 64,
+        // 128, 192} — positions 0, 64, 128 are below the sliding
+        // floor and 192 falls in the step-skip gap, leaving the test
+        // with zero emittable matches.
+        let dict: alloc::vec::Vec<u8> = (0..200u8).map(|i| 0x40 + (i % 4)).collect();
         m.accept_data(dict.clone());
         m.start_matching(|_| {}); // populate hash table from dict
         m.max_window_size = m.max_window_size.saturating_add(200);
@@ -1770,7 +1782,7 @@ mod tests {
         // ~history_len (200..300), since the inflated max_window
         // (328) keeps even the dict's earliest bytes inside the
         // sliding floor.
-        let block: alloc::vec::Vec<u8> = (0..100u8).map(|i| 0x40 + (i % 64)).collect();
+        let block: alloc::vec::Vec<u8> = (0..100u8).map(|i| 0x40 + (i % 4)).collect();
         m.accept_data(block);
 
         let mut max_emitted_offset = 0usize;

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -649,8 +649,10 @@ impl FastKernelMatcher {
             (4, false) => compress_block_fast::<4, false>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -659,8 +661,10 @@ impl FastKernelMatcher {
             (4, true) => compress_block_fast::<4, true>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -669,8 +673,10 @@ impl FastKernelMatcher {
             (5, false) => compress_block_fast::<5, false>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -679,8 +685,10 @@ impl FastKernelMatcher {
             (5, true) => compress_block_fast::<5, true>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -689,8 +697,10 @@ impl FastKernelMatcher {
             (6, false) => compress_block_fast::<6, false>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -699,8 +709,10 @@ impl FastKernelMatcher {
             (6, true) => compress_block_fast::<6, true>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -709,8 +721,10 @@ impl FastKernelMatcher {
             (7, false) => compress_block_fast::<7, false>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -719,8 +733,10 @@ impl FastKernelMatcher {
             (7, true) => compress_block_fast::<7, true>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -729,8 +745,10 @@ impl FastKernelMatcher {
             (8, false) => compress_block_fast::<8, false>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,
@@ -739,8 +757,10 @@ impl FastKernelMatcher {
             (8, true) => compress_block_fast::<8, true>(
                 history,
                 block_start,
-                prefix_start_index,
-                window_low,
+                super::fast_kernel::kernel::PrefixBounds {
+                    prefix_start_index,
+                    window_low,
+                },
                 hash_table,
                 rep_in,
                 self.step_size,

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -257,19 +257,24 @@ impl StrategyTag {
     ///
     /// Matches `LEVEL_TABLE` in `match_generator.rs` and the donor
     /// `clevels.h` table:
-    /// * 1 → `Fast`
-    /// * 2-3 → `Dfast`
-    /// * 4 → `Greedy`
-    /// * 5-15 → `Lazy`
+    /// Mirrors donor `ZSTD_defaultCParameters[0]` (srcSize > 256 KiB
+    /// tier) strategy column at `zstd/lib/compress/clevels.h:25-50`:
+    ///
+    /// * 1-2 → `Fast`
+    /// * 3-4 → `Dfast`
+    /// * 5 → `Greedy`
+    /// * 6-15 → `Lazy` (donor splits 6/7=lazy, 8-12=lazy2,
+    ///   13-15=btlazy2; we collapse all three onto our `Lazy` tag and
+    ///   carry the lazy_depth variance via `LevelParams.lazy_depth`)
     /// * 16-17 → `BtOpt`
     /// * 18-19 → `BtUltra`
     /// * 20-22 → `BtUltra2`
     pub(crate) const fn for_level(level: u8) -> Self {
         match level {
-            1 => Self::Fast,
-            2 | 3 => Self::Dfast,
-            4 => Self::Greedy,
-            5..=15 => Self::Lazy,
+            1 | 2 => Self::Fast,
+            3 | 4 => Self::Dfast,
+            5 => Self::Greedy,
+            6..=15 => Self::Lazy,
             16 | 17 => Self::BtOpt,
             18 | 19 => Self::BtUltra,
             _ => Self::BtUltra2,
@@ -367,10 +372,10 @@ mod tests {
     fn level_to_tag_matches_donor_table() {
         // Spot-check every band boundary and one mid-band level.
         assert_eq!(StrategyTag::for_level(1), StrategyTag::Fast);
-        assert_eq!(StrategyTag::for_level(2), StrategyTag::Dfast);
+        assert_eq!(StrategyTag::for_level(2), StrategyTag::Fast);
         assert_eq!(StrategyTag::for_level(3), StrategyTag::Dfast);
-        assert_eq!(StrategyTag::for_level(4), StrategyTag::Greedy);
-        assert_eq!(StrategyTag::for_level(5), StrategyTag::Lazy);
+        assert_eq!(StrategyTag::for_level(4), StrategyTag::Dfast);
+        assert_eq!(StrategyTag::for_level(5), StrategyTag::Greedy);
         assert_eq!(StrategyTag::for_level(9), StrategyTag::Lazy);
         assert_eq!(StrategyTag::for_level(15), StrategyTag::Lazy);
         assert_eq!(StrategyTag::for_level(16), StrategyTag::BtOpt);

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -87,6 +87,14 @@ pub(crate) struct HufCStream<'a> {
     /// flushes skip the check; `FAST=false` clamps `cursor = end_ptr`
     /// on overflow (donor's `if (!kFast && ptr > endPtr) ptr = endPtr`).
     end_ptr: usize,
+    /// Set to `true` by `flush_bits::<false>` when the clamp at
+    /// `cursor > end_ptr` actually fires. `close()` uses this flag to
+    /// emit donor's overflow result (return 0). Without it, the clamp
+    /// would mask overflow: post-clamp `cursor == end_ptr`, so a
+    /// `cursor >= end_ptr + 8` post-flush check could never fire, and
+    /// an undersized `dst_capacity` would silently succeed with a
+    /// truncated stream.
+    overflow: bool,
 }
 
 impl<'a> HufCStream<'a> {
@@ -116,6 +124,7 @@ impl<'a> HufCStream<'a> {
             start_idx,
             cursor: start_idx,
             end_ptr: start_idx + dst_capacity - 8,
+            overflow: false,
         })
     }
 
@@ -200,6 +209,7 @@ impl<'a> HufCStream<'a> {
         self.cursor += nb_bytes;
         if !FAST && self.cursor > self.end_ptr {
             self.cursor = self.end_ptr;
+            self.overflow = true;
         }
     }
 
@@ -221,11 +231,16 @@ impl<'a> HufCStream<'a> {
         self.add_bits::<false>(end_mark, 0);
         self.flush_bits::<false>();
         let nb_bits = self.pending_bits();
-        if self.cursor >= self.end_ptr + 8 {
-            // Overflow — donor returns 0. `start_idx == output.len()`
-            // pre-construction (no `resize` was done; we wrote into
-            // spare capacity), so no truncate is needed — the Vec's
-            // logical length is already correct.
+        if self.overflow {
+            // Overflow — donor returns 0. The clamp in
+            // `flush_bits::<false>` already capped `cursor` at
+            // `end_ptr`, so a post-flush `cursor >= end_ptr + 8`
+            // check would never fire — we rely on the explicit
+            // `overflow` flag set at the moment of the clamp.
+            // `start_idx == output.len()` pre-construction (no
+            // `resize` was done; we wrote into spare capacity), so
+            // no truncate is needed — the Vec's logical length is
+            // already correct.
             return 0;
         }
         // Total bytes: full bytes flushed + (1 byte for trailing partial bits).

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -102,12 +102,13 @@ impl<'a> HufCStream<'a> {
         }
         let start_idx = output.len();
         // Reserve capacity for the worst-case write + 8 byte flush slack.
-        // The Vec must have `start_idx + dst_capacity` bytes addressable
-        // for our raw pointer writes.
+        // We DO NOT pre-zero (`resize`) the spare capacity — the hot
+        // path writes via raw pointers into the spare slots and
+        // `close()` calls `set_len` only after committing the actual
+        // byte count. For large literal sections (table_log=11 → up
+        // to 2.7 MiB per stream), the eager memset was a measurable
+        // regression on the worker hot path.
         output.reserve(dst_capacity);
-        // Zero-extend so the bytes are valid (Vec invariant: `len`
-        // bytes are initialized). We'll truncate back in `finalize`.
-        output.resize(start_idx + dst_capacity, 0);
         Some(Self {
             bit_container: [0, 0],
             bit_pos: [0, 0],
@@ -187,10 +188,15 @@ impl<'a> HufCStream<'a> {
         // 8-byte LE write at `cursor`. Bytes at [cursor+nb_bytes..cursor+8]
         // are overwritten by the next flush; we don't care about them.
         let bytes = bit_container.to_le_bytes();
-        // SAFETY: `cursor + 8 <= output.capacity()` (and `<= output.len()`
-        // by the resize at construction); the slice is valid for write.
-        let dst = &mut self.output[self.cursor..self.cursor + 8];
-        dst.copy_from_slice(&bytes);
+        // SAFETY: `new()` reserved `dst_capacity` bytes via
+        // `Vec::reserve` (without zeroing), so `cursor + 8 <=
+        // start_idx + dst_capacity <= output.capacity()`. The write
+        // targets uninitialised spare capacity; `close()` reconciles
+        // `len` afterwards.
+        unsafe {
+            let dst = self.output.as_mut_ptr().add(self.cursor);
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), dst, 8);
+        }
         self.cursor += nb_bytes;
         if !FAST && self.cursor > self.end_ptr {
             self.cursor = self.end_ptr;
@@ -216,14 +222,22 @@ impl<'a> HufCStream<'a> {
         self.flush_bits::<false>();
         let nb_bits = self.pending_bits();
         if self.cursor >= self.end_ptr + 8 {
-            // Overflow — donor returns 0.
-            self.output.truncate(self.start_idx);
+            // Overflow — donor returns 0. `start_idx == output.len()`
+            // pre-construction (no `resize` was done; we wrote into
+            // spare capacity), so no truncate is needed — the Vec's
+            // logical length is already correct.
             return 0;
         }
         // Total bytes: full bytes flushed + (1 byte for trailing partial bits).
         let bytes_written = (self.cursor - self.start_idx) + usize::from(nb_bits > 0);
-        // Truncate output to the actual bytes used.
-        self.output.truncate(self.start_idx + bytes_written);
+        // Commit the previously-uninitialised spare-capacity writes
+        // by advancing `len`. SAFETY: `flush_bits` wrote exactly
+        // `bytes_written` bytes into spare capacity at positions
+        // [start_idx, start_idx + bytes_written), all within
+        // `output.capacity()` per the reserve in `new()`.
+        unsafe {
+            self.output.set_len(self.start_idx + bytes_written);
+        }
         bytes_written
     }
 }

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -59,8 +59,12 @@ pub(crate) fn pack_huf_celt(value: u32, nb_bits: u8) -> u64 {
 ///
 /// Operates directly on a borrowed `Vec<u8>` — the caller pre-reserves
 /// enough capacity so the hot path can do unchecked 8-byte writes via
-/// raw pointer without growing the Vec. `finalize` truncates back to
-/// the exact `bytes_written` count.
+/// raw pointer without growing the Vec. [`Self::close`] is the
+/// finalization API: it bumps `Vec::len()` once to the exact
+/// `bytes_written` count (from the construction-time `start_idx`),
+/// surfacing the committed bytes to safe Rust readers. Until `close`
+/// runs, `Vec::len()` stays at its construction-time value and all
+/// raw-pointer writes target spare capacity past `len`.
 ///
 /// Lifetime / borrow rules: holds `output: &mut Vec<u8>` for its
 /// lifetime; caller must finish all encoding work via this stream
@@ -74,18 +78,23 @@ pub(crate) struct HufCStream<'a> {
     /// carry "dirty" noise from donor's `nbBitsFast` trick and must
     /// be masked with `0xFF` on read.
     bit_pos: [u64; 2],
-    /// Output buffer. `cursor` indexes into this Vec; we keep
-    /// `Vec::len()` in sync after every flush so the buffer always
-    /// reflects bytes actually written.
+    /// Output buffer. `cursor` indexes into this Vec; `Vec::len()`
+    /// stays at the construction-time value through the entire
+    /// add/flush cycle and is advanced ONCE by [`Self::close`] via
+    /// `set_len(start_idx + bytes_written)`. In-flight bytes live
+    /// in spare capacity past `len`.
     output: &'a mut Vec<u8>,
     /// Byte index of the first byte this stream writes (= `output.len()`
-    /// at construction). Used to compute `bytes_written` in `finalize`.
+    /// at construction). Used to compute `bytes_written` in `close`.
     start_idx: usize,
     /// Current write cursor. Always satisfies
     /// `start_idx <= cursor <= output.capacity()`. Bytes in
-    /// `output[start_idx..cursor]` are committed; bytes in
-    /// `output[cursor..cursor+8]` are scratch the next flush will
-    /// overwrite.
+    /// `output[start_idx..cursor]` ARE committed by raw-pointer
+    /// writes but NOT yet reflected in `output.len()` (which still
+    /// points at `start_idx`); bytes in `output[cursor..cursor+8]`
+    /// are scratch the next flush will overwrite. `close` is the
+    /// only call that bumps `len` and surfaces the committed bytes
+    /// to safe Rust readers of the `Vec`.
     cursor: usize,
     /// `cursor` must never reach this value — beyond it the 8-byte
     /// flush write would overrun the reserved capacity. `FAST=true`
@@ -277,11 +286,6 @@ mod tests {
         s.add_bits::<false>(elt, 0);
         let n = s.close();
         assert!(n > 0);
-        // Value 0b1011 (4 bits) + end-mark 1 (1 bit) = 5 bits used in container.
-        // After flush: container top-5 bits = [1011, 1] (high→low), written
-        // to output as low byte: bits packed top-down → low byte = 0b1011_1000
-        // = 0xB8 (after the closing flush, the partial 5 bits become the
-        // single tail byte; close() pads to full byte).
         assert_eq!(out.len(), 1);
         // Donor `HUF_addBits` + `HUF_flushBits` layout (top-down
         // packing in the 64-bit container, then `flushBits` shifts

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -283,9 +283,24 @@ mod tests {
         // = 0xB8 (after the closing flush, the partial 5 bits become the
         // single tail byte; close() pads to full byte).
         assert_eq!(out.len(), 1);
-        // The exact byte value depends on the bit packing order. Donor
-        // emits the same byte as we will — the test is mainly a
-        // smoke test that close() doesn't OOB.
+        // Donor `HUF_addBits` + `HUF_flushBits` layout (top-down
+        // packing in the 64-bit container, then `flushBits` shifts
+        // the buffered bits down to the bottom of a 0-padded word
+        // and `MEM_writeLE` stores 8 bytes little-endian — emitted
+        // byte 0 is the LOW byte of that word):
+        //
+        // After `add_bits(pack_huf_celt(0b1011, 4), 0)`:
+        //   container top 4 bits = 0b1011, bit_pos = 4
+        // After `close()` prepends end-mark `(value=1, nb_bits=1)`:
+        //   container top 5 bits = [1, 1, 0, 1, 1] (high → low),
+        //   bit_pos = 5
+        // `flush_bits` then `container >> (64 - 5)` produces 0b11011
+        // = 27 = 0x1B, which lands in `out[0]`.
+        assert_eq!(
+            out[0], 0x1B,
+            "first emitted byte must mirror donor's HUF_addBits + \
+             HUF_endMark packing collapsed to a 5-bit prefix 0b11011",
+        );
     }
 
     /// Encode multiple symbols summing to > 64 bits; expect the

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -25,9 +25,14 @@
 
 use alloc::vec::Vec;
 
-/// Donor `HUF_BITS_IN_CONTAINER = sizeof(size_t) * 8`. We commit to 64
-/// (donor's `MEM_32bits()` path is irrelevant on the targets we care
-/// about — every host that runs production zstd is 64-bit).
+/// Donor `HUF_BITS_IN_CONTAINER = sizeof(size_t) * 8`. We hard-code 64
+/// regardless of target pointer width. Donor's `MEM_32bits()` branch
+/// switches the container to `u32` on 32-bit hosts; this crate's CI
+/// includes i686, but a 32-bit `usize` host can still operate a 64-bit
+/// arithmetic accumulator — the container is just `u64`, not
+/// `[u8; size_of::<usize>()]`. Skipping the 32-bit branch keeps the
+/// type signatures uniform across targets and matches the speed of
+/// the 64-bit hot path on all supported architectures.
 pub(crate) const HUF_BITS_IN_CONTAINER: usize = 64;
 
 /// Donor `HUF_TABLELOG_ABSOLUTEMAX = 12` (defined in `common/huf.h`).

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -1,0 +1,295 @@
+//! Donor-faithful port of `HUF_CStream_t` from `lib/compress/huf_compress.c`.
+//!
+//! Three differences vs the generic `BitWriter`:
+//!
+//! 1. `add_bits` takes a packed `HUF_CElt` (`u64`) where the bottom 8 bits
+//!    hold `nb_bits` and the top `(64 - nb_bits)` bits hold the value
+//!    left-shifted to the high end of the word. Allows a single
+//!    `shr + or + add` per symbol on x86_64 BMI2.
+//! 2. The bit container is filled from the TOP DOWN (donor convention).
+//!    To add an N-bit value: `container >>= N; container |= value`.
+//! 3. Two indexed containers (`bit_container[0]` and `bit_container[1]`).
+//!    Caller can encode into both in parallel (breaking data dependencies)
+//!    then merge before flushing — the trick donor uses in the unrolled
+//!    `HUF_compress1X_usingCTable_internal_body_loop` to extract
+//!    instruction-level parallelism.
+//!
+//! All hot-path methods are `#[inline(always)]` and accept a const
+//! generic `FAST: bool`. `FAST=true` skips the bottom-8-bit mask on the
+//! incoming value AND skips the `ptr > end_ptr` overflow check on
+//! flush; caller must guarantee a-priori that the bit container has
+//! at least `HUF_TABLELOG_ABSOLUTEMAX = 12` free bits before the add
+//! and that the output buffer has 8 bytes of slack before the flush.
+//!
+//! Donor reference: `lib/compress/huf_compress.c:824-983`.
+
+use alloc::vec::Vec;
+
+/// Donor `HUF_BITS_IN_CONTAINER = sizeof(size_t) * 8`. We commit to 64
+/// (donor's `MEM_32bits()` path is irrelevant on the targets we care
+/// about — every host that runs production zstd is 64-bit).
+pub(crate) const HUF_BITS_IN_CONTAINER: usize = 64;
+
+/// Donor `HUF_TABLELOG_ABSOLUTEMAX = 12` (defined in `common/huf.h`).
+pub(crate) const HUF_TABLELOG_ABSOLUTEMAX: usize = 12;
+
+/// Packed Huffman code element matching donor `HUF_CElt`:
+/// - Bits [0, 8)            = `nb_bits`
+/// - Bits [8, 64 - nb_bits) = 0
+/// - Bits [64 - nb_bits, 64) = `value`
+///
+/// Donor `HUF_setNbBits` / `HUF_setValue` in `huf_compress.c:208-221`.
+#[inline(always)]
+pub(crate) fn pack_huf_celt(value: u32, nb_bits: u8) -> u64 {
+    debug_assert!((nb_bits as usize) <= HUF_TABLELOG_ABSOLUTEMAX);
+    if nb_bits == 0 {
+        return 0;
+    }
+    let nb = nb_bits as u64;
+    debug_assert!((value as u64) >> nb == 0, "value must fit in nb_bits");
+    nb | ((value as u64) << (HUF_BITS_IN_CONTAINER as u64 - nb))
+}
+
+/// Dual-container bit packer matching donor `HUF_CStream_t`.
+///
+/// Operates directly on a borrowed `Vec<u8>` — the caller pre-reserves
+/// enough capacity so the hot path can do unchecked 8-byte writes via
+/// raw pointer without growing the Vec. `finalize` truncates back to
+/// the exact `bytes_written` count.
+///
+/// Lifetime / borrow rules: holds `output: &mut Vec<u8>` for its
+/// lifetime; caller must finish all encoding work via this stream
+/// before any other access to the Vec.
+pub(crate) struct HufCStream<'a> {
+    /// Top-down bit accumulators. New bits go into the high (top)
+    /// `nb_bits` of `container[idx]`. Container is right-shifted by
+    /// `nb_bits` before each `add` to make room at the top.
+    bit_container: [u64; 2],
+    /// Bit-count counters. ONLY the low 8 bits are real; upper bits
+    /// carry "dirty" noise from donor's `nbBitsFast` trick and must
+    /// be masked with `0xFF` on read.
+    bit_pos: [u64; 2],
+    /// Output buffer. `cursor` indexes into this Vec; we keep
+    /// `Vec::len()` in sync after every flush so the buffer always
+    /// reflects bytes actually written.
+    output: &'a mut Vec<u8>,
+    /// Byte index of the first byte this stream writes (= `output.len()`
+    /// at construction). Used to compute `bytes_written` in `finalize`.
+    start_idx: usize,
+    /// Current write cursor. Always satisfies
+    /// `start_idx <= cursor <= output.capacity()`. Bytes in
+    /// `output[start_idx..cursor]` are committed; bytes in
+    /// `output[cursor..cursor+8]` are scratch the next flush will
+    /// overwrite.
+    cursor: usize,
+    /// `cursor` must never reach this value — beyond it the 8-byte
+    /// flush write would overrun the reserved capacity. `FAST=true`
+    /// flushes skip the check; `FAST=false` clamps `cursor = end_ptr`
+    /// on overflow (donor's `if (!kFast && ptr > endPtr) ptr = endPtr`).
+    end_ptr: usize,
+}
+
+impl<'a> HufCStream<'a> {
+    /// Donor `HUF_initCStream`. Requires `output.capacity() >=
+    /// output.len() + dst_capacity` AND `dst_capacity > 8` (else
+    /// returns `None`, mirroring donor's `ERROR(dstSize_tooSmall)`).
+    ///
+    /// `dst_capacity` is the upper bound on bytes this stream may write;
+    /// donor uses `HUF_tightCompressBound(srcSize, tableLog) + 8` slack.
+    pub(crate) fn new(output: &'a mut Vec<u8>, dst_capacity: usize) -> Option<Self> {
+        if dst_capacity <= 8 {
+            return None;
+        }
+        let start_idx = output.len();
+        // Reserve capacity for the worst-case write + 8 byte flush slack.
+        // The Vec must have `start_idx + dst_capacity` bytes addressable
+        // for our raw pointer writes.
+        output.reserve(dst_capacity);
+        // Zero-extend so the bytes are valid (Vec invariant: `len`
+        // bytes are initialized). We'll truncate back in `finalize`.
+        output.resize(start_idx + dst_capacity, 0);
+        Some(Self {
+            bit_container: [0, 0],
+            bit_pos: [0, 0],
+            output,
+            start_idx,
+            cursor: start_idx,
+            end_ptr: start_idx + dst_capacity - 8,
+        })
+    }
+
+    /// Donor `HUF_addBits`: insert `elt`'s value into the top `nb_bits`
+    /// of `bit_container[idx]`.
+    ///
+    /// `FAST=true` matches donor's `kFast=1`: caller guarantees ≥ 4
+    /// free bits remain in the container post-add, so we can skip the
+    /// `& !0xFF` value mask. Donor uses `HUF_getValueFast` here which
+    /// is just `elt` (dirty bottom 8 bits get shifted out by the next
+    /// container shr anyway).
+    #[inline(always)]
+    pub(crate) fn add_bits<const FAST: bool>(&mut self, elt: u64, idx: usize) {
+        debug_assert!(idx <= 1);
+        let nb_bits = elt & 0xFF;
+        debug_assert!((nb_bits as usize) <= HUF_TABLELOG_ABSOLUTEMAX);
+        // Make room at the top by right-shifting the container.
+        // SAFETY: `nb_bits <= 12 < 64`, so the shift amount is in range.
+        self.bit_container[idx] >>= nb_bits;
+        // OR in the value. In FAST mode the bottom 8 bits of `elt`
+        // (which hold nb_bits) are "dirty" but they land in the
+        // already-occupied lower portion that the next shr will
+        // overwrite — donor's `HUF_getValueFast` exploits this.
+        let value = if FAST { elt } else { elt & !0xFFu64 };
+        self.bit_container[idx] |= value;
+        // Donor `HUF_getNbBitsFast(elt) = elt` — we accumulate the
+        // whole word; only the low 8 bits of `bit_pos` are real on
+        // any subsequent read (always masked with `0xFF`).
+        let nb_add = if FAST { elt } else { nb_bits };
+        self.bit_pos[idx] = self.bit_pos[idx].wrapping_add(nb_add);
+    }
+
+    /// Donor `HUF_zeroIndex1`.
+    #[inline(always)]
+    pub(crate) fn zero_index1(&mut self) {
+        self.bit_container[1] = 0;
+        self.bit_pos[1] = 0;
+    }
+
+    /// Donor `HUF_mergeIndex1`: fold `bit_container[1]` into `[0]`.
+    #[inline(always)]
+    pub(crate) fn merge_index1(&mut self) {
+        let nb_bits_1 = self.bit_pos[1] & 0xFF;
+        self.bit_container[0] >>= nb_bits_1;
+        self.bit_container[0] |= self.bit_container[1];
+        self.bit_pos[0] = self.bit_pos[0].wrapping_add(self.bit_pos[1]);
+    }
+
+    /// Donor `HUF_flushBits`: write the top `nb_bytes` of
+    /// `bit_container[0]` to `output[cursor..cursor+8]`, advance
+    /// `cursor` by `nb_bytes`, keep the trailing `< 8` bits in the
+    /// container for the next flush.
+    ///
+    /// `FAST=true` skips the `cursor > end_ptr` overflow clamp; caller
+    /// must have pre-sized the buffer to guarantee no overrun.
+    #[inline(always)]
+    pub(crate) fn flush_bits<const FAST: bool>(&mut self) {
+        let nb_bits = (self.bit_pos[0] & 0xFF) as usize;
+        let nb_bytes = nb_bits >> 3;
+        // Top `nb_bits` of the container become the next bytes.
+        // Donor uses `bitContainer >> (HUF_BITS_IN_CONTAINER - nb_bits)`.
+        // Guard the shift: `nb_bits == 0` would shift by 64 (UB in Rust).
+        let bit_container = if nb_bits == 0 {
+            0
+        } else {
+            self.bit_container[0] >> (HUF_BITS_IN_CONTAINER - nb_bits)
+        };
+        // Mask `bit_pos` to keep the leftover < 8 bits in the low 3 bits.
+        self.bit_pos[0] &= 7;
+        // 8-byte LE write at `cursor`. Bytes at [cursor+nb_bytes..cursor+8]
+        // are overwritten by the next flush; we don't care about them.
+        let bytes = bit_container.to_le_bytes();
+        // SAFETY: `cursor + 8 <= output.capacity()` (and `<= output.len()`
+        // by the resize at construction); the slice is valid for write.
+        let dst = &mut self.output[self.cursor..self.cursor + 8];
+        dst.copy_from_slice(&bytes);
+        self.cursor += nb_bytes;
+        if !FAST && self.cursor > self.end_ptr {
+            self.cursor = self.end_ptr;
+        }
+    }
+
+    /// Number of bits currently buffered in `bit_container[0]`.
+    /// Useful for the close-stream finalization (donor writes a final
+    /// partial byte if bits remain).
+    #[inline(always)]
+    pub(crate) fn pending_bits(&self) -> usize {
+        (self.bit_pos[0] & 0xFF) as usize
+    }
+
+    /// Donor `HUF_closeCStream`: append the 1-bit end marker (value=1,
+    /// nb_bits=1), final flush, return total bytes written. Returns 0
+    /// on overflow (donor convention).
+    pub(crate) fn close(mut self) -> usize {
+        // Donor `HUF_endMark()` returns a HUF_CElt with nbBits=1, value=1.
+        // Packed: low byte = 1 (nb_bits), top bit of u64 = 1 (value).
+        let end_mark: u64 = 1u64 | (1u64 << (HUF_BITS_IN_CONTAINER as u64 - 1));
+        self.add_bits::<false>(end_mark, 0);
+        self.flush_bits::<false>();
+        let nb_bits = self.pending_bits();
+        if self.cursor >= self.end_ptr + 8 {
+            // Overflow — donor returns 0.
+            self.output.truncate(self.start_idx);
+            return 0;
+        }
+        // Total bytes: full bytes flushed + (1 byte for trailing partial bits).
+        let bytes_written = (self.cursor - self.start_idx) + usize::from(nb_bits > 0);
+        // Truncate output to the actual bytes used.
+        self.output.truncate(self.start_idx + bytes_written);
+        bytes_written
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Roundtrip a single short symbol through HufCStream and verify
+    /// the byte output decodes back to the same bit pattern.
+    #[test]
+    fn add_bits_single_symbol_emits_correct_byte() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut s = HufCStream::new(&mut out, 64).expect("init ok");
+        // Symbol: nb_bits=4, value=0b1011 (11). Packed: low=4, top=11<<60.
+        let elt = pack_huf_celt(0b1011, 4);
+        s.add_bits::<false>(elt, 0);
+        let n = s.close();
+        assert!(n > 0);
+        // Value 0b1011 (4 bits) + end-mark 1 (1 bit) = 5 bits used in container.
+        // After flush: container top-5 bits = [1011, 1] (high→low), written
+        // to output as low byte: bits packed top-down → low byte = 0b1011_1000
+        // = 0xB8 (after the closing flush, the partial 5 bits become the
+        // single tail byte; close() pads to full byte).
+        assert_eq!(out.len(), 1);
+        // The exact byte value depends on the bit packing order. Donor
+        // emits the same byte as we will — the test is mainly a
+        // smoke test that close() doesn't OOB.
+    }
+
+    /// Encode multiple symbols summing to > 64 bits; expect the
+    /// container to flush partway and write whole bytes to output.
+    #[test]
+    fn add_bits_overflowing_container_flushes_correctly() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut s = HufCStream::new(&mut out, 256).expect("init ok");
+        // 8 symbols of 8 bits each = 64 bits — exactly fills container.
+        for i in 0..8 {
+            let elt = pack_huf_celt(i as u32, 8);
+            s.add_bits::<false>(elt, 0);
+        }
+        s.flush_bits::<false>();
+        // After flushing 64 bits = 8 bytes; cursor advanced 8.
+        assert_eq!(s.cursor - s.start_idx, 8);
+        // pending bits should be 0 (cleanly flushed).
+        assert_eq!(s.pending_bits(), 0);
+        let n = s.close();
+        // close adds 1-bit end mark + flush → 1 trailing byte for end mark.
+        assert!(n >= 8);
+    }
+
+    /// Dual-container parallel encode: add to idx=1, merge, verify the
+    /// merged stream contains both sub-streams concatenated.
+    #[test]
+    fn merge_index1_concatenates_streams() {
+        let mut out: Vec<u8> = Vec::new();
+        let mut s = HufCStream::new(&mut out, 64).expect("init ok");
+        // Stream 0: 4-bit value 0b1100 (12)
+        s.add_bits::<false>(pack_huf_celt(0b1100, 4), 0);
+        // Stream 1: 4-bit value 0b0011 (3)
+        s.zero_index1();
+        s.add_bits::<false>(pack_huf_celt(0b0011, 4), 1);
+        // Merge: stream0 should now contain 8 bits (stream0's 4 + stream1's 4).
+        s.merge_index1();
+        assert_eq!(s.pending_bits(), 8);
+        let n = s.close();
+        assert!(n > 0);
+    }
+}

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -107,6 +107,20 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
                 Self::encode_one_stream(packed_codes, &mut bit_c, segment, table_log);
                 bit_c.close()
             });
+            // Donor `HUF_CStream_close` returns 0 on overflow (the
+            // dst_capacity was exhausted before close completed) and
+            // truncates the output back to the segment start. Our
+            // `huf_tight_compress_bound` is sized exactly per donor's
+            // spec, so this branch is unreachable under a correctly
+            // sized buffer — but if a future change ever mis-sizes
+            // the bound, silently emitting a 0-length stream would
+            // produce an invalid jump table that decompresses to
+            // garbage. Panic loudly instead.
+            assert!(
+                bytes_written > 0,
+                "HufCStream::close overflowed dst_capacity for segment {i}; \
+                 huf_tight_compress_bound is undersized for table_log={table_log}",
+            );
             if i < 3 {
                 assert!(
                     bytes_written <= u16::MAX as usize,

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -102,8 +102,19 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
         for (i, segment) in segments.iter().enumerate() {
             let bytes_written = self.writer.with_aligned_output_mut(|output| {
                 let dst_capacity = Self::huf_tight_compress_bound(segment.len(), table_log);
-                let mut bit_c = super::huf_cstream::HufCStream::new(output, dst_capacity)
-                    .expect("output buffer is too small to fit Huffman stream");
+                // `HufCStream::new` returns `None` only when
+                // `dst_capacity <= 8` (8-byte flush slack would have
+                // nowhere to go). Capacity itself is reserved
+                // inside `new` via `Vec::reserve(dst_capacity)`, so
+                // there is no "output buffer too small" failure mode
+                // — the only way to trip this is the upstream
+                // `huf_tight_compress_bound` returning ≤ 8 bytes,
+                // which it never does for a non-empty segment under
+                // `table_log >= 1` (formula: src*table_log/8 + 24).
+                let mut bit_c = super::huf_cstream::HufCStream::new(output, dst_capacity).expect(
+                    "HufCStream::new returned None — dst_capacity (from \
+                         huf_tight_compress_bound) must be > 8 for a non-empty segment",
+                );
                 Self::encode_one_stream(packed_codes, &mut bit_c, segment, table_log);
                 bit_c.close()
             });

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -46,56 +46,219 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
         Self::encode_stream(self.table, self.writer, data);
     }
 
-    /// Encodes the data using the provided table in 4 concatenated streams
-    /// Writes
-    /// * Table description
-    /// * Jumptable
-    /// * Encoded data in 4 streams, each padded to fill the last byte
+    /// Encodes the data using the provided table in 4 concatenated streams.
+    ///
+    /// Donor-faithful port of `HUF_compress4X_usingCTable_internal_body`
+    /// (`huf_compress.c:1169-1216`): emits the table description (if
+    /// requested), a 6-byte jump-table placeholder, then four
+    /// independent 1X Huffman bitstreams via the unrolled
+    /// dual-container loop in [`Self::encode_one_stream`]. Stream
+    /// sizes are patched back into the jump table after encoding.
+    ///
+    /// Donor's `HUF_compress1X_usingCTable_internal_body_loop` (lines
+    /// 991-1043) extracts ILP by encoding `kUnroll` symbols into
+    /// `bitContainer[0]` and another `kUnroll` symbols into
+    /// `bitContainer[1]` in parallel, then merging — breaking the
+    /// data dependency that a single accumulator would impose. We
+    /// mirror that here via `HufCStream::add_bits<FAST=true>` +
+    /// `zero_index1` / `merge_index1`.
+    ///
+    /// `kUnroll` choice mirrors donor's `tableLog`-driven dispatch
+    /// (`huf_compress.c:1077-1108`) so each instantiation keeps the
+    /// container's per-symbol nb_bits sum below 64 - 4 (the donor "≥
+    /// 4 free bits" precondition for `kFast=1`).
     pub fn encode4x(&mut self, data: &[u8], with_table: bool) {
-        assert!(data.len() >= 4);
+        assert!(
+            data.len() >= 12,
+            "donor HUF_compress4X requires srcSize >= 12"
+        );
 
-        // Split data in 4 equally sized parts (the last one might be a bit smaller than the rest)
-        let split_size = data.len().div_ceil(4);
-        let src1 = &data[..split_size];
-        let src2 = &data[split_size..split_size * 2];
-        let src3 = &data[split_size * 2..split_size * 3];
-        let src4 = &data[split_size * 3..];
-
-        // Write table description
         if with_table {
             self.write_table();
         }
 
-        // Reserve space for the jump table, will be changed later
-        let size_idx = self.writer.index();
+        // Donor's jump table: 3 × u16 LE sizes (size1, size2, size3);
+        // size4 is implicit from total - sum. Reserve 6 bytes here,
+        // patch in after each stream finishes.
+        let jt_bit_idx = self.writer.index();
         self.writer.write_bits(0u16, 16);
         self.writer.write_bits(0u16, 16);
         self.writer.write_bits(0u16, 16);
 
-        // Write the 4 streams, noting the sizes of the encoded streams
-        let index_before = self.writer.index();
-        Self::encode_stream(self.table, self.writer, src1);
-        let size1 = (self.writer.index() - index_before) / 8;
+        // Donor: `segmentSize = (srcSize + 3) / 4` for the first 3
+        // segments; last segment takes whatever remains.
+        let segment_size = data.len().div_ceil(4);
+        let segments = [
+            &data[..segment_size],
+            &data[segment_size..segment_size * 2],
+            &data[segment_size * 2..segment_size * 3],
+            &data[segment_size * 3..],
+        ];
 
-        let index_before = self.writer.index();
-        Self::encode_stream(self.table, self.writer, src2);
-        let size2 = (self.writer.index() - index_before) / 8;
+        let table_log = self.table.table_log();
+        let packed_codes = self.table.packed_codes();
+        let mut stream_sizes = [0u16; 3];
 
-        let index_before = self.writer.index();
-        Self::encode_stream(self.table, self.writer, src3);
-        let size3 = (self.writer.index() - index_before) / 8;
+        for (i, segment) in segments.iter().enumerate() {
+            let bytes_written = self.writer.with_aligned_output_mut(|output| {
+                let dst_capacity = Self::huf_tight_compress_bound(segment.len(), table_log);
+                let mut bit_c = super::huf_cstream::HufCStream::new(output, dst_capacity)
+                    .expect("output buffer is too small to fit Huffman stream");
+                Self::encode_one_stream(packed_codes, &mut bit_c, segment, table_log);
+                bit_c.close()
+            });
+            if i < 3 {
+                assert!(
+                    bytes_written <= u16::MAX as usize,
+                    "Huffman stream exceeded 64 KiB jump-table limit",
+                );
+                stream_sizes[i] = bytes_written as u16;
+            }
+        }
 
-        Self::encode_stream(self.table, self.writer, src4);
+        self.writer.change_bits(jt_bit_idx, stream_sizes[0], 16);
+        self.writer
+            .change_bits(jt_bit_idx + 16, stream_sizes[1], 16);
+        self.writer
+            .change_bits(jt_bit_idx + 32, stream_sizes[2], 16);
+    }
 
-        // Sanity check, if this doesn't hold we produce a broken stream
-        assert!(size1 <= u16::MAX as usize);
-        assert!(size2 <= u16::MAX as usize);
-        assert!(size3 <= u16::MAX as usize);
+    /// Donor `HUF_tightCompressBound(srcSize, tableLog)` from
+    /// `huf_compress.c:1050-1053`: an upper bound on encoded bytes
+    /// that lets the hot path skip per-symbol bounds checks. We add
+    /// 16 extra slack for the trailing end-mark byte + close-flush
+    /// overshoot.
+    #[inline(always)]
+    fn huf_tight_compress_bound(src_size: usize, table_log: u32) -> usize {
+        ((src_size * table_log as usize) >> 3) + 8 + 16
+    }
 
-        // Update the jumptable with the real sizes
-        self.writer.change_bits(size_idx, size1 as u16, 16);
-        self.writer.change_bits(size_idx + 16, size2 as u16, 16);
-        self.writer.change_bits(size_idx + 32, size3 as u16, 16);
+    /// Dispatch on table_log to pick `kUnroll`, `kFastFlush`,
+    /// `kLastFast` matching donor's 64-bit branch in
+    /// `huf_compress.c:1092-1110`.
+    fn encode_one_stream(
+        table: &[u64],
+        bit_c: &mut super::huf_cstream::HufCStream<'_>,
+        data: &[u8],
+        table_log: u32,
+    ) {
+        // Donor's fallback for tableLog > 11 OR insufficient dst
+        // capacity: kUnroll=4 (on 64-bit), kFast=0, kLastFast=0.
+        // We always reserve `huf_tight_compress_bound` worth of dst,
+        // so the dst-capacity branch never fires; only tableLog > 11
+        // routes here, which clevels.h does not produce for L1-L22
+        // Fast/DFast workloads but is correct to handle defensively.
+        match table_log {
+            11 => Self::encode_one_stream_unrolled::<5, true, false>(table, bit_c, data),
+            10 => Self::encode_one_stream_unrolled::<5, true, true>(table, bit_c, data),
+            9 => Self::encode_one_stream_unrolled::<6, true, false>(table, bit_c, data),
+            8 => Self::encode_one_stream_unrolled::<7, true, false>(table, bit_c, data),
+            7 => Self::encode_one_stream_unrolled::<8, true, false>(table, bit_c, data),
+            // tableLog ∈ {1..=6, 12} — donor's "default" branch falls
+            // here too. kUnroll=4 keeps per-flush bit budget safe.
+            _ => Self::encode_one_stream_unrolled::<4, false, false>(table, bit_c, data),
+        }
+    }
+
+    /// Donor `HUF_compress1X_usingCTable_internal_body_loop`
+    /// (`huf_compress.c:991-1043`). Three phases:
+    ///
+    /// 1. Encode `n % K_UNROLL` symbols (slow / `FAST=false`) to
+    ///    align to a `K_UNROLL` boundary, then flush.
+    /// 2. If still not aligned to `2 * K_UNROLL`, encode another
+    ///    `K_UNROLL` symbols (with the last using `K_LAST_FAST`),
+    ///    then flush.
+    /// 3. Main loop: encode `K_UNROLL` symbols into stream 0, flush;
+    ///    `zero_index1`, encode `K_UNROLL` symbols into stream 1,
+    ///    merge into stream 0, flush. Loop processes `2 * K_UNROLL`
+    ///    input symbols per iteration with the two parallel
+    ///    sub-streams breaking the dependency chain.
+    ///
+    /// Symbols are consumed in REVERSE (`data[n-1]` then `data[n-2]`
+    /// …) matching donor's `ip[--n]` cadence — the resulting
+    /// bitstream is decoded forward, but encoding right-to-left lets
+    /// donor pack high-frequency low-bit codes against the top of
+    /// the container.
+    ///
+    /// `K_FAST_FLUSH`: skip the post-write overflow clamp in
+    /// `flush_bits`. Safe whenever the output buffer was sized via
+    /// `huf_tight_compress_bound`.
+    /// `K_LAST_FAST`: use `FAST=true` for the final `add_bits` of
+    /// each unroll group. Safe when `K_UNROLL * max_nb_bits + 4 <=
+    /// 64`, i.e. `K_UNROLL <= (60 / table_log)`.
+    fn encode_one_stream_unrolled<
+        const K_UNROLL: usize,
+        const K_FAST_FLUSH: bool,
+        const K_LAST_FAST: bool,
+    >(
+        table: &[u64],
+        bit_c: &mut super::huf_cstream::HufCStream<'_>,
+        data: &[u8],
+    ) {
+        let mut n = data.len();
+        let rem = n % K_UNROLL;
+
+        // Phase 1: tail symbols (< K_UNROLL) on the SLOW path.
+        if rem > 0 {
+            for _ in 0..rem {
+                n -= 1;
+                let elt = table[data[n] as usize];
+                bit_c.add_bits::<false>(elt, 0);
+            }
+            bit_c.flush_bits::<K_FAST_FLUSH>();
+        }
+        debug_assert!(n.is_multiple_of(K_UNROLL));
+
+        // Phase 2: bring n down to a multiple of 2 * K_UNROLL.
+        if !n.is_multiple_of(2 * K_UNROLL) {
+            for u in 1..K_UNROLL {
+                let elt = table[data[n - u] as usize];
+                bit_c.add_bits::<true>(elt, 0);
+            }
+            let last_elt = table[data[n - K_UNROLL] as usize];
+            if K_LAST_FAST {
+                bit_c.add_bits::<true>(last_elt, 0);
+            } else {
+                bit_c.add_bits::<false>(last_elt, 0);
+            }
+            bit_c.flush_bits::<K_FAST_FLUSH>();
+            n -= K_UNROLL;
+        }
+        debug_assert!(n.is_multiple_of(2 * K_UNROLL));
+
+        // Phase 3: dual-container main loop.
+        while n > 0 {
+            // K_UNROLL symbols into stream 0.
+            for u in 1..K_UNROLL {
+                let elt = table[data[n - u] as usize];
+                bit_c.add_bits::<true>(elt, 0);
+            }
+            let last_elt_0 = table[data[n - K_UNROLL] as usize];
+            if K_LAST_FAST {
+                bit_c.add_bits::<true>(last_elt_0, 0);
+            } else {
+                bit_c.add_bits::<false>(last_elt_0, 0);
+            }
+            bit_c.flush_bits::<K_FAST_FLUSH>();
+
+            // K_UNROLL symbols into stream 1 (independent of 0).
+            bit_c.zero_index1();
+            for u in 1..K_UNROLL {
+                let elt = table[data[n - K_UNROLL - u] as usize];
+                bit_c.add_bits::<true>(elt, 1);
+            }
+            let last_elt_1 = table[data[n - K_UNROLL - K_UNROLL] as usize];
+            if K_LAST_FAST {
+                bit_c.add_bits::<true>(last_elt_1, 1);
+            } else {
+                bit_c.add_bits::<false>(last_elt_1, 1);
+            }
+            bit_c.merge_index1();
+            bit_c.flush_bits::<K_FAST_FLUSH>();
+
+            n -= 2 * K_UNROLL;
+        }
+        debug_assert_eq!(n, 0);
     }
 
     /// Encode one stream and pad it to fill the last byte
@@ -264,6 +427,18 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
 pub struct HuffmanTable {
     /// Index is the symbol, values are the bitstring in the lower bits of the u32 and the amount of bits in the u8
     codes: Vec<(u32, u8)>,
+    /// Donor-format packed Huffman codes (`HUF_CElt`): one `u64` per
+    /// symbol where the bottom 8 bits hold `nb_bits` and the top
+    /// `(64 - nb_bits)` bits hold `value` left-shifted to the high
+    /// end. Built in lockstep with `codes` so the donor-style
+    /// dual-container [`super::huf_cstream::HufCStream`] can index
+    /// symbols with a single u64 load (no per-symbol shift+combine).
+    /// See `huf_compress.c:208-221` for the donor format.
+    packed_codes: Vec<u64>,
+    /// Active Huffman table-log (1..=12). Stored explicitly so
+    /// `encode4x_donor` can dispatch to the correct `kUnroll`
+    /// template instantiation without re-scanning `codes`.
+    table_log: u32,
     /// Lazy cache of the FSE-encoded weight description. Avoids re-running
     /// `encode_weight_description` across `try_table_description_size` and
     /// `write_table` for the same table instance. **std-only** —
@@ -464,6 +639,8 @@ impl HuffmanTable {
         let table_log = highest_bit_set(weight_sum) - 1;
         let mut table = HuffmanTable {
             codes: alloc::vec![(0, 0); weights.len()],
+            packed_codes: alloc::vec![0u64; weights.len()],
+            table_log: table_log as u32,
             #[cfg(feature = "std")]
             cached_encoded_weight_description: CachedDescription::new(),
         };
@@ -488,9 +665,26 @@ impl HuffmanTable {
             let value = val_per_rank[nb_bits];
             val_per_rank[nb_bits] += 1;
             table.codes[symbol] = (value as u32, nb_bits as u8);
+            table.packed_codes[symbol] =
+                super::huf_cstream::pack_huf_celt(value as u32, nb_bits as u8);
         }
 
         table
+    }
+
+    /// Donor-format packed code table for the hot encode loop.
+    /// One `HUF_CElt` (`u64`) per symbol — see
+    /// `huf_compress.c:208-221` for the layout.
+    #[inline(always)]
+    pub(crate) fn packed_codes(&self) -> &[u64] {
+        &self.packed_codes
+    }
+
+    /// Active Huffman table-log (1..=12) — drives the `kUnroll`
+    /// dispatch in `encode4x_donor`.
+    #[inline(always)]
+    pub(crate) fn table_log(&self) -> u32 {
+        self.table_log
     }
 
     pub fn can_encode(&self, other: &Self) -> Option<usize> {

--- a/zstd/src/huff0/mod.rs
+++ b/zstd/src/huff0/mod.rs
@@ -4,6 +4,7 @@
 /// will start with the same sequence of bits.
 pub(crate) mod huff0_decoder;
 pub use huff0_decoder::*;
+pub(crate) mod huf_cstream;
 pub mod huff0_encoder;
 
 /// Only needed for testing.


### PR DESCRIPTION
## Summary

Donor-parity changes in the encoder hot paths, accumulated while
investigating the Fast L1 ratio residual on `decodecorpus-z000033`.
The PR closed the original ratio investigation (sequence-stream
parity with donor confirmed at 100% on L1), but along the way the
diff grew to cover Huff0 / FSE / BitWriter hot paths and a
level→strategy mapping correction.

Part of #220.

## Changes

### `zstd/src/encoding/simple/fast_kernel/kernel.rs`

`match_found` dropped two redundant defensive bounds checks
(`match_pos + 4 > data_len` and `match_pos >= ip_pos`); donor
`ZSTD_match4Found_branch` (`zstd_fast.c:128-141`) relies on the
same scan invariants and emits exactly one prefix filter plus one
4-byte equality compare. `match_found` is invoked twice per inner
loop iteration, so the savings compound. `PrefixBounds` struct
now bundles `prefix_start_index` (sentinel-aware filter) and
`window_low` (donor `windowLow`) so the prologue's
`max_rep = ip0 - window_low` and the backward-extension
`match_pos > window_low` paths reach the canonical donor
positions even when the sentinel-1 floor would otherwise raise
the filter.

Root cause of the original L1 ratio gap: `SEARCH_STRENGTH=6`
was off-by-one (donor `kSearchStrength=8`); step doubling fired
4× too often. Fixed in an earlier commit on this branch.

### `zstd/src/huff0/huf_cstream.rs` + `zstd/src/huff0/huff0_encoder.rs`

Donor-faithful port of `HUF_CStream_t` (`huf_compress.c:HUF_addBits`
/ `HUF_flushBits`): dual indexed bit containers
(`bit_container[0/1]`, `bit_pos[0/1]`) with packed `HUF_CElt`
codes (low 8 bits = `nb_bits`, top `64-nb_bits` = value). The
4X-encoder unrolls per `tableLog` via const generics
(`K_UNROLL`, `K_FAST_FLUSH`, `K_LAST_FAST`), runs the donor's
three-phase loop (align-to-K, align-to-2K, dual-stream main
body with `zero_index1` / `merge_index1` / `flush`), and pre-
reserves output via `huf_tight_compress_bound(src_size, table_log)`.

Writes go through raw pointers into spare capacity (no eager
memset of the worst-case destination), and `close()`
`set_len`s only after the actual byte count is known.
`encode4x` asserts `bytes_written > 0` per segment so a
mis-sized bound can't silently emit a 0-length stream.

### `zstd/src/bit_io/bit_writer.rs`

`flush_bulk` (donor `BIT_flushBitsFast`) added as `unsafe fn`
with an explicit SAFETY contract: caller pre-reserves 8 bytes
via `reserve_output` and the function performs an unconditional
8-byte raw store + `set_len(len + nb_bytes)`. `extend_from_slice`
for tiny (0..=7-byte) tails was previously hot — its per-call
capacity check + memcpy dispatch cost dwarfed the actual byte
write at FSE flush cadence (~54K flushes per L1 compress).

`write_bits_64_no_check` (donor `BIT_addBitsFast`) — unchecked
fast path with `debug_assert!` that
`num_bits + bits_in_partial <= 64`. Used by the donor-faithful
FSE sequence encoder with explicit `flush_bulk` calls at safe
burst boundaries.

### `zstd/src/encoding/blocks/compressed.rs`

Single-pass histogram replacing three sequential `iter().map`
chains over the sequence list. Restructured `encode_sequences`
inner loop with `write_bits_64_no_check` + explicit `flush_bulk`
at state-diffs and extras burst boundaries (donor
`ZSTD_encodeSequences_body` cycle-for-cycle).

Correctness fix: the extras-burst layout
`ll + ml + of + partial_leftover` can exceed 64 bits when
`of_num_bits > 24` (reachable on `window_log >= 25`); a
conditional `flush_bulk()` between `ml` and `of` drains the
container so the unchecked path's precondition holds. Donor
handles the same scenario via `longOffsets` mode.

`append_literals` helper routes literal-section appends through
`simd_copy::copy_bytes_overshooting` for slices ≤ 32 bytes (no
libc memmove call); longer runs fall through to
`extend_from_slice` where libc memmove amortises.

### `zstd/src/encoding/strategy.rs` + `zstd/src/encoding/match_generator.rs`

Aligned `StrategyTag::for_level` and `LEVEL_TABLE` with donor's
`ZSTD_defaultCParameters[0]` strategy column at
`zstd/lib/compress/clevels.h:25-50`:

| Level | Strategy | (was) |
|-------|----------|-------|
| 1-2 | Fast | (L2 was Dfast) |
| 3-4 | Dfast | (L4 was Greedy) |
| 5 | Greedy | (was Lazy) |
| 6-15 | Lazy / Lazy2 | (same tag, lazy_depth carries the variance) |

The mapping shift had widened sequence-stream divergence on
L2-L12; matcher routing now agrees with donor for every level
where we have the same strategy implementation. Per-level
cparam alignment (window_log, hash_log, mls, target_len,
search_depth) is a separate follow-up.

### `zstd/src/decoding/mod.rs`

`simd_copy` module visibility bumped from `mod` to `pub(crate) mod`
so the encode side can reach the helper.

## Test plan

- [x] full nextest suite (592 / 592 passing locally)
- [x] lint + typecheck clean
- [x] Sequence comparator on `decodecorpus-z000033` reports 100%
  match (rust 27763 vs ffi 27763) at L1
- [x] Roundtrip + FFI cross-validation tests across all levels
- [x] Bench on Linux server (i9-9900K, BMI2/AVX2):
  `compress/level_1_fast/decodecorpus-z000033 pure_rust` throughput
  153.87 → 154.50 MiB/s (in noise; FFI side 351 MiB/s, throughput
  parity left to a follow-up that drives matcher hot-loop SIMD
  intrinsics)