### PR TITLE
perf(bench): pre-touch decompress output Vec to kill page-fault artifact

### DIFF
--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -284,20 +284,22 @@ fn pretouch_pages(buf: &mut [u8]) {
     if buf.is_empty() {
         return;
     }
-    // 4 KiB is the small-page size on every supported target. Targets
-    // with larger base pages (16 KiB on Apple Silicon, etc.) just touch
-    // more often than strictly required — still correct, cheap.
+    // 4 KiB is a common base page size; on systems with larger base
+    // pages (16 KiB on Apple Silicon, 64 KiB on some aarch64 kernels)
+    // we touch more often than strictly required — still correct,
+    // cheap.
     const STRIDE: usize = 4096;
     let len = buf.len();
     let ptr = buf.as_mut_ptr();
     // SAFETY: `ptr` is non-null (buf non-empty above) and each
-    // `ptr.add(off)` stays within `len` due to the loop bound.
-    // `write_volatile` of `0u8` does not alias other live references.
+    // `ptr.add(off)` stays within `len` due to the `step_by` range
+    // bound. `write_volatile` of `0u8` does not alias other live
+    // references. Iterating via `(0..len).step_by(STRIDE)` guarantees
+    // termination — no `usize` overflow risk that a manual `off +=
+    // STRIDE` accumulator carries for buffers approaching `usize::MAX`.
     unsafe {
-        let mut off = 0usize;
-        while off < len {
+        for off in (0..len).step_by(STRIDE) {
             ptr.add(off).write_volatile(0);
-            off += STRIDE;
         }
         // Also touch the final byte so the tail page is in even if
         // `len` is not a multiple of STRIDE.

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -264,6 +264,47 @@ fn bench_decompress(c: &mut Criterion) {
     }
 }
 
+/// Force every page of `buf` into the process's resident set with one
+/// volatile write per page-sized stride. `vec![0u8; N]` returns pages
+/// CoW-mapped to the kernel zero page on Linux; the first real write
+/// per page in the timed iter would otherwise trigger a synchronous
+/// page-fault to allocate the anon backing. On `--profile-time` runs
+/// (no warmup) that accounted for 67% of total samples on z000033 L-3
+/// c_stream flamegraph.
+///
+/// Volatile writes are required because under the bench profile's fat
+/// LTO + single-codegen-unit settings, a plain `slice::fill(0)` /
+/// `Vec::resize` followed by full-slice overwrite from the decoder is
+/// a dead-store the optimizer can elide. `write_volatile` is a guaranteed
+/// side effect — LLVM may not remove it. One write per 4 KiB stride
+/// (the most common page size; larger huge pages still get touched at
+/// the smaller stride) is enough to fault each anon page in.
+#[inline(never)]
+fn pretouch_pages(buf: &mut [u8]) {
+    if buf.is_empty() {
+        return;
+    }
+    // 4 KiB is the small-page size on every supported target. Targets
+    // with larger base pages (16 KiB on Apple Silicon, etc.) just touch
+    // more often than strictly required — still correct, cheap.
+    const STRIDE: usize = 4096;
+    let len = buf.len();
+    let ptr = buf.as_mut_ptr();
+    // SAFETY: `ptr` is non-null (buf non-empty above) and each
+    // `ptr.add(off)` stays within `len` due to the loop bound.
+    // `write_volatile` of `0u8` does not alias other live references.
+    unsafe {
+        let mut off = 0usize;
+        while off < len {
+            ptr.add(off).write_volatile(0);
+            off += STRIDE;
+        }
+        // Also touch the final byte so the tail page is in even if
+        // `len` is not a multiple of STRIDE.
+        ptr.add(len - 1).write_volatile(0);
+    }
+}
+
 fn bench_decompress_source(
     c: &mut Criterion,
     scenario: &Scenario,
@@ -308,21 +349,7 @@ fn bench_decompress_source(
     group.bench_function("pure_rust", |b| {
         let compressed = materialize();
         let mut target = vec![0u8; expected_len];
-        // `vec![0u8; N]` performs a zero-initialized allocation via
-        // `alloc_zeroed`. On glibc + Linux that typically resolves to
-        // `mmap(MAP_ANONYMOUS)` (or `calloc` for smaller buffers),
-        // both of which return pages CoW-mapped to the kernel zero
-        // page. First write to each page in the measured iter
-        // triggers a page-fault to allocate a real anon page. On
-        // `--profile-time` runs (no warmup) that synchronous
-        // allocation accounted for 67% of total samples on the
-        // z000033 L-3 c_stream flamegraph. Allocator / OS specifics
-        // vary, but the lazy-zero-page CoW behaviour is common
-        // enough that pre-touching is the portable fix: a non-zero
-        // fill then a reset to zero forces every page into the
-        // resident set before measurement starts.
-        target.fill(0xAA);
-        target.fill(0);
+        pretouch_pages(&mut target);
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
@@ -345,9 +372,7 @@ fn bench_decompress_source(
         // duplicating its value so the bench can't silently drift
         // off the direct path if the slack changes.
         let mut target = vec![0u8; expected_len + structured_zstd::WILDCOPY_OVERLENGTH];
-        // See note on pure_rust above — same lazy-zero-page CoW story.
-        target.fill(0xAA);
-        target.fill(0);
+        pretouch_pages(&mut target);
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
@@ -367,12 +392,7 @@ fn bench_decompress_source(
         let compressed = materialize();
         let mut dctx = FfiDCtxHandle::new();
         let mut target = vec![0u8; expected_len];
-        // See note on pure_rust above — c_ffi gets the same pre-touch
-        // so the timing comparison stays apples-to-apples (FFI side
-        // would otherwise pay the identical lazy-zero-page CoW tax
-        // hidden inside one big ZSTD_decompressDCtx call).
-        target.fill(0xAA);
-        target.fill(0);
+        pretouch_pages(&mut target);
         b.iter(|| {
             let written = dctx.decompress_into(black_box(compressed), &mut target);
             assert_eq!(written, expected_len);

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -308,14 +308,19 @@ fn bench_decompress_source(
     group.bench_function("pure_rust", |b| {
         let compressed = materialize();
         let mut target = vec![0u8; expected_len];
-        // `vec![0u8; N]` calls calloc which maps the kernel zero-page
-        // CoW for every anonymous page. First write to each page in
-        // the measured iter triggers a page-fault to allocate a real
-        // anon page. On `--profile-time` runs (no warmup) that
-        // synchronous allocation accounted for 67% of total samples
-        // on the z000033 L-3 c_stream flamegraph. Pre-touching with
-        // a non-zero fill then resetting to zero forces every page
-        // into the resident set before measurement starts.
+        // `vec![0u8; N]` performs a zero-initialized allocation via
+        // `alloc_zeroed`. On glibc + Linux that typically resolves to
+        // `mmap(MAP_ANONYMOUS)` (or `calloc` for smaller buffers),
+        // both of which return pages CoW-mapped to the kernel zero
+        // page. First write to each page in the measured iter
+        // triggers a page-fault to allocate a real anon page. On
+        // `--profile-time` runs (no warmup) that synchronous
+        // allocation accounted for 67% of total samples on the
+        // z000033 L-3 c_stream flamegraph. Allocator / OS specifics
+        // vary, but the lazy-zero-page CoW behaviour is common
+        // enough that pre-touching is the portable fix: a non-zero
+        // fill then a reset to zero forces every page into the
+        // resident set before measurement starts.
         target.fill(0xAA);
         target.fill(0);
         let mut decoder = FrameDecoder::new();
@@ -340,7 +345,7 @@ fn bench_decompress_source(
         // duplicating its value so the bench can't silently drift
         // off the direct path if the slack changes.
         let mut target = vec![0u8; expected_len + structured_zstd::WILDCOPY_OVERLENGTH];
-        // See note on pure_rust above — same calloc page-fault story.
+        // See note on pure_rust above — same lazy-zero-page CoW story.
         target.fill(0xAA);
         target.fill(0);
         let mut decoder = FrameDecoder::new();
@@ -363,7 +368,9 @@ fn bench_decompress_source(
         let mut dctx = FfiDCtxHandle::new();
         let mut target = vec![0u8; expected_len];
         // See note on pure_rust above — c_ffi gets the same pre-touch
-        // so the timing comparison stays apples-to-apples.
+        // so the timing comparison stays apples-to-apples (FFI side
+        // would otherwise pay the identical lazy-zero-page CoW tax
+        // hidden inside one big ZSTD_decompressDCtx call).
         target.fill(0xAA);
         target.fill(0);
         b.iter(|| {

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -308,6 +308,16 @@ fn bench_decompress_source(
     group.bench_function("pure_rust", |b| {
         let compressed = materialize();
         let mut target = vec![0u8; expected_len];
+        // `vec![0u8; N]` calls calloc which maps the kernel zero-page
+        // CoW for every anonymous page. First write to each page in
+        // the measured iter triggers a page-fault to allocate a real
+        // anon page. On `--profile-time` runs (no warmup) that
+        // synchronous allocation accounted for 67% of total samples
+        // on the z000033 L-3 c_stream flamegraph. Pre-touching with
+        // a non-zero fill then resetting to zero forces every page
+        // into the resident set before measurement starts.
+        target.fill(0xAA);
+        target.fill(0);
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
@@ -330,6 +340,9 @@ fn bench_decompress_source(
         // duplicating its value so the bench can't silently drift
         // off the direct path if the slack changes.
         let mut target = vec![0u8; expected_len + structured_zstd::WILDCOPY_OVERLENGTH];
+        // See note on pure_rust above — same calloc page-fault story.
+        target.fill(0xAA);
+        target.fill(0);
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
@@ -349,6 +362,10 @@ fn bench_decompress_source(
         let compressed = materialize();
         let mut dctx = FfiDCtxHandle::new();
         let mut target = vec![0u8; expected_len];
+        // See note on pure_rust above — c_ffi gets the same pre-touch
+        // so the timing comparison stays apples-to-apples.
+        target.fill(0xAA);
+        target.fill(0);
         b.iter(|| {
             let written = dctx.decompress_into(black_box(compressed), &mut target);
             assert_eq!(written, expected_len);


### PR DESCRIPTION
## Summary

`vec![0u8; N]` is calloc-backed: CoW-maps the kernel zero page for every anonymous page in the buffer. First write to each page during the timed iter triggers a synchronous page-fault to allocate a real anon page. On `--profile-time` runs (which skip criterion's warmup phase), the page-fault stack dominated the flamegraph on `decompress/level_-3_fast/decodecorpus-z000033/c_stream/matrix/pure_rust_direct` — 67% of samples in `asm_exc_page_fault` / `handle_mm_fault` (60%) / `do_anonymous_page` (55%).

This is a **bench-harness artifact**, not a decoder property. The dashboard delta on z000033 L-3 of `-54.68%` vs FFI was mostly this artifact (FFI was paying the same tax, but it's hidden inside one big `ZSTD_decompressDCtx` call instead of being split across many small Rust calls visible to the profiler — same wall-clock impact, different flamegraph picture).

## Fix

Force every page into the resident set before `b.iter` by writing `0xAA` then `0`:

```rust
target.fill(0xAA);
target.fill(0);
```

Both fills are visible writes the compiler can't elide; the two-pass shape leaves the buffer in its original zero state for the decoder's first iter.

Applied to all three closures (`pure_rust` / `pure_rust_direct` / `c_ffi`) so the timing comparison stays apples-to-apples.

## Testing

- `cargo nextest run -p structured-zstd --lib` — 618/618 pass.
- Bench compiles clean (`cargo check --benches`).
- Local sanity check: `compare_ffi` runs to completion.

I'll fold a follow-up flamegraph comparison (z000033 L-3 c_stream pure_rust_direct, pre vs post) into the verification reply once CI is green on i9.

Closes #257. Part of #247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved benchmark measurement accuracy by refining buffer initialization to minimize zero-page fault effects during performance timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->