### PR TITLE
perf(decode): RingBuffer % cap → branchless wrap helper (kills divl on i686, divq on x86_64)

### DIFF
--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -66,6 +66,33 @@ impl RingBuffer {
         self.cap
     }
 
+    /// Branchless wrap-around for indices that may overshoot capacity
+    /// by at most one cap-length. Replaces `% self.cap` (which compiles
+    /// to `divl` on i686 / `divq` on x86_64 because `cap` is runtime
+    /// `2^N + 1` per the empty-vs-full sentinel invariant — neither
+    /// power-of-two-AND nor strength-reduce-multiply applies). LLVM
+    /// lowers this to a single CMOV: ~1 cycle vs the ~26-cycle divl.
+    ///
+    /// # Invariant for callers
+    /// `x < 2 * self.cap` — i.e. the input is at most one cap-length
+    /// past the end. Every existing call site (`(tail + len)`,
+    /// `(head + idx)`, `(head + amount)`) satisfies this because the
+    /// addends are bounded: `len`/`amount` come from a write/drain
+    /// that `reserve` already sized for, and `head`/`tail` are
+    /// themselves `< cap` at all times. A double-wrap input would
+    /// leave `x - self.cap` still `>= self.cap` and produce a wrong
+    /// index; the debug_assert below catches that in fuzz builds.
+    #[inline(always)]
+    fn wrap(&self, x: usize) -> usize {
+        debug_assert!(
+            x < self.cap.saturating_mul(2) || self.cap == 0,
+            "ringbuffer wrap: x ({}) must be < 2*cap ({})",
+            x,
+            self.cap.saturating_mul(2)
+        );
+        if x >= self.cap { x - self.cap } else { x }
+    }
+
     /// Current write cursor, used by `DecodeBuffer::checkpoint` to
     /// record a rollback point before speculative writes. Same
     /// forwarding contract as `cap()` above.
@@ -227,7 +254,7 @@ impl RingBuffer {
         // SAFETY: Upholds invariant 2 by writing initialized memory
         unsafe { self.buf.as_ptr().add(self.tail).write(byte) };
         // SAFETY: Upholds invariant 3 by wrapping `tail` around
-        self.tail = (self.tail + 1) % self.cap;
+        self.tail = self.wrap(self.tail + 1);
     }
 
     /// Fetch the byte stored at the selected index from the buffer, returning it, or
@@ -237,7 +264,7 @@ impl RingBuffer {
         if idx < self.len() {
             // SAFETY: Establishes invariants on memory being initialized and the range being in-bounds
             // (Invariants 2 & 3)
-            let idx = (self.head + idx) % self.cap;
+            let idx = self.wrap(self.head + idx);
             Some(unsafe { self.buf.as_ptr().add(idx).read() })
         } else {
             None
@@ -368,7 +395,7 @@ impl RingBuffer {
             }
         }
         // SAFETY: Upholds invariant 3 by wrapping `tail` around.
-        self.tail = (self.tail + len) % self.cap;
+        self.tail = self.wrap(self.tail + len);
     }
 
     /// Advance head past `amount` elements, effectively removing
@@ -378,7 +405,7 @@ impl RingBuffer {
         let amount = usize::min(amount, self.len());
         // SAFETY: we maintain invariant 2 here since this will always lead to a smaller buffer
         // for amount≤len
-        self.head = (self.head + amount) % self.cap;
+        self.head = self.wrap(self.head + amount);
     }
 
     /// Return the size of the two contiguous occupied sections of memory used
@@ -588,7 +615,7 @@ impl RingBuffer {
                 // D: Destination bytes, going to be copied from S bytes
                 // _: Uninvolved bytes in the writable section
 
-                let start = (self.head + start) % self.cap;
+                let start = self.wrap(self.head + start);
 
                 let src = (
                     // SAFETY: `len <= isize::MAX` and fits the memory range of `buf`
@@ -686,7 +713,7 @@ impl RingBuffer {
             }
         }
 
-        self.tail = (self.tail + len) % self.cap;
+        self.tail = self.wrap(self.tail + len);
     }
 
     pub fn extend_and_fill(&mut self, fill_with: u8, fill_length: usize) {
@@ -707,7 +734,7 @@ impl RingBuffer {
                 ptr2.write_bytes(fill_with, fill2);
             }
         }
-        self.tail = (self.tail + fill_length) % self.cap;
+        self.tail = self.wrap(self.tail + fill_length);
     }
 
     pub fn extend_from_reader<R: Read>(
@@ -736,7 +763,7 @@ impl RingBuffer {
             };
             read.read_exact(s2)?;
         }
-        self.tail = (self.tail + fill_length) % self.cap;
+        self.tail = self.wrap(self.tail + fill_length);
         Ok(())
     }
 
@@ -816,7 +843,7 @@ impl RingBuffer {
             copy_with_nobranch_check(
                 m1_ptr, m2_ptr, f1_ptr, f2_ptr, m1_in_f1, m2_in_f1, m1_in_f2, m2_in_f2,
             );
-            self.tail = (self.tail + len) % self.cap;
+            self.tail = self.wrap(self.tail + len);
         }
     }
 }

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -12,6 +12,21 @@ use crate::decoding::sequence_execution::{do_offset_history, execute_sequences_f
 use crate::fse::FSEDecoder;
 use alloc::vec::Vec;
 
+// 8-slot software pipeline mirroring donor
+// `ZSTD_decompressSequencesLong_body`'s `STORED_SEQS = 8`. The
+// 8-deep lookahead lets the prefetch issued at iteration `i`
+// resolve through L1/L2 by the time iteration `i + 8` consumes it,
+// whereas 4-deep often wasn't enough gap on long-distance workloads.
+const ADVANCE: usize = 8;
+const ADVANCE_MASK: usize = ADVANCE - 1;
+// `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
+// power of two. Compile-time guard so a future ADVANCE tweak can't
+// silently corrupt the ring index.
+const _: () = assert!(
+    ADVANCE.is_power_of_two(),
+    "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
+);
+
 /// Fused decode + execute pipeline: decodes each sequence from the FSE
 /// bitstream and immediately executes it (literal copy + match copy)
 /// without materialising the intermediate `Vec<Sequence>` round-trip.
@@ -142,16 +157,8 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     // u32 carries the resolved offset from the decode-ahead shadow
     // walk so the execute side can skip do_offset_history); still
     // well within register-pressure budget.
-    const ADVANCE: usize = 8;
-    const ADVANCE_MASK: usize = ADVANCE - 1;
-    // `i & ADVANCE_MASK` only equals `i % ADVANCE` when ADVANCE is a
-    // power of two. Compile-time guard so a future ADVANCE tweak
-    // can't silently corrupt the ring index if someone picks a
-    // non-power-of-two value.
-    const _: () = assert!(
-        ADVANCE.is_power_of_two(),
-        "ADVANCE must be a power of two; ring indexing uses `i & (ADVANCE - 1)` as `i % ADVANCE`"
-    );
+    // ADVANCE / ADVANCE_MASK hoisted to module scope so the extracted
+    // `run_pipelined_sequence_loop` can reach them.
 
     // Donor `ZSTD_getOffsetInfo` parity. The share of FSE offset
     // codes > LONG_OFFSET_CODE_THRESHOLD (scaled to donor's
@@ -190,134 +197,26 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         // had N-1 partial writes — diverging from the non-pipelined
         // path (which mutates hist in lockstep per executed sequence)
         // and leaving scratch internally inconsistent for any
-        // post-Err reuse. Wrap the entire pipelined work in an IIFE so
-        // a single rollback site catches all mid-loop Errs uniformly.
-        let pipeline_result: Result<(), DecompressBlockError> = (|| {
-            // `prefetch_pos` is the logical buffer index (same frame as
-            // `buffer.len()`) at which the NEXT not-yet-decoded sequence
-            // will start pushing literals. We pre-decode `ADVANCE` ahead, so we
-            // accumulate (ll + ml) per decoded seq to keep this position
-            // synchronised with where execute will eventually be.
-            let mut prefetch_pos: usize = old_buffer_size;
-            // Shadow copy of `offset_hist`, advanced by
-            // `do_offset_history` for every decoded-ahead sequence. The
-            // REAL `offset_hist` is only mutated inside
-            // `execute_one_sequence` (preserving the legacy 'partial
-            // output, no rewound history' rollback contract), but the
-            // prefetch needs the exact post-resolution offset for repcode
-            // 1..=3 cases that read history — a stale read would skip
-            // the long-distance prefetch precisely when a fresh huge
-            // offset is followed by a repcode that aliases it. The
-            // shadow is a local `[u32; 3]` (12 bytes) so the simulation cost
-            // is negligible.
-            let mut shadow_hist: [u32; 3] = *offset_hist;
-            // Stack ring of `(decoded_seq, resolved_offset)` pairs. The
-            // decode-ahead phase resolves repcodes against `shadow_hist`
-            // and stores the resolved offset alongside the raw sequence,
-            // so the execute phase consumes a pre-resolved offset and
-            // skips `do_offset_history` entirely — saves one function
-            // call + one cache write on real `offset_hist` per sequence.
-            // The real `offset_hist` is updated ONCE from `shadow_hist`
-            // after a successful drain (below); on a malformed-block
-            // rollback the saved snapshot is restored, so real hist is
-            // never observed in a partial mid-pipeline state.
-            let mut ring: [(Sequence, u32); ADVANCE] = [(
-                Sequence {
-                    ll: 0,
-                    ml: 0,
-                    of: 0,
-                },
-                0u32,
-            ); ADVANCE];
-
-            // Pre-fill the ring. The outer `num_sequences >= ADVANCE * 2`
-            // gate guarantees `num_sequences > ADVANCE`, so the FSE
-            // state update is needed after every prefill decode — no
-            // `isLastSeq` guard required here, only in the steady-state
-            // loop where `i + 1 == num_sequences` is reachable.
-            for slot in ring.iter_mut() {
-                let seq =
-                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-                // EXACT actual_offset via shadow history.
-                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
-                // wrapping_add: prefetch_pos / seq.ll / seq.ml are
-                // derived from the bitstream, so a malformed frame can
-                // present values that would overflow usize and panic
-                // under debug. The result feeds only the prefetch
-                // hint — `prefetch_lookahead_match_source` bound-checks
-                // the logical position against `buffer.len()` and drops
-                // wrap-derived garbage indices, so the wrap is harmless
-                // here while keeping the decoder fuzz-stable.
-                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-                let source_idx = match_start.wrapping_sub(actual_offset as usize);
-                buffer.prefetch_lookahead_match_source(source_idx);
-                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-                *slot = (seq, actual_offset);
-                br.ensure_bits(max_update_bits);
-                ll_dec.update_state_fast(&mut br);
-                ml_dec.update_state_fast(&mut br);
-                of_dec.update_state_fast(&mut br);
-            }
-
-            // Steady state: decode next, prefetch its source, execute
-            // the oldest slot in the ring (with its pre-resolved offset).
-            for i in ADVANCE..num_sequences {
-                let seq =
-                    decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-                let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
-                let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
-                let source_idx = match_start.wrapping_sub(actual_offset as usize);
-                buffer.prefetch_lookahead_match_source(source_idx);
-                prefetch_pos = match_start.wrapping_add(seq.ml as usize);
-
-                let slot = i & ADVANCE_MASK;
-                let (exec_seq, exec_offset) = ring[slot];
-                ring[slot] = (seq, actual_offset);
-
-                execute_one_sequence_pipelined(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    exec_seq,
-                    exec_offset,
-                )?;
-                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-
-                if i + 1 < num_sequences {
-                    br.ensure_bits(max_update_bits);
-                    ll_dec.update_state_fast(&mut br);
-                    ml_dec.update_state_fast(&mut br);
-                    of_dec.update_state_fast(&mut br);
-                }
-            }
-
-            // Drain: execute remaining ADVANCE sequences with their
-            // pre-resolved offsets. Iteration order matches the ring
-            // slot they occupy from the steady-state loop's final write.
-            for k in 0..ADVANCE {
-                let slot = (num_sequences + k) & ADVANCE_MASK;
-                let (exec_seq, exec_offset) = ring[slot];
-                execute_one_sequence_pipelined(
-                    buffer,
-                    literals_buffer,
-                    &mut lit_cur,
-                    literals_buffer_len,
-                    exec_seq,
-                    exec_offset,
-                )?;
-                seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
-            }
-
-            // Single committing point for real offset history on the
-            // pipelined success path. Shadow walked every queued
-            // sequence already; copy that state back so the next
-            // block sees the post-block repcodes. Rollback on a later
-            // bitstream-failure overwrites this with
-            // `saved_offset_hist`, undoing the commit.
-            *offset_hist = shadow_hist;
-            Ok(())
-        })();
+        // post-Err reuse. The pipelined work runs in a separate
+        // top-level fn so a single rollback site catches all mid-loop
+        // Errs uniformly AND a future `#[target_feature]` wrapper can
+        // be added without dragging the outer fn into target_feature
+        // scope.
+        let pipeline_result = run_pipelined_sequence_loop(
+            &mut br,
+            &mut ll_dec,
+            &mut ml_dec,
+            &mut of_dec,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            &mut lit_cur,
+            literals_buffer_len,
+            num_sequences,
+            old_buffer_size,
+            max_update_bits,
+            &mut seq_sum,
+        );
         if let Err(e) = pipeline_result {
             // Mid-loop execute Err: rollback buffer + hist so post-Err
             // scratch reuse stays consistent. `*offset_hist` is still
@@ -406,6 +305,129 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         seq_sum as usize, diff,
         "seq_sum {seq_sum} != buffer growth {diff}"
     );
+    Ok(())
+}
+
+/// Pipelined sequence-decode + execute loop (long-block hot path).
+/// Extracted from `decode_and_execute_sequences` so it can be wrapped
+/// with `#[target_feature]` in a follow-up commit — that wrapper is
+/// what lets `peek_bits_triple`'s `extract_triple_pext` call inline
+/// through the now-target_feature-scoped caller, eliminating the
+/// `(u64,u64,u64)` sret ABI boundary that perf annotate attributed
+/// ~19.96% of its own samples to (and ~3.95% of total decode time).
+///
+/// Caller (`decode_and_execute_sequences`) owns the rollback on Err:
+/// on Err, the buffer-checkpoint restore and `*offset_hist = saved`
+/// fire at the call site, NOT inside this fn. This fn only commits
+/// `*offset_hist = shadow_hist` on the success-tail (after the drain
+/// loop), matching the legacy IIFE contract.
+fn run_pipelined_sequence_loop<B: super::buffer_backend::BufferBackend>(
+    br: &mut BitReaderReversed<'_>,
+    ll_dec: &mut FSEDecoder<'_>,
+    ml_dec: &mut FSEDecoder<'_>,
+    of_dec: &mut FSEDecoder<'_>,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    lit_cur: &mut usize,
+    literals_buffer_len: usize,
+    num_sequences: usize,
+    old_buffer_size: usize,
+    max_update_bits: u8,
+    seq_sum: &mut u32,
+) -> Result<(), DecompressBlockError> {
+    // `prefetch_pos` is the logical buffer index (same frame as
+    // `buffer.len()`) at which the NEXT not-yet-decoded sequence
+    // will start pushing literals. We pre-decode `ADVANCE` ahead,
+    // accumulating (ll + ml) per decoded seq to keep this position
+    // synchronised with where execute will eventually be.
+    let mut prefetch_pos: usize = old_buffer_size;
+    let mut shadow_hist: [u32; 3] = *offset_hist;
+    let mut ring: [(Sequence, u32); ADVANCE] = [(
+        Sequence {
+            ll: 0,
+            ml: 0,
+            of: 0,
+        },
+        0u32,
+    ); ADVANCE];
+
+    // Pre-fill the ring. Outer `num_sequences >= ADVANCE * 2` gate
+    // guarantees `num_sequences > ADVANCE`, so the FSE state update
+    // is needed after every prefill decode.
+    for slot in ring.iter_mut() {
+        let seq = decode_one_sequence_inline(ll_dec, ml_dec, of_dec, br);
+        let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+        // wrapping_add: bitstream-derived values can overflow on
+        // malformed frames; `prefetch_lookahead_match_source` bound-
+        // checks against `buffer.len()` and drops wrap-derived
+        // indices, so the wrap is harmless while keeping the decoder
+        // fuzz-stable.
+        let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+        let source_idx = match_start.wrapping_sub(actual_offset as usize);
+        buffer.prefetch_lookahead_match_source(source_idx);
+        prefetch_pos = match_start.wrapping_add(seq.ml as usize);
+        *slot = (seq, actual_offset);
+        br.ensure_bits(max_update_bits);
+        ll_dec.update_state_fast(br);
+        ml_dec.update_state_fast(br);
+        of_dec.update_state_fast(br);
+    }
+
+    // Steady state: decode next, prefetch its source, execute the
+    // oldest slot in the ring (with its pre-resolved offset).
+    for i in ADVANCE..num_sequences {
+        let seq = decode_one_sequence_inline(ll_dec, ml_dec, of_dec, br);
+        let actual_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+        let match_start = prefetch_pos.wrapping_add(seq.ll as usize);
+        let source_idx = match_start.wrapping_sub(actual_offset as usize);
+        buffer.prefetch_lookahead_match_source(source_idx);
+        prefetch_pos = match_start.wrapping_add(seq.ml as usize);
+
+        let slot = i & ADVANCE_MASK;
+        let (exec_seq, exec_offset) = ring[slot];
+        ring[slot] = (seq, actual_offset);
+
+        execute_one_sequence_pipelined(
+            buffer,
+            literals_buffer,
+            lit_cur,
+            literals_buffer_len,
+            exec_seq,
+            exec_offset,
+        )?;
+        *seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+
+        if i + 1 < num_sequences {
+            br.ensure_bits(max_update_bits);
+            ll_dec.update_state_fast(br);
+            ml_dec.update_state_fast(br);
+            of_dec.update_state_fast(br);
+        }
+    }
+
+    // Drain: execute remaining ADVANCE sequences with their
+    // pre-resolved offsets. Iteration order matches the ring slot
+    // they occupy from the steady-state loop's final write.
+    for k in 0..ADVANCE {
+        let slot = (num_sequences + k) & ADVANCE_MASK;
+        let (exec_seq, exec_offset) = ring[slot];
+        execute_one_sequence_pipelined(
+            buffer,
+            literals_buffer,
+            lit_cur,
+            literals_buffer_len,
+            exec_seq,
+            exec_offset,
+        )?;
+        *seq_sum = seq_sum.wrapping_add(exec_seq.ll).wrapping_add(exec_seq.ml);
+    }
+
+    // Single committing point for real offset history on the
+    // pipelined success path. Shadow walked every queued sequence;
+    // copy that state back so the next block sees the post-block
+    // repcodes. Caller rolls back on Err.
+    *offset_hist = shadow_hist;
     Ok(())
 }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -321,6 +321,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
 /// fire at the call site, NOT inside this fn. This fn only commits
 /// `*offset_hist = shadow_hist` on the success-tail (after the drain
 /// loop), matching the legacy IIFE contract.
+///
+/// 13 parameters: the closure capture set the IIFE used implicitly.
+/// Grouping into a struct would push pressure off the argument
+/// registers and onto memory loads, undoing the extraction's win.
+#[allow(clippy::too_many_arguments)]
 fn run_pipelined_sequence_loop<B: super::buffer_backend::BufferBackend>(
     br: &mut BitReaderReversed<'_>,
     ll_dec: &mut FSEDecoder<'_>,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -121,79 +121,6 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     //     `*offset_hist = saved_offset_hist`. Cheap no-op on the
     //     pipelined branch (real hist was never touched mid-loop),
     //     correct rewind on the non-pipelined branch.
-    #[inline(always)]
-    fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
-        buffer: &mut super::decode_buffer::DecodeBuffer<B>,
-        literals: &[u8],
-        lit_cur: &mut usize,
-        lit_len: usize,
-        offset_hist: &mut [u32; 3],
-        seq: Sequence,
-    ) -> Result<(), DecompressBlockError> {
-        let high = *lit_cur + seq.ll as usize;
-        if high > lit_len {
-            return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
-                wanted: high,
-                have: lit_len,
-            }
-            .into());
-        }
-        // SAFETY: high <= lit_len (just verified) and *lit_cur <= high
-        // (high = lit_cur + seq.ll, seq.ll >= 0).
-        let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
-        *lit_cur = high;
-        buffer.push(lits);
-
-        let actual = do_offset_history(seq.of, seq.ll, offset_hist);
-        if actual == 0 {
-            return Err(ExecuteSequencesError::ZeroOffset.into());
-        }
-        buffer
-            .repeat(actual as usize, seq.ml as usize)
-            .map_err(ExecuteSequencesError::from)?;
-        Ok(())
-    }
-
-    /// Pipelined-path variant: takes the offset already resolved by
-    /// the decode-ahead `shadow_hist` walk, so `do_offset_history` is
-    /// NOT called here (caller mutated only the shadow). Routes the
-    /// match copy through `repeat_lookahead_prefetched`, which skips
-    /// only the in-loop `prefetch_match_source` (redundant because
-    /// the lookahead pipeline already issued a PREFETCH_L1 ADVANCE
-    /// iterations earlier). The per-call `buffer.reserve(match_length)`
-    /// is preserved by that variant — required for memory safety
-    /// against malformed inputs whose `match_length` exceeds the
-    /// upfront `reserve(MAX_BLOCK_SIZE)` headroom.
-    #[inline(always)]
-    fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
-        buffer: &mut super::decode_buffer::DecodeBuffer<B>,
-        literals: &[u8],
-        lit_cur: &mut usize,
-        lit_len: usize,
-        seq: Sequence,
-        resolved_offset: u32,
-    ) -> Result<(), DecompressBlockError> {
-        let high = *lit_cur + seq.ll as usize;
-        if high > lit_len {
-            return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
-                wanted: high,
-                have: lit_len,
-            }
-            .into());
-        }
-        // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
-        let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
-        *lit_cur = high;
-        buffer.push(lits);
-
-        if resolved_offset == 0 {
-            return Err(ExecuteSequencesError::ZeroOffset.into());
-        }
-        buffer
-            .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
-            .map_err(ExecuteSequencesError::from)?;
-        Ok(())
-    }
 
     let num_sequences = section.num_sequences as usize;
 
@@ -479,6 +406,84 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
         seq_sum as usize, diff,
         "seq_sum {seq_sum} != buffer growth {diff}"
     );
+    Ok(())
+}
+
+/// Per-sequence executor for the non-pipelined (short-block) fallback
+/// path. Mutates the real `offset_hist` in lockstep with the sequence
+/// being executed — preserving the legacy "Err leaves partial output +
+/// pre-mutation hist" rollback contract.
+#[inline(always)]
+fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    literals: &[u8],
+    lit_cur: &mut usize,
+    lit_len: usize,
+    offset_hist: &mut [u32; 3],
+    seq: Sequence,
+) -> Result<(), DecompressBlockError> {
+    let high = *lit_cur + seq.ll as usize;
+    if high > lit_len {
+        return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
+            wanted: high,
+            have: lit_len,
+        }
+        .into());
+    }
+    // SAFETY: high <= lit_len (just verified) and *lit_cur <= high
+    // (high = lit_cur + seq.ll, seq.ll >= 0).
+    let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
+    *lit_cur = high;
+    buffer.push(lits);
+
+    let actual = do_offset_history(seq.of, seq.ll, offset_hist);
+    if actual == 0 {
+        return Err(ExecuteSequencesError::ZeroOffset.into());
+    }
+    buffer
+        .repeat(actual as usize, seq.ml as usize)
+        .map_err(ExecuteSequencesError::from)?;
+    Ok(())
+}
+
+/// Pipelined-path executor variant: takes the offset already resolved
+/// by the decode-ahead `shadow_hist` walk, so `do_offset_history` is
+/// NOT called here (caller mutated only the shadow). Routes the match
+/// copy through `repeat_lookahead_prefetched`, which skips only the
+/// in-loop `prefetch_match_source` (redundant because the lookahead
+/// pipeline already issued a PREFETCH_L1 ADVANCE iterations earlier).
+/// The per-call `buffer.reserve(match_length)` is preserved by that
+/// variant — required for memory safety against malformed inputs whose
+/// `match_length` exceeds the upfront `reserve(MAX_BLOCK_SIZE)`
+/// headroom.
+#[inline(always)]
+fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    literals: &[u8],
+    lit_cur: &mut usize,
+    lit_len: usize,
+    seq: Sequence,
+    resolved_offset: u32,
+) -> Result<(), DecompressBlockError> {
+    let high = *lit_cur + seq.ll as usize;
+    if high > lit_len {
+        return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
+            wanted: high,
+            have: lit_len,
+        }
+        .into());
+    }
+    // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
+    let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
+    *lit_cur = high;
+    buffer.push(lits);
+
+    if resolved_offset == 0 {
+        return Err(ExecuteSequencesError::ZeroOffset.into());
+    }
+    buffer
+        .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
+        .map_err(ExecuteSequencesError::from)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

RingBuffer's per-call `(idx + delta) % self.cap` modulo compiles to a hardware division (`divl` on i686, `divq` on x86_64) because `cap` is `2^N + 1` — the `+1` is load-bearing (empty-vs-full sentinel, invariant 4), so the compiler cannot lower to bitwise AND or strength-reduce via shift-multiply.

`perf annotate` on the i686 `pure_rust` matrix arm of the primary fixture (`decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust`) attributed **29.40% of `extend_from_within_unchecked_branchless`'s own samples to a single `divl` instruction** (the match-copy wrap). Same `% self.cap` pattern in 8 other call sites (push_back, get, extend, drain, fill, fill_with, extend_from_within_unchecked, branchless variant, and the get fallback).

All `% self.cap` call sites satisfy `result < 2 * self.cap` (addends are bounded by `reserve(...)` invariants and head/tail invariants), so a single branchless conditional subtract — `if x >= self.cap { x - self.cap } else { x }` — produces the identical result with one CMOV instead of a divide. Centralised in a new `RingBuffer::wrap(&self, x)` helper.

## Bench

i9-9900K bench host, primary fixture matrix:

| matrix arm | pre-wrap | post-wrap | Δ |
|---|---|---|---|
| **i686 pure_rust** | 2.7323 ms | **2.5951 ms** | **−6.81%** (p<0.05) |
| i686 pure_rust_direct (UserSlice) | 2.0775 ms | 2.0348 ms | −2.06% noise |
| i686 c_ffi (donor) | 1.1975 ms | 1.1936 ms | −0.33% noise |
| **x86_64 pure_rust** | 2.2224 ms | **2.0666 ms** | **−7.01%** (p<0.05) |
| x86_64 pure_rust_direct (UserSlice) | 1.6201 ms | 1.6284 ms | +0.51% noise (UserSlice doesn't use RingBuffer) |
| x86_64 c_ffi (donor) | 640.66 µs | 641.66 µs | +0.16% noise |

Pure-rust RingBuffer path wins **~7% on both architectures**. UserSlice-backed direct path is neutral (it doesn't touch RingBuffer code).

## Structural prep (folded in)

The PR also includes two prerequisite refactors needed for follow-up Tier 9/10 K-propagation work. They are independent of the wrap helper; together they shrink `decode_and_execute_sequences` from ~500 LOC to ~250 LOC so a future `#[target_feature]` wrapper can be applied without hitting the documented "outer wrap on >200 LOC fn regresses 5%" pattern:

1. **`refactor(decode): hoist execute_one_sequence helpers to top-level fns`** — lifts the two `execute_one_sequence*` helpers out of the outer fn body. No behavior change. NEUTRAL on bench.
2. **`refactor(decode): extract pipelined sequence loop into top-level fn`** — moves the IIFE pipelined-branch body into a standalone `run_pipelined_sequence_loop<B>` fn (~150 LOC, well under the 200-LOC threshold). 13 explicit `&mut` parameters replacing the implicit closure capture set. NEUTRAL on bench.

## Testing

- `cargo nextest run -p structured-zstd` — 637/637 passes.
- `cargo clippy -p structured-zstd --features hash,std,dict_builder --lib --tests -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

Part of #247.
