### PR TITLE
test(bench): add decompress-dict group to compare_ffi

### DIFF
--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -471,6 +471,29 @@ fn bench_dictionary(c: &mut Criterion) {
 
         group.finish();
 
+        // Pre-parse the `DictionaryHandle` once per scenario. The
+        // handle depends only on `ffi_dictionary` (which is fixed
+        // across levels), so parsing it inside the per-level loop
+        // below would redo the same work N times AND emit the same
+        // BENCH_WARN per level if it ever failed. If parsing fails
+        // we still want the existing `compress-dict/...` groups to
+        // run, so we skip ONLY the `decompress-dict/...` groups
+        // (handle stays `None` and the per-level decompress
+        // branch falls through).
+        let rust_dict_handle = match structured_zstd::decoding::DictionaryHandle::decode_dict(
+            ffi_dictionary.as_slice(),
+        ) {
+            Ok(handle) => Some(handle),
+            Err(err) => {
+                eprintln!(
+                    "BENCH_WARN skipping decompress-dict for scenario {} \
+                         (failed to parse FFI dict bytes into a Rust DictionaryHandle: {err:?})",
+                    scenario.id
+                );
+                None
+            }
+        };
+
         for level in supported_levels_filtered() {
             let mut no_dict = zstd::bulk::Compressor::new(level.ffi_level).unwrap();
             let mut with_dict =
@@ -508,12 +531,18 @@ fn bench_dictionary(c: &mut Criterion) {
 
             group.finish();
 
-            // decompress-dict: measure end-to-end decompress throughput
+            // decompress-dict: measure steady-state decode throughput
             // for a dictionary-driven .zst payload, both sides. Uses
             // `with_dict_bytes` (the FFI dict-encoded payload above) as
             // the fixed input on both branches so the throughput
             // metric is apples-to-apples (Rust and FFI decode the SAME
             // bytes — what differs is the decoder implementation).
+            // Dictionary parsing AND `FrameDecoder` / FFI `Decompressor`
+            // construction are hoisted out of `b.iter` (the
+            // per-scenario `rust_dict_handle` parse above, and the
+            // per-bench-function `decoder` / `decompressor` set up once
+            // before the timing loop) so the numbers reflect the
+            // hot-path decode kernel rather than per-frame setup.
             //
             // CRITICAL: `with_dict_bytes` was compressed using
             // `ffi_dictionary` (`Compressor::with_dictionary(level,
@@ -532,13 +561,7 @@ fn bench_dictionary(c: &mut Criterion) {
             //     mirror with `decompress_to_buffer` quietly producing
             //     garbage — even worse than a clean error.
             // Either way the bench would measure the wrong path.
-            let Ok(rust_dict_handle) =
-                structured_zstd::decoding::DictionaryHandle::decode_dict(ffi_dictionary.as_slice())
-            else {
-                eprintln!(
-                    "BENCH_WARN skipping decompress-dict for {} level={} (failed to parse FFI dict bytes into a Rust DictionaryHandle)",
-                    scenario.id, level.name
-                );
+            let Some(rust_dict_handle) = rust_dict_handle.as_ref() else {
                 continue;
             };
             let expected_len = scenario.bytes.len();
@@ -558,7 +581,7 @@ fn bench_dictionary(c: &mut Criterion) {
                         .decode_all_with_dict_handle(
                             with_dict_bytes.as_slice(),
                             output.as_mut_slice(),
-                            &rust_dict_handle,
+                            rust_dict_handle,
                         )
                         .expect("rust decode-with-dict must succeed");
                     assert_eq!(n, expected_len, "rust decode wrote a partial output");

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -514,15 +514,26 @@ fn bench_dictionary(c: &mut Criterion) {
             // the fixed input on both branches so the throughput
             // metric is apples-to-apples (Rust and FFI decode the SAME
             // bytes — what differs is the decoder implementation).
+            //
+            // CRITICAL: `with_dict_bytes` was compressed using
+            // `ffi_dictionary` (`Compressor::with_dictionary(level,
+            // &ffi_dictionary)` above), so the decoder MUST hold the
+            // SAME dictionary bytes — the inner zstd frame's `dict_id`
+            // header is derived from those bytes. Parsing the handle
+            // from `rust_dictionary` (different bytes, different
+            // `dict_id`) would cause `decode_all_with_dict_handle` to
+            // fail with `DictNotProvided` and the FFI side to operate
+            // on the wrong dictionary, both measuring the wrong path.
             let Ok(rust_dict_handle) =
-                structured_zstd::decoding::DictionaryHandle::decode_dict(&rust_dictionary)
+                structured_zstd::decoding::DictionaryHandle::decode_dict(ffi_dictionary.as_slice())
             else {
                 eprintln!(
-                    "BENCH_WARN skipping decompress-dict for {} level={} (failed to parse Rust dict handle)",
+                    "BENCH_WARN skipping decompress-dict for {} level={} (failed to parse FFI dict bytes into a Rust DictionaryHandle)",
                     scenario.id, level.name
                 );
                 continue;
             };
+            let expected_len = scenario.bytes.len();
             let decompress_dict_name = format!(
                 "decompress-dict/{}/{}/{}",
                 level.name, scenario.id, "matrix"
@@ -533,7 +544,7 @@ fn bench_dictionary(c: &mut Criterion) {
 
             group.bench_function("pure_rust_with_dict", |b| {
                 let mut decoder = FrameDecoder::new();
-                let mut output = vec![0u8; scenario.bytes.len()];
+                let mut output = vec![0u8; expected_len];
                 b.iter(|| {
                     let n = decoder
                         .decode_all_with_dict_handle(
@@ -542,19 +553,21 @@ fn bench_dictionary(c: &mut Criterion) {
                             &rust_dict_handle,
                         )
                         .expect("rust decode-with-dict must succeed");
-                    black_box(n);
+                    assert_eq!(n, expected_len, "rust decode wrote a partial output");
+                    black_box(&output[..n]);
                 })
             });
 
             group.bench_function("c_ffi_with_dict", |b| {
                 let mut decompressor =
                     zstd::bulk::Decompressor::with_dictionary(&ffi_dictionary).unwrap();
-                let mut output = vec![0u8; scenario.bytes.len()];
+                let mut output = vec![0u8; expected_len];
                 b.iter(|| {
                     let n = decompressor
                         .decompress_to_buffer(with_dict_bytes.as_slice(), output.as_mut_slice())
                         .expect("ffi decode-with-dict must succeed");
-                    black_box(n);
+                    assert_eq!(n, expected_len, "ffi decode wrote a partial output");
+                    black_box(&output[..n]);
                 })
             });
 

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -573,13 +573,55 @@ fn bench_dictionary(c: &mut Criterion) {
             configure_group(&mut group, scenario);
             group.throughput(Throughput::Bytes(scenario.throughput_bytes()));
 
+            // One-time byte-equality verification BEFORE the bench loops.
+            // `decode_all_with_dict_handle` explicitly warns that decoding
+            // with the wrong dictionary produces silently-corrupt output
+            // (no error), so verifying once against `scenario.bytes`
+            // outside the timing sample catches a desynced
+            // (rust_dict_handle, with_dict_bytes) pairing before it would
+            // silently inflate or deflate throughput numbers. FFI side
+            // gets the same treatment for parity. Matches the donor shape
+            // used by `bench_decompress_source` →
+            // `assert_decompress_matches_reference`.
+            {
+                let mut verify_decoder = FrameDecoder::new();
+                let mut verify_out = vec![0u8; expected_len];
+                let n = verify_decoder
+                    .decode_all_with_dict_handle(
+                        with_dict_bytes.as_slice(),
+                        verify_out.as_mut_slice(),
+                        rust_dict_handle,
+                    )
+                    .expect("rust decode-with-dict verification must succeed");
+                assert_eq!(n, expected_len, "rust dict decode wrote a partial output");
+                assert_eq!(
+                    &verify_out[..n],
+                    scenario.bytes.as_slice(),
+                    "rust dict decode bytes diverge from scenario reference",
+                );
+
+                let mut verify_decompressor =
+                    zstd::bulk::Decompressor::with_dictionary(&ffi_dictionary)
+                        .expect("ffi dict verification: with_dictionary");
+                let mut verify_out_ffi = vec![0u8; expected_len];
+                let nf = verify_decompressor
+                    .decompress_to_buffer(with_dict_bytes.as_slice(), verify_out_ffi.as_mut_slice())
+                    .expect("ffi decode-with-dict verification must succeed");
+                assert_eq!(nf, expected_len, "ffi dict decode wrote a partial output");
+                assert_eq!(
+                    &verify_out_ffi[..nf],
+                    scenario.bytes.as_slice(),
+                    "ffi dict decode bytes diverge from scenario reference",
+                );
+            }
+
             group.bench_function("pure_rust_with_dict", |b| {
                 let mut decoder = FrameDecoder::new();
                 let mut output = vec![0u8; expected_len];
                 b.iter(|| {
                     let n = decoder
                         .decode_all_with_dict_handle(
-                            with_dict_bytes.as_slice(),
+                            black_box(with_dict_bytes.as_slice()),
                             output.as_mut_slice(),
                             rust_dict_handle,
                         )
@@ -595,7 +637,10 @@ fn bench_dictionary(c: &mut Criterion) {
                 let mut output = vec![0u8; expected_len];
                 b.iter(|| {
                     let n = decompressor
-                        .decompress_to_buffer(with_dict_bytes.as_slice(), output.as_mut_slice())
+                        .decompress_to_buffer(
+                            black_box(with_dict_bytes.as_slice()),
+                            output.as_mut_slice(),
+                        )
                         .expect("ffi decode-with-dict must succeed");
                     assert_eq!(n, expected_len, "ffi decode wrote a partial output");
                     black_box(&output[..n]);

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -486,8 +486,7 @@ fn bench_dictionary(c: &mut Criterion) {
             Ok(handle) => Some(handle),
             Err(err) => {
                 eprintln!(
-                    "BENCH_WARN skipping decompress-dict for scenario {} \
-                         (failed to parse FFI dict bytes into a Rust DictionaryHandle: {err:?})",
+                    "BENCH_WARN skipping decompress-dict for scenario {} (failed to parse FFI dict bytes into a Rust DictionaryHandle: {err:?})",
                     scenario.id
                 );
                 None

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -521,9 +521,17 @@ fn bench_dictionary(c: &mut Criterion) {
             // SAME dictionary bytes — the inner zstd frame's `dict_id`
             // header is derived from those bytes. Parsing the handle
             // from `rust_dictionary` (different bytes, different
-            // `dict_id`) would cause `decode_all_with_dict_handle` to
-            // fail with `DictNotProvided` and the FFI side to operate
-            // on the wrong dictionary, both measuring the wrong path.
+            // `dict_id`) would fail one of two ways:
+            //   - if the frame header carries a `dict_id`,
+            //     `decode_all_with_dict_handle` returns
+            //     `DictIdMismatch { expected, got }` (see
+            //     `frame_decoder.rs::reset_with_dict_handle`);
+            //   - if the encoder omitted the `dict_id` (some configs do),
+            //     decode would SILENTLY corrupt the output by applying
+            //     the wrong reference bytes, which the FFI side would
+            //     mirror with `decompress_to_buffer` quietly producing
+            //     garbage — even worse than a clean error.
+            // Either way the bench would measure the wrong path.
             let Ok(rust_dict_handle) =
                 structured_zstd::decoding::DictionaryHandle::decode_dict(ffi_dictionary.as_slice())
             else {

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -507,6 +507,58 @@ fn bench_dictionary(c: &mut Criterion) {
             });
 
             group.finish();
+
+            // decompress-dict: measure end-to-end decompress throughput
+            // for a dictionary-driven .zst payload, both sides. Uses
+            // `with_dict_bytes` (the FFI dict-encoded payload above) as
+            // the fixed input on both branches so the throughput
+            // metric is apples-to-apples (Rust and FFI decode the SAME
+            // bytes — what differs is the decoder implementation).
+            let Ok(rust_dict_handle) =
+                structured_zstd::decoding::DictionaryHandle::decode_dict(&rust_dictionary)
+            else {
+                eprintln!(
+                    "BENCH_WARN skipping decompress-dict for {} level={} (failed to parse Rust dict handle)",
+                    scenario.id, level.name
+                );
+                continue;
+            };
+            let decompress_dict_name = format!(
+                "decompress-dict/{}/{}/{}",
+                level.name, scenario.id, "matrix"
+            );
+            let mut group = c.benchmark_group(decompress_dict_name);
+            configure_group(&mut group, scenario);
+            group.throughput(Throughput::Bytes(scenario.throughput_bytes()));
+
+            group.bench_function("pure_rust_with_dict", |b| {
+                let mut decoder = FrameDecoder::new();
+                let mut output = vec![0u8; scenario.bytes.len()];
+                b.iter(|| {
+                    let n = decoder
+                        .decode_all_with_dict_handle(
+                            with_dict_bytes.as_slice(),
+                            output.as_mut_slice(),
+                            &rust_dict_handle,
+                        )
+                        .expect("rust decode-with-dict must succeed");
+                    black_box(n);
+                })
+            });
+
+            group.bench_function("c_ffi_with_dict", |b| {
+                let mut decompressor =
+                    zstd::bulk::Decompressor::with_dictionary(&ffi_dictionary).unwrap();
+                let mut output = vec![0u8; scenario.bytes.len()];
+                b.iter(|| {
+                    let n = decompressor
+                        .decompress_to_buffer(with_dict_bytes.as_slice(), output.as_mut_slice())
+                        .expect("ffi decode-with-dict must succeed");
+                    black_box(n);
+                })
+            });
+
+            group.finish();
         }
     }
 }


### PR DESCRIPTION
## Summary

Partial close of #230. Adds the missing `decompress-dict/{level}/{scenario}/matrix` benchmark group inside `bench_dictionary`. Train + compress-with-dict groups already exist; this fills the gap on the decompress side so dict-driven decode throughput regressions land on the bench dashboard.

## What it measures

For each level in the existing matrix (re-uses the per-scenario `ffi_dictionary` + `rust_dictionary` already trained earlier in the same iteration):

- `pure_rust_with_dict` — `FrameDecoder::decode_all_with_dict_handle` against a pre-parsed `DictionaryHandle` so the bench measures only the decode hot path (no per-iter dictionary parse).
- `c_ffi_with_dict` — `zstd::bulk::Decompressor::with_dictionary` + `decompress_to_buffer`, matching the parsed-dictionary shape of the Rust side.

Both branches decode the SAME `with_dict_bytes` payload (the FFI dict-encoded compressed bytes already produced earlier in the loop) so the throughput numbers are apples-to-apples — the only thing differing between sides is the decoder implementation.

## What's NOT in this PR

Per the issue's full scope, the following pieces of #230 are NOT in this PR (separate follow-ups):
- `pure_rust_with_dict` branch on the existing `compress-dict/...` group (FFI-only today)
- Dashboard wiring (`profileLogicalMetric` extension + `benchmark-relative.json` stages)
- `.github/scripts/run-benchmarks.sh` emission for the new stage

Each is a small, separable diff; opening as a single-purpose PR for cleaner review.

## Test plan

- `cargo check -p structured-zstd --benches --features "dict_builder bench_internals"` clean
- `cargo nextest run -p structured-zstd` — 590/590 pass (no test regressions; bench is additive)
- `cargo clippy -p structured-zstd --benches --features "dict_builder bench_internals" -- -D warnings` clean

Part of #230.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended dictionary benchmark suite with a new decompression stage for dictionary-encoded payloads.
  * Measures steady-state decode throughput across compression levels.
  * Added comparative benchmarks for native Rust and C-FFI decompression implementations.
  * Benchmarks skip scenarios gracefully if a trained dictionary cannot be parsed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->