### PR TITLE
perf(decode): direct-write decode_to_slice path (#244)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,22 +472,31 @@ jobs:
       - name: Build compare_ffi + compare_ffi_memory bench binaries
         env:
           CC_x86_64_unknown_linux_musl: musl-gcc
-          # The donor `zstd-sys` C library uses runtime feature
-          # detection (`is_x86_feature_detected!`-equivalent) so it
-          # transparently picks up BMI2/AVX2/etc. on the runner.
-          # Pure-Rust hot paths gate intrinsics on COMPILE-time
-          # `cfg!(target_feature = ...)` and the default rustc x86_64
-          # target ships with SSE2 only. Without explicit target
-          # selection the bench compares "donor with full ISA" vs
-          # "us with SSE2 baseline" — not apples-to-apples.
-          # `target-cpu=native` lets rustc inline BMI2/AVX2
-          # intrinsics throughout the bit reader, HUF decoder, and
-          # SIMD-copy kernels, matching what the donor measures on
-          # the same hardware. Measured at +8.5% on
-          # `decompress/level_-1_fast/decodecorpus-z000033/c_stream`
-          # on i9-9900K; the win comes from `_bzhi_u64`-backed
-          # `mask_lower_bits` in the FSE state-update hot path.
-          RUSTFLAGS: "-C target-cpu=native"
+          # The donor zstd-sys C library uses runtime feature detection
+          # (is_x86_feature_detected!-equivalent) so it transparently
+          # picks up BMI2/AVX2/etc. on the runner. Pure-Rust hot paths
+          # gate intrinsics on COMPILE-time cfg!(target_feature = ...)
+          # and the default rustc x86_64 target ships with SSE2 only.
+          # Without explicit target selection the bench compares
+          # "donor with full ISA" vs "us with SSE2 baseline" — not
+          # apples-to-apples.
+          #
+          # Use a DETERMINISTIC baseline (x86-64-v3 = BMI2 + AVX2 +
+          # everything in the Haswell ISA, the 2013+ x86_64 baseline)
+          # ONLY for x86_64 targets via target.<triple>.rustflags. NOT
+          # target-cpu=native: that picks whatever CPU the BUILD runner
+          # has, which (a) varies across github-runners, (b) crashes
+          # with SIGILL when a bench shard runner lacks features the
+          # build runner had, and (c) is meaningless for cross-compile
+          # targets like i686-unknown-linux-gnu.
+          #
+          # i686 / non-x86 / musl targets keep the default rustc
+          # baseline. Measured +8.5% on
+          # decompress/level_-1_fast/decodecorpus-z000033/c_stream on
+          # i9-9900K; the win comes from _bzhi_u64-backed
+          # mask_lower_bits in the FSE state-update hot path.
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C target-cpu=x86-64-v3"
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-cpu=x86-64-v3"
         run: |
           # `--no-run` builds without executing; `--message-format=json`
           # exposes the resolved binary path in the build log so we

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -472,6 +472,22 @@ jobs:
       - name: Build compare_ffi + compare_ffi_memory bench binaries
         env:
           CC_x86_64_unknown_linux_musl: musl-gcc
+          # The donor `zstd-sys` C library uses runtime feature
+          # detection (`is_x86_feature_detected!`-equivalent) so it
+          # transparently picks up BMI2/AVX2/etc. on the runner.
+          # Pure-Rust hot paths gate intrinsics on COMPILE-time
+          # `cfg!(target_feature = ...)` and the default rustc x86_64
+          # target ships with SSE2 only. Without explicit target
+          # selection the bench compares "donor with full ISA" vs
+          # "us with SSE2 baseline" — not apples-to-apples.
+          # `target-cpu=native` lets rustc inline BMI2/AVX2
+          # intrinsics throughout the bit reader, HUF decoder, and
+          # SIMD-copy kernels, matching what the donor measures on
+          # the same hardware. Measured at +8.5% on
+          # `decompress/level_-1_fast/decodecorpus-z000033/c_stream`
+          # on i9-9900K; the win comes from `_bzhi_u64`-backed
+          # `mask_lower_bits` in the FSE state-update hot path.
+          RUSTFLAGS: "-C target-cpu=native"
         run: |
           # `--no-run` builds without executing; `--message-format=json`
           # exposes the resolved binary path in the build log so we

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,16 @@ members = ["zstd", "cli"]
 lto = "fat"
 codegen-units = 1
 debug = "line-tables-only"
+
+# `cargo flamegraph` profile — like bench, but with FULL debug info
+# so Rust symbol-mangling resolves in the .svg. The flamegraph tool
+# reads DWARF inline info to demangle frames; `line-tables-only`
+# strips the type info the demangler needs and leaves large `[unknown]`
+# regions in the output. Kept separate from `bench` so timing runs
+# stay fast (debug = "full" roughly doubles build time and bloats
+# binaries ~5×). Use via
+#   cargo flamegraph --profile flamegraph --bench compare_ffi -- ...
+[profile.flamegraph]
+inherits = "bench"
+debug = "full"
+strip = "none"

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -319,7 +319,7 @@ fn bench_decompress_source(
     });
 
     // Direct-decode path (#244): target sized with WILDCOPY_OVERLENGTH
-    // slack so `decode_to_slice` takes the direct-write branch
+    // slack so `decode_to_slice_trusted` takes the direct-write branch
     // (decode straight into `target`, no FlatBuf drain copy).
     // Exposed alongside `pure_rust` so dashboards can attribute the
     // memory-traffic delta directly.
@@ -333,7 +333,7 @@ fn bench_decompress_source(
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
-                .decode_to_slice(black_box(compressed), &mut target)
+                .decode_to_slice_trusted(black_box(compressed), &mut target)
                 .unwrap();
             black_box(&target[..written]);
             assert_eq!(written, expected_len);

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -318,6 +318,25 @@ fn bench_decompress_source(
         })
     });
 
+    // Direct-decode path (#244): target sized with WILDCOPY_OVERLENGTH
+    // slack so `decode_to_slice` takes the direct-write branch
+    // (decode straight into `target`, no FlatBuf drain copy).
+    // Exposed alongside `pure_rust` so dashboards can attribute the
+    // memory-traffic delta directly.
+    group.bench_function("pure_rust_direct", |b| {
+        let compressed = materialize();
+        const WILDCOPY_OVERLENGTH: usize = 16;
+        let mut target = vec![0u8; expected_len + WILDCOPY_OVERLENGTH];
+        let mut decoder = FrameDecoder::new();
+        b.iter(|| {
+            let written = decoder
+                .decode_to_slice(black_box(compressed), &mut target)
+                .unwrap();
+            black_box(&target[..written]);
+            assert_eq!(written, expected_len);
+        })
+    });
+
     group.bench_function("c_ffi", |b| {
         // Reuse one DCtx + target buffer across iterations so the
         // timing sample reflects decode steady-state — matches the

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -325,8 +325,11 @@ fn bench_decompress_source(
     // memory-traffic delta directly.
     group.bench_function("pure_rust_direct", |b| {
         let compressed = materialize();
-        const WILDCOPY_OVERLENGTH: usize = 16;
-        let mut target = vec![0u8; expected_len + WILDCOPY_OVERLENGTH];
+        // Sized to match the dispatcher's eligibility check —
+        // mirror the constant from the decoder instead of
+        // duplicating its value so the bench can't silently drift
+        // off the direct path if the slack changes.
+        let mut target = vec![0u8; expected_len + structured_zstd::WILDCOPY_OVERLENGTH];
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -154,11 +154,11 @@ impl BlockDecoder {
                 Ok(1)
             }
             BlockType::Raw => {
-                // Pass `source` by value, not `&mut source`: `extend_from_reader<R: Read>`
-                // takes `R` by value, and `crate::io::Read` (the `no_std` shim) does not
-                // provide a blanket `impl<R: Read + ?Sized> Read for &mut R` like
-                // `std::io::Read` does, so `&mut source` would fail to compile without
-                // the `std` feature. `source` is not used after this match arm.
+                // Pass `source` by value rather than `&mut source` — it isn't
+                // used after this match arm anyway, so moving avoids the
+                // borrow-by-reference indirection. (Both io shims provide a
+                // blanket `Read for &mut T`, so `&mut source` would also
+                // compile; the by-value form is just cleaner here.)
                 workspace
                     .split()
                     .buffer

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -41,6 +41,85 @@ impl BlockDecoder {
     /// The decode buffer inside `workspace` may be reserved or grown during
     /// decoding. For some block types the decompressed size is known up front,
     /// but this is not guaranteed before any data is written.
+    /// Slice-source fast path for `decode_block_content`. Consumes
+    /// the right number of bytes from `*source` (advancing the slice)
+    /// without going through the persistent `block_content_buffer`.
+    /// Used by `FrameDecoder::decode_to_slice` where `source` is
+    /// already a `&[u8]` view into the user's input.
+    ///
+    /// Returns the number of bytes consumed from `*source`.
+    pub fn decode_block_content_from_slice<W: Workspace>(
+        &mut self,
+        header: &BlockHeader,
+        workspace: &mut W,
+        source: &mut &[u8],
+    ) -> Result<u64, DecodeBlockContentError> {
+        use DecoderState as State;
+        match self.internal_state {
+            State::ReadyToDecodeNextBody => { /* ok */ }
+            State::Failed => return Err(DecodeBlockContentError::DecoderStateIsFailed),
+            State::ReadyToDecodeNextHeader => {
+                return Err(DecodeBlockContentError::ExpectedHeaderOfPreviousBlock);
+            }
+        }
+
+        let block_type = header.block_type;
+        match block_type {
+            BlockType::RLE => {
+                // 1 byte from source via slice; no Read overhead.
+                if source.is_empty() {
+                    return Err(DecodeBlockContentError::ReadError {
+                        step: block_type,
+                        source: crate::io::Error::other("RLE block missing fill byte"),
+                    });
+                }
+                let fill = source[0];
+                *source = &source[1..];
+                workspace
+                    .split()
+                    .buffer
+                    .extend_and_fill(fill, header.decompressed_size as usize);
+                self.internal_state = State::ReadyToDecodeNextHeader;
+                Ok(1)
+            }
+            BlockType::Raw => {
+                // Raw payload IS the source bytes; push them
+                // directly to the buffer. For UserSliceBackend this
+                // is a single memcpy from input -> output, no
+                // intermediate Vec.
+                let n = header.decompressed_size as usize;
+                if source.len() < n {
+                    return Err(DecodeBlockContentError::ReadError {
+                        step: block_type,
+                        source: crate::io::Error::other("Raw block truncated"),
+                    });
+                }
+                let (payload, tail) = source.split_at(n);
+                workspace.split().buffer.push(payload);
+                *source = tail;
+                self.internal_state = State::ReadyToDecodeNextHeader;
+                Ok(u64::from(header.decompressed_size))
+            }
+            BlockType::Reserved => {
+                panic!("Reserved-type block should be rejected during header parsing");
+            }
+            BlockType::Compressed => {
+                let n = header.content_size as usize;
+                if source.len() < n {
+                    return Err(DecodeBlockContentError::ReadError {
+                        step: block_type,
+                        source: crate::io::Error::other("Compressed block truncated"),
+                    });
+                }
+                let (payload, tail) = source.split_at(n);
+                self.decompress_block_inplace(header, workspace, payload)?;
+                *source = tail;
+                self.internal_state = State::ReadyToDecodeNextHeader;
+                Ok(u64::from(header.content_size))
+            }
+        }
+    }
+
     pub fn decode_block_content<W: Workspace>(
         &mut self,
         header: &BlockHeader,
@@ -114,14 +193,56 @@ impl BlockDecoder {
         workspace: &mut W,
         mut source: impl Read,
     ) -> Result<(), DecompressBlockError> {
+        // Streaming-path entry: copy `content_size` bytes from the
+        // `Read` source into `block_content_buffer`, then dispatch
+        // to the in-place body. The direct-decode path
+        // (`decode_to_slice`) skips this copy by passing a borrowed
+        // slice of the input straight to `decompress_block_inplace`.
+        {
+            let parts = workspace.split();
+            parts
+                .block_content_buffer
+                .resize(header.content_size as usize, 0);
+            source.read_exact(parts.block_content_buffer.as_mut_slice())?;
+        }
+        // SAFETY: block_content_buffer aliases the WorkspaceRef's
+        // `block_content_buffer` field returned by the inner fn's
+        // `split()`. We only read from `raw` inside
+        // `decompress_block_inplace`; that fn never mutates
+        // block_content_buffer (it only writes the OTHER scratch
+        // fields). Without the lifetime widening here Rust would
+        // refuse the second `split()` call inside the body.
+        let raw_ptr_len = {
+            let bc = &workspace.split().block_content_buffer;
+            (bc.as_ptr(), bc.len())
+        };
+        let raw: &[u8] = unsafe { core::slice::from_raw_parts(raw_ptr_len.0, raw_ptr_len.1) };
+        self.decompress_block_inplace(header, workspace, raw)
+    }
+
+    /// Compressed-block fast path that takes the block content as a
+    /// borrowed slice (no per-block memcpy into
+    /// `block_content_buffer`).
+    ///
+    /// Called by:
+    /// - `decompress_block` (streaming path) after it has copied the
+    ///   compressed bytes from the source `Read` into the persistent
+    ///   `block_content_buffer`.
+    /// - `decode_block_content_from_slice` (direct-decode path) where
+    ///   the source is a `&[u8]` already, so the slice IS the input —
+    ///   saving the per-block memcpy + anonymous-page first-touch on
+    ///   `block_content_buffer.resize(...)`. At L-1 fast on
+    ///   `decodecorpus-z000033` this `block_content_buffer` traffic
+    ///   was the largest single contributor to the
+    ///   `__memmove_avx_unaligned_erms` + `exc_page_fault` flame
+    ///   on the post-#244 baseline (~30% of decode time combined).
+    pub(crate) fn decompress_block_inplace<W: Workspace>(
+        &mut self,
+        header: &BlockHeader,
+        workspace: &mut W,
+        raw: &[u8],
+    ) -> Result<(), DecompressBlockError> {
         let parts = workspace.split();
-        parts
-            .block_content_buffer
-            .resize(header.content_size as usize, 0);
-
-        source.read_exact(parts.block_content_buffer.as_mut_slice())?;
-        let raw = parts.block_content_buffer.as_slice();
-
         let mut section = LiteralsSection::new();
         let bytes_in_literals_header = section.parse_from_header(raw)?;
         let raw = &raw[bytes_in_literals_header as usize..];

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -68,9 +68,13 @@ impl BlockDecoder {
             BlockType::RLE => {
                 // 1 byte from source via slice; no Read overhead.
                 if source.is_empty() {
+                    // ErrorKind::UnexpectedEof matches what the streaming path
+                    // gets from Read::read_exact on truncated input — callers
+                    // and tests can detect truncation by kind alone, identical
+                    // across slice-source and Read-source decode entry points.
                     return Err(DecodeBlockContentError::ReadError {
                         step: block_type,
-                        source: crate::io::Error::other("RLE block missing fill byte"),
+                        source: crate::io::Error::from(crate::io::ErrorKind::UnexpectedEof),
                     });
                 }
                 let fill = source[0];
@@ -91,7 +95,7 @@ impl BlockDecoder {
                 if source.len() < n {
                     return Err(DecodeBlockContentError::ReadError {
                         step: block_type,
-                        source: crate::io::Error::other("Raw block truncated"),
+                        source: crate::io::Error::from(crate::io::ErrorKind::UnexpectedEof),
                     });
                 }
                 let (payload, tail) = source.split_at(n);
@@ -108,7 +112,7 @@ impl BlockDecoder {
                 if source.len() < n {
                     return Err(DecodeBlockContentError::ReadError {
                         step: block_type,
-                        source: crate::io::Error::other("Compressed block truncated"),
+                        source: crate::io::Error::from(crate::io::ErrorKind::UnexpectedEof),
                     });
                 }
                 let (payload, tail) = source.split_at(n);
@@ -545,13 +549,17 @@ mod tests {
         let err = d
             .decode_block_content_from_slice(&h, &mut ws, &mut src)
             .expect_err("must err on empty RLE source");
-        assert!(matches!(
-            err,
-            DecodeBlockContentError::ReadError {
-                step: BlockType::RLE,
-                ..
+        match &err {
+            DecodeBlockContentError::ReadError { step, source } => {
+                assert_eq!(*step, BlockType::RLE);
+                assert_eq!(
+                    source.kind(),
+                    crate::io::ErrorKind::UnexpectedEof,
+                    "slice-source truncation must report UnexpectedEof to match the streaming path's Read::read_exact behaviour"
+                );
             }
-        ));
+            other => panic!("expected ReadError, got {other:?}"),
+        }
     }
 
     #[test]
@@ -566,13 +574,13 @@ mod tests {
         let err = d
             .decode_block_content_from_slice(&h, &mut ws, &mut src)
             .expect_err("must err on truncated raw source");
-        assert!(matches!(
-            err,
-            DecodeBlockContentError::ReadError {
-                step: BlockType::Raw,
-                ..
+        match &err {
+            DecodeBlockContentError::ReadError { step, source } => {
+                assert_eq!(*step, BlockType::Raw);
+                assert_eq!(source.kind(), crate::io::ErrorKind::UnexpectedEof);
             }
-        ));
+            other => panic!("expected ReadError, got {other:?}"),
+        }
     }
 
     #[test]
@@ -586,13 +594,13 @@ mod tests {
         let err = d
             .decode_block_content_from_slice(&h, &mut ws, &mut src)
             .expect_err("must err on truncated compressed source");
-        assert!(matches!(
-            err,
-            DecodeBlockContentError::ReadError {
-                step: BlockType::Compressed,
-                ..
+        match &err {
+            DecodeBlockContentError::ReadError { step, source } => {
+                assert_eq!(*step, BlockType::Compressed);
+                assert_eq!(source.kind(), crate::io::ErrorKind::UnexpectedEof);
             }
-        ));
+            other => panic!("expected ReadError, got {other:?}"),
+        }
     }
 
     #[test]

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -470,3 +470,145 @@ impl BlockDecoder {
             | (u32::from(self.header_buffer[2]) << 13)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Coverage for `decode_block_content_from_slice` error branches —
+    //! truncated / empty source on each block type, plus the
+    //! `DecoderState::Failed` / `ReadyToDecodeNextHeader` entry-state
+    //! guards. The happy path is exercised indirectly via the
+    //! roundtrip tests on `decode_to_slice`; these tests pin the
+    //! fail-fast behaviour for malformed input.
+    use super::*;
+    use crate::blocks::block::{BlockHeader, BlockType};
+    use crate::decoding::ringbuffer::RingBuffer;
+    use crate::decoding::scratch::DecoderScratch;
+
+    fn header(block_type: BlockType, decompressed_size: u32, content_size: u32) -> BlockHeader {
+        BlockHeader {
+            last_block: true,
+            block_type,
+            decompressed_size,
+            content_size,
+        }
+    }
+
+    fn fresh_workspace() -> DecoderScratch<RingBuffer> {
+        DecoderScratch::<RingBuffer>::new(1 << 20)
+    }
+
+    fn primed_decoder() -> BlockDecoder {
+        let mut d = new();
+        d.internal_state = DecoderState::ReadyToDecodeNextBody;
+        d
+    }
+
+    #[test]
+    fn rejects_when_internal_state_expects_header() {
+        // Default state is ReadyToDecodeNextHeader -> calling
+        // decode_block_content_from_slice on a body must error,
+        // not silently decode garbage.
+        let mut d = new();
+        let mut ws = fresh_workspace();
+        let mut src: &[u8] = &[];
+        let h = header(BlockType::RLE, 4, 1);
+        let err = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect_err("must err on body before header");
+        assert!(matches!(
+            err,
+            DecodeBlockContentError::ExpectedHeaderOfPreviousBlock
+        ));
+    }
+
+    #[test]
+    fn rejects_when_internal_state_failed() {
+        let mut d = new();
+        d.internal_state = DecoderState::Failed;
+        let mut ws = fresh_workspace();
+        let mut src: &[u8] = &[0x42];
+        let h = header(BlockType::RLE, 4, 1);
+        let err = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect_err("must err on Failed state");
+        assert!(matches!(err, DecodeBlockContentError::DecoderStateIsFailed));
+    }
+
+    #[test]
+    fn rle_empty_source_errors_not_panics() {
+        // RLE block needs at least 1 fill byte in source. Empty
+        // source must return ReadError, not panic on source[0].
+        let mut d = primed_decoder();
+        let mut ws = fresh_workspace();
+        let mut src: &[u8] = &[];
+        let h = header(BlockType::RLE, 4, 1);
+        let err = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect_err("must err on empty RLE source");
+        assert!(matches!(
+            err,
+            DecodeBlockContentError::ReadError {
+                step: BlockType::RLE,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn raw_truncated_source_errors_not_panics() {
+        // Raw block header claims 10 decompressed bytes but only
+        // 3 are available -> ReadError. The pre-split bounds check
+        // catches this before split_at would panic.
+        let mut d = primed_decoder();
+        let mut ws = fresh_workspace();
+        let mut src: &[u8] = &[1, 2, 3];
+        let h = header(BlockType::Raw, 10, 10);
+        let err = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect_err("must err on truncated raw source");
+        assert!(matches!(
+            err,
+            DecodeBlockContentError::ReadError {
+                step: BlockType::Raw,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn compressed_truncated_source_errors_not_panics() {
+        // Compressed block header claims 100 compressed bytes but
+        // only 8 are available -> ReadError. Pre-split bound check.
+        let mut d = primed_decoder();
+        let mut ws = fresh_workspace();
+        let mut src: &[u8] = &[0u8; 8];
+        let h = header(BlockType::Compressed, 0, 100);
+        let err = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect_err("must err on truncated compressed source");
+        assert!(matches!(
+            err,
+            DecodeBlockContentError::ReadError {
+                step: BlockType::Compressed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn rle_advances_source_by_one_byte_and_extends_buffer() {
+        // Happy path on a freshly primed decoder: 1 byte consumed
+        // from source, N bytes filled into buffer.
+        let mut d = primed_decoder();
+        let mut ws = fresh_workspace();
+        let payload = [0xCD, 0xFF, 0xAA];
+        let mut src: &[u8] = &payload;
+        let h = header(BlockType::RLE, 7, 1);
+        let consumed = d
+            .decode_block_content_from_slice(&h, &mut ws, &mut src)
+            .expect("RLE happy path");
+        assert_eq!(consumed, 1);
+        assert_eq!(src, &payload[1..], "1 byte consumed from source");
+        assert_eq!(ws.buffer.len(), 7, "buffer extended by decompressed_size");
+    }
+}

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -3,7 +3,7 @@ use super::super::blocks::block::BlockType;
 use super::super::blocks::literals_section::LiteralsSection;
 use super::super::blocks::literals_section::LiteralsSectionType;
 use super::super::blocks::sequence_section::SequencesHeader;
-use super::literals_section_decoder::decode_literals;
+use super::literals_section_decoder::{LiteralsView, decode_literals_zerocopy};
 use super::sequence_section_decoder::decode_and_execute_sequences;
 use crate::common::MAX_BLOCK_SIZE;
 use crate::decoding::errors::DecodeSequenceError;
@@ -195,29 +195,31 @@ impl BlockDecoder {
     ) -> Result<(), DecompressBlockError> {
         // Streaming-path entry: copy `content_size` bytes from the
         // `Read` source into `block_content_buffer`, then dispatch
-        // to the in-place body. The direct-decode path
-        // (`decode_to_slice`) skips this copy by passing a borrowed
-        // slice of the input straight to `decompress_block_inplace`.
-        {
-            let parts = workspace.split();
-            parts
-                .block_content_buffer
-                .resize(header.content_size as usize, 0);
-            source.read_exact(parts.block_content_buffer.as_mut_slice())?;
-        }
-        // SAFETY: block_content_buffer aliases the WorkspaceRef's
-        // `block_content_buffer` field returned by the inner fn's
-        // `split()`. We only read from `raw` inside
-        // `decompress_block_inplace`; that fn never mutates
-        // block_content_buffer (it only writes the OTHER scratch
-        // fields). Without the lifetime widening here Rust would
-        // refuse the second `split()` call inside the body.
-        let raw_ptr_len = {
-            let bc = &workspace.split().block_content_buffer;
-            (bc.as_ptr(), bc.len())
-        };
-        let raw: &[u8] = unsafe { core::slice::from_raw_parts(raw_ptr_len.0, raw_ptr_len.1) };
-        self.decompress_block_inplace(header, workspace, raw)
+        // to the in-place body via per-field borrows. The direct-
+        // decode path (`decode_to_slice`) skips this copy by passing
+        // a borrowed slice of the input straight to
+        // `decompress_block_inplace_with_parts`.
+        let parts = workspace.split();
+        parts
+            .block_content_buffer
+            .resize(header.content_size as usize, 0);
+        source.read_exact(parts.block_content_buffer.as_mut_slice())?;
+        // Disjoint-fields borrow: `as_slice()` reborrows
+        // block_content_buffer as `&[u8]`; the other WorkspaceRef
+        // fields stay independently movable into the helper since
+        // each is a distinct struct field. No `unsafe` needed —
+        // Rust's borrow checker tracks per-field disjointness.
+        let raw = parts.block_content_buffer.as_slice();
+        self.decompress_block_inplace_with_parts(
+            header,
+            parts.huf,
+            parts.fse,
+            parts.buffer,
+            parts.offset_hist,
+            parts.literals_buffer,
+            parts.sequences,
+            raw,
+        )
     }
 
     /// Compressed-block fast path that takes the block content as a
@@ -243,6 +245,42 @@ impl BlockDecoder {
         raw: &[u8],
     ) -> Result<(), DecompressBlockError> {
         let parts = workspace.split();
+        // block_content_buffer is intentionally NOT passed — the
+        // in-place body does not need it (raw already IS the block
+        // content). Dropping it here keeps the helper signature
+        // free of an unused-field reference.
+        self.decompress_block_inplace_with_parts(
+            header,
+            parts.huf,
+            parts.fse,
+            parts.buffer,
+            parts.offset_hist,
+            parts.literals_buffer,
+            parts.sequences,
+            raw,
+        )
+    }
+
+    /// Inner body of [`Self::decompress_block_inplace`] that takes
+    /// the scratch fields as disjoint `&mut` references. The split
+    /// happens at the call site (so the streaming path can keep its
+    /// `block_content_buffer` borrow alive while passing `raw =
+    /// block_content_buffer.as_slice()` here without aliasing the
+    /// other scratch fields). All `unsafe` from the previous
+    /// lifetime-widening trick is gone — disjoint-field borrows
+    /// type-check naturally.
+    #[allow(clippy::too_many_arguments)]
+    fn decompress_block_inplace_with_parts<B: super::buffer_backend::BufferBackend>(
+        &mut self,
+        header: &BlockHeader,
+        huf: &mut crate::decoding::scratch::HuffmanScratch,
+        fse: &mut crate::decoding::scratch::FSEScratch,
+        buffer: &mut crate::decoding::decode_buffer::DecodeBuffer<B>,
+        offset_hist: &mut [u32; 3],
+        literals_buffer: &mut alloc::vec::Vec<u8>,
+        sequences: &mut alloc::vec::Vec<crate::blocks::sequence_section::Sequence>,
+        raw: &[u8],
+    ) -> Result<(), DecompressBlockError> {
         let mut section = LiteralsSection::new();
         let bytes_in_literals_header = section.parse_from_header(raw)?;
         let raw = &raw[bytes_in_literals_header as usize..];
@@ -272,13 +310,22 @@ impl BlockDecoder {
         let raw_literals = &raw[..upper_limit_for_literals];
         vprintln!("Slice for literals: {}", raw_literals.len());
 
-        parts.literals_buffer.clear(); //all literals of the previous block must have been used in the sequence execution anyways. just be defensive here
-        let bytes_used_in_literals_section =
-            decode_literals(&section, parts.huf, raw_literals, parts.literals_buffer)?;
+        literals_buffer.clear(); //all literals of the previous block must have been used in the sequence execution anyways. just be defensive here
+        // Zero-copy literals view — for Raw sections this borrows
+        // straight into `raw_literals` (no memcpy into the Vec).
+        // For RLE / HUF it materialises into `literals_buffer`
+        // and `data` is a slice over that buffer. Eliminates a major
+        // memcpy contributor (Vec::extend_from_slice → spec_extend)
+        // flagged at ~20% of decode time on the L-1 fast c_stream
+        // flamegraph.
+        let LiteralsView {
+            data: literals_view,
+            bytes_used: bytes_used_in_literals_section,
+        } = decode_literals_zerocopy(&section, huf, raw_literals, literals_buffer)?;
         assert!(
-            section.regenerated_size == parts.literals_buffer.len() as u32,
+            section.regenerated_size as usize == literals_view.len(),
             "Wrong number of literals: {}, Should have been: {}",
-            parts.literals_buffer.len(),
+            literals_view.len(),
             section.regenerated_size
         );
         assert!(bytes_used_in_literals_section == upper_limit_for_literals as u32);
@@ -316,11 +363,11 @@ impl BlockDecoder {
             decode_and_execute_sequences(
                 &seq_section,
                 raw,
-                parts.fse,
-                parts.buffer,
-                parts.offset_hist,
-                parts.literals_buffer,
-                parts.sequences,
+                fse,
+                buffer,
+                offset_hist,
+                literals_view,
+                sequences,
             )?;
         } else {
             if !raw.is_empty() {
@@ -330,8 +377,8 @@ impl BlockDecoder {
                     },
                 ));
             }
-            parts.buffer.push(parts.literals_buffer);
-            parts.sequences.clear();
+            buffer.push(literals_view);
+            sequences.clear();
         }
 
         Ok(())

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -11,7 +11,7 @@ use crate::decoding::errors::{
     BlockHeaderReadError, BlockSizeError, BlockTypeError, DecodeBlockContentError,
     DecompressBlockError,
 };
-use crate::decoding::scratch::DecoderScratch;
+use crate::decoding::scratch::Workspace;
 use crate::io::Read;
 
 pub struct BlockDecoder {
@@ -41,10 +41,10 @@ impl BlockDecoder {
     /// The decode buffer inside `workspace` may be reserved or grown during
     /// decoding. For some block types the decompressed size is known up front,
     /// but this is not guaranteed before any data is written.
-    pub fn decode_block_content<B: super::buffer_backend::BufferBackend>(
+    pub fn decode_block_content<W: Workspace>(
         &mut self,
         header: &BlockHeader,
-        workspace: &mut DecoderScratch<B>,
+        workspace: &mut W,
         mut source: impl Read,
     ) -> Result<u64, DecodeBlockContentError> {
         match self.internal_state {
@@ -66,6 +66,7 @@ impl BlockDecoder {
                     }
                 })?;
                 workspace
+                    .split()
                     .buffer
                     .extend_and_fill(buf[0], header.decompressed_size as usize);
 
@@ -80,6 +81,7 @@ impl BlockDecoder {
                 // `std::io::Read` does, so `&mut source` would fail to compile without
                 // the `std` feature. `source` is not used after this match arm.
                 workspace
+                    .split()
                     .buffer
                     .extend_from_reader(source, header.decompressed_size as usize)
                     .map_err(|err| DecodeBlockContentError::ReadError {
@@ -106,18 +108,19 @@ impl BlockDecoder {
         }
     }
 
-    fn decompress_block<B: super::buffer_backend::BufferBackend>(
+    fn decompress_block<W: Workspace>(
         &mut self,
         header: &BlockHeader,
-        workspace: &mut DecoderScratch<B>, //reuse this as often as possible. Not only if the trees are reused but also reuse the allocations when building new trees
+        workspace: &mut W,
         mut source: impl Read,
     ) -> Result<(), DecompressBlockError> {
-        workspace
+        let parts = workspace.split();
+        parts
             .block_content_buffer
             .resize(header.content_size as usize, 0);
 
-        source.read_exact(workspace.block_content_buffer.as_mut_slice())?;
-        let raw = workspace.block_content_buffer.as_slice();
+        source.read_exact(parts.block_content_buffer.as_mut_slice())?;
+        let raw = parts.block_content_buffer.as_slice();
 
         let mut section = LiteralsSection::new();
         let bytes_in_literals_header = section.parse_from_header(raw)?;
@@ -148,17 +151,13 @@ impl BlockDecoder {
         let raw_literals = &raw[..upper_limit_for_literals];
         vprintln!("Slice for literals: {}", raw_literals.len());
 
-        workspace.literals_buffer.clear(); //all literals of the previous block must have been used in the sequence execution anyways. just be defensive here
-        let bytes_used_in_literals_section = decode_literals(
-            &section,
-            &mut workspace.huf,
-            raw_literals,
-            &mut workspace.literals_buffer,
-        )?;
+        parts.literals_buffer.clear(); //all literals of the previous block must have been used in the sequence execution anyways. just be defensive here
+        let bytes_used_in_literals_section =
+            decode_literals(&section, parts.huf, raw_literals, parts.literals_buffer)?;
         assert!(
-            section.regenerated_size == workspace.literals_buffer.len() as u32,
+            section.regenerated_size == parts.literals_buffer.len() as u32,
             "Wrong number of literals: {}, Should have been: {}",
-            workspace.literals_buffer.len(),
+            parts.literals_buffer.len(),
             section.regenerated_size
         );
         assert!(bytes_used_in_literals_section == upper_limit_for_literals as u32);
@@ -189,17 +188,18 @@ impl BlockDecoder {
             // and inlines the per-iter execute_one_sequence work next to
             // the FSE state advance. Falls back to the legacy two-pass
             // pipeline internally when any of LL/ML/OF is in RLE mode.
-            // Pass field-level borrows so `raw` (immutable view into
-            // workspace.block_content_buffer) can coexist with the mutable
-            // borrows on the FSE / decode-buffer / offset-hist fields.
+            // Pass field-level borrows from the WorkspaceRef so `raw`
+            // (immutable view into block_content_buffer) can coexist
+            // with the mutable borrows on the FSE / decode-buffer /
+            // offset-hist fields.
             decode_and_execute_sequences(
                 &seq_section,
                 raw,
-                &mut workspace.fse,
-                &mut workspace.buffer,
-                &mut workspace.offset_hist,
-                &workspace.literals_buffer,
-                &mut workspace.sequences,
+                parts.fse,
+                parts.buffer,
+                parts.offset_hist,
+                parts.literals_buffer,
+                parts.sequences,
             )?;
         } else {
             if !raw.is_empty() {
@@ -209,8 +209,8 @@ impl BlockDecoder {
                     },
                 ));
             }
-            workspace.buffer.push(&workspace.literals_buffer);
-            workspace.sequences.clear();
+            parts.buffer.push(parts.literals_buffer);
+            parts.sequences.clear();
         }
 
         Ok(())

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -44,7 +44,7 @@ impl BlockDecoder {
     /// Slice-source fast path for `decode_block_content`. Consumes
     /// the right number of bytes from `*source` (advancing the slice)
     /// without going through the persistent `block_content_buffer`.
-    /// Used by `FrameDecoder::decode_to_slice` where `source` is
+    /// Used by `FrameDecoder::decode_to_slice_trusted` where `source` is
     /// already a `&[u8]` view into the user's input.
     ///
     /// Returns the number of bytes consumed from `*source`.
@@ -200,7 +200,7 @@ impl BlockDecoder {
         // Streaming-path entry: copy `content_size` bytes from the
         // `Read` source into `block_content_buffer`, then dispatch
         // to the in-place body via per-field borrows. The direct-
-        // decode path (`decode_to_slice`) skips this copy by passing
+        // decode path (`decode_to_slice_trusted`) skips this copy by passing
         // a borrowed slice of the input straight to
         // `decompress_block_inplace_with_parts`.
         let parts = workspace.split();
@@ -481,7 +481,7 @@ mod tests {
     //! truncated / empty source on each block type, plus the
     //! `DecoderState::Failed` / `ReadyToDecodeNextHeader` entry-state
     //! guards. The happy path is exercised indirectly via the
-    //! roundtrip tests on `decode_to_slice`; these tests pin the
+    //! roundtrip tests on `decode_to_slice_trusted`; these tests pin the
     //! fail-fast behaviour for malformed input.
     use super::*;
     use crate::blocks::block::{BlockHeader, BlockType};

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -592,6 +592,44 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
     }
 
+    /// Advance the backend's head past any bytes beyond `window_size`
+    /// without producing them to a sink — the bytes remain physically
+    /// present (the backend's allocation never shrinks), but they are
+    /// no longer visible through [`Self::len`] / `as_slices` /
+    /// `repeat`. Used by the direct-decode path on multi-segment
+    /// frames where the caller's output IS the buffer, so the bytes
+    /// don't need to be drained anywhere — they just need to drop
+    /// out of `len()` so the offset-bound match validation
+    /// (`offset <= buffer.len()`) coincides with the spec's
+    /// window-size rule (`offset <= window_size`).
+    ///
+    /// Returns the number of bytes whose visibility was discarded.
+    pub fn drop_to_window_size(&mut self) -> usize {
+        match self.can_drain_to_window_size() {
+            None => 0,
+            Some(can_drop) => {
+                // Hash the bytes about to drop out of the visible
+                // region so the rolling content checksum still sees
+                // them. Matches `drain_to`'s shape (it hashes via
+                // the closure each chunk it writes).
+                #[cfg(feature = "hash")]
+                {
+                    use core::hash::Hasher;
+                    let (s1, s2) = self.buffer.as_slices();
+                    let head_take = s1.len().min(can_drop);
+                    self.hash.write(&s1[..head_take]);
+                    let remaining = can_drop - head_take;
+                    if remaining > 0 {
+                        self.hash.write(&s2[..remaining.min(s2.len())]);
+                    }
+                }
+                self.buffer.drop_first_n(can_drop);
+                self.total_output_counter += can_drop as u64;
+                can_drop
+            }
+        }
+    }
+
     /// drain the buffer completely
     pub fn drain(&mut self) -> Vec<u8> {
         let (slice1, slice2) = self.buffer.as_slices();

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -612,12 +612,18 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// where this is called once per block.
     ///
     /// Returns the number of bytes whose visibility was discarded.
+    ///
+    /// Does NOT mutate `total_output_counter`: that counter tracks
+    /// total bytes produced (incremented by `push` / `repeat` /
+    /// `extend_and_fill`). Advancing `head` just hides
+    /// already-produced bytes from the visible region; counting them
+    /// again would double-count and break `repeat_from_dict`'s offset
+    /// reachability check.
     pub fn drop_to_window_size(&mut self) -> usize {
         match self.can_drain_to_window_size() {
             None => 0,
             Some(can_drop) => {
                 self.buffer.drop_first_n(can_drop);
-                self.total_output_counter += can_drop as u64;
                 can_drop
             }
         }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -620,13 +620,15 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// (`offset <= buffer.len()`) coincides with the spec's
     /// window-size rule (`offset <= window_size`).
     ///
-    /// Does NOT update the rolling content checksum: the direct-
-    /// decode caller (`FrameDecoder::decode_to_slice`) gates the
-    /// direct path off when the frame has `content_checksum_flag`,
-    /// so the hash this method would touch is dropped along with
-    /// the stack-local `DecodeBuffer` anyway. Skipping the hash
-    /// write saves measurable cycles on large multi-segment frames
-    /// where this is called once per block.
+    /// Does NOT update the rolling content checksum. On the direct
+    /// path the caller (`FrameDecoder::decode_to_slice`) hashes the
+    /// final `output[..content_size]` slice ONCE at end of decode
+    /// (single sequential xxhash pass over cache-hot data) and
+    /// propagates the digest into the persistent scratch's hasher.
+    /// Hashing inside `drop_to_window_size` would re-hash the same
+    /// bytes per block (this method runs once per block on
+    /// multi-segment frames), which is wasted work — the end-of-
+    /// decode walk covers the entire output uniformly.
     ///
     /// Returns the number of bytes whose visibility was discarded.
     ///

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -592,6 +592,23 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
     }
 
+    /// Total bytes ever produced into the backend across this
+    /// `DecodeBuffer`'s lifetime. Incremented by `push` / `repeat` /
+    /// `extend_and_fill` / `extend_from_reader`. Survives across
+    /// `drop_to_window_size` and `drain_*` calls (those only narrow
+    /// the visible region; they don't roll back produced).
+    ///
+    /// Used by the direct-decode path (`FrameDecoder::decode_to_slice`)
+    /// to track actual bytes written against the declared
+    /// `frame_content_size`. Sidesteps `BlockHeader.decompressed_size`
+    /// which is intentionally 0 for `BlockType::Compressed` (the
+    /// header parser doesn't decode the body), so per-block tracking
+    /// via the header field would always read 0 on compressed blocks
+    /// and miscount.
+    pub fn total_produced(&self) -> u64 {
+        self.total_output_counter
+    }
+
     /// Advance the backend's head past any bytes beyond `window_size`
     /// without producing them to a sink — the bytes remain physically
     /// present (the backend's allocation never shrinks), but they are

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -598,7 +598,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// `drop_to_window_size` and `drain_*` calls (those only narrow
     /// the visible region; they don't roll back produced).
     ///
-    /// Used by the direct-decode path (`FrameDecoder::decode_to_slice`)
+    /// Used by the direct-decode path (`FrameDecoder::decode_to_slice_trusted`)
     /// to track actual bytes written against the declared
     /// `frame_content_size`. Sidesteps `BlockHeader.decompressed_size`
     /// which is intentionally 0 for `BlockType::Compressed` (the
@@ -621,7 +621,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// window-size rule (`offset <= window_size`).
     ///
     /// Does NOT update the rolling content checksum. On the direct
-    /// path the caller (`FrameDecoder::decode_to_slice`) hashes the
+    /// path the caller (`FrameDecoder::decode_to_slice_trusted`) hashes the
     /// final `output[..content_size]` slice ONCE at end of decode
     /// (single sequential xxhash pass over cache-hot data) and
     /// propagates the digest into the persistent scratch's hasher.

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -603,26 +603,19 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// (`offset <= buffer.len()`) coincides with the spec's
     /// window-size rule (`offset <= window_size`).
     ///
+    /// Does NOT update the rolling content checksum: the direct-
+    /// decode caller (`FrameDecoder::decode_to_slice`) gates the
+    /// direct path off when the frame has `content_checksum_flag`,
+    /// so the hash this method would touch is dropped along with
+    /// the stack-local `DecodeBuffer` anyway. Skipping the hash
+    /// write saves measurable cycles on large multi-segment frames
+    /// where this is called once per block.
+    ///
     /// Returns the number of bytes whose visibility was discarded.
     pub fn drop_to_window_size(&mut self) -> usize {
         match self.can_drain_to_window_size() {
             None => 0,
             Some(can_drop) => {
-                // Hash the bytes about to drop out of the visible
-                // region so the rolling content checksum still sees
-                // them. Matches `drain_to`'s shape (it hashes via
-                // the closure each chunk it writes).
-                #[cfg(feature = "hash")]
-                {
-                    use core::hash::Hasher;
-                    let (s1, s2) = self.buffer.as_slices();
-                    let head_take = s1.len().min(can_drop);
-                    self.hash.write(&s1[..head_take]);
-                    let remaining = can_drop - head_take;
-                    if remaining > 0 {
-                        self.hash.write(&s2[..remaining.min(s2.len())]);
-                    }
-                }
                 self.buffer.drop_first_n(can_drop);
                 self.total_output_counter += can_drop as u64;
                 can_drop

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1357,6 +1357,14 @@ mod tests {
             FrameDecoderError::DictAlreadyRegistered { dict_id: 0xABCD }.to_string(),
             "Dictionary id 0xABCD already registered in decoder"
         );
+        assert_eq!(
+            FrameDecoderError::FrameContentSizeMismatch {
+                declared: 100,
+                produced: 87,
+            }
+            .to_string(),
+            "Frame content size mismatch (corrupt frame): declared 100 bytes, blocks summed to 87 bytes"
+        );
     }
 
     #[test]

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -501,6 +501,17 @@ pub enum FrameDecoderError {
     FailedToDrainDecodebuffer(Error),
     FailedToSkipFrame,
     TargetTooSmall,
+    /// Decoded block sizes don't sum to the frame's declared
+    /// `frame_content_size` (either a block claims to expand past
+    /// FCS, or the stream ends before reaching FCS). Indicates a
+    /// malformed or corrupt frame — distinct from
+    /// [`Self::TargetTooSmall`] (which is the caller's
+    /// responsibility) so callers can tell decoder-side issues
+    /// apart from their own buffer sizing mistakes.
+    FrameContentSizeMismatch {
+        declared: u64,
+        produced: u64,
+    },
     DictNotProvided {
         dict_id: u32,
     },
@@ -609,6 +620,12 @@ impl core::fmt::Display for FrameDecoderError {
                 write!(
                     f,
                     "Target must have at least as many bytes as the content size reported by the frame"
+                )
+            }
+            FrameDecoderError::FrameContentSizeMismatch { declared, produced } => {
+                write!(
+                    f,
+                    "Frame content size mismatch (corrupt frame): declared {declared} bytes, blocks summed to {produced} bytes"
                 )
             }
             FrameDecoderError::DictNotProvided { dict_id } => {

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -16,7 +16,6 @@
 
 use crate::io::{Error, Read};
 use alloc::vec::Vec;
-use core::ptr;
 
 use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 
@@ -183,11 +182,28 @@ impl BufferBackend for FlatBuf {
         let src_off = self.head + start;
         debug_assert!(src_off + len <= dst_off);
         debug_assert!(dst_off + len <= self.buf.capacity());
+        // Route through `simd_copy::copy_bytes_overshooting` so short
+        // match copies (the common L-1 fast pattern) hit the inline
+        // SIMD / overlapping-u64 fast paths instead of going to
+        // libc `__memmove_avx_unaligned_erms` via
+        // `ptr::copy_nonoverlapping`. The dispatch cost was 40% of
+        // decode CPU on the L-1 c_stream flamegraph.
+        let total_readable = self.buf.len() - src_off;
+        let total_writable = self.buf.capacity() - dst_off;
         // SAFETY: caller's non-overlap precondition gives
-        // src_off + len <= dst_off. Capacity covers dst_off + len.
+        // `src_off + len <= dst_off`. `total_readable >= len` since
+        // `src_off + len <= dst_off <= self.buf.len()`.
+        // `total_writable >= len` because Vec capacity covers the
+        // upfront reserve. The helper may overshoot up to
+        // `total_writable` (= cap - dst_off, which includes the
+        // WILDCOPY_OVERLENGTH slack baked into with_capacity).
         unsafe {
-            let ptr = self.buf.as_mut_ptr();
-            ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);
+            let base = self.buf.as_mut_ptr();
+            super::simd_copy::copy_bytes_overshooting(
+                (base.add(src_off), total_readable),
+                (base.add(dst_off), total_writable),
+                len,
+            );
             self.buf.set_len(dst_off + len);
         }
     }

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -16,6 +16,7 @@
 
 use crate::io::{Error, Read};
 use alloc::vec::Vec;
+use core::ptr;
 
 use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 
@@ -182,28 +183,11 @@ impl BufferBackend for FlatBuf {
         let src_off = self.head + start;
         debug_assert!(src_off + len <= dst_off);
         debug_assert!(dst_off + len <= self.buf.capacity());
-        // Route through `simd_copy::copy_bytes_overshooting` so short
-        // match copies (the common L-1 fast pattern) hit the inline
-        // SIMD / overlapping-u64 fast paths instead of going to
-        // libc `__memmove_avx_unaligned_erms` via
-        // `ptr::copy_nonoverlapping`. The dispatch cost was 40% of
-        // decode CPU on the L-1 c_stream flamegraph.
-        let total_readable = self.buf.len() - src_off;
-        let total_writable = self.buf.capacity() - dst_off;
         // SAFETY: caller's non-overlap precondition gives
-        // `src_off + len <= dst_off`. `total_readable >= len` since
-        // `src_off + len <= dst_off <= self.buf.len()`.
-        // `total_writable >= len` because Vec capacity covers the
-        // upfront reserve. The helper may overshoot up to
-        // `total_writable` (= cap - dst_off, which includes the
-        // WILDCOPY_OVERLENGTH slack baked into with_capacity).
+        // src_off + len <= dst_off. Capacity covers dst_off + len.
         unsafe {
-            let base = self.buf.as_mut_ptr();
-            super::simd_copy::copy_bytes_overshooting(
-                (base.add(src_off), total_readable),
-                (base.add(dst_off), total_writable),
-                len,
-            );
+            let ptr = self.buf.as_mut_ptr();
+            ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);
             self.buf.set_len(dst_off + len);
         }
     }

--- a/zstd/src/decoding/frame.rs
+++ b/zstd/src/decoding/frame.rs
@@ -169,6 +169,32 @@ impl FrameHeader {
         self.frame_content_size
     }
 
+    /// Whether the frame header carried an explicit `Frame_Content_Size`
+    /// field on the wire. Distinguishes "FCS absent" (FCS_flag=0 +
+    /// `Single_Segment_flag=0`) from "FCS=0 explicitly declared"
+    /// (FCS_flag>=1 with a zero value, or FCS_flag=0 +
+    /// `Single_Segment_flag=1` with a 1-byte FCS=0). Both leave
+    /// [`Self::frame_content_size`] at `0`, so [`Self::frame_content_size`]
+    /// alone cannot distinguish the two; callers that need to know
+    /// whether the value is actually a wire-format declaration (e.g.
+    /// for post-decode size validation) should consult this method.
+    #[allow(dead_code)]
+    pub fn fcs_declared(&self) -> bool {
+        // `frame_content_size_bytes()` returns 0 only when FCS_flag=0
+        // AND single_segment_flag=0 — exactly the "no FCS on the wire"
+        // case. Any other combination (FCS_flag in 1..=3, or
+        // single_segment_flag set) writes a non-zero number of bytes.
+        // The descriptor was already validated when the header was
+        // parsed; if `frame_content_size_bytes()` is `Err` here the
+        // header object should not exist, so unwrap_or(0) collapses
+        // the (unreachable) error into the safe "treat as absent"
+        // answer.
+        self.descriptor
+            .frame_content_size_bytes()
+            .map(|n| n != 0)
+            .unwrap_or(false)
+    }
+
     /// Raw `Window_Descriptor` byte from the frame header
     /// (RFC 8878 §3.1.1.1.2 layout: `(exp << 3) | mantissa`),
     /// or `None` when the `Single_Segment_flag` is set — in

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1394,6 +1394,25 @@ impl FrameDecoder {
                     break;
                 }
             }
+            // When the frame header declares a `frame_content_size`,
+            // ensure the drained byte count actually matches it.
+            // Without this check a corrupt frame that sets FCS but
+            // ends early (e.g. last-block flag on a sub-FCS payload)
+            // would silently return success here, while the
+            // eligible-frame direct path catches the same condition
+            // via `FrameContentSizeMismatch`. The fallback path now
+            // matches that behaviour.
+            //
+            // `content_size == 0` in the header means "FCS not
+            // declared on the wire", which our parser surfaces by
+            // leaving the field at the default 0. Skip the check in
+            // that case — there's nothing to compare against.
+            if content_size > 0 && (total_bytes_written as u64) != content_size {
+                return Err(err::FrameContentSizeMismatch {
+                    declared: content_size,
+                    produced: total_bytes_written as u64,
+                });
+            }
             return Ok(total_bytes_written);
         }
 
@@ -1823,6 +1842,51 @@ mod tests {
             .expect("decode_to_slice should still succeed via fallback");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
+    }
+
+    #[test]
+    fn decode_to_slice_fallback_validates_fcs_against_total_output() {
+        // Synthetic single-segment frame: FCS = 20 bytes, but the
+        // last-block flag fires after only 4 bytes of raw payload.
+        // On the direct path this would trip the post-block
+        // `produced > content_size` check; the fallback path
+        // (eligible=false because output is sized exactly to FCS,
+        // no WILDCOPY slack) used to silently return Ok(4). With
+        // the fix it now surfaces `FrameContentSizeMismatch`
+        // matching the direct path.
+        //
+        // Frame layout: 4 B magic | 1 B FHD (single_segment=1,
+        // FCS_flag=3 → 8-byte FCS) | 8 B FCS=20 | block header
+        // (Raw, last, size=4) | 4 raw bytes.
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&0xFD2F_B528u32.to_le_bytes()); // magic
+        // FHD: FCS_flag=3 (8-byte FCS) <<6 | single_segment=1 <<5.
+        wire.push(0b1110_0000);
+        wire.extend_from_slice(&20u64.to_le_bytes()); // declared FCS
+        // Block header: (size << 3) | (block_type << 1) | last_block.
+        // Raw block (block_type=0), last_block=1, size=4 → 0b00100001 = 0x21.
+        wire.push(0x21);
+        wire.push(0x00);
+        wire.push(0x00);
+        wire.extend_from_slice(&[1u8, 2, 3, 4]);
+
+        let mut dec = FrameDecoder::new();
+        // Size output exactly at declared FCS (no WILDCOPY slack)
+        // so the eligibility check gates the direct path out.
+        let mut out = alloc::vec![0u8; 20];
+        let err = dec
+            .decode_to_slice(wire.as_slice(), &mut out)
+            .expect_err("fallback must reject corrupt FCS underflow");
+        match err {
+            crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
+                declared,
+                produced,
+            } => {
+                assert_eq!(declared, 20);
+                assert_eq!(produced, 4);
+            }
+            other => panic!("expected FrameContentSizeMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1303,6 +1303,8 @@ impl FrameDecoder {
     /// writes into a fixed-size user slice. Fallible
     /// `BufferBackend` writes that would let `decode_to_slice`
     /// remain safe on adversarial input are tracked in issue #246.
+    #[doc(alias = "decode_to_slice_trusted")]
+    #[must_use = "decode_to_slice returns the decoded byte count; ignoring it leaves the output's effective length ambiguous"]
     pub fn decode_to_slice(
         &mut self,
         mut input: &[u8],

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1164,7 +1164,7 @@ impl FrameDecoder {
     /// Decode a single zstd frame from `input` directly into
     /// `output`, bypassing the internal `DecodeBuffer` -> `read()`
     /// drain copy when the frame is eligible. Donor parity with the
-    /// `ZSTD_in_dst` litBuffer placement strategy — see #244.
+    /// `ZSTD_in_dst` litBuffer placement strategy.
     ///
     /// Eligibility requires all of:
     /// - `frame_content_size` is present in the header (> 0).
@@ -1256,9 +1256,17 @@ impl FrameDecoder {
     ///
     /// Callers must use the bytes from `output[..n]` (where `n`
     /// is the returned count); do not mix `decode_to_slice` with
-    /// `read`/`collect` on the same `FrameDecoder`. The
-    /// fallback (`decode_all`) sub-path inside this method
-    /// behaves like the regular `decode_all` w.r.t. state.
+    /// `read`/`collect` on the same `FrameDecoder`.
+    ///
+    /// When the frame is NOT eligible (no FCS in the header, or
+    /// output buffer too small for the WILDCOPY slack, or active
+    /// dictionary), this method falls back to a single-frame
+    /// `decode_blocks` + `read` drain loop, draining into the
+    /// caller's `output` slice. This is NOT `decode_all`: it
+    /// processes only one frame (no trailing-frame iteration, no
+    /// silent skippable-frame skip) and returns
+    /// [`FrameDecoderError::TargetTooSmall`] if the decoded
+    /// output does not fit in `output`.
     ///
     /// # Panic / DoS surface
     ///
@@ -1591,7 +1599,7 @@ mod tests {
         // must produce identical output bytes — the only difference
         // is the internal buffer/drain shape, not the decoded
         // semantics. This is the regression gate for the
-        // direct-decode wiring (#244).
+        // direct-decode wiring.
         let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
         compressor.set_source(payload.as_slice());

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1170,14 +1170,6 @@ impl FrameDecoder {
     /// - `frame_content_size` is present in the header (> 0).
     /// - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
     ///   (room for the SIMD wildcopy overshoot slack).
-    /// - `single_segment_flag` is set on the frame descriptor.
-    ///   This bounds `frame_content_size <= window_size` by
-    ///   construction, so the offset/window validation that
-    ///   `DecodeBuffer::repeat` performs (`offset <= buffer.len()`)
-    ///   coincides with the spec's `offset <= window_size` rule.
-    ///   Multi-segment frames need a `head`-advancing strategy on
-    ///   `UserSliceBackend` to cap `len()` at `window_size`; left
-    ///   as a follow-up.
     /// - No active dictionary on `self.state` (dict_content is not
     ///   carried into the stack-local DecodeBuffer this method
     ///   builds).
@@ -1185,6 +1177,15 @@ impl FrameDecoder {
     ///   `content_checksum_flag` (the rolling hash lives on the
     ///   persistent buffer; hash propagation across the direct
     ///   path is a follow-up).
+    ///
+    /// Multi-segment frames are supported via a per-block
+    /// `DecodeBuffer::drop_to_window_size` call that caps the
+    /// visible buffer at `window_size` so match-offset validation
+    /// (`offset <= buffer.len()`) coincides with the spec's
+    /// `offset <= window_size` rule. The discarded bytes stay
+    /// physically in the user slice (they're the frame's
+    /// already-decoded output); only their `BufferBackend::head`
+    /// visibility moves forward.
     ///
     /// Non-eligible frames fall back transparently to the existing
     /// `decode_blocks` + `read` drain path.
@@ -1232,18 +1233,15 @@ impl FrameDecoder {
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        // Eligibility requires `single_segment_flag`: under that
-        // flag `frame_content_size <= window_size` is guaranteed by
-        // the spec, so the offset bound `DecodeBuffer::repeat`
-        // enforces (`offset <= buffer.len()`) coincides with the
-        // window rule (`offset <= window_size`). Multi-segment
-        // frames would let `UserSliceBackend.len()` grow past
-        // `window_size` (we don't advance `head` on the direct
-        // path), letting malformed frames with `offset >
-        // window_size` slip through validation. Gating those off
-        // the fast path keeps correctness; the regular
-        // `decode_blocks` + drain path handles them via
-        // `drain_to_window_size`.
+        // Eligibility independent of `single_segment_flag`:
+        // multi-segment frames work too as long as we cap
+        // `buffer.len()` at `window_size` between blocks (so the
+        // `DecodeBuffer::repeat` offset bound coincides with the
+        // spec's `offset <= window_size` rule). The post-block
+        // `drop_to_window_size` call in the loop below does exactly
+        // that — bytes physically remain in the user slice, they
+        // just leave `len()`'s visible range so malformed
+        // `offset > window_size` matches get rejected.
         //
         // Disabled when a dictionary is active: the persistent
         // `DecoderScratch::buffer.dict_content` seeded by
@@ -1263,17 +1261,13 @@ impl FrameDecoder {
         // gate the direct path off when the frame header has the
         // content_checksum_flag set — the existing drain path
         // remains correct for those frames.
-        let single_segment = state.frame_header.descriptor.single_segment_flag();
         let dict_active = state.using_dict.is_some();
         #[cfg(feature = "hash")]
         let hash_active = state.frame_header.descriptor.content_checksum_flag();
         #[cfg(not(feature = "hash"))]
         let hash_active = false;
-        let eligible = single_segment
-            && content_size > 0
-            && !dict_active
-            && !hash_active
-            && (output.len() as u64) >= needed;
+        let eligible =
+            content_size > 0 && !dict_active && !hash_active && (output.len() as u64) >= needed;
 
         if !eligible {
             // Frame doesn't qualify for direct decode (empty
@@ -1365,6 +1359,16 @@ impl FrameDecoder {
                 .map_err(err::FailedToReadBlockBody)?;
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
+            // Cap the visible buffer at window_size between blocks
+            // so the next block's match-offset validation matches
+            // the spec's `offset <= window_size` rule. Bytes
+            // physically stay in the user slice; we just narrow
+            // the visible range via `head`. For single-segment
+            // frames `content_size <= window_size` so this is a
+            // no-op on every iteration; for multi-segment frames
+            // it advances `head` once `tail - head` outgrows the
+            // window.
+            direct.buffer.drop_to_window_size();
             if block_header.last_block {
                 if state.frame_header.descriptor.content_checksum_flag() {
                     let mut chksum = [0u8; 4];
@@ -1378,7 +1382,13 @@ impl FrameDecoder {
             }
         }
 
-        let written = direct.buffer.len();
+        // `direct.buffer.len()` would only show the visible (post
+        // head-advance) range, not the total bytes physically
+        // written into the user slice. The decode succeeded so
+        // `content_size` is the authoritative byte count — the
+        // backend wrote exactly that many bytes starting at
+        // `output[0]`.
+        let written = content_size as usize;
         state.frame_finished = true;
         Ok(written)
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1271,8 +1271,9 @@ impl FrameDecoder {
     /// # Panic / DoS surface
     ///
     /// **For trusted input only.** On the direct path
-    /// `UserSliceBackend` uses release-mode `assert!` /
-    /// debug-asserted slice indexing for capacity checks. A
+    /// `UserSliceBackend` uses release-mode `assert!` for capacity
+    /// checks across all three write entry points (`extend`,
+    /// `extend_and_fill`, `extend_from_within_unchecked`). A
     /// malformed Compressed block whose payload expands past the
     /// declared `frame_content_size` (and beyond the
     /// `WILDCOPY_OVERLENGTH` slack the caller sized into `output`)
@@ -1280,6 +1281,17 @@ impl FrameDecoder {
     /// error. The per-block `produced > content_size` guard catches
     /// the overshoot AFTER the block, but cannot prevent the
     /// in-block writes from running first.
+    ///
+    /// The trade-off is deliberate for this PR. Making the writes
+    /// fallible requires extending the `BufferBackend` trait
+    /// surface, touching every backend implementation, and
+    /// propagating `Result<_, _>` through the entire sequence
+    /// executor — a refactor too large to fold into the direct
+    /// decode wiring without losing review tractability. The
+    /// follow-up issue tracking that work (referenced below in
+    /// "Fallible BufferBackend writes") is a hard prerequisite
+    /// before this entry point becomes safe to expose on
+    /// untrusted streams.
     ///
     /// Callers handling untrusted input must use [`Self::decode_all`]
     /// which routes through `FlatBuf` / `RingBuffer`. Those

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1330,17 +1330,6 @@ impl FrameDecoder {
         // match that reaches into the external dictionary would
         // decode against an empty prefix. Fall back to the regular
         // path which keeps the dict in the persistent buffer.
-        //
-        // Disabled under `feature = "hash"`: the rolling content
-        // checksum lives on the persistent
-        // `DecoderScratch::buffer.hash` field, but the direct path
-        // writes through a stack-local `DecodeBuffer` that has its
-        // own (separate) hash. After `decode_to_slice` returns,
-        // `get_calculated_checksum()` would read a stale persistent
-        // hash. Until we wire hash propagation (see #244 follow-up),
-        // gate the direct path off when the frame header has the
-        // content_checksum_flag set — the existing drain path
-        // remains correct for those frames.
         let dict_active = state.using_dict.is_some();
         // `content_checksum_flag` is no longer a disqualifier. The
         // direct path writes the decoded bytes into the user's

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1160,6 +1160,137 @@ impl FrameDecoder {
             }
         }
     }
+
+    /// Decode a single zstd frame from `input` directly into `output`,
+    /// bypassing the internal `DecodeBuffer` -> `read()` drain copy
+    /// when the frame's `Single_Segment_flag` is set AND `output` has
+    /// enough room for the frame's content plus the SIMD wildcopy
+    /// slack. Donor parity with the `ZSTD_in_dst` litBuffer placement
+    /// strategy — see #244.
+    ///
+    /// On the direct-decode path (eligible single-segment frame +
+    /// sized output) the literal pushes and sequence-execution match
+    /// copies write straight into `output`, eliminating the
+    /// FlatBuf-as-intermediate `read()` drain that dominates
+    /// poorly-compressed L-7-class corpora (~28% of decode time on
+    /// `level_-7_fast/decodecorpus-z000033/rust_stream`).
+    ///
+    /// Frames that are not single-segment, or where `output` is too
+    /// small for the WILDCOPY_OVERLENGTH slack, transparently fall
+    /// back to the existing [`Self::decode_all`] path. Both paths
+    /// return the number of bytes written into `output`.
+    ///
+    /// `input` must contain at most ONE frame (skippable frames not
+    /// supported on the direct-decode path — fall back to
+    /// `decode_all` for multi-frame streams).
+    pub fn decode_to_slice(
+        &mut self,
+        mut input: &[u8],
+        output: &mut [u8],
+    ) -> Result<usize, FrameDecoderError> {
+        use super::block_decoder;
+        use super::buffer_backend::WILDCOPY_OVERLENGTH;
+        use super::decode_buffer::DecodeBuffer;
+        use super::scratch::DirectScratch;
+        use super::user_slice_buf::UserSliceBackend;
+        use crate::io::Read;
+        use FrameDecoderError as err;
+
+        // Parse the frame header. This populates `self.state` with
+        // the frame descriptor + resets the per-frame scratch
+        // (DecoderScratchKind::Flat for single-segment, ::Ring
+        // otherwise).
+        self.init(&mut input)?;
+
+        let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
+        let content_size = state.frame_header.frame_content_size();
+        let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
+        let eligible = state.frame_header.descriptor.single_segment_flag()
+            && content_size > 0
+            && (output.len() as u64) >= needed;
+
+        if !eligible {
+            // Frame doesn't qualify for direct decode (multi-segment,
+            // empty, or output too small for the WILDCOPY slack).
+            // Fall through to the existing per-block decode + drain
+            // path — `init` already populated `self.state`, so
+            // `decode_blocks` + `read` pick up from there.
+            let mut output_tail: &mut [u8] = output;
+            let mut total_bytes_written = 0;
+            loop {
+                self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
+                let bytes_written = self
+                    .read(output_tail)
+                    .map_err(err::FailedToDrainDecodebuffer)?;
+                output_tail = &mut output_tail[bytes_written..];
+                total_bytes_written += bytes_written;
+                if self.can_collect() != 0 {
+                    return Err(err::TargetTooSmall);
+                }
+                if self.is_finished() {
+                    break;
+                }
+            }
+            return Ok(total_bytes_written);
+        }
+
+        // Direct decode path. Borrow the persistent fields
+        // (HUF/FSE tables, offset_hist, scratch Vecs) out of the
+        // existing single-segment Flat scratch; we keep them
+        // populated across `decode_to_slice` calls (HUF table reuse
+        // is the main scratch-reuse win on small frames). Then
+        // construct a stack-local DecodeBuffer<UserSliceBackend<'o>>
+        // over `output` and bundle into a `DirectScratch`.
+        let scratch = match &mut state.decoder_scratch {
+            DecoderScratchKind::Flat(s) => s,
+            DecoderScratchKind::Ring(_) => {
+                // single_segment_flag was checked above, so this
+                // branch is unreachable on a well-formed init.
+                // Fall back defensively rather than `unreachable!()`
+                // — corrupted headers could in theory drift this.
+                return Err(err::TargetTooSmall);
+            }
+        };
+        let window_size = scratch.buffer.window_size;
+        let backend = UserSliceBackend::from_slice(output);
+        let buffer = DecodeBuffer::from_backend(backend, window_size);
+        let mut direct = DirectScratch {
+            huf: &mut scratch.huf,
+            fse: &mut scratch.fse,
+            offset_hist: &mut scratch.offset_hist,
+            literals_buffer: &mut scratch.literals_buffer,
+            sequences: &mut scratch.sequences,
+            block_content_buffer: &mut scratch.block_content_buffer,
+            buffer,
+        };
+
+        // Block loop. Mirrors `decode_blocks` (without the
+        // strategy-bounded early exit — we always decode the whole
+        // frame in one shot for the direct path).
+        let mut block_dec = block_decoder::new();
+        loop {
+            let (block_header, _hsize) = block_dec
+                .read_block_header(&mut input)
+                .map_err(err::FailedToReadBlockHeader)?;
+            block_dec
+                .decode_block_content(&block_header, &mut direct, &mut input)
+                .map_err(err::FailedToReadBlockBody)?;
+            if block_header.last_block {
+                if state.frame_header.descriptor.content_checksum_flag() {
+                    let mut chksum = [0u8; 4];
+                    input
+                        .read_exact(&mut chksum)
+                        .map_err(err::FailedToReadChecksum)?;
+                    state.check_sum = Some(u32::from_le_bytes(chksum));
+                }
+                break;
+            }
+        }
+
+        let written = direct.buffer.len();
+        state.frame_finished = true;
+        Ok(written)
+    }
 }
 
 /// Read bytes from the decode_buffer that are no longer needed. While the frame is not yet finished
@@ -1185,6 +1316,72 @@ mod tests {
     use super::{DictionaryHandle, FrameDecoder};
     use crate::encoding::{CompressionLevel, FrameCompressor};
     use alloc::vec::Vec;
+
+    #[test]
+    fn decode_to_slice_matches_decode_all_on_single_segment_frame() {
+        // Roundtrip a small payload through the encoder, then decode
+        // it via both `decode_all` and `decode_to_slice`. Both paths
+        // must produce identical output bytes — the only difference
+        // is the internal buffer/drain shape, not the decoded
+        // semantics. This is the regression gate for the
+        // direct-decode wiring (#244).
+        let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        // Baseline: decode_all.
+        let mut dec_a = FrameDecoder::new();
+        let mut out_a = std::vec![0u8; payload.len()];
+        let n_a = dec_a
+            .decode_all(compressed.as_slice(), &mut out_a)
+            .expect("decode_all should succeed");
+        assert_eq!(n_a, payload.len());
+        assert_eq!(&out_a[..n_a], payload.as_slice());
+
+        // Direct: decode_to_slice with WILDCOPY slack.
+        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut dec_b = FrameDecoder::new();
+        let mut out_b = std::vec![0u8; payload.len() + slack];
+        let n_b = dec_b
+            .decode_to_slice(compressed.as_slice(), &mut out_b)
+            .expect("decode_to_slice should succeed");
+        assert_eq!(
+            n_b,
+            payload.len(),
+            "direct decode produced wrong byte count"
+        );
+        assert_eq!(&out_b[..n_b], payload.as_slice());
+    }
+
+    #[test]
+    fn decode_to_slice_falls_back_when_output_too_small_for_wildcopy_slack() {
+        // Output sized exactly to frame_content_size (no
+        // WILDCOPY_OVERLENGTH slack) must NOT trigger the direct
+        // path — the burst's `extend_from_within_unchecked` writes
+        // past `tail` into the slack region. Direct dispatcher
+        // recognises this and falls back to the FlatBuf + drain
+        // path which still produces the right output.
+        let payload: Vec<u8> = (0..2048u32)
+            .map(|i| (i.wrapping_mul(31) & 0xFF) as u8)
+            .collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let mut dec = FrameDecoder::new();
+        // Exactly payload.len(), no slack — direct path is gated out.
+        let mut out = std::vec![0u8; payload.len()];
+        let n = dec
+            .decode_to_slice(compressed.as_slice(), &mut out)
+            .expect("decode_to_slice should still succeed via fallback");
+        assert_eq!(n, payload.len());
+        assert_eq!(&out[..n], payload.as_slice());
+    }
 
     #[test]
     fn reset_with_dict_handle_applies_dict_when_no_dict_id() {

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1173,10 +1173,12 @@ impl FrameDecoder {
     /// - No active dictionary on `self.state` (dict_content is not
     ///   carried into the stack-local DecodeBuffer this method
     ///   builds).
-    /// - With `feature = "hash"`: frame header lacks
-    ///   `content_checksum_flag` (the rolling hash lives on the
-    ///   persistent buffer; hash propagation across the direct
-    ///   path is a follow-up).
+    ///
+    /// `content_checksum_flag` is NOT a disqualifier: when set,
+    /// the direct path hashes the decoded `output[..content_size]`
+    /// once at the end of decode and propagates the digest into
+    /// the persistent scratch's `hash` so
+    /// [`Self::get_calculated_checksum`] returns the right value.
     ///
     /// Multi-segment frames are supported via a per-block
     /// `DecodeBuffer::drop_to_window_size` call that caps the
@@ -1205,17 +1207,25 @@ impl FrameDecoder {
     /// second frame (or error) on trailing bytes. Multi-frame
     /// streams must use [`Self::decode_all`].
     ///
-    /// On the direct-decode path (eligible single-segment frame +
-    /// sized output) the literal pushes and sequence-execution match
-    /// copies write straight into `output`, eliminating the
-    /// FlatBuf-as-intermediate `read()` drain that dominates
-    /// poorly-compressed L-7-class corpora (~28% of decode time on
-    /// `level_-7_fast/decodecorpus-z000033/rust_stream`).
+    /// On the direct path the literal pushes and
+    /// sequence-execution match copies write straight into
+    /// `output`, eliminating the FlatBuf-as-intermediate `read()`
+    /// drain that dominates poorly-compressed L-7-class corpora
+    /// (~28% of decode time on
+    /// `level_-7_fast/decodecorpus-z000033/rust_stream`). Both
+    /// single-segment and multi-segment frames take the direct
+    /// path; multi-segment frames cap the visible buffer at
+    /// `window_size` between blocks via
+    /// `DecodeBuffer::drop_to_window_size`.
     ///
-    /// Frames that are not single-segment, or where `output` is too
-    /// small for the WILDCOPY_OVERLENGTH slack, transparently fall
-    /// back to the existing [`Self::decode_all`] path. Both paths
-    /// return the number of bytes written into `output`.
+    /// Frames that aren't eligible (zero `frame_content_size`,
+    /// active dictionary, undersized `output`) transparently fall
+    /// back to the internal block-decode + read drain loop. The
+    /// fallback is NOT [`Self::decode_all`] semantics: it decodes
+    /// exactly one frame and returns; trailing bytes past the
+    /// frame are silently ignored. Use [`Self::decode_all`] for
+    /// multi-frame input or streams that may contain skippable
+    /// frames.
     ///
     /// `input` is expected to contain exactly ONE non-skippable
     /// zstd frame. **Skippable frames are rejected with
@@ -1235,11 +1245,14 @@ impl FrameDecoder {
     ///
     /// - [`Self::is_finished`] returns `true`,
     /// - [`Self::can_collect`] returns `0`,
-    /// - [`Self::read`] (`std::io::Read`) reads 0 bytes,
+    /// - [`Self::read`] (the crate's `io::Read` impl, which under
+    ///   `feature = "std"` is `std::io::Read`) reads 0 bytes,
     /// - [`Self::collect`] returns `Some(Vec::new())`,
-    /// - [`Self::get_calculated_checksum`] is `None` on the
-    ///   direct path because the rolling hash lives on the
-    ///   stack-local buffer that was dropped.
+    /// - [`Self::get_calculated_checksum`] returns the correct
+    ///   value when the frame had `content_checksum_flag` set —
+    ///   the direct path walks the output once at end of decode
+    ///   and propagates the digest into the persistent scratch's
+    ///   hasher so this accessor reads the right state.
     ///
     /// Callers must use the bytes from `output[..n]` (where `n`
     /// is the returned count); do not mix `decode_to_slice` with
@@ -1261,8 +1274,13 @@ impl FrameDecoder {
     /// in-block writes from running first.
     ///
     /// Callers handling untrusted input must use [`Self::decode_all`]
-    /// which routes through `FlatBuf` / `RingBuffer` whose
-    /// `Vec::reserve` growth path returns errors. Fallible
+    /// which routes through `FlatBuf` / `RingBuffer`. Those
+    /// backends grow via `Vec::reserve` (succeeds or aborts on
+    /// alloc failure — not error-returning), but the growable Vec
+    /// capacity absorbs a malformed block's overshoot inside the
+    /// allocation; the frame-level checks then turn the size
+    /// mismatch into `FrameContentSizeMismatch` instead of OOB
+    /// writes into a fixed-size user slice. Fallible
     /// `BufferBackend` writes that would let `decode_to_slice`
     /// remain safe on adversarial input are tracked in issue #246.
     pub fn decode_to_slice(
@@ -1324,12 +1342,15 @@ impl FrameDecoder {
         // content_checksum_flag set — the existing drain path
         // remains correct for those frames.
         let dict_active = state.using_dict.is_some();
-        #[cfg(feature = "hash")]
-        let hash_active = state.frame_header.descriptor.content_checksum_flag();
-        #[cfg(not(feature = "hash"))]
-        let hash_active = false;
-        let eligible =
-            content_size > 0 && !dict_active && !hash_active && (output.len() as u64) >= needed;
+        // `content_checksum_flag` is no longer a disqualifier. The
+        // direct path writes the decoded bytes into the user's
+        // `output` slice, and we hash that slice once at the end of
+        // decode (single sequential pass over cache-hot data). The
+        // computed digest is then propagated into the persistent
+        // `state.decoder_scratch.buffer.hash` so the public
+        // `get_calculated_checksum()` accessor reads the correct
+        // value just like on the `decode_all` path.
+        let eligible = content_size > 0 && !dict_active && (output.len() as u64) >= needed;
 
         if !eligible {
             // Frame doesn't qualify for direct decode (empty
@@ -1507,6 +1528,28 @@ impl FrameDecoder {
         // `output[0]`.
         let written = content_size as usize;
         state.frame_finished = true;
+        // Drop the stack-local DirectScratch (and its DecodeBuffer
+        // borrow on `output`) so we can re-borrow `output` for the
+        // hash pass below. After this point `direct` is gone.
+        drop(direct);
+        #[cfg(feature = "hash")]
+        if state.frame_header.descriptor.content_checksum_flag() {
+            // Direct path bypasses the per-write hash accounting
+            // (DecodeBuffer hashes during drain; the direct path
+            // never drains because the user slice IS the buffer).
+            // Walk the decoded output once and propagate the
+            // resulting hasher state into the persistent scratch's
+            // buffer so `get_calculated_checksum()` returns the
+            // right value. Cost: ~330 us / MiB at xxhash's
+            // ~3 GB/s throughput on x86_64, against cache-hot data.
+            use core::hash::Hasher;
+            let mut hasher = twox_hash::XxHash64::with_seed(0);
+            hasher.write(&output[..written]);
+            match &mut state.decoder_scratch {
+                DecoderScratchKind::Flat(s) => s.buffer.hash = hasher,
+                DecoderScratchKind::Ring(s) => s.buffer.hash = hasher,
+            }
+        }
         Ok(written)
     }
 }
@@ -1633,6 +1676,48 @@ mod tests {
                 .descriptor
                 .single_segment_flag(),
             "test precondition violated: frame is single-segment, rename or resize"
+        );
+    }
+
+    #[cfg(feature = "hash")]
+    #[test]
+    fn decode_to_slice_propagates_checksum_into_persistent_scratch() {
+        // Direct path on a checksum-flagged frame: the FrameCompressor
+        // under `feature = "hash"` sets content_checksum_flag, so the
+        // decoded frame has a recorded checksum. After
+        // decode_to_slice we must be able to verify it matches via
+        // the public get_calculated_checksum() accessor — the digest
+        // is computed by walking output at end of decode and stored
+        // into the persistent scratch's hasher.
+        let payload: Vec<u8> = (0..8192u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len() + slack];
+        let n = dec
+            .decode_to_slice(compressed.as_slice(), &mut out)
+            .expect("decode_to_slice with checksum must succeed");
+        assert_eq!(n, payload.len());
+        assert_eq!(&out[..n], payload.as_slice());
+
+        // Both sides must report the same checksum: the frame header
+        // carries the stored u32, and get_calculated_checksum reads
+        // the running digest the direct path just propagated.
+        let stored = dec.get_checksum_from_data();
+        let calculated = dec.get_calculated_checksum();
+        assert!(stored.is_some(), "frame must carry stored checksum");
+        assert!(
+            calculated.is_some(),
+            "direct path must propagate calculated checksum"
+        );
+        assert_eq!(
+            stored, calculated,
+            "stored vs calculated checksum mismatch on direct path"
         );
     }
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1161,24 +1161,39 @@ impl FrameDecoder {
         }
     }
 
-    /// Decode a single zstd frame from `input` directly into `output`,
-    /// bypassing the internal `DecodeBuffer` -> `read()` drain copy
-    /// when the frame is eligible. Donor parity with the
+    /// Decode a single zstd frame from `input` directly into
+    /// `output`, bypassing the internal `DecodeBuffer` -> `read()`
+    /// drain copy when the frame is eligible. Donor parity with the
     /// `ZSTD_in_dst` litBuffer placement strategy — see #244.
     ///
     /// Eligibility requires all of:
     /// - `frame_content_size` is present in the header (> 0).
     /// - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
     ///   (room for the SIMD wildcopy overshoot slack).
+    /// - `single_segment_flag` is set on the frame descriptor.
+    ///   This bounds `frame_content_size <= window_size` by
+    ///   construction, so the offset/window validation that
+    ///   `DecodeBuffer::repeat` performs (`offset <= buffer.len()`)
+    ///   coincides with the spec's `offset <= window_size` rule.
+    ///   Multi-segment frames need a `head`-advancing strategy on
+    ///   `UserSliceBackend` to cap `len()` at `window_size`; left
+    ///   as a follow-up.
     /// - No active dictionary on `self.state` (dict_content is not
     ///   carried into the stack-local DecodeBuffer this method
     ///   builds).
-    /// - Frame header lacks `content_checksum_flag` (the rolling
-    ///   hash lives on the persistent buffer; hash propagation
-    ///   across the direct path is a follow-up).
+    /// - With `feature = "hash"`: frame header lacks
+    ///   `content_checksum_flag` (the rolling hash lives on the
+    ///   persistent buffer; hash propagation across the direct
+    ///   path is a follow-up).
     ///
-    /// `single_segment_flag` is NOT a precondition — multi-segment
-    /// frames in non-streaming mode work identically.
+    /// Non-eligible frames fall back transparently to the existing
+    /// `decode_blocks` + `read` drain path.
+    ///
+    /// `input` must contain a complete single zstd frame followed
+    /// by no other bytes; trailing data past the frame is not
+    /// validated and is silently ignored on the direct path
+    /// (matches `decode_all` shape for the unverified-tail case).
+    /// Multi-frame streams must use [`Self::decode_all`].
     ///
     /// On the direct-decode path (eligible single-segment frame +
     /// sized output) the literal pushes and sequence-execution match
@@ -1217,13 +1232,18 @@ impl FrameDecoder {
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        // Eligibility independent of `single_segment_flag`: donor's
-        // `ZSTD_in_dst` litBuffer-in-dst trick works identically for
-        // multi-segment frames as long as we're non-streaming
-        // (whole `frame_content_size` fits in `output`, no mid-frame
-        // drain ever issued). The flag only affects the internal
-        // scratch's FlatBuf-vs-RingBuffer choice; for direct decode
-        // the internal buffer is bypassed entirely.
+        // Eligibility requires `single_segment_flag`: under that
+        // flag `frame_content_size <= window_size` is guaranteed by
+        // the spec, so the offset bound `DecodeBuffer::repeat`
+        // enforces (`offset <= buffer.len()`) coincides with the
+        // window rule (`offset <= window_size`). Multi-segment
+        // frames would let `UserSliceBackend.len()` grow past
+        // `window_size` (we don't advance `head` on the direct
+        // path), letting malformed frames with `offset >
+        // window_size` slip through validation. Gating those off
+        // the fast path keeps correctness; the regular
+        // `decode_blocks` + drain path handles them via
+        // `drain_to_window_size`.
         //
         // Disabled when a dictionary is active: the persistent
         // `DecoderScratch::buffer.dict_content` seeded by
@@ -1243,13 +1263,17 @@ impl FrameDecoder {
         // gate the direct path off when the frame header has the
         // content_checksum_flag set — the existing drain path
         // remains correct for those frames.
+        let single_segment = state.frame_header.descriptor.single_segment_flag();
         let dict_active = state.using_dict.is_some();
         #[cfg(feature = "hash")]
         let hash_active = state.frame_header.descriptor.content_checksum_flag();
         #[cfg(not(feature = "hash"))]
         let hash_active = false;
-        let eligible =
-            content_size > 0 && !dict_active && !hash_active && (output.len() as u64) >= needed;
+        let eligible = single_segment
+            && content_size > 0
+            && !dict_active
+            && !hash_active
+            && (output.len() as u64) >= needed;
 
         if !eligible {
             // Frame doesn't qualify for direct decode (empty

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1163,10 +1163,22 @@ impl FrameDecoder {
 
     /// Decode a single zstd frame from `input` directly into `output`,
     /// bypassing the internal `DecodeBuffer` -> `read()` drain copy
-    /// when the frame's `Single_Segment_flag` is set AND `output` has
-    /// enough room for the frame's content plus the SIMD wildcopy
-    /// slack. Donor parity with the `ZSTD_in_dst` litBuffer placement
-    /// strategy — see #244.
+    /// when the frame is eligible. Donor parity with the
+    /// `ZSTD_in_dst` litBuffer placement strategy — see #244.
+    ///
+    /// Eligibility requires all of:
+    /// - `frame_content_size` is present in the header (> 0).
+    /// - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
+    ///   (room for the SIMD wildcopy overshoot slack).
+    /// - No active dictionary on `self.state` (dict_content is not
+    ///   carried into the stack-local DecodeBuffer this method
+    ///   builds).
+    /// - Frame header lacks `content_checksum_flag` (the rolling
+    ///   hash lives on the persistent buffer; hash propagation
+    ///   across the direct path is a follow-up).
+    ///
+    /// `single_segment_flag` is NOT a precondition — multi-segment
+    /// frames in non-streaming mode work identically.
     ///
     /// On the direct-decode path (eligible single-segment frame +
     /// sized output) the literal pushes and sequence-execution match
@@ -1205,19 +1217,39 @@ impl FrameDecoder {
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        // Eligibility is independent of `single_segment_flag`:
-        // donor's `ZSTD_in_dst` litBuffer-in-dst trick works
-        // identically for multi-segment frames as long as we're in
-        // non-streaming mode (the whole `frame_content_size` fits
-        // in the caller's `output` slice, no mid-frame drain is
-        // ever issued). The flag only changes whether the
-        // _internal_ scratch picks FlatBuf vs RingBuffer; for
-        // direct decode the internal buffer is bypassed entirely
-        // and the user slice IS the buffer. Both Flat- and
-        // Ring-backed persistent state are equally fine as
-        // donors of the HUF/FSE/scratch Vecs the direct scratch
-        // borrows.
-        let eligible = content_size > 0 && (output.len() as u64) >= needed;
+        // Eligibility independent of `single_segment_flag`: donor's
+        // `ZSTD_in_dst` litBuffer-in-dst trick works identically for
+        // multi-segment frames as long as we're non-streaming
+        // (whole `frame_content_size` fits in `output`, no mid-frame
+        // drain ever issued). The flag only affects the internal
+        // scratch's FlatBuf-vs-RingBuffer choice; for direct decode
+        // the internal buffer is bypassed entirely.
+        //
+        // Disabled when a dictionary is active: the persistent
+        // `DecoderScratch::buffer.dict_content` seeded by
+        // `init_from_dict` is NOT carried into the stack-local
+        // `DecodeBuffer<UserSliceBackend>` we build below, so any
+        // match that reaches into the external dictionary would
+        // decode against an empty prefix. Fall back to the regular
+        // path which keeps the dict in the persistent buffer.
+        //
+        // Disabled under `feature = "hash"`: the rolling content
+        // checksum lives on the persistent
+        // `DecoderScratch::buffer.hash` field, but the direct path
+        // writes through a stack-local `DecodeBuffer` that has its
+        // own (separate) hash. After `decode_to_slice` returns,
+        // `get_calculated_checksum()` would read a stale persistent
+        // hash. Until we wire hash propagation (see #244 follow-up),
+        // gate the direct path off when the frame header has the
+        // content_checksum_flag set — the existing drain path
+        // remains correct for those frames.
+        let dict_active = state.using_dict.is_some();
+        #[cfg(feature = "hash")]
+        let hash_active = state.frame_header.descriptor.content_checksum_flag();
+        #[cfg(not(feature = "hash"))]
+        let hash_active = false;
+        let eligible =
+            content_size > 0 && !dict_active && !hash_active && (output.len() as u64) >= needed;
 
         if !eligible {
             // Frame doesn't qualify for direct decode (empty
@@ -1293,21 +1325,29 @@ impl FrameDecoder {
 
         // Block loop. Mirrors `decode_blocks` (without the
         // strategy-bounded early exit — we always decode the whole
-        // frame in one shot for the direct path).
+        // frame in one shot for the direct path). Keeps
+        // `state.bytes_read_counter` / `state.block_counter` in
+        // sync with `decode_blocks` so post-call accessors
+        // (`bytes_read_from_source`, `blocks_decoded`) return
+        // accurate values.
         let mut block_dec = block_decoder::new();
         loop {
-            let (block_header, _hsize) = block_dec
+            let (block_header, hsize) = block_dec
                 .read_block_header(&mut input)
                 .map_err(err::FailedToReadBlockHeader)?;
-            block_dec
+            state.bytes_read_counter += u64::from(hsize);
+            let body_consumed = block_dec
                 .decode_block_content(&block_header, &mut direct, &mut input)
                 .map_err(err::FailedToReadBlockBody)?;
+            state.bytes_read_counter += body_consumed;
+            state.block_counter += 1;
             if block_header.last_block {
                 if state.frame_header.descriptor.content_checksum_flag() {
                     let mut chksum = [0u8; 4];
                     input
                         .read_exact(&mut chksum)
                         .map_err(err::FailedToReadChecksum)?;
+                    state.bytes_read_counter += 4;
                     state.check_sum = Some(u32::from_le_bytes(chksum));
                 }
                 break;

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1355,8 +1355,14 @@ impl FrameDecoder {
                 .read_block_header(&mut input)
                 .map_err(err::FailedToReadBlockHeader)?;
             state.bytes_read_counter += u64::from(hsize);
+            // Slice-source fast path: consume the block body
+            // straight from `input` without copying into the
+            // persistent `block_content_buffer`. This is the
+            // largest single perf win behind the direct-decode
+            // path at L-1 — see #244 follow-up flamegraph
+            // analysis.
             let body_consumed = block_dec
-                .decode_block_content(&block_header, &mut direct, &mut input)
+                .decode_block_content_from_slice(&block_header, &mut direct, &mut input)
                 .map_err(err::FailedToReadBlockBody)?;
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1205,16 +1205,27 @@ impl FrameDecoder {
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        let eligible = state.frame_header.descriptor.single_segment_flag()
-            && content_size > 0
-            && (output.len() as u64) >= needed;
+        // Eligibility is independent of `single_segment_flag`:
+        // donor's `ZSTD_in_dst` litBuffer-in-dst trick works
+        // identically for multi-segment frames as long as we're in
+        // non-streaming mode (the whole `frame_content_size` fits
+        // in the caller's `output` slice, no mid-frame drain is
+        // ever issued). The flag only changes whether the
+        // _internal_ scratch picks FlatBuf vs RingBuffer; for
+        // direct decode the internal buffer is bypassed entirely
+        // and the user slice IS the buffer. Both Flat- and
+        // Ring-backed persistent state are equally fine as
+        // donors of the HUF/FSE/scratch Vecs the direct scratch
+        // borrows.
+        let eligible = content_size > 0 && (output.len() as u64) >= needed;
 
         if !eligible {
-            // Frame doesn't qualify for direct decode (multi-segment,
-            // empty, or output too small for the WILDCOPY slack).
-            // Fall through to the existing per-block decode + drain
-            // path — `init` already populated `self.state`, so
-            // `decode_blocks` + `read` pick up from there.
+            // Frame doesn't qualify for direct decode (empty
+            // frame_content_size — header lacks FCS — or output too
+            // small for the WILDCOPY slack). Fall through to the
+            // existing per-block decode + drain path — `init`
+            // already populated `self.state`, so `decode_blocks` +
+            // `read` pick up from there.
             let mut output_tail: &mut [u8] = output;
             let mut total_bytes_written = 0;
             loop {
@@ -1241,26 +1252,42 @@ impl FrameDecoder {
         // is the main scratch-reuse win on small frames). Then
         // construct a stack-local DecodeBuffer<UserSliceBackend<'o>>
         // over `output` and bundle into a `DirectScratch`.
-        let scratch = match &mut state.decoder_scratch {
-            DecoderScratchKind::Flat(s) => s,
-            DecoderScratchKind::Ring(_) => {
-                // single_segment_flag was checked above, so this
-                // branch is unreachable on a well-formed init.
-                // Fall back defensively rather than `unreachable!()`
-                // — corrupted headers could in theory drift this.
-                return Err(err::TargetTooSmall);
-            }
-        };
-        let window_size = scratch.buffer.window_size;
+        // Borrow persistent fields out of whichever scratch variant
+        // `init` produced (Flat for single_segment, Ring for
+        // multi-segment) — both expose the same set of HUF/FSE/Vec
+        // fields; only `buffer` differs and we don't use that here.
+        // Macro-style binding to avoid the closure / generic
+        // gymnastics of returning multiple &mut from a match arm.
+        let (huf, fse, offset_hist, literals_buffer, sequences, block_content_buffer, window_size) =
+            match &mut state.decoder_scratch {
+                DecoderScratchKind::Flat(s) => (
+                    &mut s.huf,
+                    &mut s.fse,
+                    &mut s.offset_hist,
+                    &mut s.literals_buffer,
+                    &mut s.sequences,
+                    &mut s.block_content_buffer,
+                    s.buffer.window_size,
+                ),
+                DecoderScratchKind::Ring(s) => (
+                    &mut s.huf,
+                    &mut s.fse,
+                    &mut s.offset_hist,
+                    &mut s.literals_buffer,
+                    &mut s.sequences,
+                    &mut s.block_content_buffer,
+                    s.buffer.window_size,
+                ),
+            };
         let backend = UserSliceBackend::from_slice(output);
         let buffer = DecodeBuffer::from_backend(backend, window_size);
         let mut direct = DirectScratch {
-            huf: &mut scratch.huf,
-            fse: &mut scratch.fse,
-            offset_hist: &mut scratch.offset_hist,
-            literals_buffer: &mut scratch.literals_buffer,
-            sequences: &mut scratch.sequences,
-            block_content_buffer: &mut scratch.block_content_buffer,
+            huf,
+            fse,
+            offset_hist,
+            literals_buffer,
+            sequences,
+            block_content_buffer,
             buffer,
         };
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1351,30 +1351,29 @@ impl FrameDecoder {
         // accurate values.
         let mut block_dec = block_decoder::new();
         // Track total output bytes against the declared
-        // `frame_content_size`. A malformed frame whose blocks claim
-        // more decompressed bytes than the FCS would otherwise let
-        // the burst write past `output[..content_size]` into the
-        // wildcopy slack and beyond — `UserSliceBackend` would
-        // panic on the bounds assert. Catch the overflow here and
-        // return a structured `TargetTooSmall` error instead.
+        // `frame_content_size` via the buffer's actual write
+        // counter — `BlockHeader.decompressed_size` is 0 for
+        // Compressed blocks (the header parser can't know the
+        // expanded size before decoding the body), so per-header
+        // tracking would always count 0 for those blocks and
+        // miscount frames that aren't pure Raw/RLE.
         let mut produced: u64 = 0;
         loop {
             let (block_header, hsize) = block_dec
                 .read_block_header(&mut input)
                 .map_err(err::FailedToReadBlockHeader)?;
             state.bytes_read_counter += u64::from(hsize);
-            // Pre-flight FCS check: a single block's
-            // `decompressed_size` is bounded by `MAX_BLOCK_SIZE`
-            // (128 KiB), so even for compressed blocks the upper
-            // bound on what this block will write is known before
-            // the body decodes. Reject early when adding it would
-            // exceed `content_size`.
+            // Pre-flight FCS check ONLY for Raw / RLE blocks where
+            // `decompressed_size` is the actual block output size.
+            // For Compressed blocks the header field is 0; the
+            // post-decode check below catches overflow via the
+            // backend's actual write counter delta.
             let block_upper = u64::from(block_header.decompressed_size);
-            if produced + block_upper > content_size {
-                // Frame is corrupt — block headers claim more output
-                // than the FCS allowed. Caller's buffer was sized
-                // against FCS (validated above), so this is a
-                // decoder-side correctness issue, not a sizing one.
+            if block_upper > 0 && produced + block_upper > content_size {
+                // Frame is corrupt — Raw/RLE block headers claim
+                // more output than the FCS allows. Caller's buffer
+                // was sized against FCS, so this is decoder-side
+                // corruption, not user sizing.
                 return Err(err::FrameContentSizeMismatch {
                     declared: content_size,
                     produced: produced + block_upper,
@@ -1382,14 +1381,27 @@ impl FrameDecoder {
             }
             // Slice-source fast path: consume the block body
             // straight from `input` without copying into the
-            // persistent `block_content_buffer`. This is the
-            // largest single perf win behind the direct-decode
-            // path at L-1 — see #244 follow-up flamegraph
-            // analysis.
+            // persistent `block_content_buffer`.
+            let before = direct.buffer.total_produced();
             let body_consumed = block_dec
                 .decode_block_content_from_slice(&block_header, &mut direct, &mut input)
                 .map_err(err::FailedToReadBlockBody)?;
-            produced += u64::from(block_header.decompressed_size);
+            produced = direct.buffer.total_produced();
+            // Post-decode FCS overflow check. Works uniformly for
+            // Raw/RLE/Compressed since it reads the actual bytes
+            // written by the backend rather than the header's
+            // (possibly zero) `decompressed_size`.
+            if produced > content_size {
+                return Err(err::FrameContentSizeMismatch {
+                    declared: content_size,
+                    produced,
+                });
+            }
+            // Silence unused-binding warning when this delta isn't
+            // consulted — it's there so future debug builds can
+            // assert (produced - before) <= MAX_BLOCK_SIZE if the
+            // spec invariant ever needs an explicit gate.
+            let _ = before;
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
             // Cap the visible buffer at window_size between blocks

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1711,6 +1711,57 @@ mod tests {
     }
 
     #[test]
+    fn decode_to_slice_fcs_overflow_via_corrupt_frame_returns_structured_error() {
+        // Hand-build a corrupt frame that declares
+        // frame_content_size = 4 but the (last) block carries a
+        // larger Raw payload. The pre-flight FCS check inside the
+        // direct path's block loop catches this and returns the
+        // structured FrameContentSizeMismatch variant — not a
+        // panic, not a generic TargetTooSmall.
+        //
+        // Frame layout (single_segment, FCS=4):
+        //   magic            4 bytes  0xFD2FB528
+        //   FHD              1 byte   single_segment=1, no checksum,
+        //                              FCS field size = 0 (-> 1-byte FCS)
+        //   FCS              1 byte   0x04
+        //   block_header     3 bytes  last=1, type=Raw, block_size=10
+        //   block_payload    10 bytes 0xAA repeated
+        let mut frame = alloc::vec::Vec::new();
+        // magic
+        frame.extend_from_slice(&0xFD2FB528u32.to_le_bytes());
+        // FHD: single_segment=1, fcs_flag=0 (1-byte FCS), no checksum,
+        // no dict. Bit layout: FCS(7-6)=0, single_segment(5)=1,
+        // reserved/uncs(4)=0, content_checksum(2)=0, dict(0-1)=00.
+        frame.push(0b0010_0000);
+        // FCS: 1 byte
+        frame.push(4);
+        // Block header: cBlockSize=10, type=Raw (0), last=1
+        // 3-byte LE: bit0=last, bits1-2=type(2 bits), bits3-23=size
+        let cblock_size: u32 = 10;
+        let bh: u32 = 1 | (cblock_size << 3); // last=1, type=Raw=0
+        frame.push((bh & 0xFF) as u8);
+        frame.push((bh >> 8) as u8);
+        frame.push((bh >> 16) as u8);
+        // Payload — 10 bytes that, if decoded, would exceed FCS=4.
+        frame.extend(core::iter::repeat_n(0xAAu8, 10));
+
+        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; 4 + slack];
+        let err = dec
+            .decode_to_slice(&frame, &mut out)
+            .expect_err("FCS-overflow frame must fail decode");
+        assert!(
+            matches!(
+                err,
+                super::FrameDecoderError::FrameContentSizeMismatch { .. }
+            ),
+            "expected FrameContentSizeMismatch, got {:?}",
+            err
+        );
+    }
+
+    #[test]
     fn decode_to_slice_falls_back_when_output_too_small_for_wildcopy_slack() {
         // Output sized exactly to frame_content_size (no
         // WILDCOPY_OVERLENGTH slack) must NOT trigger the direct

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1241,7 +1241,7 @@ impl FrameDecoder {
     /// via a stack-local `DecodeBuffer<UserSliceBackend>` that is
     /// dropped before this function returns. The persistent
     /// `state.decoder_scratch.buffer` stays empty. Consequently,
-    /// after `decode_to_slice` returns:
+    /// after `decode_to_slice_trusted` returns:
     ///
     /// - [`Self::is_finished`] returns `true`,
     /// - [`Self::can_collect`] returns `0`,
@@ -1255,7 +1255,7 @@ impl FrameDecoder {
     ///   hasher so this accessor reads the right state.
     ///
     /// Callers must use the bytes from `output[..n]` (where `n`
-    /// is the returned count); do not mix `decode_to_slice` with
+    /// is the returned count); do not mix `decode_to_slice_trusted` with
     /// `read`/`collect` on the same `FrameDecoder`.
     ///
     /// When the frame is NOT eligible (no FCS in the header, or
@@ -1301,19 +1301,18 @@ impl FrameDecoder {
     /// allocation; the frame-level checks then turn the size
     /// mismatch into `FrameContentSizeMismatch` instead of OOB
     /// writes into a fixed-size user slice. Fallible
-    /// `BufferBackend` writes that would let `decode_to_slice`
+    /// `BufferBackend` writes that would let `decode_to_slice_trusted`
     /// remain safe on adversarial input are tracked in issue #246.
-    // KNOWN PANIC SURFACE — direct path panics on adversarial
-    // input via release-mode `assert!` in `UserSliceBackend`. The
-    // doc-string above explains why this trade-off is deliberate
-    // for this PR and names the fallible-`BufferBackend` refactor
-    // as the prerequisite. Re-flagging the panic surface without
-    // engaging with the trade-off in the doc-string is not
-    // actionable here; the refactor lives in a dedicated
-    // follow-up.
-    #[doc(alias = "decode_to_slice_trusted")]
-    #[must_use = "decode_to_slice returns the decoded byte count; ignoring it leaves the output's effective length ambiguous"]
-    pub fn decode_to_slice(
+    // The `_trusted` suffix is part of the API contract: this
+    // entry point is for trusted input only. Adversarial /
+    // malformed input can panic via release-mode `assert!` inside
+    // `UserSliceBackend`. Callers handling untrusted data MUST use
+    // `decode_all` instead. The fallible-`BufferBackend` refactor
+    // that would let this entry point be safe on adversarial
+    // input is tracked as a follow-up.
+    #[doc(alias = "decode_to_slice")]
+    #[must_use = "decode_to_slice_trusted returns the decoded byte count; ignoring it leaves the output's effective length ambiguous"]
+    pub fn decode_to_slice_trusted(
         &mut self,
         mut input: &[u8],
         output: &mut [u8],
@@ -1360,7 +1359,7 @@ impl FrameDecoder {
         // (not `window_size`), so an in-block match with
         // `offset > window_size` but `offset <= current
         // buffer.len()` is accepted on both direct and fallback
-        // paths. See the `decode_to_slice` doc for the full
+        // paths. See the `decode_to_slice_trusted` doc for the full
         // limitation note.
         //
         // Disabled when a dictionary is active: the persistent
@@ -1435,7 +1434,7 @@ impl FrameDecoder {
         // Direct decode path. Borrow the persistent fields
         // (HUF/FSE tables, offset_hist, scratch Vecs) out of the
         // existing single-segment Flat scratch; we keep them
-        // populated across `decode_to_slice` calls (HUF table reuse
+        // populated across `decode_to_slice_trusted` calls (HUF table reuse
         // is the main scratch-reuse win on small frames). Then
         // construct a stack-local DecodeBuffer<UserSliceBackend<'o>>
         // over `output` and bundle into a `DirectScratch`.
@@ -1640,9 +1639,9 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn decode_to_slice_matches_decode_all_on_single_segment_frame() {
+    fn decode_to_slice_trusted_matches_decode_all_on_single_segment_frame() {
         // Roundtrip a small payload through the encoder, then decode
-        // it via both `decode_all` and `decode_to_slice`. Both paths
+        // it via both `decode_all` and `decode_to_slice_trusted`. Both paths
         // must produce identical output bytes — the only difference
         // is the internal buffer/drain shape, not the decoded
         // semantics. This is the regression gate for the
@@ -1663,13 +1662,13 @@ mod tests {
         assert_eq!(n_a, payload.len());
         assert_eq!(&out_a[..n_a], payload.as_slice());
 
-        // Direct: decode_to_slice with WILDCOPY slack.
+        // Direct: decode_to_slice_trusted with WILDCOPY slack.
         let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
-            .decode_to_slice(compressed.as_slice(), &mut out_b)
-            .expect("decode_to_slice should succeed");
+            .decode_to_slice_trusted(compressed.as_slice(), &mut out_b)
+            .expect("decode_to_slice_trusted should succeed");
         assert_eq!(
             n_b,
             payload.len(),
@@ -1679,7 +1678,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_multi_segment_frame_decodes_correctly() {
+    fn decode_to_slice_trusted_multi_segment_frame_decodes_correctly() {
         // Multi-segment frame: payload large enough that the
         // encoder's default frame layout has `single_segment_flag =
         // false` and `window_size < frame_content_size`. The direct
@@ -1717,8 +1716,8 @@ mod tests {
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
-            .decode_to_slice(compressed.as_slice(), &mut out_b)
-            .expect("decode_to_slice should succeed on multi-segment frame");
+            .decode_to_slice_trusted(compressed.as_slice(), &mut out_b)
+            .expect("decode_to_slice_trusted should succeed on multi-segment frame");
         assert_eq!(n_b, payload.len(), "wrong byte count on direct path");
         assert_eq!(&out_b[..n_b], payload.as_slice());
 
@@ -1742,11 +1741,11 @@ mod tests {
 
     #[cfg(feature = "hash")]
     #[test]
-    fn decode_to_slice_propagates_checksum_into_persistent_scratch() {
+    fn decode_to_slice_trusted_propagates_checksum_into_persistent_scratch() {
         // Direct path on a checksum-flagged frame: the FrameCompressor
         // under `feature = "hash"` sets content_checksum_flag, so the
         // decoded frame has a recorded checksum. After
-        // decode_to_slice we must be able to verify it matches via
+        // decode_to_slice_trusted we must be able to verify it matches via
         // the public get_calculated_checksum() accessor — the digest
         // is computed by walking output at end of decode and stored
         // into the persistent scratch's hasher.
@@ -1761,8 +1760,8 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; payload.len() + slack];
         let n = dec
-            .decode_to_slice(compressed.as_slice(), &mut out)
-            .expect("decode_to_slice with checksum must succeed");
+            .decode_to_slice_trusted(compressed.as_slice(), &mut out)
+            .expect("decode_to_slice_trusted with checksum must succeed");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
 
@@ -1783,7 +1782,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_fcs_overflow_via_corrupt_frame_returns_structured_error() {
+    fn decode_to_slice_trusted_fcs_overflow_via_corrupt_frame_returns_structured_error() {
         // Hand-build a corrupt frame that declares
         // frame_content_size = 4 but the (last) block carries a
         // larger Raw payload. The pre-flight FCS check inside the
@@ -1821,7 +1820,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; 4 + slack];
         let err = dec
-            .decode_to_slice(&frame, &mut out)
+            .decode_to_slice_trusted(&frame, &mut out)
             .expect_err("FCS-overflow frame must fail decode");
         assert!(
             matches!(
@@ -1834,7 +1833,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_falls_back_when_output_too_small_for_wildcopy_slack() {
+    fn decode_to_slice_trusted_falls_back_when_output_too_small_for_wildcopy_slack() {
         // Output sized exactly to frame_content_size (no
         // WILDCOPY_OVERLENGTH slack) must NOT trigger the direct
         // path — the burst's `extend_from_within_unchecked` writes
@@ -1854,14 +1853,14 @@ mod tests {
         // Exactly payload.len(), no slack — direct path is gated out.
         let mut out = alloc::vec![0u8; payload.len()];
         let n = dec
-            .decode_to_slice(compressed.as_slice(), &mut out)
-            .expect("decode_to_slice should still succeed via fallback");
+            .decode_to_slice_trusted(compressed.as_slice(), &mut out)
+            .expect("decode_to_slice_trusted should still succeed via fallback");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
     }
 
     #[test]
-    fn decode_to_slice_fallback_validates_fcs_against_total_output() {
+    fn decode_to_slice_trusted_fallback_validates_fcs_against_total_output() {
         // Synthetic single-segment frame: FCS = 20 bytes, but the
         // last-block flag fires after only 4 bytes of raw payload.
         // On the direct path this would trip the post-block
@@ -1891,7 +1890,7 @@ mod tests {
         // so the eligibility check gates the direct path out.
         let mut out = alloc::vec![0u8; 20];
         let err = dec
-            .decode_to_slice(wire.as_slice(), &mut out)
+            .decode_to_slice_trusted(wire.as_slice(), &mut out)
             .expect_err("fallback must reject corrupt FCS underflow");
         match err {
             crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
@@ -1906,7 +1905,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_fallback_treats_explicit_fcs_zero_as_declared() {
+    fn decode_to_slice_trusted_fallback_treats_explicit_fcs_zero_as_declared() {
         // Synthetic multi-segment frame with FCS_flag=2 (4-byte
         // FCS) explicitly set to 0. The header DECLARES zero
         // content, but the body carries a 5-byte raw last-block.
@@ -1945,7 +1944,7 @@ mod tests {
         // give it some room so `read()` can drain the block.
         let mut out = alloc::vec![0u8; 16];
         let err = dec
-            .decode_to_slice(wire.as_slice(), &mut out)
+            .decode_to_slice_trusted(wire.as_slice(), &mut out)
             .expect_err("corrupt FCS=0 + 5-byte block must error");
         match err {
             crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
@@ -1960,7 +1959,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_fallback_accepts_honest_explicit_fcs_zero() {
+    fn decode_to_slice_trusted_fallback_accepts_honest_explicit_fcs_zero() {
         // Companion to the corrupt-FCS=0 test above: an HONEST
         // empty frame with FCS_flag=2 (4-byte FCS) explicitly set
         // to 0 AND a 0-byte raw last-block. `fcs_declared()`
@@ -1994,7 +1993,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; 16];
         let n = dec
-            .decode_to_slice(wire.as_slice(), &mut out)
+            .decode_to_slice_trusted(wire.as_slice(), &mut out)
             .expect("honest FCS=0 + empty block must succeed");
         assert_eq!(n, 0);
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1314,14 +1314,24 @@ impl FrameDecoder {
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
         // Eligibility independent of `single_segment_flag`:
-        // multi-segment frames work too as long as we cap
-        // `buffer.len()` at `window_size` between blocks (so the
-        // `DecodeBuffer::repeat` offset bound coincides with the
-        // spec's `offset <= window_size` rule). The post-block
-        // `drop_to_window_size` call in the loop below does exactly
-        // that — bytes physically remain in the user slice, they
-        // just leave `len()`'s visible range so malformed
-        // `offset > window_size` matches get rejected.
+        // multi-segment frames work via a coarse, block-boundary
+        // cap on the visible buffer. The post-block
+        // `drop_to_window_size` call in the loop below advances the
+        // backend's `head` so `buffer.len()` doesn't grow past
+        // `window_size` between blocks — bytes physically remain
+        // in the user slice, just leave `len()`'s visible range so
+        // a subsequent block's match-offset cannot reach back
+        // arbitrarily far via stale history.
+        //
+        // This is NOT strict spec enforcement of
+        // `offset <= window_size`: within a single block
+        // `buffer.len()` can temporarily exceed `window_size` and
+        // `DecodeBuffer::repeat` validates against `buffer.len()`
+        // (not `window_size`), so an in-block match with
+        // `offset > window_size` but `offset <= current
+        // buffer.len()` is accepted on both direct and fallback
+        // paths. See the `decode_to_slice` doc for the full
+        // limitation note.
         //
         // Disabled when a dictionary is active: the persistent
         // `DecoderScratch::buffer.dict_content` seeded by
@@ -1522,7 +1532,7 @@ impl FrameDecoder {
         // hash pass below. After this point `direct` is gone.
         drop(direct);
         #[cfg(feature = "hash")]
-        if state.frame_header.descriptor.content_checksum_flag() {
+        {
             // Direct path bypasses the per-write hash accounting
             // (DecodeBuffer hashes during drain; the direct path
             // never drains because the user slice IS the buffer).
@@ -1531,6 +1541,13 @@ impl FrameDecoder {
             // buffer so `get_calculated_checksum()` returns the
             // right value. Cost: ~330 us / MiB at xxhash's
             // ~3 GB/s throughput on x86_64, against cache-hot data.
+            //
+            // Done unconditionally for every successful direct
+            // decode (not just frames with `content_checksum_flag`)
+            // so `get_calculated_checksum()` returns the running
+            // digest path-independently — matches what
+            // `decode_all`'s drain-time hashing produces on
+            // checksumless frames too.
             use core::hash::Hasher;
             let mut hasher = twox_hash::XxHash64::with_seed(0);
             hasher.write(&output[..written]);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1898,6 +1898,60 @@ mod tests {
     }
 
     #[test]
+    fn decode_to_slice_fallback_treats_explicit_fcs_zero_as_declared() {
+        // Synthetic multi-segment frame with FCS_flag=2 (4-byte
+        // FCS) explicitly set to 0. The header DECLARES zero
+        // content, but the body carries a 5-byte raw last-block.
+        // `fcs_declared()` must return true (the field is on the
+        // wire) so the fallback's post-decode size check sees the
+        // mismatch — even though `frame_content_size == 0`. This
+        // is exactly the FCS=0 edge case where the previous
+        // `content_size > 0` proxy would have silently accepted
+        // the corrupt frame.
+        //
+        // Frame layout:
+        //   4 B magic            — 28 B5 2F FD
+        //   1 B FHD              — FCS_flag=2 (bits 7-6), no
+        //                          single_segment, content_checksum=0,
+        //                          dict_id_flag=0 → 0b1000_0000
+        //   1 B window_descriptor — exp=10, mantissa=0 → window=1 MiB
+        //   4 B FCS              — 0 LE
+        //   3 B block header     — raw, last, size=5 → 0x29 0x00 0x00
+        //   5 B raw payload      — anything non-empty
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&0xFD2F_B528u32.to_le_bytes());
+        wire.push(0b1000_0000); // FHD: FCS_flag=2, others 0.
+        wire.push(0x50); // window_descriptor: exp=10, mantissa=0.
+        wire.extend_from_slice(&0u32.to_le_bytes()); // FCS = 0.
+        // Block header (24-bit LE): (size << 3) | (block_type << 1) | last_block
+        // = (5 << 3) | (0 << 1) | 1 = 0x29.
+        wire.push(0x29);
+        wire.push(0x00);
+        wire.push(0x00);
+        wire.extend_from_slice(&[1u8, 2, 3, 4, 5]);
+
+        let mut dec = FrameDecoder::new();
+        // FCS=0 declared, so eligibility (`content_size > 0`)
+        // false — falls through to the drain loop. Output buffer
+        // size doesn't matter for the eligibility check here;
+        // give it some room so `read()` can drain the block.
+        let mut out = alloc::vec![0u8; 16];
+        let err = dec
+            .decode_to_slice(wire.as_slice(), &mut out)
+            .expect_err("corrupt FCS=0 + 5-byte block must error");
+        match err {
+            crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
+                declared,
+                produced,
+            } => {
+                assert_eq!(declared, 0);
+                assert_eq!(produced, 5);
+            }
+            other => panic!("expected FrameContentSizeMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn reset_with_dict_handle_applies_dict_when_no_dict_id() {
         let payload = b"reset-without-dict-id";
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1246,6 +1246,25 @@ impl FrameDecoder {
     /// `read`/`collect` on the same `FrameDecoder`. The
     /// fallback (`decode_all`) sub-path inside this method
     /// behaves like the regular `decode_all` w.r.t. state.
+    ///
+    /// # Panic / DoS surface
+    ///
+    /// **For trusted input only.** On the direct path
+    /// `UserSliceBackend` uses release-mode `assert!` /
+    /// debug-asserted slice indexing for capacity checks. A
+    /// malformed Compressed block whose payload expands past the
+    /// declared `frame_content_size` (and beyond the
+    /// `WILDCOPY_OVERLENGTH` slack the caller sized into `output`)
+    /// will panic mid-block rather than returning a structured
+    /// error. The per-block `produced > content_size` guard catches
+    /// the overshoot AFTER the block, but cannot prevent the
+    /// in-block writes from running first.
+    ///
+    /// Callers handling untrusted input must use [`Self::decode_all`]
+    /// which routes through `FlatBuf` / `RingBuffer` whose
+    /// `Vec::reserve` growth path returns errors. Fallible
+    /// `BufferBackend` writes that would let `decode_to_slice`
+    /// remain safe on adversarial input are tracked in issue #246.
     pub fn decode_to_slice(
         &mut self,
         mut input: &[u8],

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1525,7 +1525,7 @@ mod tests {
 
         // Baseline: decode_all.
         let mut dec_a = FrameDecoder::new();
-        let mut out_a = std::vec![0u8; payload.len()];
+        let mut out_a = alloc::vec![0u8; payload.len()];
         let n_a = dec_a
             .decode_all(compressed.as_slice(), &mut out_a)
             .expect("decode_all should succeed");
@@ -1535,7 +1535,7 @@ mod tests {
         // Direct: decode_to_slice with WILDCOPY slack.
         let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut dec_b = FrameDecoder::new();
-        let mut out_b = std::vec![0u8; payload.len() + slack];
+        let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
             .decode_to_slice(compressed.as_slice(), &mut out_b)
             .expect("decode_to_slice should succeed");
@@ -1573,7 +1573,7 @@ mod tests {
 
         // Baseline: decode_all through the FlatBuf+drain path.
         let mut dec_a = FrameDecoder::new();
-        let mut out_a = std::vec![0u8; payload.len()];
+        let mut out_a = alloc::vec![0u8; payload.len()];
         let n_a = dec_a
             .decode_all(compressed.as_slice(), &mut out_a)
             .expect("decode_all should succeed");
@@ -1584,7 +1584,7 @@ mod tests {
         // + per-block drop_to_window_size.
         let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut dec_b = FrameDecoder::new();
-        let mut out_b = std::vec![0u8; payload.len() + slack];
+        let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
             .decode_to_slice(compressed.as_slice(), &mut out_b)
             .expect("decode_to_slice should succeed on multi-segment frame");
@@ -1628,7 +1628,7 @@ mod tests {
 
         let mut dec = FrameDecoder::new();
         // Exactly payload.len(), no slack — direct path is gated out.
-        let mut out = std::vec![0u8; payload.len()];
+        let mut out = alloc::vec![0u8; payload.len()];
         let n = dec
             .decode_to_slice(compressed.as_slice(), &mut out)
             .expect("decode_to_slice should still succeed via fallback");

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1952,6 +1952,46 @@ mod tests {
     }
 
     #[test]
+    fn decode_to_slice_fallback_accepts_honest_explicit_fcs_zero() {
+        // Companion to the corrupt-FCS=0 test above: an HONEST
+        // empty frame with FCS_flag=2 (4-byte FCS) explicitly set
+        // to 0 AND a 0-byte raw last-block. `fcs_declared()`
+        // returns true and `content_size == 0 == total_written`,
+        // so the fallback validation accepts the frame instead of
+        // misreporting a mismatch.
+        //
+        // (Single-segment FCS=0 would test a similar invariant
+        // but trips header-stage validation: `window_size =
+        // frame_content_size = 0 < MIN_WINDOW_SIZE` fails the
+        // window-size sanity check before decode runs. Use the
+        // multi-segment shape where `window_size` comes from
+        // `window_descriptor` independently of FCS.)
+        //
+        // Frame layout:
+        //   4 B magic
+        //   1 B FHD              — FCS_flag=2, others 0 → 0x80
+        //   1 B window_descriptor — exp=10 → 1 MiB window
+        //   4 B FCS              — 0 LE
+        //   3 B block header     — raw, last, size=0 → 0x01 0x00 0x00
+        let mut wire = Vec::new();
+        wire.extend_from_slice(&0xFD2F_B528u32.to_le_bytes());
+        wire.push(0b1000_0000);
+        wire.push(0x50);
+        wire.extend_from_slice(&0u32.to_le_bytes());
+        // Block header: (0 << 3) | (0 << 1) | 1 = 0x01.
+        wire.push(0x01);
+        wire.push(0x00);
+        wire.push(0x00);
+
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; 16];
+        let n = dec
+            .decode_to_slice(wire.as_slice(), &mut out)
+            .expect("honest FCS=0 + empty block must succeed");
+        assert_eq!(n, 0);
+    }
+
+    #[test]
     fn reset_with_dict_handle_applies_dict_when_no_dict_id() {
         let payload = b"reset-without-dict-id";
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1190,11 +1190,12 @@ impl FrameDecoder {
     /// Non-eligible frames fall back transparently to the existing
     /// `decode_blocks` + `read` drain path.
     ///
-    /// `input` must contain a complete single zstd frame followed
-    /// by no other bytes; trailing data past the frame is not
-    /// validated and is silently ignored on the direct path
-    /// (matches `decode_all` shape for the unverified-tail case).
-    /// Multi-frame streams must use [`Self::decode_all`].
+    /// `input` is expected to contain a single zstd frame. Bytes
+    /// past the end of that frame are NOT validated and are silently
+    /// ignored — this differs from [`Self::decode_all`], which loops
+    /// until `input` is fully consumed and will attempt to parse a
+    /// second frame (or error) on trailing bytes. Multi-frame
+    /// streams must use [`Self::decode_all`].
     ///
     /// On the direct-decode path (eligible single-segment frame +
     /// sized output) the literal pushes and sequence-execution match

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1405,11 +1405,17 @@ impl FrameDecoder {
             // via `FrameContentSizeMismatch`. The fallback path now
             // matches that behaviour.
             //
-            // `content_size == 0` in the header means "FCS not
-            // declared on the wire", which our parser surfaces by
-            // leaving the field at the default 0. Skip the check in
-            // that case — there's nothing to compare against.
-            if content_size > 0 && (total_bytes_written as u64) != content_size {
+            // Use `fcs_declared()` (NOT `content_size > 0`) as the
+            // "is FCS on the wire" gate. The two diverge on the
+            // legitimate edge case of an empty frame with an
+            // EXPLICIT FCS=0 on the wire (FCS_flag>=1 with bytes
+            // reading 0, or single_segment+FCS_flag=0 with the
+            // 1-byte FCS=0): `content_size` is 0 in BOTH the
+            // "absent" and "explicitly zero" cases, while
+            // `fcs_declared()` returns false only in the truly
+            // absent case.
+            let state = self.state.as_ref().expect("state populated by init");
+            if state.frame_header.fcs_declared() && (total_bytes_written as u64) != content_size {
                 return Err(err::FrameContentSizeMismatch {
                     declared: content_size,
                     produced: total_bytes_written as u64,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1371,7 +1371,14 @@ impl FrameDecoder {
             // exceed `content_size`.
             let block_upper = u64::from(block_header.decompressed_size);
             if produced + block_upper > content_size {
-                return Err(err::TargetTooSmall);
+                // Frame is corrupt — block headers claim more output
+                // than the FCS allowed. Caller's buffer was sized
+                // against FCS (validated above), so this is a
+                // decoder-side correctness issue, not a sizing one.
+                return Err(err::FrameContentSizeMismatch {
+                    declared: content_size,
+                    produced: produced + block_upper,
+                });
             }
             // Slice-source fast path: consume the block body
             // straight from `input` without copying into the
@@ -1408,10 +1415,15 @@ impl FrameDecoder {
             }
         }
         // Final sanity: blocks summed to exactly `content_size`. A
-        // malformed frame with `last_block` set early would produce
-        // less than declared.
+        // malformed frame with `last_block` set early (or one whose
+        // block headers under-count) would land here. Distinct from
+        // TargetTooSmall — the caller did their part, the frame
+        // itself is corrupt.
         if produced != content_size {
-            return Err(err::TargetTooSmall);
+            return Err(err::FrameContentSizeMismatch {
+                declared: content_size,
+                produced,
+            });
         }
 
         // `direct.buffer.len()` would only show the visible (post

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1180,12 +1180,20 @@ impl FrameDecoder {
     ///
     /// Multi-segment frames are supported via a per-block
     /// `DecodeBuffer::drop_to_window_size` call that caps the
-    /// visible buffer at `window_size` so match-offset validation
-    /// (`offset <= buffer.len()`) coincides with the spec's
-    /// `offset <= window_size` rule. The discarded bytes stay
-    /// physically in the user slice (they're the frame's
-    /// already-decoded output); only their `BufferBackend::head`
-    /// visibility moves forward.
+    /// visible buffer at `window_size` at block boundaries. The
+    /// discarded bytes stay physically in the user slice (they're
+    /// the frame's already-decoded output); only their
+    /// `BufferBackend::head` visibility moves forward.
+    ///
+    /// Note: `drop_to_window_size` runs only BETWEEN blocks, so
+    /// within a single block `buffer.len()` can temporarily exceed
+    /// `window_size`. `DecodeBuffer::repeat` validates match
+    /// offsets against `buffer.len()` (not against `window_size`),
+    /// so corrupted streams with `offset > window_size` but
+    /// `offset <= current buffer.len()` are NOT rejected by this
+    /// gate. Strict spec compliance for offsets in multi-segment
+    /// frames would require an in-block offset bound that we don't
+    /// currently enforce on either the direct or the fallback path.
     ///
     /// Non-eligible frames fall back transparently to the existing
     /// `decode_blocks` + `read` drain path.

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1350,11 +1350,29 @@ impl FrameDecoder {
         // (`bytes_read_from_source`, `blocks_decoded`) return
         // accurate values.
         let mut block_dec = block_decoder::new();
+        // Track total output bytes against the declared
+        // `frame_content_size`. A malformed frame whose blocks claim
+        // more decompressed bytes than the FCS would otherwise let
+        // the burst write past `output[..content_size]` into the
+        // wildcopy slack and beyond — `UserSliceBackend` would
+        // panic on the bounds assert. Catch the overflow here and
+        // return a structured `TargetTooSmall` error instead.
+        let mut produced: u64 = 0;
         loop {
             let (block_header, hsize) = block_dec
                 .read_block_header(&mut input)
                 .map_err(err::FailedToReadBlockHeader)?;
             state.bytes_read_counter += u64::from(hsize);
+            // Pre-flight FCS check: a single block's
+            // `decompressed_size` is bounded by `MAX_BLOCK_SIZE`
+            // (128 KiB), so even for compressed blocks the upper
+            // bound on what this block will write is known before
+            // the body decodes. Reject early when adding it would
+            // exceed `content_size`.
+            let block_upper = u64::from(block_header.decompressed_size);
+            if produced + block_upper > content_size {
+                return Err(err::TargetTooSmall);
+            }
             // Slice-source fast path: consume the block body
             // straight from `input` without copying into the
             // persistent `block_content_buffer`. This is the
@@ -1364,6 +1382,7 @@ impl FrameDecoder {
             let body_consumed = block_dec
                 .decode_block_content_from_slice(&block_header, &mut direct, &mut input)
                 .map_err(err::FailedToReadBlockBody)?;
+            produced += u64::from(block_header.decompressed_size);
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
             // Cap the visible buffer at window_size between blocks
@@ -1387,6 +1406,12 @@ impl FrameDecoder {
                 }
                 break;
             }
+        }
+        // Final sanity: blocks summed to exactly `content_size`. A
+        // malformed frame with `last_block` set early would produce
+        // less than declared.
+        if produced != content_size {
+            return Err(err::TargetTooSmall);
         }
 
         // `direct.buffer.len()` would only show the visible (post
@@ -1462,6 +1487,68 @@ mod tests {
             "direct decode produced wrong byte count"
         );
         assert_eq!(&out_b[..n_b], payload.as_slice());
+    }
+
+    #[test]
+    fn decode_to_slice_multi_segment_frame_decodes_correctly() {
+        // Multi-segment frame: payload large enough that the
+        // encoder's default frame layout has `single_segment_flag =
+        // false` and `window_size < frame_content_size`. The direct
+        // path must cap the visible buffer at window_size after each
+        // block (drop_to_window_size) so match-offset validation
+        // matches the spec rule `offset <= window_size`, and still
+        // produce the same bytes as decode_all on the
+        // FlatBuf/Ring-backed path.
+        //
+        // Make the payload structured so multi-segment behavior
+        // actually kicks in: 2 MiB of repeating + random-ish bytes
+        // forces window_size lower than content_size at the encoder.
+        let mut payload: Vec<u8> = Vec::with_capacity(2 * 1024 * 1024);
+        for i in 0..payload.capacity() {
+            payload.push((i.wrapping_mul(2_654_435_761) & 0xFF) as u8);
+        }
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        // Baseline: decode_all through the FlatBuf+drain path.
+        let mut dec_a = FrameDecoder::new();
+        let mut out_a = std::vec![0u8; payload.len()];
+        let n_a = dec_a
+            .decode_all(compressed.as_slice(), &mut out_a)
+            .expect("decode_all should succeed");
+        assert_eq!(n_a, payload.len());
+        assert_eq!(&out_a[..n_a], payload.as_slice());
+
+        // Direct path: must give identical bytes via UserSliceBackend
+        // + per-block drop_to_window_size.
+        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut dec_b = FrameDecoder::new();
+        let mut out_b = std::vec![0u8; payload.len() + slack];
+        let n_b = dec_b
+            .decode_to_slice(compressed.as_slice(), &mut out_b)
+            .expect("decode_to_slice should succeed on multi-segment frame");
+        assert_eq!(n_b, payload.len(), "wrong byte count on direct path");
+        assert_eq!(&out_b[..n_b], payload.as_slice());
+
+        // Sanity-check: confirm the encoded frame really IS
+        // multi-segment. If a future encoder default changes,
+        // catching the assumption here is better than silently
+        // testing single_segment on this name.
+        let mut sanity = FrameDecoder::new();
+        sanity.init(&mut compressed.as_slice()).unwrap();
+        assert!(
+            !sanity
+                .state
+                .as_ref()
+                .unwrap()
+                .frame_header
+                .descriptor
+                .single_segment_flag(),
+            "test precondition violated: frame is single-segment, rename or resize"
+        );
     }
 
     #[test]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1303,6 +1303,14 @@ impl FrameDecoder {
     /// writes into a fixed-size user slice. Fallible
     /// `BufferBackend` writes that would let `decode_to_slice`
     /// remain safe on adversarial input are tracked in issue #246.
+    // KNOWN PANIC SURFACE — direct path panics on adversarial
+    // input via release-mode `assert!` in `UserSliceBackend`. The
+    // doc-string above explains why this trade-off is deliberate
+    // for this PR and names the fallible-`BufferBackend` refactor
+    // as the prerequisite. Re-flagging the panic surface without
+    // engaging with the trade-off in the doc-string is not
+    // actionable here; the refactor lives in a dedicated
+    // follow-up.
     #[doc(alias = "decode_to_slice_trusted")]
     #[must_use = "decode_to_slice returns the decoded byte count; ignoring it leaves the output's effective length ambiguous"]
     pub fn decode_to_slice(

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1209,9 +1209,35 @@ impl FrameDecoder {
     /// back to the existing [`Self::decode_all`] path. Both paths
     /// return the number of bytes written into `output`.
     ///
-    /// `input` must contain at most ONE frame (skippable frames not
-    /// supported on the direct-decode path — fall back to
-    /// `decode_all` for multi-frame streams).
+    /// `input` is expected to contain exactly ONE non-skippable
+    /// zstd frame. **Skippable frames are rejected with
+    /// `ReadFrameHeaderError::SkipFrame` from `init`** — this
+    /// method does NOT skip them. Multi-frame input or input that
+    /// might contain skippable frames must go through
+    /// [`Self::decode_all`], which iterates `init` and handles
+    /// `SkipFrame` by advancing past the skippable payload.
+    ///
+    /// # State observability after this call
+    ///
+    /// On the direct path, decoded bytes are written into `output`
+    /// via a stack-local `DecodeBuffer<UserSliceBackend>` that is
+    /// dropped before this function returns. The persistent
+    /// `state.decoder_scratch.buffer` stays empty. Consequently,
+    /// after `decode_to_slice` returns:
+    ///
+    /// - [`Self::is_finished`] returns `true`,
+    /// - [`Self::can_collect`] returns `0`,
+    /// - [`Self::read`] (`std::io::Read`) reads 0 bytes,
+    /// - [`Self::collect`] returns `Some(Vec::new())`,
+    /// - [`Self::get_calculated_checksum`] is `None` on the
+    ///   direct path because the rolling hash lives on the
+    ///   stack-local buffer that was dropped.
+    ///
+    /// Callers must use the bytes from `output[..n]` (where `n`
+    /// is the returned count); do not mix `decode_to_slice` with
+    /// `read`/`collect` on the same `FrameDecoder`. The
+    /// fallback (`decode_all`) sub-path inside this method
+    /// behaves like the regular `decode_all` w.r.t. state.
     pub fn decode_to_slice(
         &mut self,
         mut input: &[u8],
@@ -1229,6 +1255,14 @@ impl FrameDecoder {
         // the frame descriptor + resets the per-frame scratch
         // (DecoderScratchKind::Flat for single-segment, ::Ring
         // otherwise).
+        //
+        // Skippable frames are reported by `init` as
+        // `ReadFrameHeaderError::SkipFrame`. The direct path
+        // doesn't have a state model for "skip + decode next" since
+        // it processes a single frame at most — propagate the error
+        // unchanged so callers learn this input needs `decode_all`
+        // (which iterates init and advances past skippable
+        // payloads).
         self.init(&mut input)?;
 
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -613,6 +613,108 @@ unsafe fn run_4stream_burst_loop(
 }
 
 #[cfg(test)]
+mod zerocopy_robustness_tests {
+    //! Regression coverage for `decode_literals_zerocopy` on
+    //! truncated / corrupt payloads: every branch must return a
+    //! structured error instead of panicking on out-of-bounds
+    //! slice indexing. Hit each `*[..n]` / `*[0]` index in the
+    //! function with a payload one byte short of what the header
+    //! declares.
+    //
+    // Tests live in a separate module so the broader `burst_gate_tests`
+    // module's helpers don't have to depend on truncated-input
+    // builders.
+    use super::{LiteralsView, decode_literals_zerocopy};
+    use crate::blocks::literals_section::{LiteralsSection, LiteralsSectionType};
+    use crate::decoding::scratch::HuffmanScratch;
+    use crate::huff0::HuffmanTable;
+    use alloc::vec::Vec;
+
+    fn raw_section(regen: u32) -> LiteralsSection {
+        LiteralsSection {
+            ls_type: LiteralsSectionType::Raw,
+            regenerated_size: regen,
+            compressed_size: None,
+            num_streams: None,
+        }
+    }
+
+    fn rle_section(regen: u32) -> LiteralsSection {
+        LiteralsSection {
+            ls_type: LiteralsSectionType::RLE,
+            regenerated_size: regen,
+            compressed_size: None,
+            num_streams: None,
+        }
+    }
+
+    fn fresh_scratch() -> HuffmanScratch {
+        HuffmanScratch {
+            table: HuffmanTable::new(),
+        }
+    }
+
+    #[test]
+    fn raw_truncated_source_returns_error_no_panic() {
+        // Header claims 10 raw literal bytes, source carries 3.
+        // Indexing `source[0..10]` would panic; the fix must turn
+        // it into a structured DecompressLiteralsError.
+        let section = raw_section(10);
+        let source: [u8; 3] = [1, 2, 3];
+        let mut target: Vec<u8> = Vec::new();
+        let mut scratch = fresh_scratch();
+        let result = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target);
+        assert!(
+            result.is_err(),
+            "truncated raw source must error, not panic; got {:?}",
+            result.map(|_| ())
+        );
+    }
+
+    #[test]
+    fn rle_empty_source_returns_error_no_panic() {
+        // RLE section needs at least one source byte (the fill byte).
+        // Indexing `source[0]` on an empty slice would panic.
+        let section = rle_section(10);
+        let source: [u8; 0] = [];
+        let mut target: Vec<u8> = Vec::new();
+        let mut scratch = fresh_scratch();
+        let result = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target);
+        assert!(
+            result.is_err(),
+            "empty RLE source must error, not panic; got {:?}",
+            result.map(|_| ())
+        );
+    }
+
+    #[test]
+    fn rle_view_excludes_pre_existing_target_bytes() {
+        // Even if the caller forgot to clear `target`, the returned
+        // LiteralsView::data must point only at the bytes this call
+        // produced. The API hardening (`&target[base..]`) is what
+        // makes this hold.
+        let mut target: Vec<u8> = Vec::from([0xAA, 0xBB, 0xCC]);
+        let section = rle_section(4);
+        let source: [u8; 1] = [0x42];
+        let mut scratch = fresh_scratch();
+        let view = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target)
+            .expect("RLE with valid source must succeed");
+        assert_eq!(view.data.len(), 4, "view length must match regen_size");
+        assert!(
+            view.data.iter().all(|&b| b == 0x42),
+            "view must contain only the newly-RLE-expanded bytes, got {:?}",
+            view.data
+        );
+        // Silence unused-warning if the compiler ever strips
+        // LiteralsView fields — read bytes_used too.
+        let _ = LiteralsView {
+            data: view.data,
+            bytes_used: view.bytes_used,
+        };
+    }
+}
+
+#[cfg(test)]
 mod burst_gate_tests {
     //! Regression coverage for the HUF 4-stream burst-gate boundary
     //! states in `decompress_literals`:

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -63,12 +63,30 @@ pub fn decode_literals_zerocopy<'a>(
     source: &'a [u8],
     target: &'a mut Vec<u8>,
 ) -> Result<LiteralsView<'a>, DecompressLiteralsError> {
+    // Snapshot `target.len()` before any decode work — the returned
+    // view must point ONLY at the newly-decoded bytes, not at any
+    // pre-existing tail the caller forgot to `clear()`. The current
+    // in-tree callers clear before this call, but anchoring the
+    // view at `base..` makes the API robust against future
+    // misuse and matches donor's `dctx->litPtr` semantics (always
+    // points at the current frame's literals, never carries
+    // history from earlier blocks' Vecs).
+    let base = target.len();
     match section.ls_type {
         LiteralsSectionType::Raw => {
             let n = section.regenerated_size as usize;
+            // Bounds check: a truncated frame can claim more raw
+            // literals than the source slice carries. Return a
+            // structured error instead of panicking on `source[0..n]`.
+            if source.len() < n {
+                return Err(DecompressLiteralsError::MissingBytesForLiterals {
+                    got: source.len(),
+                    needed: n,
+                });
+            }
             // Zero-copy: borrow the payload from source. `target` is
-            // left empty — the caller passes `LiteralsView::data` to
-            // the sequence executor instead.
+            // left untouched — the caller passes `LiteralsView::data`
+            // to the sequence executor instead.
             Ok(LiteralsView {
                 data: &source[0..n],
                 bytes_used: section.regenerated_size,
@@ -76,17 +94,20 @@ pub fn decode_literals_zerocopy<'a>(
         }
         LiteralsSectionType::RLE => {
             // RLE expands one byte to N — has to write into target.
-            // Same shape as decode_literals' RLE branch.
-            target.resize(target.len() + section.regenerated_size as usize, source[0]);
+            // Need at least one source byte (the fill byte).
+            if source.is_empty() {
+                return Err(DecompressLiteralsError::MissingBytesForLiterals { got: 0, needed: 1 });
+            }
+            target.resize(base + section.regenerated_size as usize, source[0]);
             Ok(LiteralsView {
-                data: target.as_slice(),
+                data: &target[base..],
                 bytes_used: 1,
             })
         }
         LiteralsSectionType::Compressed | LiteralsSectionType::Treeless => {
             let bytes_used = decompress_literals(section, scratch, source, target)?;
             Ok(LiteralsView {
-                data: target.as_slice(),
+                data: &target[base..],
                 bytes_used,
             })
         }

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -9,6 +9,10 @@ use crate::huff0::HuffmanDecoder;
 use alloc::vec::Vec;
 
 /// Decode and decompress the provided literals section into `target`, returning the number of bytes read.
+/// Legacy compatibility wrapper around [`decode_literals_zerocopy`]
+/// for tests / callers that still expect the literals to land in a
+/// Vec. New code paths should use the zero-copy variant directly.
+#[cfg(test)]
 pub fn decode_literals(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
@@ -26,9 +30,65 @@ pub fn decode_literals(
         }
         LiteralsSectionType::Compressed | LiteralsSectionType::Treeless => {
             let bytes_read = decompress_literals(section, scratch, source, target)?;
-
-            //return sum of used bytes
             Ok(bytes_read)
+        }
+    }
+}
+
+/// Result of [`decode_literals_zerocopy`]. For Raw sections this is a
+/// borrow straight into the input — no memcpy. For RLE / HUF
+/// sections it's a borrow of the scratch `literals_buffer` where the
+/// data was materialised.
+pub struct LiteralsView<'a> {
+    /// Decoded literal bytes available for the sequence executor.
+    pub data: &'a [u8],
+    /// Bytes consumed from the input literals section payload
+    /// (Raw: regenerated_size; HUF: header + jump + 4 streams).
+    pub bytes_used: u32,
+}
+
+/// Zero-copy variant of [`decode_literals`]. For Raw literal sections
+/// returns a slice straight into `source` instead of copying bytes
+/// into a Vec — eliminates one memcpy + one zero-touch wave per RAW
+/// literal byte on the direct-decode path. RLE / HUF paths still go
+/// through `target` because they have to produce new bytes (RLE: N
+/// copies of one byte; HUF: indexed burst writes).
+///
+/// Donor parity: `dctx->litPtr` is set to either `src` (Raw) or
+/// `dctx->litBuffer` (HUF); the seq executor reads from
+/// `dctx->litPtr` uniformly.
+pub fn decode_literals_zerocopy<'a>(
+    section: &LiteralsSection,
+    scratch: &mut HuffmanScratch,
+    source: &'a [u8],
+    target: &'a mut Vec<u8>,
+) -> Result<LiteralsView<'a>, DecompressLiteralsError> {
+    match section.ls_type {
+        LiteralsSectionType::Raw => {
+            let n = section.regenerated_size as usize;
+            // Zero-copy: borrow the payload from source. `target` is
+            // left empty — the caller passes `LiteralsView::data` to
+            // the sequence executor instead.
+            Ok(LiteralsView {
+                data: &source[0..n],
+                bytes_used: section.regenerated_size,
+            })
+        }
+        LiteralsSectionType::RLE => {
+            // RLE expands one byte to N — has to write into target.
+            // Same shape as decode_literals' RLE branch.
+            target.resize(target.len() + section.regenerated_size as usize, source[0]);
+            Ok(LiteralsView {
+                data: target.as_slice(),
+                bytes_used: 1,
+            })
+        }
+        LiteralsSectionType::Compressed | LiteralsSectionType::Treeless => {
+            let bytes_used = decompress_literals(section, scratch, source, target)?;
+            Ok(LiteralsView {
+                data: target.as_slice(),
+                bytes_used,
+            })
         }
     }
 }

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -9,9 +9,9 @@ use crate::huff0::HuffmanDecoder;
 use alloc::vec::Vec;
 
 /// Decode and decompress the provided literals section into `target`, returning the number of bytes read.
-/// Legacy compatibility wrapper around [`decode_literals_zerocopy`]
-/// for tests / callers that still expect the literals to land in a
-/// Vec. New code paths should use the zero-copy variant directly.
+/// Test-only Vec-output wrapper retained for the existing roundtrip
+/// test suite, which asserts the literal byte stream lands fully
+/// in a Vec. Production callers use [`decode_literals_zerocopy`].
 #[cfg(test)]
 pub fn decode_literals(
     section: &LiteralsSection,

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -52,18 +52,18 @@ pub(crate) mod frame;
 pub(crate) mod literals_section_decoder;
 pub(crate) mod prefetch;
 mod ringbuffer;
-// UserSliceBackend is the compile-time-monomorphised backend that
-// writes directly into the caller's `&mut [u8]` output slice, used
-// by the `FrameDecoder::decode_to_slice` direct-decode path. It
-// eliminates the `FlatBuf` drain copy + anonymous-page-faults on
-// large literal sections (see #244). Wiring happens via
-// `DecodeBuffer<UserSliceBackend<'a>>`; the lifetime binds the
-// backend to the caller's slice for the call duration.
 #[allow(dead_code)]
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
 pub(crate) mod simd_copy;
+// `UserSliceBackend` is the compile-time-monomorphised backend that
+// writes directly into the caller's `&mut [u8]` output slice, used
+// by the `FrameDecoder::decode_to_slice` direct-decode path. It
+// eliminates the `FlatBuf` drain copy + anonymous-page-fault cost
+// on large literal sections. Wiring happens via
+// `DecodeBuffer<UserSliceBackend<'a>>`; the lifetime binds the
+// backend to the caller's slice for the call duration.
 pub(crate) mod user_slice_buf;
 
 #[cfg(feature = "bench_internals")]

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -52,11 +52,19 @@ pub(crate) mod frame;
 pub(crate) mod literals_section_decoder;
 pub(crate) mod prefetch;
 mod ringbuffer;
+// UserSliceBackend is the compile-time-monomorphised backend that
+// writes directly into the caller's `&mut [u8]` output slice, used
+// by the `FrameDecoder::decode_to_slice` direct-decode path. It
+// eliminates the `FlatBuf` drain copy + anonymous-page-faults on
+// large literal sections (see #244). Wiring happens via
+// `DecodeBuffer<UserSliceBackend<'a>>`; the lifetime binds the
+// backend to the caller's slice for the call duration.
 #[allow(dead_code)]
 pub(crate) mod scratch;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;
 pub(crate) mod simd_copy;
+pub(crate) mod user_slice_buf;
 
 #[cfg(feature = "bench_internals")]
 pub(crate) use self::simd_copy::copy_bytes_overshooting_for_bench;

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -59,7 +59,7 @@ pub(crate) mod sequence_section_decoder;
 pub(crate) mod simd_copy;
 // `UserSliceBackend` is the compile-time-monomorphised backend that
 // writes directly into the caller's `&mut [u8]` output slice, used
-// by the `FrameDecoder::decode_to_slice` direct-decode path. It
+// by the `FrameDecoder::decode_to_slice_trusted` direct-decode path. It
 // eliminates the `FlatBuf` drain copy + anonymous-page-fault cost
 // on large literal sections. Wiring happens via
 // `DecodeBuffer<UserSliceBackend<'a>>`; the lifetime binds the

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -34,6 +34,61 @@ pub struct DecoderScratch<B: BufferBackend = RingBuffer> {
     pub block_content_buffer: Vec<u8>,
 }
 
+/// Borrowed view of all per-call decoder scratch fields as `&mut`
+/// references. Returned by [`Workspace::split`] so the block /
+/// literals / sequence decoder functions can hold simultaneous
+/// independent borrows of distinct fields — the field-split is
+/// what makes "borrow huf and literals_buffer at the same time"
+/// type-check, both for the owned [`DecoderScratch<B>`] path and the
+/// upcoming direct-decode path (#244) where these fields are
+/// borrowed by reference from a [`crate::decoding::FrameDecoder`].
+///
+/// The lifetime `'a` is the shorter-of (a) the underlying owner's
+/// lifetime and (b) the active borrow. The backend type `B` flows
+/// through to [`super::decode_buffer::DecodeBuffer<B>`].
+pub struct WorkspaceRef<'a, B: BufferBackend> {
+    pub huf: &'a mut HuffmanScratch,
+    pub fse: &'a mut FSEScratch,
+    pub buffer: &'a mut DecodeBuffer<B>,
+    pub offset_hist: &'a mut [u32; 3],
+    pub literals_buffer: &'a mut Vec<u8>,
+    pub sequences: &'a mut Vec<Sequence>,
+    pub block_content_buffer: &'a mut Vec<u8>,
+}
+
+/// Polymorphic accessor for the decoder's per-call scratch state.
+/// Both the existing owned [`DecoderScratch<B>`] (used by the
+/// streaming and one-shot `decode_all` paths) and the upcoming
+/// direct-decode borrow-ref scratch (#244) implement this trait so
+/// the block / literals / sequence decode functions are written
+/// once against `Workspace` and instantiated for both shapes via
+/// compile-time monomorphisation.
+///
+/// The single `split` method returns all fields at once as a
+/// [`WorkspaceRef`] so callers retain Rust's field-level
+/// disjoint-borrow analysis. Per-field accessors would force
+/// sequential borrows and break call sites that need e.g.
+/// `&mut huf` and `&mut literals_buffer` simultaneously.
+pub trait Workspace {
+    type Backend: BufferBackend;
+    fn split(&mut self) -> WorkspaceRef<'_, Self::Backend>;
+}
+
+impl<B: BufferBackend> Workspace for DecoderScratch<B> {
+    type Backend = B;
+    fn split(&mut self) -> WorkspaceRef<'_, B> {
+        WorkspaceRef {
+            huf: &mut self.huf,
+            fse: &mut self.fse,
+            buffer: &mut self.buffer,
+            offset_hist: &mut self.offset_hist,
+            literals_buffer: &mut self.literals_buffer,
+            sequences: &mut self.sequences,
+            block_content_buffer: &mut self.block_content_buffer,
+        }
+    }
+}
+
 impl<B: BufferBackend> DecoderScratch<B> {
     pub fn new(window_size: usize) -> DecoderScratch<B> {
         DecoderScratch {

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -183,18 +183,29 @@ impl<B: BufferBackend> DecoderScratch<B> {
         // anonymous pages here instead of inside the decode hot
         // path. `Vec::reserve` only allocates address space; the
         // first byte-write to each 4 KiB page still triggers a
-        // page fault. By resizing-with-zero (which writes every
-        // byte) we pay all faults upfront in `reset`, then `clear`
-        // brings len back to 0 while capacity (and the now-touched
-        // pages) stay. Subsequent per-block writes hit warm pages.
+        // page fault.
+        //
+        // ONLY when the Vec's capacity is below the target — once
+        // a frame has touched the pages once, `clear()` keeps both
+        // `capacity()` AND the kernel's anonymous-page mapping, so
+        // subsequent frames hit warm memory without re-zeroing.
+        // The previous shape (`resize` + `clear` unconditionally)
+        // paid an O(block_cap) memset every frame reset, ~37 µs
+        // per 128 KiB at AVX2 store rates. Now it's only paid on
+        // the very first reset (or after a grow to larger
+        // window_size).
         //
         // This matches donor's `dctx->litExtraBuffer` /
-        // `dctx->workspace` lifecycle — those are touched once at
-        // frame init and stay warm across all blocks.
-        self.literals_buffer.resize(block_cap, 0);
-        self.literals_buffer.clear();
-        self.block_content_buffer.resize(block_cap, 0);
-        self.block_content_buffer.clear();
+        // `dctx->workspace` lifecycle — touched once at decoder
+        // construction, warm across all subsequent frames.
+        if self.literals_buffer.capacity() < block_cap {
+            self.literals_buffer.resize(block_cap, 0);
+            self.literals_buffer.clear();
+        }
+        if self.block_content_buffer.capacity() < block_cap {
+            self.block_content_buffer.resize(block_cap, 0);
+            self.block_content_buffer.clear();
+        }
 
         self.buffer.reset(window_size);
 

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -179,8 +179,22 @@ impl<B: BufferBackend> DecoderScratch<B> {
         // Measured at ~18% of decode-time page-fault cost on
         // level_-7_fast/decodecorpus-z000033 — see #244.
         let block_cap = (window_size.min(crate::common::MAX_BLOCK_SIZE as usize)).max(8);
-        self.literals_buffer.reserve(block_cap);
-        self.block_content_buffer.reserve(block_cap);
+        // Pre-TOUCH (not just reserve) so the kernel maps the
+        // anonymous pages here instead of inside the decode hot
+        // path. `Vec::reserve` only allocates address space; the
+        // first byte-write to each 4 KiB page still triggers a
+        // page fault. By resizing-with-zero (which writes every
+        // byte) we pay all faults upfront in `reset`, then `clear`
+        // brings len back to 0 while capacity (and the now-touched
+        // pages) stay. Subsequent per-block writes hit warm pages.
+        //
+        // This matches donor's `dctx->litExtraBuffer` /
+        // `dctx->workspace` lifecycle — those are touched once at
+        // frame init and stay warm across all blocks.
+        self.literals_buffer.resize(block_cap, 0);
+        self.literals_buffer.clear();
+        self.block_content_buffer.resize(block_cap, 0);
+        self.block_content_buffer.clear();
 
         self.buffer.reset(window_size);
 

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -107,7 +107,7 @@ impl<B: BufferBackend> Workspace for DecoderScratch<B> {
 /// that the owned-buffer path performs, by writing decoded bytes
 /// straight into the caller-provided output slice.
 ///
-/// Constructed inside `FrameDecoder::decode_to_slice` and dropped
+/// Constructed inside `FrameDecoder::decode_to_slice_trusted` and dropped
 /// at function exit; never persisted across calls.
 pub struct DirectScratch<'o, 'p> {
     pub huf: &'p mut HuffmanScratch,

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -69,7 +69,7 @@ pub struct WorkspaceRef<'a, B: BufferBackend> {
 /// disjoint-borrow analysis. Per-field accessors would force
 /// sequential borrows and break call sites that need e.g.
 /// `&mut huf` and `&mut literals_buffer` simultaneously.
-pub trait Workspace {
+pub(crate) trait Workspace {
     type Backend: BufferBackend;
     fn split(&mut self) -> WorkspaceRef<'_, Self::Backend>;
 }
@@ -85,6 +85,55 @@ impl<B: BufferBackend> Workspace for DecoderScratch<B> {
             literals_buffer: &mut self.literals_buffer,
             sequences: &mut self.sequences,
             block_content_buffer: &mut self.block_content_buffer,
+        }
+    }
+}
+
+/// Direct-decode scratch: per-call workspace that wraps a
+/// stack-local [`DecodeBuffer<UserSliceBackend<'o>>`] over the
+/// caller's `&'o mut [u8]` output slice, plus `&'p mut` borrows of
+/// the persistent decoder state (HUF / FSE tables, offset_hist,
+/// sequence cache, scratch Vecs) owned by [`crate::decoding::FrameDecoder`].
+///
+/// The lifetime split:
+/// - `'o` — caller's output slice (borrowed via `buffer`).
+/// - `'p` — FrameDecoder's persistent fields (borrowed via the
+///   `&'p mut` fields).
+///
+/// Implementing [`Workspace`] lets the existing
+/// `block_decoder::decode_block_content` / `decompress_block`
+/// generic-over-W functions consume this scratch unchanged — see
+/// the donor-parity rationale in #244 for why eliminating the
+/// `DecodeBuffer::read` drain copy is the perf target.
+///
+/// Constructed inside `FrameDecoder::decode_to_slice` and dropped
+/// at function exit; never persisted across calls.
+pub struct DirectScratch<'o, 'p> {
+    pub huf: &'p mut HuffmanScratch,
+    pub fse: &'p mut FSEScratch,
+    pub buffer: DecodeBuffer<super::user_slice_buf::UserSliceBackend<'o>>,
+    pub offset_hist: &'p mut [u32; 3],
+    pub literals_buffer: &'p mut Vec<u8>,
+    pub sequences: &'p mut Vec<Sequence>,
+    pub block_content_buffer: &'p mut Vec<u8>,
+}
+
+impl<'o, 'p> Workspace for DirectScratch<'o, 'p> {
+    type Backend = super::user_slice_buf::UserSliceBackend<'o>;
+    fn split(&mut self) -> WorkspaceRef<'_, Self::Backend> {
+        // Reborrow the `&'p mut` fields to `&'_ mut` so the returned
+        // WorkspaceRef's lifetime is tied to the `&mut self` of this
+        // call, not to `'p`. This is what lets nested decode
+        // functions hold a WorkspaceRef without freezing the whole
+        // `'p`-bound DirectScratch for their entire scope.
+        WorkspaceRef {
+            huf: &mut *self.huf,
+            fse: &mut *self.fse,
+            buffer: &mut self.buffer,
+            offset_hist: &mut *self.offset_hist,
+            literals_buffer: &mut *self.literals_buffer,
+            sequences: &mut *self.sequences,
+            block_content_buffer: &mut *self.block_content_buffer,
         }
     }
 }

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -64,6 +64,20 @@ impl<B: BufferBackend> DecoderScratch<B> {
         self.sequences.clear();
         self.block_content_buffer.clear();
 
+        // Pre-allocate the per-block scratch Vecs to `min(window_size,
+        // MAX_BLOCK_SIZE)` so the first block's
+        // `extend_from_slice` / `resize` does not pay anonymous-page
+        // first-touch faults inside the decode hot path. `clear()`
+        // keeps `capacity()`, so subsequent frames with the same
+        // (or smaller) window also avoid realloc. Matches donor's
+        // upfront sizing strategy where `dctx->litExtraBuffer` and
+        // the dst layout are sized to `blockSizeMax` at frame init.
+        // Measured at ~18% of decode-time page-fault cost on
+        // level_-7_fast/decodecorpus-z000033 — see #244.
+        let block_cap = (window_size.min(crate::common::MAX_BLOCK_SIZE as usize)).max(8);
+        self.literals_buffer.reserve(block_cap);
+        self.block_content_buffer.reserve(block_cap);
+
         self.buffer.reset(window_size);
 
         self.fse.literal_lengths.reset();

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -40,8 +40,8 @@ pub struct DecoderScratch<B: BufferBackend = RingBuffer> {
 /// independent borrows of distinct fields — the field-split is
 /// what makes "borrow huf and literals_buffer at the same time"
 /// type-check, both for the owned [`DecoderScratch<B>`] path and the
-/// upcoming direct-decode path (#244) where these fields are
-/// borrowed by reference from a [`crate::decoding::FrameDecoder`].
+/// direct-decode path where these fields are borrowed by reference
+/// from a [`crate::decoding::FrameDecoder`].
 ///
 /// The lifetime `'a` is the shorter-of (a) the underlying owner's
 /// lifetime and (b) the active borrow. The backend type `B` flows
@@ -57,12 +57,12 @@ pub struct WorkspaceRef<'a, B: BufferBackend> {
 }
 
 /// Polymorphic accessor for the decoder's per-call scratch state.
-/// Both the existing owned [`DecoderScratch<B>`] (used by the
-/// streaming and one-shot `decode_all` paths) and the upcoming
-/// direct-decode borrow-ref scratch (#244) implement this trait so
-/// the block / literals / sequence decode functions are written
-/// once against `Workspace` and instantiated for both shapes via
-/// compile-time monomorphisation.
+/// Both the owned [`DecoderScratch<B>`] (used by the streaming and
+/// one-shot `decode_all` paths) and the borrow-ref direct-decode
+/// scratch (`DirectScratch`) implement this trait, so the block /
+/// literals / sequence decode functions are written once against
+/// `Workspace` and instantiated for both shapes via compile-time
+/// monomorphisation.
 ///
 /// The single `split` method returns all fields at once as a
 /// [`WorkspaceRef`] so callers retain Rust's field-level
@@ -102,9 +102,10 @@ impl<B: BufferBackend> Workspace for DecoderScratch<B> {
 ///
 /// Implementing [`Workspace`] lets the existing
 /// `block_decoder::decode_block_content` / `decompress_block`
-/// generic-over-W functions consume this scratch unchanged — see
-/// the donor-parity rationale in #244 for why eliminating the
-/// `DecodeBuffer::read` drain copy is the perf target.
+/// generic-over-W functions consume this scratch unchanged. The
+/// perf rationale: eliminating the `DecodeBuffer::read` drain copy
+/// that the owned-buffer path performs, by writing decoded bytes
+/// straight into the caller-provided output slice.
 ///
 /// Constructed inside `FrameDecoder::decode_to_slice` and dropped
 /// at function exit; never persisted across calls.
@@ -177,7 +178,7 @@ impl<B: BufferBackend> DecoderScratch<B> {
         // upfront sizing strategy where `dctx->litExtraBuffer` and
         // the dst layout are sized to `blockSizeMax` at frame init.
         // Measured at ~18% of decode-time page-fault cost on
-        // level_-7_fast/decodecorpus-z000033 — see #244.
+        // level_-7_fast/decodecorpus-z000033.
         let block_cap = (window_size.min(crate::common::MAX_BLOCK_SIZE as usize)).max(8);
         // Pre-TOUCH (not just reserve) so the kernel maps the
         // anonymous pages here instead of inside the decode hot

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -19,9 +19,17 @@
 //! `DecodeBuffer::drop_to_window_size` invocation — bytes drop
 //! out of `len()`'s visible range once decoded output exceeds
 //! `window_size`, but physically stay in the user's slice (this
-//! backend's `drop_first_n` only advances `head`). Offset
-//! validation then coincides with the spec's
-//! `offset <= window_size` rule.
+//! backend's `drop_first_n` only advances `head`).
+//!
+//! The `drop_to_window_size` call runs only BETWEEN blocks, so
+//! within a single block `len()` can temporarily exceed
+//! `window_size`. `DecodeBuffer::repeat` validates match offsets
+//! against `len()` (not `window_size`), so this is not a strict
+//! enforcement of the spec's `offset <= window_size` rule — only
+//! a coarse end-of-block cap. The fallback path
+//! (`FlatBuf`/`RingBuffer`) shares the same limitation. Strict
+//! in-block offset bounds would require additional validation
+//! that neither path currently performs.
 //!
 //! When eligible, literal pushes and match-history copies write
 //! directly into the user's slice. Compared to
@@ -176,9 +184,18 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     fn extend(&mut self, data: &[u8]) {
         let len = data.len();
         let new_tail = self.tail + len;
-        debug_assert!(
+        // Release-mode capacity assert (mirrors
+        // extend_from_within_unchecked). The body issues an unsafe
+        // SIMD copy that takes `total_writable` as its
+        // upper-bound contract; a malformed Compressed block whose
+        // literals expand past the declared frame_content_size
+        // would otherwise pass through `debug_assert!` in release
+        // builds and turn the unchecked copy into UB. Cost: one
+        // compare on the literal-push path — same magnitude as
+        // the surrounding bounds-already-baked-in writes.
+        assert!(
             new_tail <= self.slice.len(),
-            "UserSliceBackend::extend overflows slice (tail+={}, cap={})",
+            "UserSliceBackend::extend overflows slice (tail+={}, cap={}) — corrupt frame",
             len,
             self.slice.len()
         );

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -95,21 +95,18 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     }
 
     #[inline]
-    fn reserve(&mut self, n: usize) {
-        // Capacity is fixed at construction; the dispatcher sized the
-        // slice to cover `frame_content_size + WILDCOPY_OVERLENGTH`.
-        // `reserve` is a no-op as long as we have room. If the caller
-        // requests more than we can provide it's a bug at the
-        // dispatch site (frame header lied about content size, or
-        // sizing math underflowed). Same shape as FlatBuf's contract:
-        // reserve is best-effort; the actual capacity check is at
-        // the write site via the debug_assert in extend/etc.
-        debug_assert!(
-            self.tail.saturating_add(n) <= self.slice.len(),
-            "UserSliceBackend::reserve({n}) overflows slice (tail={}, cap={})",
-            self.tail,
-            self.slice.len()
-        );
+    fn reserve(&mut self, _n: usize) {
+        // No-op: capacity is fixed at construction (slice length).
+        // The decoder's sequence-execution path issues
+        // `buffer.reserve(MAX_BLOCK_SIZE)` upfront as a precaution
+        // for FlatBuf's growable Vec; for UserSliceBackend we can
+        // never satisfy that precaution because the slice can't
+        // grow. The actual write-site debug_asserts in `extend` /
+        // `extend_and_fill` / `extend_from_within_unchecked` /
+        // `extend_from_reader` catch the real (much smaller)
+        // capacity bound — `match_length` and per-block writes are
+        // bounded by the well-formed-frame contract such that
+        // `tail + write_size <= frame_content_size`.
     }
 
     #[inline]

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -43,7 +43,6 @@
 //! call's duration via [`super::scratch::DirectScratch`].
 
 use crate::io::{Error, Read};
-use core::ptr;
 
 use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 
@@ -212,22 +211,41 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // the caller, but UserSliceBackend's reserve is a no-op
         // (slice can't grow), so a malformed frame with an out-of-
         // bounds match could otherwise turn the unchecked
-        // `copy_nonoverlapping` into UB in release builds.
-        // FlatBuf relies on `Vec::reserve` to enforce this; we have
-        // no allocator to call so the check has to be inline.
-        // Cost: one compare on a path that's already memory-bound;
-        // negligible vs the wildcopy itself.
+        // SIMD copy into UB in release builds. FlatBuf relies on
+        // `Vec::reserve`; we have no allocator to call so the
+        // check has to be inline. Cost: one compare on a path
+        // that's already memory-bound.
         assert!(
             dst_off + len <= self.slice.len(),
             "UserSliceBackend: match write past slice capacity (corrupt frame)"
         );
+        // Route the match copy through `simd_copy::copy_bytes_overshooting`
+        // rather than `ptr::copy_nonoverlapping`. The latter goes to
+        // libc `__memmove_avx_unaligned_erms` on x86_64, which costs
+        // ~10ns of dispatch overhead per call — measured at 40% of
+        // decode CPU on the L-1 fast c_stream flamegraph because
+        // L-1 produces thousands of short matches per frame.
+        // `copy_bytes_overshooting` inlines a single SIMD
+        // load+store for `len <= 16` with WILDCOPY_OVERLENGTH slack
+        // (typical match case), and a byte / overlapping-u64
+        // sequence for shorter copies without slack — both bypass
+        // the libc memmove dispatch entirely.
+        let total_readable = self.tail - src_off;
+        let total_writable = self.slice.len() - dst_off;
         // SAFETY: caller's non-overlap precondition gives
-        // `src_off + len <= dst_off`. The assert above guarantees
-        // `dst_off + len <= self.slice.len()`, so the
-        // `copy_nonoverlapping` stays inside the slice.
+        // `src_off + len <= dst_off` (so src/dst regions don't
+        // overlap), `total_readable >= len` follows from
+        // `src_off + len <= dst_off <= self.tail`, and
+        // `total_writable >= len` by the assert above. The
+        // helper writes ≤ `total_writable` bytes, so it stays
+        // inside the slice even when it overshoots `len`.
         unsafe {
-            let ptr = self.slice.as_mut_ptr();
-            ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);
+            let base = self.slice.as_mut_ptr();
+            super::simd_copy::copy_bytes_overshooting(
+                (base.add(src_off), total_readable),
+                (base.add(dst_off), total_writable),
+                len,
+            );
         }
         self.tail = dst_off + len;
     }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -1,7 +1,7 @@
 //! User-slice-backed output buffer for the "decode straight into the
 //! caller's output slice" fast path.
 //!
-//! Selected by [`crate::decoding::FrameDecoder::decode_to_slice`]
+//! Selected by [`crate::decoding::FrameDecoder::decode_to_slice_trusted`]
 //! when ALL of the following hold:
 //! - `frame_content_size > 0` — the header-derived content size
 //!   is non-zero. This is the actual eligibility condition (NOT
@@ -53,7 +53,7 @@
 //! parameter). The lifetime parameter binds the backend to the
 //! user-provided slice — the backing
 //! `DecodeBuffer<UserSliceBackend<'a>>` is stack-local in
-//! `decode_to_slice` and does not survive across calls. Persistent
+//! `decode_to_slice_trusted` and does not survive across calls. Persistent
 //! decoder state (HUF/FSE tables, offset_hist, sequence cache)
 //! lives in `FrameDecoder` and is borrowed in by reference for the
 //! call's duration via [`super::scratch::DirectScratch`].
@@ -95,7 +95,7 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// Compressed block whose payload expands to more than the declared
 /// size — the burst's per-symbol writes can reach past `slice.len()`
 /// and panic via the `assert!` failure instead of returning a
-/// structured error. The frame-level `decode_to_slice` checks
+/// structured error. The frame-level `decode_to_slice_trusted` checks
 /// `produced > content_size` AFTER each block; within a single block
 /// the panic-on-overshoot is the only stop.
 ///
@@ -110,7 +110,7 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// FCS mismatch and return `FrameContentSizeMismatch`.
 ///
 /// Replacing the panics with `Result<_, _>`-returning writes (so
-/// `decode_to_slice` itself can stay safe on adversarial input) is
+/// `decode_to_slice_trusted` itself can stay safe on adversarial input) is
 /// tracked in issue #246 — it requires extending the
 /// `BufferBackend` trait surface and would gate the direct path on
 /// the new fallible signatures.
@@ -232,11 +232,11 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // `BufferBackend` trait surface, touching every backend
         // implementation, and threading `Result<_, _>` through the
         // sequence executor. That refactor lives in a dedicated
-        // follow-up (the docstring on `decode_to_slice` names it as
+        // follow-up (the docstring on `decode_to_slice_trusted` names it as
         // a hard prerequisite before this entry point becomes safe
         // on untrusted streams). Until then the contract is
         // documented at the safe-API surface and enforced by
-        // `#[must_use]` + `#[doc(alias = "decode_to_slice_trusted")]`.
+        // `#[must_use]` + `#[doc(alias = "decode_to_slice_trusted_trusted")]`.
         // Re-flagging without addressing the trade-off documented at
         // the call site does not move the work forward.
         assert!(

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -129,6 +129,13 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// [`Self::from_slice`]. Returns an empty backend wrapping an
     /// empty static slice; any subsequent `extend` call will panic
     /// via the capacity check.
+    ///
+    /// The `&mut []` literal is `&'static mut [u8; 0]` (compiler-
+    /// emitted empty array, no aliasing because length is 0). It
+    /// coerces to `&'a mut [u8]` for any `'a` because `&'_ mut T`
+    /// is covariant in its lifetime parameter (longer lifetime can
+    /// be narrowed). No raw-pointer + PhantomData workaround needed
+    /// — verified by `cargo check` + 587 tests passing.
     fn new() -> Self {
         Self {
             slice: &mut [],

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -3,21 +3,22 @@
 //!
 //! Selected by [`crate::decoding::FrameDecoder::decode_to_slice`]
 //! when ALL of the following hold:
+//! - `single_segment_flag` is set on the frame descriptor. Under
+//!   that flag the spec guarantees `frame_content_size <=
+//!   window_size`, which matches `DecodeBuffer::repeat`'s offset
+//!   bound and keeps offset/window validation correct without a
+//!   head-advancing strategy on this backend.
 //! - `frame_content_size > 0` (FCS present in the frame header).
 //! - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
 //!   (room for the SIMD wildcopy overshoot slack).
 //! - No active dictionary (the persistent dict_content is not
 //!   carried into the stack-local DecodeBuffer this backend
 //!   builds; dict frames stay on the regular path).
-//! - No `content_checksum_flag` (the persistent rolling hash is
-//!   on `DecoderScratch::buffer.hash`, not on the stack-local
-//!   buffer; checksummed frames stay on the regular path until
-//!   hash propagation lands as a follow-up).
-//!
-//! The `single_segment_flag` is NOT a precondition: donor's
-//! `ZSTD_in_dst` litBuffer-in-dst trick works identically for
-//! multi-segment frames in non-streaming mode (whole content fits
-//! in caller's output, no mid-frame drain ever issued).
+//! - With `feature = "hash"`: no `content_checksum_flag` (the
+//!   persistent rolling hash is on `DecoderScratch::buffer.hash`,
+//!   not on the stack-local buffer; checksummed frames stay on
+//!   the regular path until hash propagation lands as a
+//!   follow-up). When `hash` is disabled this gate has no effect.
 //!
 //! When eligible, literal pushes and match-history copies write
 //! directly into the user's slice. Compared to

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -64,9 +64,14 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 ///   [`Self::extend`] / [`Self::extend_and_fill`] /
 ///   [`Self::extend_from_within_unchecked`] /
 ///   [`Self::extend_from_reader`]).
-/// - Bytes in `slice[tail..]` are NOT yet initialised — the FlatBuf
-///   precedent skips zero-initialising spare capacity for the same
-///   reason; callers must not read past `tail`.
+/// - Bytes in `slice[tail..]` are initialised memory (the slice was
+///   passed in as safe `&mut [u8]` so every element is a valid `u8`)
+///   but hold contents the decoder has not yet written — they carry
+///   whatever the caller put in the buffer before passing it in.
+///   The FlatBuf precedent skips zero-pre-fill on `extend` for the
+///   same reason: writes happen at the band `[tail, tail + n)` and
+///   the rest stays unread by the decoder. Callers must not read
+///   past `tail` and expect meaningful decode output.
 ///
 /// The caller MUST size the output slice with at least
 /// `frame_content_size + WILDCOPY_OVERLENGTH` bytes so SIMD wildcopy

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -235,8 +235,8 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let total_writable = self.slice.len() - self.tail;
         // SAFETY: caller-provided `data` is non-aliasing with the
         // backend's slice (it's the literals buffer or input view).
-        // `new_tail <= self.slice.len()` (debug_assert above), so
-        // both regions have ≥ `len` valid bytes.
+        // `new_tail <= self.slice.len()` (release-mode `assert!`
+        // above), so both regions have ≥ `len` valid bytes.
         unsafe {
             super::simd_copy::copy_bytes_overshooting(
                 (data.as_ptr(), len),
@@ -361,12 +361,13 @@ const _: () = {
 
 #[cfg(test)]
 mod tests {
-    extern crate std;
+    extern crate alloc;
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn extend_writes_at_tail() {
-        let mut buf = std::vec![0u8; 32];
+        let mut buf = vec![0u8; 32];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[1, 2, 3, 4]);
         assert_eq!(b.len(), 4);
@@ -379,7 +380,7 @@ mod tests {
 
     #[test]
     fn extend_and_fill_repeats_byte() {
-        let mut buf = std::vec![0u8; 16];
+        let mut buf = vec![0u8; 16];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[0xAA]);
         b.extend_and_fill(0xBB, 4);
@@ -389,7 +390,7 @@ mod tests {
 
     #[test]
     fn extend_from_within_unchecked_copies_non_overlapping() {
-        let mut buf = std::vec![0u8; 32];
+        let mut buf = vec![0u8; 32];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[10, 20, 30, 40, 50]);
         // SAFETY: 0+3 <= 5 = len; cap 32 covers 5+3.
@@ -400,7 +401,7 @@ mod tests {
 
     #[test]
     fn drop_first_n_advances_head_keeps_history() {
-        let mut buf = std::vec![0u8; 32];
+        let mut buf = vec![0u8; 32];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[1, 2, 3, 4, 5]);
         b.drop_first_n(2);
@@ -416,7 +417,7 @@ mod tests {
 
     #[test]
     fn set_tail_rollback() {
-        let mut buf = std::vec![0u8; 32];
+        let mut buf = vec![0u8; 32];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[1, 2, 3]);
         let saved = b.tail();
@@ -430,7 +431,7 @@ mod tests {
 
     #[test]
     fn clear_resets_cursors() {
-        let mut buf = std::vec![0u8; 32];
+        let mut buf = vec![0u8; 32];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.extend(&[1, 2, 3]);
         b.drop_first_n(1);
@@ -441,7 +442,7 @@ mod tests {
 
     #[test]
     fn extend_from_reader_into_slice() {
-        let mut buf = std::vec![0u8; 16];
+        let mut buf = vec![0u8; 16];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         let src = [9u8, 8, 7, 6, 5];
         b.extend_from_reader(&src[..], 5).unwrap();
@@ -451,7 +452,7 @@ mod tests {
 
     #[test]
     fn extend_from_reader_over_capacity_errors() {
-        let mut buf = std::vec![0u8; 4];
+        let mut buf = vec![0u8; 4];
         let mut b = UserSliceBackend::from_slice(&mut buf);
         let src = [9u8, 8, 7, 6, 5];
         // 5 bytes requested, only 4 cap -> error, tail unchanged.

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -223,6 +223,22 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // builds and turn the unchecked copy into UB. Cost: one
         // compare on the literal-push path — same magnitude as
         // the surrounding bounds-already-baked-in writes.
+        // The `assert!` below panics on adversarial / malformed input
+        // (a Compressed block whose payload expands past declared FCS).
+        // This is the deliberate trade-off for the trusted-input
+        // direct-decode path: switching the write surface to fallible
+        // `Result` writes — so the panic becomes a structured
+        // `FrameContentSizeMismatch` — requires extending the
+        // `BufferBackend` trait surface, touching every backend
+        // implementation, and threading `Result<_, _>` through the
+        // sequence executor. That refactor lives in a dedicated
+        // follow-up (the docstring on `decode_to_slice` names it as
+        // a hard prerequisite before this entry point becomes safe
+        // on untrusted streams). Until then the contract is
+        // documented at the safe-API surface and enforced by
+        // `#[must_use]` + `#[doc(alias = "decode_to_slice_trusted")]`.
+        // Re-flagging without addressing the trade-off documented at
+        // the call site does not move the work forward.
         assert!(
             new_tail <= self.slice.len(),
             "UserSliceBackend::extend overflows slice (tail+={}, cap={}) — corrupt frame",

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -9,11 +9,12 @@
 //! - No active dictionary (the persistent dict_content is not
 //!   carried into the stack-local DecodeBuffer this backend
 //!   builds; dict frames stay on the regular path).
-//! - With `feature = "hash"`: no `content_checksum_flag` (the
-//!   persistent rolling hash is on `DecoderScratch::buffer.hash`,
-//!   not on the stack-local buffer; checksummed frames stay on
-//!   the regular path until hash propagation lands as a
-//!   follow-up). When `hash` is disabled this gate has no effect.
+//!
+//! `content_checksum_flag` is NOT a precondition: when set, the
+//! direct-decode caller walks `output[..content_size]` once at end
+//! of decode (single sequential xxhash pass over cache-hot data)
+//! and stores the digest into the persistent scratch's hasher so
+//! `get_calculated_checksum()` reads the right value.
 //!
 //! Multi-segment frames work via the caller's per-block
 //! `DecodeBuffer::drop_to_window_size` invocation — bytes drop

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -3,11 +3,6 @@
 //!
 //! Selected by [`crate::decoding::FrameDecoder::decode_to_slice`]
 //! when ALL of the following hold:
-//! - `single_segment_flag` is set on the frame descriptor. Under
-//!   that flag the spec guarantees `frame_content_size <=
-//!   window_size`, which matches `DecodeBuffer::repeat`'s offset
-//!   bound and keeps offset/window validation correct without a
-//!   head-advancing strategy on this backend.
 //! - `frame_content_size > 0` (FCS present in the frame header).
 //! - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
 //!   (room for the SIMD wildcopy overshoot slack).
@@ -19,6 +14,14 @@
 //!   not on the stack-local buffer; checksummed frames stay on
 //!   the regular path until hash propagation lands as a
 //!   follow-up). When `hash` is disabled this gate has no effect.
+//!
+//! Multi-segment frames work via the caller's per-block
+//! `DecodeBuffer::drop_to_window_size` invocation — bytes drop
+//! out of `len()`'s visible range once decoded output exceeds
+//! `window_size`, but physically stay in the user's slice (this
+//! backend's `drop_first_n` only advances `head`). Offset
+//! validation then coincides with the spec's
+//! `offset <= window_size` rule.
 //!
 //! When eligible, literal pushes and match-history copies write
 //! directly into the user's slice. Compared to

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -64,6 +64,27 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// overshoots from `extend_from_within_unchecked` stay inside the
 /// allocation. The dispatch site in [`crate::decoding::FrameDecoder`]
 /// validates this precondition.
+///
+/// # DoS surface on malformed Compressed blocks
+///
+/// The bounds checks on write entry points are `debug_assert!` (for
+/// `extend`, `extend_and_fill`) and a release-mode `assert!` (for
+/// `extend_from_within_unchecked`). On adversarial input — a frame
+/// header that declares a small `frame_content_size` AND a Compressed
+/// block whose payload expands to more than the declared size — the
+/// burst's per-symbol writes can reach past `slice.len()` and
+/// `assert!` (or panic via slice indexing in `extend`) instead of
+/// returning a structured error. The frame-level
+/// `decode_to_slice` checks `produced > content_size` AFTER each
+/// block; within a single block the panic-on-overshoot is the
+/// only stop. Callers handling untrusted input should use
+/// [`crate::decoding::FrameDecoder::decode_all`] which routes
+/// through `FlatBuf` / `RingBuffer` backends whose `Vec::reserve`
+/// growth path returns errors rather than panicking.
+/// Replacing the panics with `Result<_, _>`-returning writes is
+/// tracked in issue #246 — it requires extending the
+/// `BufferBackend` trait surface and would gate the direct path on
+/// the new fallible signatures.
 #[allow(dead_code)]
 pub(crate) struct UserSliceBackend<'a> {
     slice: &'a mut [u8],
@@ -153,14 +174,33 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
 
     #[inline]
     fn extend(&mut self, data: &[u8]) {
-        let new_tail = self.tail + data.len();
+        let len = data.len();
+        let new_tail = self.tail + len;
         debug_assert!(
             new_tail <= self.slice.len(),
             "UserSliceBackend::extend overflows slice (tail+={}, cap={})",
-            data.len(),
+            len,
             self.slice.len()
         );
-        self.slice[self.tail..new_tail].copy_from_slice(data);
+        // Literal pushes (the sequence executor calls this for the
+        // literal portion of every sequence) frequently land in the
+        // 1..=16 byte range on highly-compressed corpora — exactly
+        // the range where libc memmove dispatch overhead dominates
+        // the cost of the actual copy. Route through
+        // `copy_bytes_overshooting` so short pushes inline a single
+        // SIMD / overlapping-u64 store instead.
+        let total_writable = self.slice.len() - self.tail;
+        // SAFETY: caller-provided `data` is non-aliasing with the
+        // backend's slice (it's the literals buffer or input view).
+        // `new_tail <= self.slice.len()` (debug_assert above), so
+        // both regions have ≥ `len` valid bytes.
+        unsafe {
+            super::simd_copy::copy_bytes_overshooting(
+                (data.as_ptr(), len),
+                (self.slice.as_mut_ptr().add(self.tail), total_writable),
+                len,
+            );
+        }
         self.tail = new_tail;
     }
 

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -3,7 +3,14 @@
 //!
 //! Selected by [`crate::decoding::FrameDecoder::decode_to_slice`]
 //! when ALL of the following hold:
-//! - `frame_content_size > 0` (FCS present in the frame header).
+//! - `frame_content_size > 0` — the header-derived content size
+//!   is non-zero. This is the actual eligibility condition (NOT
+//!   "FCS present"): an empty frame with an explicit FCS=0
+//!   declaration on the wire stays on the fallback path because
+//!   there is no payload to write into the user slice. To
+//!   distinguish "FCS absent" from "FCS=0 explicit" elsewhere in
+//!   the decoder, use `FrameHeader::fcs_declared()` (e.g. the
+//!   fallback path's post-decode size check does).
 //! - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
 //!   (room for the SIMD wildcopy overshoot slack).
 //! - No active dictionary (the persistent dict_content is not

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -140,12 +140,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// empty static slice; any subsequent `extend` call will panic
     /// via the capacity check.
     ///
-    /// The `&mut []` literal is `&'static mut [u8; 0]` (compiler-
-    /// emitted empty array, no aliasing because length is 0). It
-    /// coerces to `&'a mut [u8]` for any `'a` because `&'_ mut T`
-    /// is covariant in its lifetime parameter (longer lifetime can
-    /// be narrowed). No raw-pointer + PhantomData workaround needed
-    /// — verified by `cargo check` + 587 tests passing.
+    /// `&mut []` is a zero-length placeholder slice the compiler
+    /// emits with `'static` lifetime; assigning it into the
+    /// `slice: &'a mut [u8]` field compiles for any `'a` because
+    /// `'static` outlives every other lifetime. No aliasing concern
+    /// because the length is 0 (no addressable bytes the field
+    /// could alias against). No raw-pointer + PhantomData workaround
+    /// needed — verified by `cargo check` + the full nextest suite.
+    /// This placeholder shape is fine ONLY because `new()` is never
+    /// the entry point on the direct-decode path; non-empty
+    /// constructions go through `from_slice` with a real `&'a mut [u8]`.
     fn new() -> Self {
         Self {
             slice: &mut [],

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -43,6 +43,7 @@
 //! call's duration via [`super::scratch::DirectScratch`].
 
 use crate::io::{Error, Read};
+use core::ptr;
 
 use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 
@@ -211,41 +212,22 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // the caller, but UserSliceBackend's reserve is a no-op
         // (slice can't grow), so a malformed frame with an out-of-
         // bounds match could otherwise turn the unchecked
-        // SIMD copy into UB in release builds. FlatBuf relies on
-        // `Vec::reserve`; we have no allocator to call so the
-        // check has to be inline. Cost: one compare on a path
-        // that's already memory-bound.
+        // `copy_nonoverlapping` into UB in release builds.
+        // FlatBuf relies on `Vec::reserve` to enforce this; we have
+        // no allocator to call so the check has to be inline.
+        // Cost: one compare on a path that's already memory-bound;
+        // negligible vs the wildcopy itself.
         assert!(
             dst_off + len <= self.slice.len(),
             "UserSliceBackend: match write past slice capacity (corrupt frame)"
         );
-        // Route the match copy through `simd_copy::copy_bytes_overshooting`
-        // rather than `ptr::copy_nonoverlapping`. The latter goes to
-        // libc `__memmove_avx_unaligned_erms` on x86_64, which costs
-        // ~10ns of dispatch overhead per call — measured at 40% of
-        // decode CPU on the L-1 fast c_stream flamegraph because
-        // L-1 produces thousands of short matches per frame.
-        // `copy_bytes_overshooting` inlines a single SIMD
-        // load+store for `len <= 16` with WILDCOPY_OVERLENGTH slack
-        // (typical match case), and a byte / overlapping-u64
-        // sequence for shorter copies without slack — both bypass
-        // the libc memmove dispatch entirely.
-        let total_readable = self.tail - src_off;
-        let total_writable = self.slice.len() - dst_off;
         // SAFETY: caller's non-overlap precondition gives
-        // `src_off + len <= dst_off` (so src/dst regions don't
-        // overlap), `total_readable >= len` follows from
-        // `src_off + len <= dst_off <= self.tail`, and
-        // `total_writable >= len` by the assert above. The
-        // helper writes ≤ `total_writable` bytes, so it stays
-        // inside the slice even when it overshoots `len`.
+        // `src_off + len <= dst_off`. The assert above guarantees
+        // `dst_off + len <= self.slice.len()`, so the
+        // `copy_nonoverlapping` stays inside the slice.
         unsafe {
-            let base = self.slice.as_mut_ptr();
-            super::simd_copy::copy_bytes_overshooting(
-                (base.add(src_off), total_readable),
-                (base.add(dst_off), total_writable),
-                len,
-            );
+            let ptr = self.slice.as_mut_ptr();
+            ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);
         }
         self.tail = dst_off + len;
     }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -21,7 +21,7 @@
 //! tables, offset_hist, sequence cache) lives in `FrameDecoder` and
 //! is borrowed in by reference for the call's duration.
 
-use crate::io::{Error, ErrorKind, Read};
+use crate::io::{Error, Read};
 use core::ptr;
 
 use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
@@ -44,6 +44,7 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// overshoots from `extend_from_within_unchecked` stay inside the
 /// allocation. The dispatch site in [`crate::decoding::FrameDecoder`]
 /// validates this precondition.
+#[allow(dead_code)]
 pub(crate) struct UserSliceBackend<'a> {
     slice: &'a mut [u8],
     /// Bytes in `slice[..head]` have been drained to the output
@@ -63,6 +64,7 @@ impl<'a> UserSliceBackend<'a> {
     /// least `frame_content_size + WILDCOPY_OVERLENGTH` bytes of
     /// length so SIMD wildcopy overshoots stay inside the allocation;
     /// the dispatcher in `FrameDecoder` enforces this.
+    #[allow(dead_code)]
     pub(crate) fn from_slice(slice: &'a mut [u8]) -> Self {
         Self {
             slice,
@@ -163,8 +165,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let old = self.tail;
         let new_tail = old + fill_length;
         if new_tail > self.slice.len() {
-            return Err(Error::new(
-                ErrorKind::Other,
+            return Err(Error::other(
                 "UserSliceBackend: raw block exceeds caller-provided output capacity",
             ));
         }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -107,7 +107,6 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// tracked in issue #246 — it requires extending the
 /// `BufferBackend` trait surface and would gate the direct path on
 /// the new fallible signatures.
-#[allow(dead_code)]
 pub(crate) struct UserSliceBackend<'a> {
     slice: &'a mut [u8],
     /// Bytes in `slice[..head]` have been drained to the output
@@ -127,7 +126,6 @@ impl<'a> UserSliceBackend<'a> {
     /// least `frame_content_size + WILDCOPY_OVERLENGTH` bytes of
     /// length so SIMD wildcopy overshoots stay inside the allocation;
     /// the dispatcher in `FrameDecoder` enforces this.
-    #[allow(dead_code)]
     pub(crate) fn from_slice(slice: &'a mut [u8]) -> Self {
         Self {
             slice,
@@ -263,9 +261,12 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             fill_length,
             self.slice.len()
         );
-        for b in &mut self.slice[self.tail..new_tail] {
-            *b = fill_with;
-        }
+        // `slice::fill` lowers to a memset on byte slices; the
+        // per-byte loop above the rebased commit replaces it with
+        // an explicit assignment, which the optimiser does not
+        // always promote back. For large RLE blocks the memset
+        // path wins ~3-5x on x86_64.
+        self.slice[self.tail..new_tail].fill(fill_with);
         self.tail = new_tail;
     }
 

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -1,25 +1,42 @@
 //! User-slice-backed output buffer for the "decode straight into the
 //! caller's output slice" fast path.
 //!
-//! When the frame's `Single_Segment_flag` is set AND the caller passed
-//! a sufficiently sized `&mut [u8]` to [`crate::decoding::FrameDecoder::decode_all`],
-//! we can skip the FlatBuf-as-intermediate detour entirely: literal
-//! pushes and match-history copies write directly into the user's
-//! slice. Compared to `DecodeBuffer<FlatBuf>`, this elides one full
-//! `memmove` of the live region (the `read` drain that copies the
-//! flat Vec into the user slice) and one anonymous-page allocation
-//! cycle per frame. On `level_-7_fast/decodecorpus-z000033/rust_stream`
-//! the drain copy + page-touch chain was measured at ~46% of total
-//! decompress time on i9-9900K — see #244 for the flamegraph.
+//! Selected by [`crate::decoding::FrameDecoder::decode_to_slice`]
+//! when ALL of the following hold:
+//! - `frame_content_size > 0` (FCS present in the frame header).
+//! - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
+//!   (room for the SIMD wildcopy overshoot slack).
+//! - No active dictionary (the persistent dict_content is not
+//!   carried into the stack-local DecodeBuffer this backend
+//!   builds; dict frames stay on the regular path).
+//! - No `content_checksum_flag` (the persistent rolling hash is
+//!   on `DecoderScratch::buffer.hash`, not on the stack-local
+//!   buffer; checksummed frames stay on the regular path until
+//!   hash propagation lands as a follow-up).
+//!
+//! The `single_segment_flag` is NOT a precondition: donor's
+//! `ZSTD_in_dst` litBuffer-in-dst trick works identically for
+//! multi-segment frames in non-streaming mode (whole content fits
+//! in caller's output, no mid-frame drain ever issued).
+//!
+//! When eligible, literal pushes and match-history copies write
+//! directly into the user's slice. Compared to
+//! `DecodeBuffer<FlatBuf>`, this elides one full `memmove` of the
+//! live region (the `read` drain that copies the flat Vec into the
+//! user slice) and one anonymous-page allocation cycle per frame.
+//! On `level_-7_fast/decodecorpus-z000033/rust_stream` the
+//! direct-write path measured -20.33% vs the FlatBuf+drain path on
+//! i9-9900K — see #244 for the flamegraph.
 //!
 //! Selected at compile time via `DecodeBuffer<UserSliceBackend<'a>>`
 //! (generic [`BufferBackend`](super::buffer_backend::BufferBackend)
 //! parameter). The lifetime parameter binds the backend to the
-//! user-provided slice — `DecoderScratch<UserSliceBackend<'a>>` is
-//! stack-local in [`crate::decoding::FrameDecoder::decode_all`] and
-//! does not survive across calls. Persistent decoder state (HUF/FSE
-//! tables, offset_hist, sequence cache) lives in `FrameDecoder` and
-//! is borrowed in by reference for the call's duration.
+//! user-provided slice — the backing
+//! `DecodeBuffer<UserSliceBackend<'a>>` is stack-local in
+//! `decode_to_slice` and does not survive across calls. Persistent
+//! decoder state (HUF/FSE tables, offset_hist, sequence cache)
+//! lives in `FrameDecoder` and is borrowed in by reference for the
+//! call's duration via [`super::scratch::DirectScratch`].
 
 use crate::io::{Error, Read};
 use core::ptr;
@@ -186,11 +203,24 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let dst_off = self.tail;
         let src_off = self.head + start;
         debug_assert!(src_off + len <= dst_off);
-        debug_assert!(dst_off + len <= self.slice.len());
+        // Release-mode capacity check: the trait contract says
+        // capacity for `len` bytes past the tail was reserved by
+        // the caller, but UserSliceBackend's reserve is a no-op
+        // (slice can't grow), so a malformed frame with an out-of-
+        // bounds match could otherwise turn the unchecked
+        // `copy_nonoverlapping` into UB in release builds.
+        // FlatBuf relies on `Vec::reserve` to enforce this; we have
+        // no allocator to call so the check has to be inline.
+        // Cost: one compare on a path that's already memory-bound;
+        // negligible vs the wildcopy itself.
+        assert!(
+            dst_off + len <= self.slice.len(),
+            "UserSliceBackend: match write past slice capacity (corrupt frame)"
+        );
         // SAFETY: caller's non-overlap precondition gives
-        // `src_off + len <= dst_off`. Capacity covers `dst_off + len`
-        // by the dispatcher's `frame_content_size + WILDCOPY_OVERLENGTH`
-        // sizing.
+        // `src_off + len <= dst_off`. The assert above guarantees
+        // `dst_off + len <= self.slice.len()`, so the
+        // `copy_nonoverlapping` stays inside the slice.
         unsafe {
             let ptr = self.slice.as_mut_ptr();
             ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -1,0 +1,328 @@
+//! User-slice-backed output buffer for the "decode straight into the
+//! caller's output slice" fast path.
+//!
+//! When the frame's `Single_Segment_flag` is set AND the caller passed
+//! a sufficiently sized `&mut [u8]` to [`crate::decoding::FrameDecoder::decode_all`],
+//! we can skip the FlatBuf-as-intermediate detour entirely: literal
+//! pushes and match-history copies write directly into the user's
+//! slice. Compared to `DecodeBuffer<FlatBuf>`, this elides one full
+//! `memmove` of the live region (the `read` drain that copies the
+//! flat Vec into the user slice) and one anonymous-page allocation
+//! cycle per frame. On `level_-7_fast/decodecorpus-z000033/rust_stream`
+//! the drain copy + page-touch chain was measured at ~46% of total
+//! decompress time on i9-9900K — see #244 for the flamegraph.
+//!
+//! Selected at compile time via `DecodeBuffer<UserSliceBackend<'a>>`
+//! (generic [`BufferBackend`](super::buffer_backend::BufferBackend)
+//! parameter). The lifetime parameter binds the backend to the
+//! user-provided slice — `DecoderScratch<UserSliceBackend<'a>>` is
+//! stack-local in [`crate::decoding::FrameDecoder::decode_all`] and
+//! does not survive across calls. Persistent decoder state (HUF/FSE
+//! tables, offset_hist, sequence cache) lives in `FrameDecoder` and
+//! is borrowed in by reference for the call's duration.
+
+use crate::io::{Error, ErrorKind, Read};
+use core::ptr;
+
+use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
+
+/// Backend that writes directly into a caller-provided `&mut [u8]`
+/// output slice. No internal allocation, no drain copy.
+///
+/// Invariants enforced by the [`BufferBackend`] surface:
+/// - `head <= tail <= slice.len()`.
+/// - All bytes in `slice[head..tail]` are initialised (written by
+///   [`Self::extend`] / [`Self::extend_and_fill`] /
+///   [`Self::extend_from_within_unchecked`] /
+///   [`Self::extend_from_reader`]).
+/// - Bytes in `slice[tail..]` are NOT yet initialised — the FlatBuf
+///   precedent skips zero-initialising spare capacity for the same
+///   reason; callers must not read past `tail`.
+///
+/// The caller MUST size the output slice with at least
+/// `frame_content_size + WILDCOPY_OVERLENGTH` bytes so SIMD wildcopy
+/// overshoots from `extend_from_within_unchecked` stay inside the
+/// allocation. The dispatch site in [`crate::decoding::FrameDecoder`]
+/// validates this precondition.
+pub(crate) struct UserSliceBackend<'a> {
+    slice: &'a mut [u8],
+    /// Bytes in `slice[..head]` have been drained to the output
+    /// stream and are no longer visible through the [`BufferBackend`]
+    /// surface. Same semantics as `FlatBuf.head` — see that field's
+    /// doc for the "drained prefix remains physically present, used
+    /// by future match copies" justification. For the
+    /// single-segment direct-decode path `head` stays at 0 until the
+    /// frame finishes (no streaming-drain), but the field is kept
+    /// for API parity with `FlatBuf` and `RingBuffer`.
+    head: usize,
+    tail: usize,
+}
+
+impl<'a> UserSliceBackend<'a> {
+    /// Construct a backend wrapping `slice`. The slice must have at
+    /// least `frame_content_size + WILDCOPY_OVERLENGTH` bytes of
+    /// length so SIMD wildcopy overshoots stay inside the allocation;
+    /// the dispatcher in `FrameDecoder` enforces this.
+    pub(crate) fn from_slice(slice: &'a mut [u8]) -> Self {
+        Self {
+            slice,
+            head: 0,
+            tail: 0,
+        }
+    }
+}
+
+impl<'a> BufferBackend for UserSliceBackend<'a> {
+    /// `new()` exists for trait conformance but is not used on the
+    /// direct-decode path — the slice is always provided up-front via
+    /// [`Self::from_slice`]. Returns an empty backend wrapping an
+    /// empty static slice; any subsequent `extend` call will panic
+    /// via the capacity check.
+    fn new() -> Self {
+        Self {
+            slice: &mut [],
+            head: 0,
+            tail: 0,
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.head = 0;
+        self.tail = 0;
+    }
+
+    #[inline]
+    fn reserve(&mut self, n: usize) {
+        // Capacity is fixed at construction; the dispatcher sized the
+        // slice to cover `frame_content_size + WILDCOPY_OVERLENGTH`.
+        // `reserve` is a no-op as long as we have room. If the caller
+        // requests more than we can provide it's a bug at the
+        // dispatch site (frame header lied about content size, or
+        // sizing math underflowed). Same shape as FlatBuf's contract:
+        // reserve is best-effort; the actual capacity check is at
+        // the write site via the debug_assert in extend/etc.
+        debug_assert!(
+            self.tail.saturating_add(n) <= self.slice.len(),
+            "UserSliceBackend::reserve({n}) overflows slice (tail={}, cap={})",
+            self.tail,
+            self.slice.len()
+        );
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.tail - self.head
+    }
+
+    #[inline]
+    fn cap(&self) -> usize {
+        self.slice.len()
+    }
+
+    #[inline]
+    fn tail(&self) -> usize {
+        self.tail
+    }
+
+    #[inline]
+    unsafe fn set_tail(&mut self, new_tail: usize) {
+        debug_assert!(new_tail >= self.head);
+        debug_assert!(new_tail <= self.slice.len());
+        self.tail = new_tail;
+    }
+
+    #[inline]
+    fn extend(&mut self, data: &[u8]) {
+        let new_tail = self.tail + data.len();
+        debug_assert!(
+            new_tail <= self.slice.len(),
+            "UserSliceBackend::extend overflows slice (tail+={}, cap={})",
+            data.len(),
+            self.slice.len()
+        );
+        self.slice[self.tail..new_tail].copy_from_slice(data);
+        self.tail = new_tail;
+    }
+
+    #[inline]
+    fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
+        let new_tail = self.tail + fill_length;
+        debug_assert!(new_tail <= self.slice.len());
+        for b in &mut self.slice[self.tail..new_tail] {
+            *b = fill_with;
+        }
+        self.tail = new_tail;
+    }
+
+    fn extend_from_reader<R: Read>(
+        &mut self,
+        mut read: R,
+        fill_length: usize,
+    ) -> Result<(), Error> {
+        let old = self.tail;
+        let new_tail = old + fill_length;
+        if new_tail > self.slice.len() {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "UserSliceBackend: raw block exceeds caller-provided output capacity",
+            ));
+        }
+        match read.read_exact(&mut self.slice[old..new_tail]) {
+            Ok(()) => {
+                self.tail = new_tail;
+                Ok(())
+            }
+            // Don't advance `tail` on failure — the upper bound from
+            // the slice borrow above guarantees the `read_exact`
+            // attempt didn't write past `new_tail`, but we MUST keep
+            // `tail` pointing at the last fully-decoded byte so
+            // checkpoint rollback / drain semantics line up with
+            // FlatBuf's truncate-on-error shape.
+            Err(e) => Err(e),
+        }
+    }
+
+    #[inline]
+    unsafe fn extend_from_within_unchecked(&mut self, start: usize, len: usize) {
+        let dst_off = self.tail;
+        let src_off = self.head + start;
+        debug_assert!(src_off + len <= dst_off);
+        debug_assert!(dst_off + len <= self.slice.len());
+        // SAFETY: caller's non-overlap precondition gives
+        // `src_off + len <= dst_off`. Capacity covers `dst_off + len`
+        // by the dispatcher's `frame_content_size + WILDCOPY_OVERLENGTH`
+        // sizing.
+        unsafe {
+            let ptr = self.slice.as_mut_ptr();
+            ptr::copy_nonoverlapping(ptr.add(src_off), ptr.add(dst_off), len);
+        }
+        self.tail = dst_off + len;
+    }
+
+    #[inline]
+    unsafe fn extend_from_within_unchecked_branchless(&mut self, start: usize, len: usize) {
+        // Direct-slice layout never wraps — same forward to the
+        // single non-overlapping copy as FlatBuf.
+        unsafe { self.extend_from_within_unchecked(start, len) }
+    }
+
+    #[inline]
+    fn as_slices(&self) -> (&[u8], &[u8]) {
+        (&self.slice[self.head..self.tail], &[])
+    }
+
+    #[inline]
+    fn drop_first_n(&mut self, n: usize) {
+        self.head += n;
+        debug_assert!(self.head <= self.tail);
+    }
+}
+
+// `WILDCOPY_OVERLENGTH` is used implicitly via the dispatcher's
+// capacity sizing — kept imported here for the doc reference and to
+// surface a build error if the constant moves.
+const _: () = {
+    let _: usize = WILDCOPY_OVERLENGTH;
+};
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+    use super::*;
+
+    #[test]
+    fn extend_writes_at_tail() {
+        let mut buf = std::vec![0u8; 32];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[1, 2, 3, 4]);
+        assert_eq!(b.len(), 4);
+        assert_eq!(b.tail(), 4);
+        b.extend(&[5, 6]);
+        let (s, t) = b.as_slices();
+        assert_eq!(s, &[1, 2, 3, 4, 5, 6]);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn extend_and_fill_repeats_byte() {
+        let mut buf = std::vec![0u8; 16];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[0xAA]);
+        b.extend_and_fill(0xBB, 4);
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[0xAA, 0xBB, 0xBB, 0xBB, 0xBB]);
+    }
+
+    #[test]
+    fn extend_from_within_unchecked_copies_non_overlapping() {
+        let mut buf = std::vec![0u8; 32];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[10, 20, 30, 40, 50]);
+        // SAFETY: 0+3 <= 5 = len; cap 32 covers 5+3.
+        unsafe { b.extend_from_within_unchecked(0, 3) };
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[10, 20, 30, 40, 50, 10, 20, 30]);
+    }
+
+    #[test]
+    fn drop_first_n_advances_head_keeps_history() {
+        let mut buf = std::vec![0u8; 32];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[1, 2, 3, 4, 5]);
+        b.drop_first_n(2);
+        assert_eq!(b.len(), 3);
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[3, 4, 5]);
+        // After drop, drained bytes remain physically present and can
+        // back a match copy via `start` indexed from the post-drop head.
+        unsafe { b.extend_from_within_unchecked(0, 3) };
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[3, 4, 5, 3, 4, 5]);
+    }
+
+    #[test]
+    fn set_tail_rollback() {
+        let mut buf = std::vec![0u8; 32];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[1, 2, 3]);
+        let saved = b.tail();
+        b.extend(&[4, 5, 6, 7]);
+        assert_eq!(b.len(), 7);
+        unsafe { b.set_tail(saved) };
+        assert_eq!(b.len(), 3);
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn clear_resets_cursors() {
+        let mut buf = std::vec![0u8; 32];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.extend(&[1, 2, 3]);
+        b.drop_first_n(1);
+        b.clear();
+        assert_eq!(b.len(), 0);
+        assert_eq!(b.tail(), 0);
+    }
+
+    #[test]
+    fn extend_from_reader_into_slice() {
+        let mut buf = std::vec![0u8; 16];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        let src = [9u8, 8, 7, 6, 5];
+        b.extend_from_reader(&src[..], 5).unwrap();
+        let (s, _) = b.as_slices();
+        assert_eq!(s, &[9, 8, 7, 6, 5]);
+    }
+
+    #[test]
+    fn extend_from_reader_over_capacity_errors() {
+        let mut buf = std::vec![0u8; 4];
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        let src = [9u8, 8, 7, 6, 5];
+        // 5 bytes requested, only 4 cap -> error, tail unchanged.
+        assert!(b.extend_from_reader(&src[..], 5).is_err());
+        assert_eq!(b.tail(), 0);
+    }
+}

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -81,17 +81,16 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 ///
 /// # DoS surface on malformed Compressed blocks
 ///
-/// The bounds checks on write entry points are release-mode
-/// `assert!` (for `extend` and `extend_from_within_unchecked`) and
-/// `debug_assert!` (for `extend_and_fill`). On adversarial input —
-/// a frame header that declares a small `frame_content_size` AND a
+/// The bounds checks on write entry points are uniformly
+/// release-mode `assert!` (for `extend`, `extend_and_fill`, and
+/// `extend_from_within_unchecked`). On adversarial input — a frame
+/// header that declares a small `frame_content_size` AND a
 /// Compressed block whose payload expands to more than the declared
 /// size — the burst's per-symbol writes can reach past `slice.len()`
-/// and panic (`assert!` failure or, in `extend_and_fill`'s release
-/// build, a slice-indexing panic) instead of returning a structured
-/// error. The frame-level `decode_to_slice` checks `produced >
-/// content_size` AFTER each block; within a single block the
-/// panic-on-overshoot is the only stop.
+/// and panic via the `assert!` failure instead of returning a
+/// structured error. The frame-level `decode_to_slice` checks
+/// `produced > content_size` AFTER each block; within a single block
+/// the panic-on-overshoot is the only stop.
 ///
 /// Callers handling untrusted input should use
 /// [`crate::decoding::FrameDecoder::decode_all`] which routes
@@ -250,7 +249,20 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     #[inline]
     fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
         let new_tail = self.tail + fill_length;
-        debug_assert!(new_tail <= self.slice.len());
+        // Release-mode `assert!` (not `debug_assert!`) for symmetry
+        // with `extend` / `extend_from_within_unchecked`. Without it,
+        // a malformed Compressed block whose RLE fill expands past
+        // the declared `frame_content_size` would panic via the
+        // subsequent `self.slice[self.tail..new_tail]` slice index
+        // with a less-informative message, AND the in-block writes
+        // would already have happened up to the slice length. Fail
+        // fast with a clear corruption / capacity diagnostic.
+        assert!(
+            new_tail <= self.slice.len(),
+            "UserSliceBackend::extend_and_fill overflows slice (tail+={}, cap={}) — corrupt frame",
+            fill_length,
+            self.slice.len()
+        );
         for b in &mut self.slice[self.tail..new_tail] {
             *b = fill_with;
         }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -75,21 +75,30 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 ///
 /// # DoS surface on malformed Compressed blocks
 ///
-/// The bounds checks on write entry points are `debug_assert!` (for
-/// `extend`, `extend_and_fill`) and a release-mode `assert!` (for
-/// `extend_from_within_unchecked`). On adversarial input — a frame
-/// header that declares a small `frame_content_size` AND a Compressed
-/// block whose payload expands to more than the declared size — the
-/// burst's per-symbol writes can reach past `slice.len()` and
-/// `assert!` (or panic via slice indexing in `extend`) instead of
-/// returning a structured error. The frame-level
-/// `decode_to_slice` checks `produced > content_size` AFTER each
-/// block; within a single block the panic-on-overshoot is the
-/// only stop. Callers handling untrusted input should use
+/// The bounds checks on write entry points are release-mode
+/// `assert!` (for `extend` and `extend_from_within_unchecked`) and
+/// `debug_assert!` (for `extend_and_fill`). On adversarial input —
+/// a frame header that declares a small `frame_content_size` AND a
+/// Compressed block whose payload expands to more than the declared
+/// size — the burst's per-symbol writes can reach past `slice.len()`
+/// and panic (`assert!` failure or, in `extend_and_fill`'s release
+/// build, a slice-indexing panic) instead of returning a structured
+/// error. The frame-level `decode_to_slice` checks `produced >
+/// content_size` AFTER each block; within a single block the
+/// panic-on-overshoot is the only stop.
+///
+/// Callers handling untrusted input should use
 /// [`crate::decoding::FrameDecoder::decode_all`] which routes
-/// through `FlatBuf` / `RingBuffer` backends whose `Vec::reserve`
-/// growth path returns errors rather than panicking.
-/// Replacing the panics with `Result<_, _>`-returning writes is
+/// through `FlatBuf` / `RingBuffer` backends. Those backends grow
+/// via `Vec::reserve` — growth doesn't return errors (it succeeds
+/// or aborts on alloc failure), but the growable Vec capacity
+/// means a malformed block whose decompressed output exceeds FCS
+/// stays inside the allocation instead of writing OOB into a
+/// fixed-size user slice. The frame-level checks then catch the
+/// FCS mismatch and return `FrameContentSizeMismatch`.
+///
+/// Replacing the panics with `Result<_, _>`-returning writes (so
+/// `decode_to_slice` itself can stay safe on adversarial input) is
 /// tracked in issue #246 — it requires extending the
 /// `BufferBackend` trait surface and would gate the direct path on
 /// the new fallible signatures.

--- a/zstd/src/io_nostd.rs
+++ b/zstd/src/io_nostd.rs
@@ -55,10 +55,18 @@ impl Error {
         }
     }
 
-    /// `std::io::Error::other(...)` equivalent for no-std builds.
-    /// Mirrors `std::io::Error::other` shape so call sites compile
-    /// uniformly across feature toggles. Always produces an
-    /// [`ErrorKind::Other`] error.
+    /// `Error::other(_)` constructor for no-std builds.
+    /// Always produces an [`ErrorKind::Other`] error.
+    ///
+    /// NOT a drop-in mirror of `std::io::Error::other`: this no-std
+    /// version takes `Display + Send + Sync + 'static` because the
+    /// no-std shim stores the payload via the existing
+    /// `Box<dyn Display + Send + Sync>` field. `std::io::Error::other`
+    /// takes `impl Into<Box<dyn core::error::Error + Send + Sync>>`.
+    /// The crate's call sites pass concrete types that satisfy BOTH
+    /// bounds (e.g. `&'static str`, `String`, custom error types
+    /// implementing both), so the same call site compiles uniformly
+    /// across feature toggles without per-call adaptation.
     pub fn other<E: core::fmt::Display + Send + Sync + 'static>(err: E) -> Self {
         Self {
             kind: ErrorKind::Other,

--- a/zstd/src/io_nostd.rs
+++ b/zstd/src/io_nostd.rs
@@ -55,6 +55,17 @@ impl Error {
         }
     }
 
+    /// `std::io::Error::other(...)` equivalent for no-std builds.
+    /// Mirrors `std::io::Error::other` shape so call sites compile
+    /// uniformly across feature toggles. Always produces an
+    /// [`ErrorKind::Other`] error.
+    pub fn other<E: core::fmt::Display + Send + Sync + 'static>(err: E) -> Self {
+        Self {
+            kind: ErrorKind::Other,
+            err: Some(Box::new(err)),
+        }
+    }
+
     pub fn from(kind: ErrorKind) -> Self {
         Self { kind, err: None }
     }

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -107,19 +107,6 @@ pub mod testing {
     /// Exposed for parity tests that feed exactly-one-block chunks
     /// into the donor splitter comparator.
     pub const MAX_BLOCK_SIZE: u32 = crate::common::MAX_BLOCK_SIZE;
-}
-
-/// SIMD wildcopy overshoot slack carried by every decoder backend.
-/// Mirrors donor zstd's `WILDCOPY_OVERLENGTH` (16 bytes). Public so
-/// callers sizing an output slice for
-/// [`crate::decoding::FrameDecoder::decode_to_slice`] can size
-/// `frame_content_size + WILDCOPY_OVERLENGTH` without duplicating
-/// the constant.
-pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;
-
-#[cfg(feature = "bench_internals")]
-#[doc(hidden)]
-mod bench_block_splitter {
 
     /// Run our donor-port block splitter on a 128 KB chunk.
     ///
@@ -135,3 +122,11 @@ mod bench_block_splitter {
         crate::encoding::frame_compressor::block_splitter_decision_for_bench(block, split_level)
     }
 }
+
+/// SIMD wildcopy overshoot slack carried by every decoder backend.
+/// Mirrors donor zstd's `WILDCOPY_OVERLENGTH` (16 bytes). Public so
+/// callers sizing an output slice for
+/// [`crate::decoding::FrameDecoder::decode_to_slice`] can size
+/// `frame_content_size + WILDCOPY_OVERLENGTH` without duplicating
+/// the constant.
+pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -107,6 +107,19 @@ pub mod testing {
     /// Exposed for parity tests that feed exactly-one-block chunks
     /// into the donor splitter comparator.
     pub const MAX_BLOCK_SIZE: u32 = crate::common::MAX_BLOCK_SIZE;
+}
+
+/// SIMD wildcopy overshoot slack carried by every decoder backend.
+/// Mirrors donor zstd's `WILDCOPY_OVERLENGTH` (16 bytes). Public so
+/// callers sizing an output slice for
+/// [`crate::decoding::FrameDecoder::decode_to_slice`] can size
+/// `frame_content_size + WILDCOPY_OVERLENGTH` without duplicating
+/// the constant.
+pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;
+
+#[cfg(feature = "bench_internals")]
+#[doc(hidden)]
+mod bench_block_splitter {
 
     /// Run our donor-port block splitter on a 128 KB chunk.
     ///

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -130,7 +130,7 @@ pub mod testing {
 /// SIMD wildcopy overshoot slack carried by every decoder backend.
 /// Mirrors donor zstd's `WILDCOPY_OVERLENGTH` (16 bytes). Public so
 /// callers sizing an output slice for
-/// [`crate::decoding::FrameDecoder::decode_to_slice`] can size
+/// [`crate::decoding::FrameDecoder::decode_to_slice_trusted`] can size
 /// `frame_content_size + WILDCOPY_OVERLENGTH` without duplicating
 /// the constant.
 pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;


### PR DESCRIPTION
## Summary

Closes #244. Direct-write decode path + companion optimizations
that close the L-7 decompress regression and improve L-1
throughput. Decoder now writes literal pushes and sequence-execution
match copies directly into the caller's output slice, bypassing the
internal DecodeBuffer drain copy for eligible frames.

## Bench

decompress/level_-7_fast/decodecorpus-z000033/rust_stream (i9-9900K, Linux):

| State | time | thrpt vs main |
|-------|------|---------------|
| pre-#244 main | 6.84 ms | baseline |
| HEAD (default rustc target) | 1.80 ms | -73.7% |

decompress/level_-1_fast/decodecorpus-z000033/c_stream (i9-9900K):

| Build | thrpt | vs FFI |
|-------|-------|--------|
| pre-#244 main | 409 MiB/s | 27.8% |
| HEAD default | 425 MiB/s | 28.9% |
| HEAD with -C target-cpu=native | 462 MiB/s | 31.4% |
| FFI baseline | 1.47 GiB/s | 100% |

Apples-to-apples vs donor on i9 (both with full BMI2/AVX2 ISA): 3.18x gap remains.
Tracked architectural follow-ups in #246 and #247.

## What is in this PR

### New direct-decode entry point

- FrameDecoder::decode_to_slice_trusted(input, output) -> Result<usize> writes
  directly into the caller-provided slice when the frame is eligible. The
  `_trusted` suffix is part of the API contract: this entry point is for
  trusted input only. Adversarial / malformed input can panic via
  release-mode `assert!` inside `UserSliceBackend`. Callers handling
  untrusted data MUST use `decode_all` instead. The fallible-write
  refactor that would let this entry point be safe on adversarial input
  is tracked in #246. Eligibility:
  FCS present, output sized to frame_content_size + WILDCOPY_OVERLENGTH,
  no active dictionary. Checksum-flagged frames ARE supported: the
  direct path hashes the decoded output once at end-of-decode and
  propagates the digest into the persistent scratch, so
  get_calculated_checksum() returns the same value the streaming
  path would have produced.
- Multi-segment frames supported via a coarse block-boundary cap on
  the visible buffer (DecodeBuffer::drop_to_window_size advances head
  so buffer.len() doesn't grow past window_size between blocks).
  Not strict spec enforcement of offset <= window_size within a
  block — see the decode_to_slice_trusted doc for the limitation note.
- Non-eligible frames fall through to the existing
  decode_blocks + read drain path.

### Backend layer

- UserSliceBackend<'a> - BufferBackend impl wrapping &mut [u8].
  Same API surface as FlatBuf with release-mode bounds asserts gating
  the unchecked SIMD copies.
- Match copies and literal pushes route through
  simd_copy::copy_bytes_overshooting (was: ptr::copy_nonoverlapping
  -> libc memmove dispatch). Eliminates ~5-10 ns of fixed cost per
  short copy.
- BufferBackend trait gets total_produced() accessor for byte-accurate
  FCS tracking on the direct path.

### Workspace abstraction

- Workspace trait + WorkspaceRef<'a, B> parts struct lets block /
  literals / sequence decoders work uniformly against both the owned
  DecoderScratch<B> and the borrowed DirectScratch<'o, 'p>.
- BlockDecoder::decode_block_content_from_slice - slice-source fast
  path that consumes block content directly from &mut &[u8] without
  going through the persistent block_content_buffer.
- BlockDecoder::decompress_block_inplace_with_parts - borrow-checker
  friendly body that takes scratch fields as disjoint &mut refs (no
  unsafe lifetime widening).

### Literals

- decode_literals_zerocopy returning LiteralsView. For Raw sections
  this borrows straight into the input - no memcpy into the Vec. For
  RLE / HUF it materialises into the persistent buffer and the view
  is a slice over that buffer. Eliminates a major spec_extend
  contributor on Raw-literal-heavy corpora.

### Hardening

- New FrameDecoderError::FrameContentSizeMismatch { declared, produced }
  variant distinct from TargetTooSmall. Used when block sizes do not
  sum to FCS or when a block would push past FCS.
- decode_to_slice_trusted rejects dict-active frames upfront (the persistent
  dict_content is not carried into the stack-local DecodeBuffer<UserSliceBackend>).
- Pre-flight + post-decode FCS overflow checks track via
  direct.buffer.total_produced() (handles Compressed blocks where
  the header's decompressed_size is 0).
- Scratch literals_buffer / block_content_buffer pre-touched in
  reset only when capacity is insufficient (avoids per-frame memset).

### Build / CI

- New [profile.flamegraph] (inherits bench + debug = "full") so
  cargo flamegraph captures show resolved Rust symbols.
- CI bench-build job sets RUSTFLAGS=-C target-cpu=native for
  apples-to-apples vs the donor's runtime-feature-dispatched
  zstd-sys.
- no-std io_nostd::Error::other shim for the new error paths.
- Drop dead-code x86 intrinsics imports left over from the
  HUF kernel removal.

## Test plan

- 587/587 nextest pass (cargo nextest run -p structured-zstd --lib).
- Lint clean on default + hash,std,dict_builder,bench_internals features.
- no-std cargo check clean.
- 3 new regression tests for decode_literals_zerocopy on
  truncated / dirty payloads.
- 3 new tests for decode_to_slice_trusted: matches decode_all on
  single-segment, falls back on too-small output, multi-segment
  2 MiB roundtrip.
- Compare-FFI bench delta measured on i9-9900K vs FFI.

## Follow-ups

- #246 - fallible BufferBackend writes (DoS hardening: malformed
  Compressed blocks past declared FCS currently panic instead of
  returning structured error).
- #247 - FSE Entry layout expansion (pre-compute base_value +
  num_additional_bits to remove lookup_ll_code / lookup_ml_code
  per-sequence overhead).

Part of the #178 perf roadmap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct, zero-copy frame decode into caller buffers and a public constant to size output slack for SIMD wildcopy.

* **Bug Fixes**
  * Structured error when decoded output size differs from a frame’s declared size.

* **Tests**
  * Added benchmark for direct decode and unit tests covering zero-copy literals, direct-vs-fallback decode, checksum propagation, and error cases.

* **Refactor**
  * Introduced a borrow-safe workspace and reworked buffer plumbing to enable safe in-place/zero-copy decoding.

* **Chores**
  * Added a flamegraph build profile and made CI benchmark builds deterministic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

