### PR TITLE
perf(decode): bump WILDCOPY_OVERLENGTH 16 → 32 for AVX2 chunked kernel reach

### DIFF
--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -23,12 +23,16 @@ use crate::io::{Error, Read};
 /// with so SIMD wildcopy reads / writes can overshoot the live region
 /// without leaving the allocation. Sized at **32 bytes** so the AVX2
 /// chunked kernel in `simd_copy::copy_bytes_overshooting` (32-byte
-/// stride via `_mm256_storeu_si256`) can fire on tail copies. The
-/// kernel gates on `min_buffer_size >= rounded(copy_at_least, 32)`;
-/// at the end of a fixed-capacity output buffer that gate fails
-/// when slack is < 32, and the dispatch falls through to libc
-/// `__memmove_avx_unaligned_erms`. Bumping slack from 16 → 32 keeps
-/// the AVX2 path live across every match-copy and literal-push.
+/// stride via `_mm256_storeu_si256` on x86-64) can fire on tail copies.
+/// The kernel gates on `min_buffer_size >= rounded(copy_at_least, 32)`;
+/// at the end of a fixed-capacity output buffer that gate fails when
+/// slack is < 32, and the dispatch falls through to whatever
+/// `ptr::copy_nonoverlapping` lowers to on the target (typically a
+/// platform-specific `memcpy` / `memmove` — on glibc x86-64 that is
+/// `__memmove_avx_unaligned_erms`, on musl a plain SIMD memmove, on
+/// other targets the corresponding libc implementation). Bumping slack
+/// from 16 → 32 keeps the AVX2 path live across every match-copy and
+/// literal-push.
 ///
 /// Both `RingBuffer` and `FlatBuf` reuse this single constant so the
 /// slack contract cannot drift between backends.

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -21,13 +21,18 @@ use crate::io::{Error, Read};
 
 /// Trailing-slack count both backends pad their physical allocation
 /// with so SIMD wildcopy reads / writes can overshoot the live region
-/// without leaving the allocation. Matches donor zstd's
-/// `WILDCOPY_OVERLENGTH` (16 bytes = the largest single chunk
-/// `simd_copy::copy_bytes_overshooting` writes when its single-op
-/// fast path fires on copies ≤ 16 bytes). Both `RingBuffer` and
-/// `FlatBuf` reuse this single constant so the slack contract
-/// cannot drift between backends.
-pub(crate) const WILDCOPY_OVERLENGTH: usize = 16;
+/// without leaving the allocation. Sized at **32 bytes** so the AVX2
+/// chunked kernel in `simd_copy::copy_bytes_overshooting` (32-byte
+/// stride via `_mm256_storeu_si256`) can fire on tail copies. The
+/// kernel gates on `min_buffer_size >= rounded(copy_at_least, 32)`;
+/// at the end of a fixed-capacity output buffer that gate fails
+/// when slack is < 32, and the dispatch falls through to libc
+/// `__memmove_avx_unaligned_erms`. Bumping slack from 16 → 32 keeps
+/// the AVX2 path live across every match-copy and literal-push.
+///
+/// Both `RingBuffer` and `FlatBuf` reuse this single constant so the
+/// slack contract cannot drift between backends.
+pub(crate) const WILDCOPY_OVERLENGTH: usize = 32;
 
 /// Storage operations the decoder needs from its output buffer.
 ///

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -27,12 +27,13 @@ use crate::io::{Error, Read};
 /// The kernel gates on `min_buffer_size >= rounded(copy_at_least, 32)`;
 /// at the end of a fixed-capacity output buffer that gate fails when
 /// slack is < 32, and the dispatch falls through to whatever
-/// `ptr::copy_nonoverlapping` lowers to on the target (typically a
-/// platform-specific `memcpy` / `memmove` — on glibc x86-64 that is
-/// `__memmove_avx_unaligned_erms`, on musl a plain SIMD memmove, on
-/// other targets the corresponding libc implementation). Bumping slack
-/// from 16 → 32 keeps the AVX2 path live across every match-copy and
-/// literal-push.
+/// `ptr::copy_nonoverlapping` lowers to on the target — a
+/// platform-specific `memcpy`-like primitive (the source/dest regions
+/// are non-overlapping by the caller's contract, so memcpy semantics
+/// apply; the exact symbol the linker resolves is libc-specific and
+/// not part of any guaranteed contract). Bumping slack from 16 → 32
+/// keeps the AVX2 path live across every match-copy and literal-push,
+/// avoiding the libc detour.
 ///
 /// Both `RingBuffer` and `FlatBuf` reuse this single constant so the
 /// slack contract cannot drift between backends.

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -141,10 +141,18 @@ pub mod testing {
     }
 }
 
-/// SIMD wildcopy overshoot slack carried by every decoder backend.
-/// Mirrors donor zstd's `WILDCOPY_OVERLENGTH` (16 bytes). Public so
-/// callers sizing an output slice for
+/// SIMD wildcopy overshoot slack carried by every decoder backend
+/// (currently **32 bytes**). Sized so the AVX2 chunked kernel in
+/// `simd_copy::copy_bytes_overshooting` (32-byte stride on x86-64) can
+/// fire on tail copies near the end of a fixed-capacity output buffer.
+/// Donor zstd's `WILDCOPY_OVERLENGTH` is also 32 bytes today; this
+/// matches that contract.
+///
+/// Public so callers sizing an output slice for
 /// [`crate::decoding::FrameDecoder::decode_to_slice_trusted`] can size
-/// `frame_content_size + WILDCOPY_OVERLENGTH` without duplicating
-/// the constant.
+/// `frame_content_size + WILDCOPY_OVERLENGTH` symbolically without
+/// duplicating the value. Use the const reference rather than a
+/// hardcoded literal — the slack size may grow in the future if a
+/// wider SIMD kernel (AVX-512, 64-byte stride) is added to the
+/// fast path.
 pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -152,7 +152,9 @@ pub mod testing {
 /// [`crate::decoding::FrameDecoder::decode_to_slice_trusted`] can size
 /// `frame_content_size + WILDCOPY_OVERLENGTH` symbolically without
 /// duplicating the value. Use the const reference rather than a
-/// hardcoded literal — the slack size may grow in the future if a
-/// wider SIMD kernel (AVX-512, 64-byte stride) is added to the
-/// fast path.
+/// hardcoded literal — `simd_copy::copy_bytes_overshooting` already
+/// ships an AVX-512 64-byte chunked kernel, and the slack may grow
+/// further to reliably enable that wider kernel at buffer tails
+/// (mirroring how the bump from 16 → 32 enabled the AVX2 32-byte
+/// kernel at the tail).
 pub const WILDCOPY_OVERLENGTH: usize = crate::decoding::buffer_backend::WILDCOPY_OVERLENGTH;


### PR DESCRIPTION
## Summary

`WILDCOPY_OVERLENGTH` was 16 bytes — enough for the `single_op_copy_16` fast path but **not enough for the AVX2 chunked kernel** in `simd_copy::copy_bytes_overshooting`, which strides 32 bytes via `_mm256_storeu_si256` and gates on `min_buffer_size >= rounded(copy_at_least, 32)`. At the tail of fixed-capacity output buffers, the gate fails and dispatch falls through to libc `__memmove_avx_unaligned_erms`.

Bumping the slack to 32 keeps the AVX2 32-byte chunked kernel live across every match-copy and literal-push, including the tail copies near `frame_content_size`. The kernel emits 1-2 cycles per 32-byte chunk via two `_mm256_storeu_si256` (vs ~25 cycles libc dispatch + ERMS setup); the win shows up on fixtures that drive many medium-length copies near the buffer end.

## Bench (i9-9900K, cargo bench, --warm-up 2 --measurement 10)

| fixture | main bcd1f7d | branch 7d83612 | change |
|---|---|---|---|
| `decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust_direct` | 1.687 ms | 1.633 ms | **−3.17%** (p<0.05) |
| `decompress/level_-1_fast/low-entropy-1m/rust_stream/matrix/pure_rust_direct` | 235.25 µs | 217.91 µs | **−7.37%** (p<0.05) |

## API

`WILDCOPY_OVERLENGTH` is `pub const` (re-exported at crate root for callers sizing direct-decode buffers). The value changes from `16` to `32`. Existing callers using `fcs + WILDCOPY_OVERLENGTH` automatically pick up the new slack with a rebuild. The `compare_ffi` bench, doctests, and integration tests reference the const symbolically, so no test/example updates needed.

## Why this is the right layer

After #256 (replacing libc memmove fallback with inline 16-byte SSE2 loop) regressed +1.73% to +3.88% across both target fixtures — Intel ERMS microcode beats 16-byte SIMD even in the 33..=256 byte range — the right fix turned out to be reaching the existing AVX2 chunked kernel that was already present but gated out by insufficient slack.

## Testing

- `cargo nextest run -p structured-zstd --lib` — 618/618 pass.
- `cargo clippy -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

Closes #259. Part of #247.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved zstd decompression performance by adjusting the internal buffer slack sizing configuration in the decoder, ensuring enhanced efficiency and maintaining optimal performance across decompression scenarios.
  * Updated crate documentation to reflect revised output buffer sizing recommendations and provide improved guidance on decoder buffer management and configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->