### PR TITLE
perf(encoder): align lazy-band target_len with donor clevels.h table[0]

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -174,14 +174,6 @@ const HC_CONFIG: HcConfig = HcConfig {
     target_len: HC_TARGET_LEN,
 };
 
-/// Best-level: deeper search, larger tables, higher target length.
-const BEST_HC_CONFIG: HcConfig = HcConfig {
-    hash_log: 21,
-    chain_log: 20,
-    search_depth: 32,
-    target_len: 128,
-};
-
 const BTOPT_HC_CONFIG: HcConfig = HcConfig {
     hash_log: 23,
     chain_log: 22,
@@ -299,17 +291,24 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 20, fast_hash_log: 16, fast_mls: 6, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
     /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 32 }, row: ROW_CONFIG },
-    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 48 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 48 }, row: ROW_CONFIG },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 64 }, row: ROW_CONFIG },
-    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 96 }, row: ROW_CONFIG },
-    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BEST_HC_CONFIG, row: ROW_CONFIG },
-    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 128 }, row: ROW_CONFIG },
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 160 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 192 }, row: ROW_CONFIG },
+    // target_len column for L5..=L15 matches donor cParams.targetLength
+    // from clevels.h table[0] (default — srcSize > 256 KB). Donor uses
+    // it as the lazy outer loop's `sufficient_len` (nice-match) threshold.
+    // Inflating it above donor forces the chain walk to complete
+    // search_depth iterations instead of breaking on the first
+    // long-enough match — the dominant cost in the L5..=L15 speed
+    // regression vs FFI (see lazy_band_target_len_matches_donor_default_table).
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 2 }, row: ROW_CONFIG },
+    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }, row: ROW_CONFIG },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
+    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
+    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 16 }, row: ROW_CONFIG },
+    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 32, target_len: 16 }, row: ROW_CONFIG },
+    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
     /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8454,3 +8454,31 @@ fn fast_levels_driver_wiring_threads_cparams_into_inner_matcher() {
         );
     }
 }
+
+/// Pins lazy-band `hc.target_len` to donor `cParams.targetLength` from
+/// `clevels.h` table[0] (default — `srcSize > 256 KB`). Donor's lazy
+/// outer loop treats `targetLength` as `sufficient_len` — the
+/// "nice match" threshold that breaks the chain walk as soon as a
+/// candidate reaches that length. Inflating it above donor forces the
+/// chain walk to complete `search_depth` iterations on inputs that
+/// would have committed early under donor — the dominant cost in
+/// the L5..=L15 speed regression vs FFI tracked at the parent issue.
+///
+/// Test queries donor via `ZSTD_getCParams(level, 0, 0)` so any future
+/// donor-table tweak in upstream zstd is reflected automatically.
+#[test]
+fn lazy_band_target_len_matches_donor_default_table() {
+    use zstd::zstd_safe::zstd_sys;
+
+    for level in 5..=15i32 {
+        // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
+        // call with any (level, srcSize, dictSize) combination.
+        let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
+        let params = resolve_level_params(CompressionLevel::Level(level), None);
+        assert_eq!(
+            params.hc.target_len as u32, donor.targetLength,
+            "L{level}: hc.target_len ({}) must match donor cParams.targetLength ({})",
+            params.hc.target_len, donor.targetLength
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Tackle the #184 L4 subtask — validate nice_match early-exit parity vs
donor in the lazy chain-walk hot path. The audit surfaced a single-axis
mismatch: our `LEVEL_TABLE.hc.target_len` column for L5..=L15 sits
3-16× above donor's `cParams.targetLength` from `clevels.h` table[0]
(the default cparams for `srcSize > 256 KB`, matching our single-table
LEVEL_TABLE shape).

Donor's lazy outer loop uses `cParams.targetLength` as
`sufficient_len` (nice-match) — once a candidate reaches that length
in the chain walk, donor breaks and commits. With our inflated values,
the chain walk runs through `search_depth` iterations on inputs that
would have committed early under donor — the dominant cost of the
5-9× speed regression vs FFI at L5..=L15 documented in #184 Phase 1.

## Changes

`LEVEL_TABLE.hc.target_len` aligned to donor table[0]:

| Level | Was  | Now |
|-------|------|-----|
| L5    | 32   | 2   |
| L6    | 48   | 4   |
| L7    | 48   | 8   |
| L8    | 64   | 16  |
| L9    | 64   | 16  |
| L10   | 96   | 16  |
| L11   | 128  | 16  (via BEST_HC_CONFIG; inlined) |
| L12   | 128  | 32  |
| L13   | 160  | 32  |
| L14   | 192  | 32  |
| L15   | 192  | 32  |

`BEST_HC_CONFIG` had only one consumer (L11); inlined at the call
site and dropped the now-unused const. Other lazy-band columns
(search_depth / hash_log / chain_log) untouched — search_depth
alignment is a follow-up subtask.

## Test plan

- [x] New regression test `lazy_band_target_len_matches_donor_default_table`
      queries donor cParams via `ZSTD_getCParams(level, 0, 0)` (srcSize=0
      selects donor's table[0]) and asserts our `params.hc.target_len`
      matches for every L5..=L15. Future upstream donor-table tweaks
      surface here automatically.
- [x] 576/576 nextest pass, including the ratio-validating
      `level22_sequences_match_donor_on_corpus_proxy` and the L0..=22
      roundtrip suites
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Bench on i9-9900K (Fedora 44, kernel 7.0.x): L8 lazy ×
      decodecorpus-z000033 compress pure_rust **65.97 ms → 55.42 ms**
      (criterion `change: [−19.107% −15.988% −12.843%]`, p < 0.05).
      FFI baseline 13.05 ms unchanged. Ratio against FFI: 0.197×
      → 0.235× (partial close of the gap; full 0.5× target requires
      the remaining #184 subtasks — L3 lookahead-result sharing and
      L5 search_depth alignment, both out of scope here).
- [x] No ratio regression on `compare_ffi` REPORT lines (criterion
      `change` columns for FFI side stayed within noise; L8 lazy FFI
      side: +0.3% to +0.5%, p = 0.01 — no semantic shift).

## Two-commit history (test-first per the bug-fix protocol)

1. `bdda3146 test(encoder): add regression test pinning lazy-band target_len to donor`
   — Failing test alone (proves the gap is real, asserts the donor source-of-truth).
2. `4936ce7e perf(encoder): align lazy-band target_len with donor clevels.h table[0]`
   — Fix that makes the test pass.

Part of #184 (L4 subtask). Other #184 subtasks (L2 reverted, L3 + L5+
remaining) stay open for follow-ups.
