### PR TITLE
perf(decode): #247 Part 1 — expand FSE Entry to ZSTD_seqSymbol shape

### DIFF
--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -124,18 +124,27 @@ impl Dictionary {
             raw_tables,
             crate::decoding::sequence_section_decoder::OF_MAX_LOG,
         )?;
+        new_dict.fse.offsets.enrich_for_offsets();
         let raw_tables = &raw_tables[of_size..];
 
         let ml_size = new_dict.fse.match_lengths.build_decoder(
             raw_tables,
             crate::decoding::sequence_section_decoder::ML_MAX_LOG,
         )?;
+        new_dict
+            .fse
+            .match_lengths
+            .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::ML_META);
         let raw_tables = &raw_tables[ml_size..];
 
         let ll_size = new_dict.fse.literal_lengths.build_decoder(
             raw_tables,
             crate::decoding::sequence_section_decoder::LL_MAX_LOG,
         )?;
+        new_dict
+            .fse
+            .literal_lengths
+            .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::LL_META);
         let raw_tables = &raw_tables[ll_size..];
 
         if raw_tables.len() < OFFSET_HISTORY_LEN {

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -493,12 +493,22 @@ fn decode_one_sequence_inline(
     of_dec: &mut FSEDecoder<'_>,
     br: &mut BitReaderReversed<'_>,
 ) -> Sequence {
-    let ll_code = ll_dec.decode_symbol();
-    let ml_code = ml_dec.decode_symbol();
-    let of_code = of_dec.decode_symbol();
+    // Read base/extra-bits directly off the active FSE state's
+    // `Entry` (populated by `enrich_with_packed_seq_meta` /
+    // `enrich_for_offsets` during table build). Drops the previous
+    // `lookup_ll_code` / `lookup_ml_code` indirections — those did
+    // a second cache touch on the separate `LL_META` / `ML_META`
+    // tables per sequence. The active entry was already loaded
+    // when `decode_symbol` read `state.symbol`, so the new fields
+    // come for free in the same cache line.
+    let ll_state = ll_dec.state;
+    let ml_state = ml_dec.state;
+    let of_code = of_dec.state.symbol;
 
-    let (ll_value, ll_num_bits) = lookup_ll_code(ll_code);
-    let (ml_value, ml_num_bits) = lookup_ml_code(ml_code);
+    let ll_value = ll_state.base_value;
+    let ll_num_bits = ll_state.num_additional_bits;
+    let ml_value = ml_state.base_value;
+    let ml_num_bits = ml_state.num_additional_bits;
 
     debug_assert!(of_code <= MAX_OFFSET_CODE);
 
@@ -574,8 +584,22 @@ fn decode_sequences_with_rle(
             of_dec.decode_symbol()
         };
 
-        let (ll_value, ll_num_bits) = lookup_ll_code(ll_code);
-        let (ml_value, ml_num_bits) = lookup_ml_code(ml_code);
+        // RLE-mode tables don't have an enriched FSE entry to read
+        // from — fall back to `lookup_ll_code` / `lookup_ml_code`
+        // for the RLE byte. FSE-mode tables read base / extra-bits
+        // directly off the active state's enriched `Entry`. The
+        // RLE-fallback path is the only place these `lookup_*`
+        // helpers are still used after #247 Part 1.
+        let (ll_value, ll_num_bits) = if scratch.ll_rle.is_some() {
+            lookup_ll_code(ll_code)
+        } else {
+            (ll_dec.state.base_value, ll_dec.state.num_additional_bits)
+        };
+        let (ml_value, ml_num_bits) = if scratch.ml_rle.is_some() {
+            lookup_ml_code(ml_code)
+        } else {
+            (ml_dec.state.base_value, ml_dec.state.num_additional_bits)
+        };
 
         // OF code / offset==0 checks dropped per FSE invariants (see comment
         // in decode_sequences_without_rle). For RLE mode, the singleton
@@ -642,7 +666,7 @@ fn decode_sequences_with_rle(
 /// `LL_EXTRA_BITS[idx]` loads (two distinct cache-line touches into
 /// 144 B + 36 B = 180 B; packed table is 144 B = one contiguous
 /// region).
-const LL_META: [u32; 36] = pack_code_meta(
+pub(crate) const LL_META: [u32; 36] = pack_code_meta(
     &[
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20, 22, 24, 28, 32, 40, 48,
         64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
@@ -656,7 +680,7 @@ const LL_META: [u32; 36] = pack_code_meta(
 /// Packed (baseline, extra_bits) pairs for match-length codes.
 /// Donor parity: `ML_base` + `ML_bits`. Codes 0..=52 per Zstandard
 /// format §3.1.1.3.2.1.1.2. Same packed layout as [`LL_META`].
-const ML_META: [u32; 53] = pack_code_meta(
+pub(crate) const ML_META: [u32; 53] = pack_code_meta(
     &[
         3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
         27, 28, 29, 30, 31, 32, 33, 34, 35, 37, 39, 41, 43, 47, 51, 59, 67, 83, 99, 131, 259, 515,
@@ -786,6 +810,9 @@ fn maybe_update_fse_tables(
         ModeType::FSECompressed => {
             let bytes = scratch.literal_lengths.build_decoder(source, LL_MAX_LOG)?;
             bytes_read += bytes;
+            scratch
+                .literal_lengths
+                .enrich_with_packed_seq_meta(&LL_META);
 
             vprintln!("Updating ll table");
             vprintln!("Used bytes: {}", bytes);
@@ -808,11 +835,14 @@ fn maybe_update_fse_tables(
                 LL_DEFAULT_ACC_LOG,
                 &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
             )?;
+            scratch
+                .literal_lengths
+                .enrich_with_packed_seq_meta(&LL_META);
             scratch.ll_rle = None;
         }
         ModeType::Repeat => {
             vprintln!("Repeat ll table");
-            /* Nothing to do */
+            /* Nothing to do — cached enriched values stay valid. */
         }
     };
 
@@ -821,6 +851,7 @@ fn maybe_update_fse_tables(
     match modes.of_mode() {
         ModeType::FSECompressed => {
             let bytes = scratch.offsets.build_decoder(of_source, OF_MAX_LOG)?;
+            scratch.offsets.enrich_for_offsets();
             vprintln!("Updating of table");
             vprintln!("Used bytes: {}", bytes);
             bytes_read += bytes;
@@ -844,12 +875,13 @@ fn maybe_update_fse_tables(
                 OF_DEFAULT_ACC_LOG,
                 &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
             )?;
+            scratch.offsets.enrich_for_offsets();
             scratch.of_rle = None;
             scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
         }
         ModeType::Repeat => {
             vprintln!("Repeat of table");
-            /* Nothing to do — cached `offsets_long_share` stays valid. */
+            /* Nothing to do — cached enriched values stay valid. */
         }
     };
 
@@ -858,6 +890,7 @@ fn maybe_update_fse_tables(
     match modes.ml_mode() {
         ModeType::FSECompressed => {
             let bytes = scratch.match_lengths.build_decoder(ml_source, ML_MAX_LOG)?;
+            scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
             bytes_read += bytes;
             vprintln!("Updating ml table");
             vprintln!("Used bytes: {}", bytes);
@@ -880,11 +913,12 @@ fn maybe_update_fse_tables(
                 ML_DEFAULT_ACC_LOG,
                 &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
             )?;
+            scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
             scratch.ml_rle = None;
         }
         ModeType::Repeat => {
             vprintln!("Repeat ml table");
-            /* Nothing to do */
+            /* Nothing to do — cached enriched values stay valid. */
         }
     };
 
@@ -981,6 +1015,8 @@ mod offsets_long_share_tests {
                 new_state: 0,
                 symbol: s,
                 num_bits: 0,
+                base_value: 0,
+                num_additional_bits: 0,
             })
             .collect();
         t

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -494,13 +494,22 @@ fn decode_one_sequence_inline(
     br: &mut BitReaderReversed<'_>,
 ) -> Sequence {
     // Read base/extra-bits directly off the active FSE state's
-    // `Entry` (populated by `enrich_with_packed_seq_meta` /
-    // `enrich_for_offsets` during table build). Drops the previous
-    // `lookup_ll_code` / `lookup_ml_code` indirections — those did
-    // a second cache touch on the separate `LL_META` / `ML_META`
-    // tables per sequence. The active entry was already loaded
-    // when `decode_symbol` read `state.symbol`, so the new fields
-    // come for free in the same cache line.
+    // `Entry`. LL / ML are populated by `enrich_with_packed_seq_meta`
+    // from the packed `LL_META` / `ML_META` tables during build;
+    // OF is enriched closed-form (`1 << code`) by `enrich_for_offsets`.
+    // Reading `state` directly drops the previous `lookup_ll_code` /
+    // `lookup_ml_code` indirections (those did a second cache touch
+    // on the separate meta tables per sequence) — the active entry
+    // is already cache-hot.
+    //
+    // OF intentionally keeps the closed-form `1u32 << of_code`
+    // baseline computation instead of reading `of_dec.state.base_value`:
+    // the shift is a single ALU op vs a 4-byte memory load, both
+    // produce identical codegen with `obits + ...` add, and `of_code`
+    // is still required for `get_bits_triple` and the
+    // `debug_assert!(of_code <= MAX_OFFSET_CODE)` precondition. The
+    // 12-byte Entry layout still pays off here through LL / ML's
+    // base_value / num_additional_bits reads.
     let ll_state = ll_dec.state;
     let ml_state = ml_dec.state;
     let of_code = of_dec.state.symbol;

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -317,6 +317,19 @@ impl FSETable {
                 let meta = packed[idx];
                 entry.base_value = meta & 0x00FF_FFFF;
                 entry.num_additional_bits = (meta >> 24) as u8;
+            } else {
+                // Out-of-range symbol — reachable only on
+                // `feature = "fuzz_exports"` builds where external
+                // code can stuff arbitrary entries into the table.
+                // Explicitly zero both fields so the next decode
+                // pass observes a clean state instead of stale
+                // metadata from a previous (well-formed) enrich
+                // call. The downstream `decode_one_sequence_inline`
+                // hot path still surfaces the corruption via the
+                // existing bitstream checks; this clears prior
+                // values rather than introducing a new fast-fail.
+                entry.base_value = 0;
+                entry.num_additional_bits = 0;
             }
         }
     }
@@ -336,6 +349,11 @@ impl FSETable {
     /// wraparound shift here.
     pub fn enrich_for_offsets(&mut self) {
         for entry in self.decode.iter_mut() {
+            // Reset before the bound check so out-of-range
+            // symbols clear stale metadata instead of carrying it
+            // over from a previous enrich pass.
+            entry.base_value = 0;
+            entry.num_additional_bits = 0;
             let code = entry.symbol;
             if code < 32 {
                 entry.base_value = 1u32 << code;

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -310,7 +310,7 @@ impl FSETable {
     /// `feature = "fuzz_exports"` builds where external code can
     /// stuff arbitrary entries; the safe default keeps the decode
     /// hot path from observing UB even in that contrived case.
-    pub fn enrich_with_packed_seq_meta(&mut self, packed: &[u32]) {
+    pub(crate) fn enrich_with_packed_seq_meta(&mut self, packed: &[u32]) {
         for entry in self.decode.iter_mut() {
             let idx = entry.symbol as usize;
             if idx < packed.len() {
@@ -347,7 +347,7 @@ impl FSETable {
     /// — the entry's fields stay at zero so the decode path
     /// surfaces the corruption downstream instead of producing a
     /// wraparound shift here.
-    pub fn enrich_for_offsets(&mut self) {
+    pub(crate) fn enrich_for_offsets(&mut self) {
         for entry in self.decode.iter_mut() {
             // Reset before the bound check so out-of-range
             // symbols clear stale metadata instead of carrying it

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -1,7 +1,6 @@
 use crate::bit_io::{BitReader, BitReaderReversed};
 use crate::decoding::errors::{FSEDecoderError, FSETableError};
 use alloc::vec::Vec;
-use core::ptr;
 
 pub struct FSEDecoder<'table> {
     /// An FSE state value represents an index in the FSE table.
@@ -18,6 +17,8 @@ impl<'t> FSEDecoder<'t> {
                 new_state: 0,
                 symbol: 0,
                 num_bits: 0,
+                base_value: 0,
+                num_additional_bits: 0,
             }),
             table,
         }
@@ -290,6 +291,59 @@ impl FSETable {
         Ok(bytes_read)
     }
 
+    /// Populate each entry's `base_value` and `num_additional_bits`
+    /// from a packed code-metadata table. The packed format matches
+    /// the donor-style `(baseline << 0) | (extra_bits << 24)` layout
+    /// used by the sequence section's `LL_META` / `ML_META`
+    /// constants. Call site indexes into `packed` by entry symbol.
+    ///
+    /// MUST be called after `build_decoding_table` for tables whose
+    /// per-sequence decode path expects pre-computed metadata (LL /
+    /// ML sub-tables of the sequence section). Tables that don't
+    /// (HUF-weight stream) skip the call and leave the new fields
+    /// at their zero default.
+    ///
+    /// Symbols outside `packed.len()` are treated as a corrupt
+    /// table — both fields stay at 0 for that entry. Upstream
+    /// `build_decoding_table` already caps symbols at
+    /// `max_symbol + 1`, so this branch is reachable only on
+    /// `feature = "fuzz_exports"` builds where external code can
+    /// stuff arbitrary entries; the safe default keeps the decode
+    /// hot path from observing UB even in that contrived case.
+    pub fn enrich_with_packed_seq_meta(&mut self, packed: &[u32]) {
+        for entry in self.decode.iter_mut() {
+            let idx = entry.symbol as usize;
+            if idx < packed.len() {
+                let meta = packed[idx];
+                entry.base_value = meta & 0x00FF_FFFF;
+                entry.num_additional_bits = (meta >> 24) as u8;
+            }
+        }
+    }
+
+    /// Populate each entry's `base_value` and `num_additional_bits`
+    /// for the sequence section's offset table.
+    ///
+    /// Offset codes follow a different shape than LL / ML: each
+    /// offset code `c` decodes to `base = 1 << c`, with `c` extra
+    /// bits read from the stream. No external meta table — the
+    /// computation is closed-form on the symbol value.
+    ///
+    /// Per the format spec, valid offset codes are 0..=31 (offsets
+    /// up to 2³¹). Larger symbols would overflow the `1 << c` shift
+    /// — the entry's fields stay at zero so the decode path
+    /// surfaces the corruption downstream instead of producing a
+    /// wraparound shift here.
+    pub fn enrich_for_offsets(&mut self) {
+        for entry in self.decode.iter_mut() {
+            let code = entry.symbol;
+            if code < 32 {
+                entry.base_value = 1u32 << code;
+                entry.num_additional_bits = code;
+            }
+        }
+    }
+
     /// Given the provided accuracy log, build a decoding table from that log.
     pub fn build_from_probabilities(
         &mut self,
@@ -411,70 +465,31 @@ impl FSETable {
         debug_assert_eq!(table_symbols.len(), table_size);
         debug_assert!(table_size <= self.decode.capacity());
 
-        #[cfg(target_endian = "little")]
-        {
-            debug_assert_eq!(core::mem::size_of::<Entry>(), 4);
-            debug_assert_eq!(core::mem::offset_of!(Entry, new_state), 0);
-            debug_assert_eq!(core::mem::offset_of!(Entry, symbol), 2);
-            debug_assert_eq!(core::mem::offset_of!(Entry, num_bits), 3);
-            // SAFETY: capacity is guaranteed by the caller; the init
-            // loop immediately below writes a full Entry to every slot
-            // in 0..table_size via raw `ptr::write_unaligned`. The
-            // set_len + writes form a single panic-free window —
-            // nothing in between this call and the loop body can unwind
-            // (no allocations, no user-visible &mut self.decode[..],
-            // no borrows that could observe uninitialized slots).
-            unsafe {
-                self.decode.set_len(table_size);
-            }
-            // Write two packed entries (8 bytes) at once:
-            // Entry bytes are [new_state_lo, new_state_hi, symbol, num_bits].
-            let mut idx = 0usize;
-            while idx + 1 < table_size {
-                let packed =
-                    ((table_symbols[idx] as u64) << 16) | ((table_symbols[idx + 1] as u64) << 48);
-                // SAFETY: idx + 1 < table_size == self.decode.len()
-                // (just set above) and capacity covers two u32 slots.
-                // Unaligned writes are intentional because `Entry`
-                // alignment may be < 8.
-                unsafe {
-                    ptr::write_unaligned(self.decode.as_mut_ptr().add(idx).cast::<u64>(), packed);
-                }
-                idx += 2;
-            }
-            if idx < table_size {
-                // Trailing odd entry: write a full 4-byte Entry { new_state: 0,
-                // symbol, num_bits: 0 } via a single u32 store. Field assignment
-                // (`self.decode[idx].symbol = …`) would have left new_state /
-                // num_bits uninitialized after the set_len above — leaking UB
-                // until the per-entry baseline pass overwrote them.
-                let packed = (table_symbols[idx] as u32) << 16;
-                // SAFETY: idx < table_size == self.decode.len(), capacity
-                // covers a u32 slot. Unaligned write is intentional
-                // because `Entry`'s alignment may be < 4 on some targets.
-                unsafe {
-                    ptr::write_unaligned(self.decode.as_mut_ptr().add(idx).cast::<u32>(), packed);
-                }
-            }
-        }
-
-        #[cfg(not(target_endian = "little"))]
-        {
-            // BE path uses iter_mut(), which constructs `&mut Entry` and
-            // therefore needs initialized storage — resize-with-default
-            // is the natural shape. No production target ships BE so
-            // the extra zero-fill is irrelevant.
-            self.decode.resize(
-                table_size,
-                Entry {
-                    new_state: 0,
-                    symbol: 0,
-                    num_bits: 0,
-                },
-            );
-            for (entry, symbol) in self.decode.iter_mut().zip(table_symbols.iter().copied()) {
-                entry.symbol = symbol;
-            }
+        // Entry is now 12 bytes (header + base_value + num_additional_bits
+        // + tail padding). The previous LE fast path that packed two
+        // 4-byte entries into a single u64 store no longer applies.
+        // Zero-init through `resize` and then set per-slot `.symbol`
+        // — the per-block table build is not on the per-sequence hot
+        // path (this runs once per FSE-mode block, not per emit), so
+        // dropping the byte-packed write here keeps the layout change
+        // contained without measurable cost.
+        //
+        // The `base_value` / `num_additional_bits` fields stay at
+        // their zero default here; per-table enrichment for LL / ML /
+        // OF runs in `enrich_for_*` after the baseline / num_bits
+        // computation below populates the rest of each entry.
+        self.decode.resize(
+            table_size,
+            Entry {
+                new_state: 0,
+                symbol: 0,
+                num_bits: 0,
+                base_value: 0,
+                num_additional_bits: 0,
+            },
+        );
+        for (entry, symbol) in self.decode.iter_mut().zip(table_symbols.iter().copied()) {
+            entry.symbol = symbol;
         }
     }
 
@@ -573,6 +588,19 @@ impl FSETable {
 }
 
 /// A single entry in an FSE table.
+///
+/// The first four bytes (`new_state`, `symbol`, `num_bits`) mirror the
+/// classical donor `FSE_decode_t` layout used by every FSE-backed
+/// decoder in the crate (sequence-section LL/ML/OF, HUF-weight
+/// stream). The trailing `base_value` + `num_additional_bits`
+/// fields are populated only by the LL / ML / OF tables in the
+/// sequence-section decoder (donor `ZSTD_seqSymbol` shape) so the
+/// per-sequence hot path can read them directly off the active
+/// entry instead of issuing a second lookup into a separate
+/// metadata table. HUF tables leave these two fields at their
+/// default zero — the extra eight bytes per slot are a fixed cost
+/// on the small HUF FSE table (≤ 64 entries) and the dominant
+/// savings live in the sequence section.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct Entry {
@@ -583,6 +611,18 @@ pub struct Entry {
     pub symbol: u8,
     /// How many bits should be read from the stream when decoding this entry.
     pub num_bits: u8,
+    /// For LL / ML / OF tables: pre-computed code baseline.
+    /// `actual_value = base_value + extra_bits_read`. Donor
+    /// `ZSTD_seqSymbol::baseValue`. Populated by the per-table
+    /// `enrich_for_*` post-build pass; stays 0 for FSE tables that
+    /// don't need it (HUF-weight stream).
+    pub base_value: u32,
+    /// For LL / ML / OF tables: number of bits to read from the
+    /// bitstream after the symbol has been decoded, to obtain the
+    /// additional value to add to `base_value`. Donor
+    /// `ZSTD_seqSymbol::nbAdditionalBits`. Populated alongside
+    /// `base_value`; stays 0 for FSE tables that don't need it.
+    pub num_additional_bits: u8,
 }
 
 #[cfg(target_endian = "little")]
@@ -592,7 +632,13 @@ const _: [(); 2] = [(); core::mem::offset_of!(Entry, symbol)];
 #[cfg(target_endian = "little")]
 const _: [(); 3] = [(); core::mem::offset_of!(Entry, num_bits)];
 #[cfg(target_endian = "little")]
-const _: [(); 4] = [(); core::mem::size_of::<Entry>()];
+const _: [(); 4] = [(); core::mem::offset_of!(Entry, base_value)];
+#[cfg(target_endian = "little")]
+const _: [(); 8] = [(); core::mem::offset_of!(Entry, num_additional_bits)];
+// 12 bytes: 4 (header) + 4 (base_value) + 1 (num_additional_bits)
+// + 3 bytes tail padding for natural u32 alignment.
+#[cfg(target_endian = "little")]
+const _: [(); 12] = [(); core::mem::size_of::<Entry>()];
 
 /// This value is added to the first 4 bits of the stream to determine the
 /// `Accuracy_Log`

--- a/zstd/src/fse/mod.rs
+++ b/zstd/src/fse/mod.rs
@@ -23,12 +23,14 @@ fn decoder_entry_layout_12_bytes_donor_seqsymbol_shape() {
     // Donor `ZSTD_seqSymbol` shape: 4-byte header (new_state /
     // symbol / num_bits), 4-byte `base_value`, 1-byte
     // `num_additional_bits` + 3-byte tail padding for natural u32
-    // alignment. Total 12 bytes. The classical 4-byte layout was
-    // grown in #247 Part 1 to remove the per-sequence
-    // `lookup_ll_code` / `lookup_ml_code` indirection — LL / ML /
-    // OF tables fill `base_value` / `num_additional_bits` from
-    // their respective code-meta tables in the post-build enrich
-    // pass; HUF-weight FSE tables leave them zero (unused).
+    // alignment. Total 12 bytes. Grown from the classical 4-byte
+    // layout to remove the per-sequence `lookup_ll_code` /
+    // `lookup_ml_code` indirection: LL and ML enrich `base_value`
+    // / `num_additional_bits` from the packed code-meta tables
+    // (`enrich_with_packed_seq_meta`), OF enriches closed-form
+    // `base_value = 1 << code`, `num_additional_bits = code`
+    // (`enrich_for_offsets`, no meta table). HUF-weight FSE tables
+    // never enrich and leave both fields zero.
     assert_eq!(core::mem::size_of::<fse_decoder::Entry>(), 12);
     assert_eq!(core::mem::offset_of!(fse_decoder::Entry, new_state), 0);
     assert_eq!(core::mem::offset_of!(fse_decoder::Entry, symbol), 2);

--- a/zstd/src/fse/mod.rs
+++ b/zstd/src/fse/mod.rs
@@ -19,11 +19,25 @@ pub use fse_decoder::*;
 pub mod fse_encoder;
 
 #[test]
-fn decoder_entry_is_packed_4_bytes() {
-    assert_eq!(core::mem::size_of::<fse_decoder::Entry>(), 4);
+fn decoder_entry_layout_12_bytes_donor_seqsymbol_shape() {
+    // Donor `ZSTD_seqSymbol` shape: 4-byte header (new_state /
+    // symbol / num_bits), 4-byte `base_value`, 1-byte
+    // `num_additional_bits` + 3-byte tail padding for natural u32
+    // alignment. Total 12 bytes. The classical 4-byte layout was
+    // grown in #247 Part 1 to remove the per-sequence
+    // `lookup_ll_code` / `lookup_ml_code` indirection — LL / ML /
+    // OF tables fill `base_value` / `num_additional_bits` from
+    // their respective code-meta tables in the post-build enrich
+    // pass; HUF-weight FSE tables leave them zero (unused).
+    assert_eq!(core::mem::size_of::<fse_decoder::Entry>(), 12);
     assert_eq!(core::mem::offset_of!(fse_decoder::Entry, new_state), 0);
     assert_eq!(core::mem::offset_of!(fse_decoder::Entry, symbol), 2);
     assert_eq!(core::mem::offset_of!(fse_decoder::Entry, num_bits), 3);
+    assert_eq!(core::mem::offset_of!(fse_decoder::Entry, base_value), 4);
+    assert_eq!(
+        core::mem::offset_of!(fse_decoder::Entry, num_additional_bits),
+        8
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Part 1 of #247 (top-level CpuKernel dispatch). Independent of Parts 2/3 — only touches the FSE Entry layout to remove the per-sequence `lookup_ll_code` / `lookup_ml_code` indirections.

`fse::Entry` grows from 4 bytes to 12 bytes (donor `ZSTD_seqSymbol` shape):

* `base_value: u32` — code baseline (LL / ML / OF).
* `num_additional_bits: u8` — extra bits read from the stream after the symbol.

Post-build enrichment populates these fields for LL / ML / OF tables. The per-sequence hot path now reads `base_value` / `num_additional_bits` straight off the active `FSEDecoder::state` instead of issuing the previous two extra cache touches into `LL_META` (144 B) + `ML_META` (212 B).

## What lands

* `Entry` expanded with `base_value` + `num_additional_bits`; `#[repr(C)]` layout doc updated; explicit offset / size const asserts added in `fse_decoder.rs` + a 12-byte layout test in `fse/mod.rs`.
* `FSETable::enrich_with_packed_seq_meta(&[u32])` — fills both fields from a packed `(base << 0) | (extra_bits << 24)` table indexed by entry symbol. Same packed layout the existing `LL_META` / `ML_META` consts use.
* `FSETable::enrich_for_offsets()` — closed-form `base = 1 << symbol`, `num_additional_bits = symbol` for the OF table (no external meta).
* `maybe_update_fse_tables` calls the appropriate `enrich_*` after each FSE-mode and Predefined-mode table build. Repeat-mode skips — the previous enrichment stays valid.
* `Dictionary::decode_dict` calls the same enrichment after each dict-trained FSE table builds.
* `decode_one_sequence_inline` reads `ll_dec.state.base_value` / `ll_dec.state.num_additional_bits` directly. The same change applies in the pipelined fused decode path which routes through this helper.
* RLE-fallback (`decode_sequences_with_rle`) keeps `lookup_*` for RLE bytes (no enriched entry to read from) and uses the active state for FSE-mode tables.
* `copy_symbols_into_decode` LE-fast-path that packed two 4-byte entries into a single u64 store no longer applies — Entry is 12 bytes now. Replaced with `Vec::resize` + per-slot `.symbol` assignment. Table build is not on the per-sequence hot path (runs once per FSE-mode block).
* `LL_META` / `ML_META` consts promoted from private to `pub(crate)` so `dictionary.rs` can pass them to enrichment.

## What does NOT change

* HUF-weight FSE table — leaves `base_value` / `num_additional_bits` at zero default (unused there).
* `lookup_ll_code` / `lookup_ml_code` helpers — still used by the RLE-fallback path only.
* `decode_symbol()` signature — still returns just the symbol byte. New fields are read via `decoder.state.*` accessor.

## Test plan

- [x] `cargo nextest run -p structured-zstd --features hash,std,dict_builder` — 652/652 green.
- [x] `cargo clippy --all-targets --features hash,std -- -D warnings` — clean.
- [x] Entry layout assertions: `size_of::<Entry>() == 12`, `offset_of(base_value) == 4`, `offset_of(num_additional_bits) == 8`.
- [ ] L-1 fast decompress bench on i9 (compare_ffi `decompress/level_-1_fast/decodecorpus-z000033/c_stream`) to confirm ≥ 2 % throughput improvement per Part 1 AC. Pending — measurement scheduled for follow-up commit on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized sequence decoding by reducing per-sequence table lookups through pre-computed metadata
  * Enhanced dictionary decoding with internal table enrichment for improved decompression efficiency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->