### PR TITLE
test(encoding): donor-parity comparator for block splitter port

### DIFF
--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -121,3 +121,7 @@ harness = false
 name = "wildcopy_candidates"
 harness = false
 required-features = ["bench_internals"]
+
+[[test]]
+name = "block_splitter_donor_parity"
+required-features = ["bench_internals"]

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -355,6 +355,31 @@ fn donor_pre_split_level(level: CompressionLevel) -> Option<usize> {
     }
 }
 
+/// Bench-only entry point for the donor-parity comparator test in
+/// `tests/block_splitter_donor_parity.rs`. Dispatches to the same
+/// `_from_borders` (split_level == 0) / `_by_chunks` (split_level ∈
+/// 1..=4) ports that `donor_optimal_block_size` itself routes
+/// through. Caller is responsible for passing exactly
+/// `MAX_BLOCK_SIZE` bytes (per donor `ZSTD_splitBlock` contract —
+/// "@blockSize must be == 128 KB" in `zstd_preSplit.h`).
+#[cfg(any(test, feature = "bench_internals"))]
+pub(crate) fn block_splitter_decision_for_bench(block: &[u8], split_level: usize) -> usize {
+    assert_eq!(
+        block.len(),
+        MAX_BLOCK_SIZE as usize,
+        "block_splitter_decision_for_bench expects exactly MAX_BLOCK_SIZE bytes"
+    );
+    assert!(
+        split_level <= 4,
+        "block_splitter_decision_for_bench: split_level must be in 0..=4, got {split_level}"
+    );
+    if split_level == 0 {
+        donor_split_block_from_borders(block)
+    } else {
+        donor_split_block_by_chunks(block, split_level)
+    }
+}
+
 pub(crate) fn donor_optimal_block_size(
     level: CompressionLevel,
     block: &[u8],

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -80,7 +80,7 @@ pub(crate) mod row;
 pub(crate) mod simple;
 pub(crate) mod strategy;
 
-mod frame_compressor;
+pub(crate) mod frame_compressor;
 mod levels;
 #[cfg(feature = "bench_internals")]
 pub mod sequence_capture;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -102,4 +102,23 @@ pub mod testing {
         // Keep decoder internals crate-private and expose only this bench shim.
         unsafe { crate::decoding::copy_bytes_overshooting_for_bench(src, dst, copy_at_least) };
     }
+
+    /// Maximum block size per RFC 8878 §3.1.1.2.3 (128 KiB).
+    /// Exposed for parity tests that feed exactly-one-block chunks
+    /// into the donor splitter comparator.
+    pub const MAX_BLOCK_SIZE: u32 = crate::common::MAX_BLOCK_SIZE;
+
+    /// Run our donor-port block splitter on a 128 KB chunk.
+    ///
+    /// `split_level` mirrors donor `ZSTD_splitBlock(level)`: `0` selects
+    /// the borders heuristic (`ZSTD_splitBlock_fromBorders`), `1..=4`
+    /// select `ZSTD_splitBlock_byChunks` at the corresponding sampling
+    /// level. Returns the split position (or `block.len()` if no split).
+    ///
+    /// Crate-internal facade for the donor-parity comparator test —
+    /// the underlying functions stay `fn` so they don't widen the
+    /// stable API surface.
+    pub fn block_splitter_decision(block: &[u8], split_level: usize) -> usize {
+        crate::encoding::frame_compressor::block_splitter_decision_for_bench(block, split_level)
+    }
 }

--- a/zstd/tests/block_splitter_donor_parity.rs
+++ b/zstd/tests/block_splitter_donor_parity.rs
@@ -56,24 +56,18 @@ unsafe extern "C" {
 }
 
 /// Resolve the decode-corpus directory. The repo ships
-/// `zstd/decodecorpus_files/` as a checked-in fixture; tests run
-/// from the workspace root or from `zstd/`, so try both.
+/// `zstd/decodecorpus_files/` as a checked-in fixture; resolve
+/// from `CARGO_MANIFEST_DIR` so the path is deterministic across
+/// runners (nextest, IDE test runners, in-tree `cargo test`,
+/// out-of-tree invocations).
 fn corpus_dir() -> PathBuf {
-    let candidates = [
-        "zstd/decodecorpus_files",
-        "decodecorpus_files",
-        "../zstd/decodecorpus_files",
-    ];
-    for candidate in candidates {
-        let path = PathBuf::from(candidate);
-        if path.is_dir() {
-            return path;
-        }
-    }
-    panic!(
-        "could not locate decodecorpus_files under any of {:?}",
-        candidates
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("decodecorpus_files");
+    assert!(
+        path.is_dir(),
+        "expected corpus directory at {}; this fixture is shipped with the crate",
+        path.display()
     );
+    path
 }
 
 /// Load every fixture file from the decode corpus into a flat byte buffer.
@@ -150,13 +144,14 @@ fn donor_decision(block: &[u8], level: i32) -> usize {
     // `ZSTD_SLIPBLOCK_WORKSPACESIZE` is in bytes; we allocate `u64`
     // slots so the buffer is naturally 8-byte aligned (satisfies the
     // donor's `size_t` alignment requirement on all supported targets,
-    // where `size_t` is at most 8 bytes). `/ 8 + 1` rounds the byte
-    // budget up to whole u64 slots — the `+ 1` covers the case where
-    // the workspace size is not a multiple of 8 (8208 is, so we get
-    // 8208/8 + 1 = 1026 slots = 8208 bytes of usable storage + one
-    // slot of slack). The actual byte count passed to donor below is
-    // `workspace.len() * 8`.
-    let mut workspace = vec![0u64; ZSTD_SLIPBLOCK_WORKSPACESIZE / 8 + 1];
+    // where `size_t` is at most 8 bytes). Slot count is the ceiling
+    // of `ZSTD_SLIPBLOCK_WORKSPACESIZE / size_of::<u64>()` so the
+    // byte budget never under-shoots the donor minimum even if the
+    // constant is later raised to a non-multiple of 8. The actual
+    // byte count passed to donor below is `workspace.len() * size_of::<u64>()`.
+    const U64_SIZE: usize = core::mem::size_of::<u64>();
+    let workspace_slots = ZSTD_SLIPBLOCK_WORKSPACESIZE.div_ceil(U64_SIZE);
+    let mut workspace = vec![0u64; workspace_slots];
     // SAFETY: block.len() == 128 KB (asserted above), level ∈ 0..=4
     // (caller-enforced in test bodies below), workspace size ≥
     // ZSTD_SLIPBLOCK_WORKSPACESIZE bytes, workspace aligned for size_t
@@ -167,7 +162,7 @@ fn donor_decision(block: &[u8], level: i32) -> usize {
             block.len(),
             level,
             workspace.as_mut_ptr() as *mut c_void,
-            workspace.len() * 8,
+            workspace.len() * U64_SIZE,
         )
     }
 }

--- a/zstd/tests/block_splitter_donor_parity.rs
+++ b/zstd/tests/block_splitter_donor_parity.rs
@@ -1,0 +1,241 @@
+//! Donor-parity verification for the block splitter port.
+//!
+//! Our `donor_split_block_from_borders` and `donor_split_block_by_chunks`
+//! ports must produce byte-identical decisions to upstream donor
+//! `ZSTD_splitBlock` for every (block, split_level) input in the
+//! decode corpus. This test invokes both implementations on the same
+//! 128 KB chunks and asserts equality.
+//!
+//! Donor reference: `lib/compress/zstd_preSplit.h` —
+//! `ZSTD_splitBlock(blockStart, blockSize == 128 KB, level ∈ 0..=4,
+//! workspace, wkspSize >= ZSTD_SLIPBLOCK_WORKSPACESIZE = 8208)`.
+//! `ZSTD_splitBlock` is NOT in the public `zstd.h` API; we declare
+//! the extern manually since `zstd-sys` does not bind it.
+//!
+//! Implements #206 (block splitter donor-parity check). Per the
+//! issue acceptance criteria, divergences correlating with ratio
+//! losses would justify porting more donor split logic; divergences
+//! that are size-neutral represent algorithmic freedom. Today we
+//! assert STRICT equality because `donor_split_block_from_borders`
+//! and `donor_split_block_by_chunks` are direct ports — any
+//! divergence is a porting bug, not algorithmic freedom.
+
+use std::ffi::c_void;
+use std::fs;
+use std::path::PathBuf;
+
+use structured_zstd::testing::{MAX_BLOCK_SIZE, block_splitter_decision};
+// Pulls in the static libzstd archive so the linker resolves
+// the manually-declared `ZSTD_splitBlock` symbol below.
+use zstd::zstd_safe::zstd_sys as _;
+
+/// Donor preSplit workspace size constant from `zstd_preSplit.h`.
+const ZSTD_SLIPBLOCK_WORKSPACESIZE: usize = 8208;
+
+unsafe extern "C" {
+    /// Donor `ZSTD_splitBlock` (internal, not in `zstd.h` public API
+    /// but exported by libzstd). Returns the split position within
+    /// `[0, blockSize)` or `blockSize` if no split is chosen.
+    ///
+    /// Contract per `zstd_preSplit.h`:
+    /// - `blockSize` MUST equal 128 KB
+    /// - `level` ∈ `0..=4` (higher = more energy on boundary detection)
+    /// - `workspace` aligned for `size_t`, size ≥ `ZSTD_SLIPBLOCK_WORKSPACESIZE`
+    fn ZSTD_splitBlock(
+        block_start: *const c_void,
+        block_size: usize,
+        level: i32,
+        workspace: *mut c_void,
+        wksp_size: usize,
+    ) -> usize;
+}
+
+/// Resolve the decode-corpus directory. The repo ships
+/// `zstd/decodecorpus_files/` as a checked-in fixture; tests run
+/// from the workspace root or from `zstd/`, so try both.
+fn corpus_dir() -> PathBuf {
+    let candidates = [
+        "zstd/decodecorpus_files",
+        "decodecorpus_files",
+        "../zstd/decodecorpus_files",
+    ];
+    for candidate in candidates {
+        let path = PathBuf::from(candidate);
+        if path.is_dir() {
+            return path;
+        }
+    }
+    panic!(
+        "could not locate decodecorpus_files under any of {:?}",
+        candidates
+    );
+}
+
+/// Load every fixture file from the decode corpus into a flat byte buffer.
+/// Skips compressed `.zst` files so each fixture is a unique raw payload.
+fn load_corpus_chunks() -> Vec<(String, Vec<u8>)> {
+    let dir = corpus_dir();
+    let mut chunks = Vec::new();
+    for entry in fs::read_dir(&dir).expect("read_dir corpus") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        // Skip compressed fixtures — we want raw payloads.
+        if path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e == "zst")
+        {
+            continue;
+        }
+        let bytes = fs::read(&path).expect("read corpus file");
+        // Donor's `ZSTD_splitBlock` only accepts exactly 128 KB.
+        // Stride through the corpus file in 128 KB chunks; skip the
+        // tail if it's not exactly one block.
+        let block_size = MAX_BLOCK_SIZE as usize;
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("<unknown>")
+            .to_string();
+        let mut offset = 0;
+        let mut chunk_idx = 0;
+        while offset + block_size <= bytes.len() {
+            chunks.push((
+                format!("{name}#chunk{chunk_idx}"),
+                bytes[offset..offset + block_size].to_vec(),
+            ));
+            offset += block_size;
+            chunk_idx += 1;
+        }
+    }
+    chunks
+}
+
+/// Synthetic 128 KB chunk with a fingerprint transition at `transition_at`.
+/// First `transition_at` bytes use one pseudo-random stream; the
+/// rest use a different one. Probes the borders / chunks heuristic
+/// at known boundary positions.
+fn synthetic_transition_chunk(transition_at: usize) -> Vec<u8> {
+    let block_size = MAX_BLOCK_SIZE as usize;
+    let mut block = Vec::with_capacity(block_size);
+    // Two distinct xorshift seeds so the byte distributions differ
+    // enough for the donor histogram to register a split.
+    let mut s1: u64 = 0xDEAD_BEEF_CAFE_F00D;
+    let mut s2: u64 = 0x0123_4567_89AB_CDEF;
+    for i in 0..block_size {
+        let v = if i < transition_at {
+            s1 ^= s1 << 13;
+            s1 ^= s1 >> 7;
+            s1 ^= s1 << 17;
+            (s1 & 0xFF) as u8
+        } else {
+            s2 ^= s2 << 13;
+            s2 ^= s2 >> 7;
+            s2 ^= s2 << 17;
+            (s2 & 0xFF) as u8
+        };
+        block.push(v);
+    }
+    block
+}
+
+/// Call donor `ZSTD_splitBlock` with a fresh stack-aligned workspace.
+fn donor_decision(block: &[u8], level: i32) -> usize {
+    assert_eq!(block.len(), MAX_BLOCK_SIZE as usize);
+    // `ZSTD_SLIPBLOCK_WORKSPACESIZE / size_of::<usize>()` u64 slots so
+    // the buffer is naturally `size_t`-aligned per the donor contract.
+    let mut workspace = vec![0u64; ZSTD_SLIPBLOCK_WORKSPACESIZE / 8 + 1];
+    // SAFETY: block.len() == 128 KB (asserted above), level ∈ 0..=4
+    // (caller-enforced in test bodies below), workspace size ≥
+    // ZSTD_SLIPBLOCK_WORKSPACESIZE bytes, workspace aligned for size_t
+    // (u64 backing storage).
+    unsafe {
+        ZSTD_splitBlock(
+            block.as_ptr() as *const c_void,
+            block.len(),
+            level,
+            workspace.as_mut_ptr() as *mut c_void,
+            workspace.len() * 8,
+        )
+    }
+}
+
+fn assert_parity(label: &str, block: &[u8], split_level: usize) {
+    let ours = block_splitter_decision(block, split_level);
+    let donor = donor_decision(block, split_level as i32);
+    assert_eq!(
+        ours,
+        donor,
+        "{label} @ split_level={split_level}: \
+         our port = {ours}, donor = {donor} \
+         (block first 16 bytes = {:02X?})",
+        &block[..16]
+    );
+}
+
+#[test]
+fn corpus_borders_heuristic_matches_donor() {
+    let chunks = load_corpus_chunks();
+    assert!(
+        !chunks.is_empty(),
+        "expected at least one 128 KB chunk from the decode corpus"
+    );
+    for (label, block) in &chunks {
+        assert_parity(label, block, 0);
+    }
+}
+
+#[test]
+fn corpus_by_chunks_matches_donor_at_each_sampling_level() {
+    let chunks = load_corpus_chunks();
+    for (label, block) in &chunks {
+        for level in 1..=4 {
+            assert_parity(label, block, level);
+        }
+    }
+}
+
+#[test]
+fn synthetic_transition_at_32k_borders_heuristic() {
+    let block = synthetic_transition_chunk(32 * 1024);
+    assert_parity("synthetic-transition-32k", &block, 0);
+}
+
+#[test]
+fn synthetic_transition_at_64k_borders_heuristic() {
+    let block = synthetic_transition_chunk(64 * 1024);
+    assert_parity("synthetic-transition-64k", &block, 0);
+}
+
+#[test]
+fn synthetic_transition_at_96k_borders_heuristic() {
+    let block = synthetic_transition_chunk(96 * 1024);
+    assert_parity("synthetic-transition-96k", &block, 0);
+}
+
+#[test]
+fn synthetic_no_transition_borders_heuristic() {
+    // No transition — single-stream chunk; donor + ours should both
+    // return block.len() (no split).
+    let block = synthetic_transition_chunk(MAX_BLOCK_SIZE as usize);
+    let split_level = 0;
+    let ours = block_splitter_decision(&block, split_level);
+    let donor = donor_decision(&block, split_level as i32);
+    assert_eq!(ours, donor, "no-transition: ours={ours} donor={donor}");
+    assert_eq!(
+        ours,
+        block.len(),
+        "no-transition: expected no split (== block.len()), got {ours}"
+    );
+}
+
+#[test]
+fn synthetic_transitions_by_chunks_all_levels() {
+    for &transition_at in &[16 * 1024usize, 32 * 1024, 48 * 1024, 64 * 1024, 96 * 1024] {
+        let block = synthetic_transition_chunk(transition_at);
+        let label = format!("synthetic-transition-{}k", transition_at / 1024);
+        for level in 1..=4 {
+            assert_parity(&label, &block, level);
+        }
+    }
+}

--- a/zstd/tests/block_splitter_donor_parity.rs
+++ b/zstd/tests/block_splitter_donor_parity.rs
@@ -83,6 +83,13 @@ fn load_corpus_chunks() -> Vec<(String, Vec<u8>)> {
     for entry in fs::read_dir(&dir).expect("read_dir corpus") {
         let entry = entry.expect("dir entry");
         let path = entry.path();
+        // Skip non-regular entries (subdirectories, symlinks-to-dirs,
+        // device nodes if the fixture tree ever grows). `fs::read` on
+        // a directory would panic and turn an extensible fixture
+        // layout into a parity-harness failure.
+        if !entry.file_type().expect("entry file_type").is_file() {
+            continue;
+        }
         // Skip compressed fixtures — we want raw payloads.
         if path
             .extension()
@@ -200,6 +207,10 @@ fn corpus_borders_heuristic_matches_donor() {
 #[test]
 fn corpus_by_chunks_matches_donor_at_each_sampling_level() {
     let chunks = load_corpus_chunks();
+    assert!(
+        !chunks.is_empty(),
+        "expected at least one 128 KB chunk from the decode corpus"
+    );
     for (label, block) in &chunks {
         for level in 1..=4 {
             assert_parity(label, block, level);

--- a/zstd/tests/block_splitter_donor_parity.rs
+++ b/zstd/tests/block_splitter_donor_parity.rs
@@ -55,16 +55,21 @@ unsafe extern "C" {
     ) -> usize;
 }
 
-/// Resolve the decode-corpus directory. The repo ships
-/// `zstd/decodecorpus_files/` as a checked-in fixture; resolve
-/// from `CARGO_MANIFEST_DIR` so the path is deterministic across
+/// Resolve the decode-corpus directory. The repository checks in
+/// `zstd/decodecorpus_files/` as a fixture for integration tests;
+/// the directory is intentionally excluded from the published
+/// crates.io package (see `[package].exclude` in `Cargo.toml`), so
+/// this test only runs against a repository checkout. Resolving
+/// from `CARGO_MANIFEST_DIR` makes the path deterministic across
 /// runners (nextest, IDE test runners, in-tree `cargo test`,
-/// out-of-tree invocations).
+/// out-of-tree invocations) when the fixture is present.
 fn corpus_dir() -> PathBuf {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("decodecorpus_files");
     assert!(
         path.is_dir(),
-        "expected corpus directory at {}; this fixture is shipped with the crate",
+        "expected corpus directory at {} — this test needs the \
+         decodecorpus_files/ fixture from the repository checkout; \
+         it is not shipped in the crates.io package",
         path.display()
     );
     path

--- a/zstd/tests/block_splitter_donor_parity.rs
+++ b/zstd/tests/block_splitter_donor_parity.rs
@@ -32,6 +32,11 @@ use zstd::zstd_safe::zstd_sys as _;
 /// Donor preSplit workspace size constant from `zstd_preSplit.h`.
 const ZSTD_SLIPBLOCK_WORKSPACESIZE: usize = 8208;
 
+// `non_snake_case` is allowed on the extern block so the donor symbol
+// keeps its exact upstream spelling — the linker resolves by name, and
+// renaming would force a `#[link_name = ...]` shim with no readability
+// gain.
+#[allow(non_snake_case)]
 unsafe extern "C" {
     /// Donor `ZSTD_splitBlock` (internal, not in `zstd.h` public API
     /// but exported by libzstd). Returns the split position within
@@ -142,8 +147,15 @@ fn synthetic_transition_chunk(transition_at: usize) -> Vec<u8> {
 /// Call donor `ZSTD_splitBlock` with a fresh stack-aligned workspace.
 fn donor_decision(block: &[u8], level: i32) -> usize {
     assert_eq!(block.len(), MAX_BLOCK_SIZE as usize);
-    // `ZSTD_SLIPBLOCK_WORKSPACESIZE / size_of::<usize>()` u64 slots so
-    // the buffer is naturally `size_t`-aligned per the donor contract.
+    // `ZSTD_SLIPBLOCK_WORKSPACESIZE` is in bytes; we allocate `u64`
+    // slots so the buffer is naturally 8-byte aligned (satisfies the
+    // donor's `size_t` alignment requirement on all supported targets,
+    // where `size_t` is at most 8 bytes). `/ 8 + 1` rounds the byte
+    // budget up to whole u64 slots — the `+ 1` covers the case where
+    // the workspace size is not a multiple of 8 (8208 is, so we get
+    // 8208/8 + 1 = 1026 slots = 8208 bytes of usable storage + one
+    // slot of slack). The actual byte count passed to donor below is
+    // `workspace.len() * 8`.
     let mut workspace = vec![0u64; ZSTD_SLIPBLOCK_WORKSPACESIZE / 8 + 1];
     // SAFETY: block.len() == 128 KB (asserted above), level ∈ 0..=4
     // (caller-enforced in test bodies below), workspace size ≥


### PR DESCRIPTION
## Summary

Closes #206. The comparator harness verifies that our donor-port
functions in `frame_compressor.rs` (`donor_split_block_from_borders`,
`donor_split_block_by_chunks`) produce **byte-identical** split
decisions to the upstream donor C function `ZSTD_splitBlock` across
the entire decode corpus + a synthetic transition-position matrix.

### Bindings ceremony

`ZSTD_splitBlock` is exported by libzstd but not part of the public
`zstd.h` API; `zstd-sys` does not bind it. The comparator declares
the `extern "C"` signature manually using the contract documented in
`zstd_preSplit.h` (`block_size == 128 KB`, `level ∈ 0..=4`,
workspace aligned for `size_t` with size ≥
`ZSTD_SLIPBLOCK_WORKSPACESIZE = 8208`). A no-op
`use zstd::zstd_safe::zstd_sys as _` forces the linker to pull in
the static libzstd archive so the manual extern resolves.

## Test plan

7 tests, gated under the `bench_internals` feature
(`required-features` in `Cargo.toml`):

- `corpus_borders_heuristic_matches_donor` — every 128 KB chunk in
  `decodecorpus_files/` at `split_level=0` (borders heuristic).
- `corpus_by_chunks_matches_donor_at_each_sampling_level` — same
  chunks across `split_level=1..=4` (byChunks at every sampling
  level).
- `synthetic_transition_at_{32k,64k,96k}_borders_heuristic` — pinned
  fixtures hitting donor's quantized split points (32 KB / 64 KB /
  96 KB / no-split).
- `synthetic_no_transition_borders_heuristic` — single-stream
  fixture: both implementations must return `block.len()` (no
  split).
- `synthetic_transitions_by_chunks_all_levels` — Cartesian product
  of 5 transition positions × 4 sampling levels.

All 7 tests PASS today, confirming the port is exact. Per the
issue's acceptance criteria, divergences correlating with ratio
loss would have justified porting more donor split logic; **zero
divergences** ⇒ the harness becomes a regression guard against
future drift.

### Verification

- [x] `cargo nextest run -p structured-zstd --features bench_internals --test block_splitter_donor_parity` — 7/7 pass
- [x] Full nextest suite: 611/611 pass with bench_internals on
- [x] `cargo clippy -p structured-zstd --all-targets --features bench_internals -- -D warnings` — clean

## Visibility changes

- `pub(crate) mod frame_compressor` (was `mod`) so the testing
  facade in `lib.rs` can route to the donor-port functions.
- Added `block_splitter_decision_for_bench` gated on
  `#[cfg(any(test, feature = "bench_internals"))]` so the
  dispatcher is visible only to tests/benches.
- `pub mod testing` (gated on `bench_internals`) gets a thin
  `block_splitter_decision` wrapper + `MAX_BLOCK_SIZE` const.

Closes #206.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to validate block splitting behavior and ensure consistency with reference implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->