### PR TITLE
perf(decode): inline sequence executor for direct path + auto-route decode_all (z000033 −24%, high-entropy-1m parity)

### DIFF
--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -350,35 +350,19 @@ fn bench_decompress_source(
 
     group.bench_function("pure_rust", |b| {
         let compressed = materialize();
-        let mut target = vec![0u8; expected_len];
-        pretouch_pages(&mut target);
-        let mut decoder = FrameDecoder::new();
-        b.iter(|| {
-            let written = decoder
-                .decode_all(black_box(compressed), &mut target)
-                .unwrap();
-            black_box(&target[..written]);
-            assert_eq!(written, expected_len);
-        })
-    });
-
-    // Direct-decode path (#244): target sized with WILDCOPY_OVERLENGTH
-    // slack so `decode_to_slice_trusted` takes the direct-write branch
-    // (decode straight into `target`, no FlatBuf drain copy).
-    // Exposed alongside `pure_rust` so dashboards can attribute the
-    // memory-traffic delta directly.
-    group.bench_function("pure_rust_direct", |b| {
-        let compressed = materialize();
-        // Sized to match the dispatcher's eligibility check —
-        // mirror the constant from the decoder instead of
-        // duplicating its value so the bench can't silently drift
-        // off the direct path if the slack changes.
+        // Target sized with WILDCOPY_OVERLENGTH slack so `decode_all`
+        // routes through the direct-write path (decode straight into
+        // `target`, no FlatBuf drain copy). The slack is the
+        // dispatcher's eligibility gate; without it the call falls
+        // back to the legacy per-block drain loop. The auto-reserve
+        // inside `decode_all_to_vec` provides the equivalent slack
+        // transparently for Vec-based callers.
         let mut target = vec![0u8; expected_len + structured_zstd::WILDCOPY_OVERLENGTH];
         pretouch_pages(&mut target);
         let mut decoder = FrameDecoder::new();
         b.iter(|| {
             let written = decoder
-                .decode_to_slice_trusted(black_box(compressed), &mut target)
+                .decode_all(black_box(compressed), &mut target)
                 .unwrap();
             black_box(&target[..written]);
             assert_eq!(written, expected_len);

--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -44,7 +44,7 @@ impl BlockDecoder {
     /// Slice-source fast path for `decode_block_content`. Consumes
     /// the right number of bytes from `*source` (advancing the slice)
     /// without going through the persistent `block_content_buffer`.
-    /// Used by `FrameDecoder::decode_to_slice_trusted` where `source` is
+    /// Used by `FrameDecoder::decode_all` where `source` is
     /// already a `&[u8]` view into the user's input.
     ///
     /// Returns the number of bytes consumed from `*source`.
@@ -216,7 +216,7 @@ impl BlockDecoder {
         // Streaming-path entry: copy `content_size` bytes from the
         // `Read` source into `block_content_buffer`, then dispatch
         // to the in-place body via per-field borrows. The direct-
-        // decode path (`decode_to_slice_trusted`) skips this copy by passing
+        // decode path (`decode_all`) skips this copy by passing
         // a borrowed slice of the input straight to
         // `decompress_block_inplace_with_parts`.
         let parts = workspace.split();
@@ -497,7 +497,7 @@ mod tests {
     //! truncated / empty source on each block type, plus the
     //! `DecoderState::Failed` / `ReadyToDecodeNextHeader` entry-state
     //! guards. The happy path is exercised indirectly via the
-    //! roundtrip tests on `decode_to_slice_trusted`; these tests pin the
+    //! roundtrip tests on `decode_all`; these tests pin the
     //! fail-fast behaviour for malformed input.
     use super::*;
     use crate::blocks::block::{BlockHeader, BlockType};

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -47,7 +47,7 @@ pub(crate) const WILDCOPY_OVERLENGTH: usize = 32;
 /// impl is the no-wrap shape of the same contract.
 pub(crate) trait BufferBackend: Sized {
     /// `true` when the backend can execute a single sequence via the
-    /// donor-shape inline `donor_exec_one_sequence` path (literal
+    /// donor-shape inline `exec_sequence_inline` path (literal
     /// copy + match copy in one straight-line body, no per-call
     /// dispatch through `extend` / `repeat`). Defaults to `false`;
     /// `UserSliceBackend` overrides to `true` on `x86_64` only —
@@ -60,7 +60,7 @@ pub(crate) trait BufferBackend: Sized {
     /// (donor body on `FlatBuf` / `RingBuffer`, existing
     /// `push`/`repeat` body on `UserSliceBackend`) carries no runtime
     /// cost.
-    const SUPPORTS_INLINE_DONOR_EXEC: bool = false;
+    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = false;
 
     /// Donor's `ZSTD_execSequence` body
     /// (zstd_decompress_block.c:1008-1105). Writes `lit_length` bytes
@@ -70,7 +70,7 @@ pub(crate) trait BufferBackend: Sized {
     /// overlap-src-before-dst).
     ///
     /// Default impl is `unreachable!`; the dispatch site only routes
-    /// here when [`Self::SUPPORTS_INLINE_DONOR_EXEC`] is `true`,
+    /// here when [`Self::SUPPORTS_INLINE_SEQUENCE_EXEC`] is `true`,
     /// which is fixed at compile time per backend type. The
     /// `unreachable!` body costs nothing on backends that gate it
     /// out (the compiler removes the call entirely).
@@ -108,7 +108,7 @@ pub(crate) trait BufferBackend: Sized {
     ///
     ///   The current dispatch site
     ///   (`sequence_section_decoder::execute_one_sequence_pipelined`)
-    ///   enforces both via `donor_path_safe = lit_cur_before + 16 <=
+    ///   enforces both via `inline_path_safe = lit_cur_before + 16 <=
     ///   lit_len && (lit_length <= 16 || lit_cur_before +
     ///   lit_length.next_multiple_of(16) <= lit_len)` and falls
     ///   through to the legacy `push`/`repeat` chain when either
@@ -121,7 +121,7 @@ pub(crate) trait BufferBackend: Sized {
     ///   `decode_buffer::DecodeBuffer::advance_output_counter`.
     #[allow(unused_variables, unused_mut)]
     #[inline(always)]
-    unsafe fn donor_exec_one_sequence(
+    unsafe fn exec_sequence_inline(
         &mut self,
         lit_src: *const u8,
         lit_length: usize,
@@ -129,12 +129,12 @@ pub(crate) trait BufferBackend: Sized {
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
         // Default body is statically unreachable when the dispatch
-        // site honours `SUPPORTS_INLINE_DONOR_EXEC`. Backends that
+        // site honours `SUPPORTS_INLINE_SEQUENCE_EXEC`. Backends that
         // return `false` from that const never see this call resolved
         // — the optimiser dead-eliminates the calling branch in the
         // monomorphised caller.
         unreachable!(
-            "donor_exec_one_sequence called on backend whose SUPPORTS_INLINE_DONOR_EXEC is false"
+            "exec_sequence_inline called on backend whose SUPPORTS_INLINE_SEQUENCE_EXEC is false"
         );
     }
 
@@ -149,6 +149,21 @@ pub(crate) trait BufferBackend: Sized {
     /// Reserve at least `n` bytes of additional writable capacity.
     /// May or may not allocate depending on current free space.
     fn reserve(&mut self, n: usize);
+
+    /// Fallible variant of [`Self::reserve`] for fixed-capacity
+    /// backends. Growable backends (`FlatBuf`, `RingBuffer`) call
+    /// `reserve` which always succeeds (or aborts on alloc failure)
+    /// and return `Ok`. Fixed-capacity backends (`UserSliceBackend`)
+    /// override with a linear `tail + n <= cap` check and return
+    /// `Err(BackendOverflow)` when the requested write would land
+    /// past the end of the user's slice — letting the safe public
+    /// decode APIs surface a structured error instead of panicking
+    /// from the per-call `assert!` inside
+    /// `extend_from_within_unchecked`.
+    fn try_reserve(&mut self, n: usize) -> Result<(), BackendOverflow> {
+        self.reserve(n);
+        Ok(())
+    }
 
     /// Live byte count: bytes between the logical head and tail.
     fn len(&self) -> usize;
@@ -230,7 +245,7 @@ pub(crate) trait BufferBackend: Sized {
     // capacity. Currently wired on Raw and RLE block paths only;
     // Compressed-block sequence execution still uses the panic-on-
     // overflow unchecked writes and will be migrated in a follow-up.
-    // Used by the direct-decode path (`decode_to_slice_trusted` +
+    // Used by the direct-decode path (`decode_all` +
     // descendants) so a malformed Raw/RLE block whose declared
     // decompressed payload exceeds the caller-provided output slice
     // surfaces as a structured `FrameDecoderError::FrameContentSizeMismatch`
@@ -377,7 +392,7 @@ pub(crate) trait BufferBackend: Sized {
 /// need to discriminate; `tail` / `requested` / `capacity` carry the
 /// diagnostic context. The decoder converts this into
 /// `FrameDecoderError::FrameContentSizeMismatch` at the
-/// `decode_to_slice_trusted` boundary, so callers never see
+/// `decode_all` boundary, so callers never see
 /// `BackendOverflow` directly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BackendOverflow {

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -83,6 +83,21 @@ pub(crate) trait BufferBackend: Sized {
     /// - `offset >= 1` and `offset <= self.len() + lits.len()`
     ///   (donor's `oLitEnd - offset` precondition).
     /// - `match_length >= 1`.
+    /// - **Read-side slack on `lits`**: the donor literal-copy path
+    ///   issues an unconditional `copy16` from `lits.as_ptr()` and,
+    ///   when `lit_length > 16`, a 16-byte-stride wildcopy that may
+    ///   load up to 15 bytes past `lits.len()` on its final
+    ///   iteration. Callers MUST ensure the backing literal buffer
+    ///   has ≥ `lits.len() + 15` initialised bytes addressable
+    ///   from `lits.as_ptr()`. The current dispatch site
+    ///   (`sequence_section_decoder::execute_one_sequence_pipelined`)
+    ///   gates on `high + 15 <= lit_len` (where `high = lit_cur +
+    ///   lit_length` and `lit_len` is the parent literals-buffer
+    ///   length) and falls through to the legacy `push`/`repeat`
+    ///   chain when the slack is unavailable — a future caller
+    ///   reusing this hook must enforce an equivalent gate or pad
+    ///   the literals buffer with 15 bytes of slack at allocation
+    ///   time.
     /// - Caller is responsible for updating any DecodeBuffer-level
     ///   counters (`total_output_counter`, hash) that mirror the
     ///   bytes this method writes — see

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -63,8 +63,8 @@ pub(crate) trait BufferBackend: Sized {
     const SUPPORTS_INLINE_DONOR_EXEC: bool = false;
 
     /// Donor's `ZSTD_execSequence` body
-    /// (zstd_decompress_block.c:1008-1105). Writes `lits.len()` bytes
-    /// from `lits` at the current tail, then writes `match_length`
+    /// (zstd_decompress_block.c:1008-1105). Writes `lit_length` bytes
+    /// from `lit_src` at the current tail, then writes `match_length`
     /// bytes via the donor offset-dispatch (offset ≥ 16 → wildcopy
     /// no-overlap; offset 1..=15 → overlapCopy8 + wildcopy
     /// overlap-src-before-dst).
@@ -76,18 +76,29 @@ pub(crate) trait BufferBackend: Sized {
     /// out (the compiler removes the call entirely).
     ///
     /// # Safety
-    /// - `lits.len() + match_length` must fit in the writable tail
+    /// - `lit_src` MUST be derived from the FULL parent literals
+    ///   buffer's `as_ptr()` (not a sub-slice). The donor body issues
+    ///   an unconditional 16-byte `_mm_loadu_si128` regardless of
+    ///   `lit_length`; reads through `lit_src` must stay within the
+    ///   parent buffer's allocated provenance even when
+    ///   `lit_length < 16`. Passing a sub-slice's `as_ptr()` whose
+    ///   `len() < 16` would be UB even when the bytes beyond
+    ///   `lit_length` happen to be valid memory in the backing
+    ///   allocation.
+    /// - `lit_length + match_length` must fit in the writable tail
     ///   slack (caller's upfront `reserve(MAX_BLOCK_SIZE)` covers
     ///   the regular case; for direct decode the slice's
     ///   `WILDCOPY_OVERLENGTH` slack covers the wildcopy overshoot).
-    /// - `offset >= 1` and `offset <= self.len() + lits.len()`
+    /// - `offset >= 1` and `offset <= self.len() + lit_length`
     ///   (donor's `oLitEnd - offset` precondition).
     /// - `match_length >= 1`.
-    /// - **Read-side slack on `lits`**: the donor literal-copy path
-    ///   issues an unconditional `copy16` from `lits.as_ptr()` and,
-    ///   when `lit_length > 16`, a 16-byte-stride wildcopy that may
-    ///   load up to 15 bytes past `lits.len()` on its final
-    ///   iteration. Callers MUST satisfy two distinct slack bounds:
+    /// - **Read-side slack on the parent literals buffer**: the donor
+    ///   literal-copy path issues an unconditional `copy16` from
+    ///   `lit_src` and, when `lit_length > 16`, a 16-byte-stride
+    ///   wildcopy that may load up to 15 bytes past
+    ///   `lit_src + lit_length` on its final iteration. Callers MUST
+    ///   satisfy two distinct slack bounds against the parent buffer
+    ///   length (`lit_len`):
     ///   - `lit_cur_before + 16 <= lit_len` ALWAYS (the
     ///     unconditional `copy16` reads 16 bytes regardless of
     ///     `lit_length`, including the `lit_length == 0` case).
@@ -111,7 +122,13 @@ pub(crate) trait BufferBackend: Sized {
     ///   `decode_buffer::DecodeBuffer::advance_output_counter`.
     #[allow(unused_variables, unused_mut)]
     #[inline(always)]
-    unsafe fn donor_exec_one_sequence(&mut self, lits: &[u8], offset: usize, match_length: usize) {
+    unsafe fn donor_exec_one_sequence(
+        &mut self,
+        lit_src: *const u8,
+        lit_length: usize,
+        offset: usize,
+        match_length: usize,
+    ) {
         // Default body is statically unreachable when the dispatch
         // site honours `SUPPORTS_INLINE_DONOR_EXEC`. Backends that
         // return `false` from that const never see this call resolved

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -46,6 +46,57 @@ pub(crate) const WILDCOPY_OVERLENGTH: usize = 32;
 /// semantics match what `RingBuffer` already provides; `FlatBuf`'s
 /// impl is the no-wrap shape of the same contract.
 pub(crate) trait BufferBackend: Sized {
+    /// `true` when the backend can execute a single sequence via the
+    /// donor-shape inline `donor_exec_one_sequence` path (literal
+    /// copy + match copy in one straight-line body, no per-call
+    /// dispatch through `extend` / `repeat`). Defaults to `false`;
+    /// `UserSliceBackend` overrides to `true` on x86/x86_64 targets.
+    ///
+    /// Reads of this const at the dispatch site fold to a compile-time
+    /// branch the optimiser dead-eliminates — the unused arm
+    /// (donor body on `FlatBuf` / `RingBuffer`, existing
+    /// `push`/`repeat` body on `UserSliceBackend`) carries no runtime
+    /// cost.
+    const SUPPORTS_INLINE_DONOR_EXEC: bool = false;
+
+    /// Donor's `ZSTD_execSequence` body
+    /// (zstd_decompress_block.c:1008-1105). Writes `lits.len()` bytes
+    /// from `lits` at the current tail, then writes `match_length`
+    /// bytes via the donor offset-dispatch (offset ≥ 16 → wildcopy
+    /// no-overlap; offset 1..=15 → overlapCopy8 + wildcopy
+    /// overlap-src-before-dst).
+    ///
+    /// Default impl is `unreachable!`; the dispatch site only routes
+    /// here when [`Self::SUPPORTS_INLINE_DONOR_EXEC`] is `true`,
+    /// which is fixed at compile time per backend type. The
+    /// `unreachable!` body costs nothing on backends that gate it
+    /// out (the compiler removes the call entirely).
+    ///
+    /// # Safety
+    /// - `lits.len() + match_length` must fit in the writable tail
+    ///   slack (caller's upfront `reserve(MAX_BLOCK_SIZE)` covers
+    ///   the regular case; for direct decode the slice's
+    ///   `WILDCOPY_OVERLENGTH` slack covers the wildcopy overshoot).
+    /// - `offset >= 1` and `offset <= self.len() + lits.len()`
+    ///   (donor's `oLitEnd - offset` precondition).
+    /// - `match_length >= 1`.
+    /// - Caller is responsible for updating any DecodeBuffer-level
+    ///   counters (`total_output_counter`, hash) that mirror the
+    ///   bytes this method writes — see
+    ///   `decode_buffer::DecodeBuffer::advance_output_counter`.
+    #[allow(unused_variables, unused_mut)]
+    #[inline(always)]
+    unsafe fn donor_exec_one_sequence(&mut self, lits: &[u8], offset: usize, match_length: usize) {
+        // Default body is statically unreachable when the dispatch
+        // site honours `SUPPORTS_INLINE_DONOR_EXEC`. Backends that
+        // return `false` from that const never see this call resolved
+        // — the optimiser dead-eliminates the calling branch in the
+        // monomorphised caller.
+        unreachable!(
+            "donor_exec_one_sequence called on backend whose SUPPORTS_INLINE_DONOR_EXEC is false"
+        );
+    }
+
     /// Construct an empty backend. Backend-specific sizing is done
     /// via `with_capacity` constructors on the concrete types (see
     /// [`super::flat_buf::FlatBuf::with_capacity`]).

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -390,9 +390,14 @@ pub(crate) trait BufferBackend: Sized {
 ///
 /// All three modes return the same struct shape so the caller doesn't
 /// need to discriminate; `tail` / `requested` / `capacity` carry the
-/// diagnostic context. The decoder converts this into
-/// `FrameDecoderError::FrameContentSizeMismatch` at the
-/// `decode_all` boundary, so callers never see
+/// diagnostic context. The decoder converts this into one of two
+/// structured variants on the way out of `FrameDecoder`:
+/// `ExecuteSequencesError::OutputBufferOverflow` (literal-push and
+/// donor-inline paths inside the sequence executor) or
+/// `DecodeBufferError::OutputBufferOverflow` (the match-repeat
+/// `try_reserve` pre-check inside `DecodeBuffer::repeat_inner`).
+/// Both bubble up as a structured `FrameDecoderError` (typically
+/// wrapped in `FailedToReadBlockBody`) — callers never see
 /// `BackendOverflow` directly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct BackendOverflow {

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -127,7 +127,7 @@ pub(crate) trait BufferBackend: Sized {
         lit_length: usize,
         offset: usize,
         match_length: usize,
-    ) {
+    ) -> Result<(), super::errors::ExecuteSequencesError> {
         // Default body is statically unreachable when the dispatch
         // site honours `SUPPORTS_INLINE_DONOR_EXEC`. Backends that
         // return `false` from that const never see this call resolved

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -87,17 +87,24 @@ pub(crate) trait BufferBackend: Sized {
     ///   issues an unconditional `copy16` from `lits.as_ptr()` and,
     ///   when `lit_length > 16`, a 16-byte-stride wildcopy that may
     ///   load up to 15 bytes past `lits.len()` on its final
-    ///   iteration. Callers MUST ensure the backing literal buffer
-    ///   has ≥ `lits.len() + 15` initialised bytes addressable
-    ///   from `lits.as_ptr()`. The current dispatch site
+    ///   iteration. Callers MUST satisfy two distinct slack bounds:
+    ///   - `lit_cur_before + 16 <= lit_len` ALWAYS (the
+    ///     unconditional `copy16` reads 16 bytes regardless of
+    ///     `lit_length`, including the `lit_length == 0` case).
+    ///   - `lit_cur_before + lit_length + 15 <= lit_len` ONLY when
+    ///     `lit_length > 16` (the wildcopy tail's final 16-byte
+    ///     load).
+    ///
+    ///   The current dispatch site
     ///   (`sequence_section_decoder::execute_one_sequence_pipelined`)
-    ///   gates on `high + 15 <= lit_len` (where `high = lit_cur +
-    ///   lit_length` and `lit_len` is the parent literals-buffer
-    ///   length) and falls through to the legacy `push`/`repeat`
-    ///   chain when the slack is unavailable — a future caller
-    ///   reusing this hook must enforce an equivalent gate or pad
-    ///   the literals buffer with 15 bytes of slack at allocation
-    ///   time.
+    ///   enforces both via `donor_path_safe = lit_cur_before + 16 <=
+    ///   lit_len && (lit_length <= 16 || high + 15 <= lit_len)`
+    ///   (with `high = lit_cur_before + lit_length`, `lit_len` =
+    ///   parent literals-buffer length) and falls through to the
+    ///   legacy `push`/`repeat` chain when either bound fails — a
+    ///   future caller reusing this hook must enforce the same gate
+    ///   or pad the literals buffer with 15 bytes of slack at
+    ///   allocation time.
     /// - Caller is responsible for updating any DecodeBuffer-level
     ///   counters (`total_output_counter`, hash) that mirror the
     ///   bytes this method writes — see

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -50,7 +50,10 @@ pub(crate) trait BufferBackend: Sized {
     /// donor-shape inline `donor_exec_one_sequence` path (literal
     /// copy + match copy in one straight-line body, no per-call
     /// dispatch through `extend` / `repeat`). Defaults to `false`;
-    /// `UserSliceBackend` overrides to `true` on x86/x86_64 targets.
+    /// `UserSliceBackend` overrides to `true` on `x86_64` only —
+    /// 32-bit `x86` is excluded because the donor helpers emit SSE2
+    /// intrinsics without a `#[target_feature]` gate, and pre-SSE2
+    /// i386 / i486 / i586 baselines would SIGILL.
     ///
     /// Reads of this const at the dispatch site fold to a compile-time
     /// branch the optimiser dead-eliminates — the unused arm

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -95,27 +95,26 @@ pub(crate) trait BufferBackend: Sized {
     /// - **Read-side slack on the parent literals buffer**: the donor
     ///   literal-copy path issues an unconditional `copy16` from
     ///   `lit_src` and, when `lit_length > 16`, a 16-byte-stride
-    ///   wildcopy that may load up to 15 bytes past
-    ///   `lit_src + lit_length` on its final iteration. Callers MUST
-    ///   satisfy two distinct slack bounds against the parent buffer
-    ///   length (`lit_len`):
+    ///   wildcopy whose final iteration's last byte read is at
+    ///   `lit_cur_before + lit_length.next_multiple_of(16) - 1`.
+    ///   Callers MUST satisfy two distinct slack bounds against the
+    ///   parent buffer length (`lit_len`):
     ///   - `lit_cur_before + 16 <= lit_len` ALWAYS (the
     ///     unconditional `copy16` reads 16 bytes regardless of
     ///     `lit_length`, including the `lit_length == 0` case).
-    ///   - `lit_cur_before + lit_length + 15 <= lit_len` ONLY when
-    ///     `lit_length > 16` (the wildcopy tail's final 16-byte
-    ///     load).
+    ///   - `lit_cur_before + lit_length.next_multiple_of(16) <=
+    ///     lit_len` ONLY when `lit_length > 16` (the wildcopy tail's
+    ///     final 16-byte load reaches through that exact offset).
     ///
     ///   The current dispatch site
     ///   (`sequence_section_decoder::execute_one_sequence_pipelined`)
     ///   enforces both via `donor_path_safe = lit_cur_before + 16 <=
-    ///   lit_len && (lit_length <= 16 || high + 15 <= lit_len)`
-    ///   (with `high = lit_cur_before + lit_length`, `lit_len` =
-    ///   parent literals-buffer length) and falls through to the
-    ///   legacy `push`/`repeat` chain when either bound fails — a
-    ///   future caller reusing this hook must enforce the same gate
-    ///   or pad the literals buffer with 15 bytes of slack at
-    ///   allocation time.
+    ///   lit_len && (lit_length <= 16 || lit_cur_before +
+    ///   lit_length.next_multiple_of(16) <= lit_len)` and falls
+    ///   through to the legacy `push`/`repeat` chain when either
+    ///   bound fails — a future caller reusing this hook must
+    ///   enforce the same gate or pad the literals buffer with 15
+    ///   bytes of slack at allocation time.
     /// - Caller is responsible for updating any DecodeBuffer-level
     ///   counters (`total_output_counter`, hash) that mirror the
     ///   bytes this method writes — see

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -42,7 +42,7 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 ///     `total_output_counter`.
 ///   * `advance_output_counter` (donor inline path) only advances
 ///     `total_output_counter` (hashing is deferred to the final
-///     full-slice pass in `FrameDecoder::decode_to_slice_trusted`).
+///     full-slice pass in `FrameDecoder::decode_all`).
 ///   * `drain_to` / `read` DO write hash, but they run BETWEEN
 ///     blocks, never inside the fused sequence loop the checkpoint
 ///     guards.
@@ -184,7 +184,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// sequence executor can write straight into the backend's
     /// physical storage and then update the buffer-level counters.
     /// Crate-internal; gated to the
-    /// `BufferBackend::SUPPORTS_INLINE_DONOR_EXEC = true` dispatch
+    /// `BufferBackend::SUPPORTS_INLINE_SEQUENCE_EXEC = true` dispatch
     /// site.
     #[inline]
     #[allow(dead_code)]
@@ -193,14 +193,14 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     }
 
     /// Advance the `total_output_counter` by `n` bytes — pair with
-    /// [`super::buffer_backend::BufferBackend::donor_exec_one_sequence`]
+    /// [`super::buffer_backend::BufferBackend::exec_sequence_inline`]
     /// which writes the actual bytes through the backend without
     /// touching DecodeBuffer-level bookkeeping. Without this helper
     /// the donor-shape path would leave `total_output_counter` stale
     /// on every sequence executed through it.
     ///
     /// **Hash is NOT mutated here.** On the direct-decode path
-    /// `FrameDecoder::decode_to_slice_trusted` walks the full output
+    /// `FrameDecoder::decode_all` walks the full output
     /// slice once at end of decode and writes the result into
     /// `self.hash`, overwriting any incremental state. Hashing per
     /// sequence here would be wasted work whose result the final
@@ -325,10 +325,19 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             // assumes the required free capacity exists; skipping it
             // would turn a malformed block (match_length past the
             // upfront `reserve(MAX_BLOCK_SIZE)`) into release-build
-            // UB. The pipelined caller already reserved MAX_BLOCK_SIZE
-            // up front, so this is a cheap no-op branch in the hot
-            // path.
-            self.buffer.reserve(match_length);
+            // UB. Use the fallible variant so fixed-capacity backends
+            // (`UserSliceBackend`) surface a structured error instead
+            // of panicking via the per-call `assert!` inside
+            // `extend_from_within_unchecked`. Growable backends'
+            // default impl never fails (allocation succeeds or
+            // aborts), so the conversion is a cheap no-op there.
+            self.buffer.try_reserve(match_length).map_err(|o| {
+                DecodeBufferError::OutputBufferOverflow {
+                    tail: o.tail,
+                    requested: o.requested,
+                    capacity: o.capacity,
+                }
+            })?;
             if !SKIP_PREFETCH {
                 self.prefetch_match_source(start_idx, match_length);
             }
@@ -698,7 +707,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// `drop_to_window_size` and `drain_*` calls (those only narrow
     /// the visible region; they don't roll back produced).
     ///
-    /// Used by the direct-decode path (`FrameDecoder::decode_to_slice_trusted`)
+    /// Used by the direct-decode path (`FrameDecoder::decode_all`)
     /// to track actual bytes written against the declared
     /// `frame_content_size`. Sidesteps `BlockHeader.decompressed_size`
     /// which is intentionally 0 for `BlockType::Compressed` (the
@@ -721,7 +730,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// window-size rule (`offset <= window_size`).
     ///
     /// Does NOT update the rolling content checksum. On the direct
-    /// path the caller (`FrameDecoder::decode_to_slice_trusted`) hashes the
+    /// path the caller (`FrameDecoder::decode_all`) hashes the
     /// final `output[..content_size]` slice ONCE at end of decode
     /// (single sequential xxhash pass over cache-hot data) and
     /// propagates the digest into the persistent scratch's hasher.

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -34,11 +34,21 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 }
 
 /// Rollback token produced by [`DecodeBuffer::checkpoint`].
-#[derive(Copy, Clone)]
+///
+/// Snapshots tail / counter / cap. Under `feature = "hash"` also
+/// snapshots the frame `XxHash64` state so a rollback after
+/// `push` / `extend_and_fill` / `advance_output_counter` (all of which
+/// fold the written bytes into `self.hash`) does not leave the hash
+/// committed for bytes the caller has discarded. Cloning `XxHash64`
+/// is cheap — internal state is a handful of u64 accumulators plus a
+/// short remainder buffer.
+#[derive(Clone)]
 pub(crate) struct DecodeBufferCheckpoint {
     tail: usize,
     total_output_counter: u64,
     cap: usize,
+    #[cfg(feature = "hash")]
+    hash: twox_hash::XxHash64,
 }
 
 impl<B: BufferBackend> Read for DecodeBuffer<B> {
@@ -120,6 +130,8 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             tail: self.buffer.tail(),
             total_output_counter: self.total_output_counter,
             cap: self.buffer.cap(),
+            #[cfg(feature = "hash")]
+            hash: self.hash.clone(),
         }
     }
 
@@ -150,6 +162,18 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // and the current tail as discarded.
         unsafe { self.buffer.set_tail(cp.tail) };
         self.total_output_counter = cp.total_output_counter;
+        #[cfg(feature = "hash")]
+        {
+            // Hash state is mutated by `push` / `extend_and_fill` /
+            // `advance_output_counter` as bytes flow in. Restoring the
+            // snapshot here undoes those mutations so the rolled-back
+            // bytes don't end up in the frame digest. Without this
+            // the checksum that ships in the frame trailer would
+            // mismatch on rollback paths that the legacy two-pass
+            // pipeline used to handle by simply never writing the
+            // bytes in the first place.
+            self.hash = cp.hash;
+        }
         true
     }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -192,12 +192,23 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         #[cfg(feature = "hash")]
         {
             // Read the just-written tail bytes via the backend's
-            // slice view. Donor-path callers always operate on
-            // contiguous slack (UserSliceBackend / FlatBuf both),
-            // so the live region is one slice; `as_slices().0` is
-            // the prefix that covers everything up to the current
-            // tail. Take the last `n` bytes of that prefix.
-            let (front, _) = self.buffer.as_slices();
+            // slice view. Donor-path callers (gated by
+            // `BufferBackend::SUPPORTS_INLINE_DONOR_EXEC = true`) are
+            // currently restricted to `UserSliceBackend`, whose
+            // `as_slices()` returns `(&slice[head..tail], &[])` — a
+            // single contiguous prefix. Two-slice ring-wrap layout
+            // (`RingBuffer`) returns `false` for the const above and
+            // therefore never reaches this helper. If a future backend
+            // opts into the donor path AND uses two-slice layout,
+            // the `as_slices().0` shortcut here would miss bytes
+            // straddling the wrap — update both slices then.
+            let (front, back) = self.buffer.as_slices();
+            debug_assert!(
+                back.is_empty(),
+                "advance_output_counter assumes contiguous front slice; \
+                 only backends with single-slice layout may opt into \
+                 SUPPORTS_INLINE_DONOR_EXEC"
+            );
             let lo = front.len().saturating_sub(n);
             self.hash.write(&front[lo..]);
         }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -162,6 +162,48 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.reserve(amount);
     }
 
+    /// Mutable backend handle — paired with
+    /// [`Self::advance_output_counter`] so the donor-shape inline
+    /// sequence executor can write straight into the backend's
+    /// physical storage and then update the buffer-level counters.
+    /// Crate-internal; gated to the
+    /// `BufferBackend::SUPPORTS_INLINE_DONOR_EXEC = true` dispatch
+    /// site.
+    #[inline]
+    #[allow(dead_code)]
+    pub(crate) fn buffer_mut(&mut self) -> &mut B {
+        &mut self.buffer
+    }
+
+    /// Advance the output counter (and frame hash if enabled) by `n`
+    /// bytes — pair with [`super::buffer_backend::BufferBackend::donor_exec_one_sequence`]
+    /// which writes the actual bytes through the backend without
+    /// touching DecodeBuffer-level bookkeeping. Without this helper
+    /// the donor-shape path would leave `total_output_counter` and
+    /// the frame-content hash stale on every sequence executed
+    /// through it.
+    ///
+    /// Hash bytes are read straight off the backend tail prior to
+    /// advancing; the caller has just written `n` bytes ending at
+    /// the current tail position.
+    #[inline]
+    #[allow(dead_code)] // wired in once donor path lands in pipelined executor
+    pub(crate) fn advance_output_counter(&mut self, n: usize) {
+        self.total_output_counter += n as u64;
+        #[cfg(feature = "hash")]
+        {
+            // Read the just-written tail bytes via the backend's
+            // slice view. Donor-path callers always operate on
+            // contiguous slack (UserSliceBackend / FlatBuf both),
+            // so the live region is one slice; `as_slices().0` is
+            // the prefix that covers everything up to the current
+            // tail. Take the last `n` bytes of that prefix.
+            let (front, _) = self.buffer.as_slices();
+            let lo = front.len().saturating_sub(n);
+            self.hash.write(&front[lo..]);
+        }
+    }
+
     /// Fill `fill_length` bytes of the output with the literal `fill_with`,
     /// advancing the ringbuffer cursor in place. Used by the RLE block path
     /// (upstream commit `fbc1f2ca`) so the decoder doesn't need a stack

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -187,7 +187,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// advancing; the caller has just written `n` bytes ending at
     /// the current tail position.
     #[inline]
-    #[allow(dead_code)] // wired in once donor path lands in pipelined executor
     pub(crate) fn advance_output_counter(&mut self, n: usize) {
         self.total_output_counter += n as u64;
         #[cfg(feature = "hash")]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -36,12 +36,24 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 /// Rollback token produced by [`DecodeBuffer::checkpoint`].
 ///
 /// Snapshots tail / counter / cap. Under `feature = "hash"` also
-/// snapshots the frame `XxHash64` state so a rollback after
-/// `push` / `extend_and_fill` / `advance_output_counter` (all of which
-/// fold the written bytes into `self.hash`) does not leave the hash
-/// committed for bytes the caller has discarded. Cloning `XxHash64`
-/// is cheap — internal state is a handful of u64 accumulators plus a
-/// short remainder buffer.
+/// snapshots the frame `XxHash64` state so a rollback after a path
+/// that folded bytes into `self.hash` does not leave the hash
+/// committed for bytes the caller has discarded. Hash mutation
+/// sites on the decode write surface are:
+///   * `advance_output_counter` — donor inline path bookkeeping
+///     (writes `n` bytes' worth straight into `self.hash`).
+///   * `drain_to` / `read` — drain-time hashing of the bytes that
+///     leave the live region.
+///
+/// `push` and `extend_and_fill` themselves do NOT touch `self.hash`
+/// — they only advance `total_output_counter`; the rolling hash gets
+/// folded later when those bytes drain out, OR (on the donor inline
+/// path) directly by `advance_output_counter`. Rollback still needs
+/// to restore the hash because the same checkpoint covers both
+/// classes of write surface.
+///
+/// Cloning `XxHash64` is cheap — internal state is a handful of u64
+/// accumulators plus a short remainder buffer.
 #[derive(Clone)]
 pub(crate) struct DecodeBufferCheckpoint {
     tail: usize,

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -35,32 +35,22 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 
 /// Rollback token produced by [`DecodeBuffer::checkpoint`].
 ///
-/// Snapshots tail / counter / cap. Under `feature = "hash"` also
-/// snapshots the frame `XxHash64` state so a rollback after a path
-/// that folded bytes into `self.hash` does not leave the hash
-/// committed for bytes the caller has discarded. Hash mutation
-/// sites on the decode write surface are:
-///   * `advance_output_counter` — donor inline path bookkeeping
-///     (writes `n` bytes' worth straight into `self.hash`).
-///   * `drain_to` / `read` — drain-time hashing of the bytes that
-///     leave the live region.
-///
-/// `push` and `extend_and_fill` themselves do NOT touch `self.hash`
-/// — they only advance `total_output_counter`; the rolling hash gets
-/// folded later when those bytes drain out, OR (on the donor inline
-/// path) directly by `advance_output_counter`. Rollback still needs
-/// to restore the hash because the same checkpoint covers both
-/// classes of write surface.
-///
-/// Cloning `XxHash64` is cheap — internal state is a handful of u64
-/// accumulators plus a short remainder buffer.
-#[derive(Clone)]
+/// Snapshots tail / counter / cap. Hash state is NOT snapshotted:
+/// no mutation site between `checkpoint()` and the matched
+/// `try_restore_checkpoint()` writes to `self.hash`:
+///   * `push` and `extend_and_fill` only advance
+///     `total_output_counter`.
+///   * `advance_output_counter` (donor inline path) only advances
+///     `total_output_counter` (hashing is deferred to the final
+///     full-slice pass in `FrameDecoder::decode_to_slice_trusted`).
+///   * `drain_to` / `read` DO write hash, but they run BETWEEN
+///     blocks, never inside the fused sequence loop the checkpoint
+///     guards.
+#[derive(Copy, Clone)]
 pub(crate) struct DecodeBufferCheckpoint {
     tail: usize,
     total_output_counter: u64,
     cap: usize,
-    #[cfg(feature = "hash")]
-    hash: twox_hash::XxHash64,
 }
 
 impl<B: BufferBackend> Read for DecodeBuffer<B> {
@@ -142,8 +132,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             tail: self.buffer.tail(),
             total_output_counter: self.total_output_counter,
             cap: self.buffer.cap(),
-            #[cfg(feature = "hash")]
-            hash: self.hash.clone(),
         }
     }
 
@@ -174,18 +162,11 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // and the current tail as discarded.
         unsafe { self.buffer.set_tail(cp.tail) };
         self.total_output_counter = cp.total_output_counter;
-        #[cfg(feature = "hash")]
-        {
-            // Hash state is mutated by `push` / `extend_and_fill` /
-            // `advance_output_counter` as bytes flow in. Restoring the
-            // snapshot here undoes those mutations so the rolled-back
-            // bytes don't end up in the frame digest. Without this
-            // the checksum that ships in the frame trailer would
-            // mismatch on rollback paths that the legacy two-pass
-            // pipeline used to handle by simply never writing the
-            // bytes in the first place.
-            self.hash = cp.hash;
-        }
+        // No hash restore: see `DecodeBufferCheckpoint` doc. No
+        // mutation site between `checkpoint()` and this call writes
+        // to `self.hash` (drain runs between blocks, not inside the
+        // fused sequence loop; the donor inline path's
+        // `advance_output_counter` advances only the counter).
         true
     }
 
@@ -211,43 +192,23 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         &mut self.buffer
     }
 
-    /// Advance the output counter (and frame hash if enabled) by `n`
-    /// bytes — pair with [`super::buffer_backend::BufferBackend::donor_exec_one_sequence`]
+    /// Advance the `total_output_counter` by `n` bytes — pair with
+    /// [`super::buffer_backend::BufferBackend::donor_exec_one_sequence`]
     /// which writes the actual bytes through the backend without
     /// touching DecodeBuffer-level bookkeeping. Without this helper
-    /// the donor-shape path would leave `total_output_counter` and
-    /// the frame-content hash stale on every sequence executed
-    /// through it.
+    /// the donor-shape path would leave `total_output_counter` stale
+    /// on every sequence executed through it.
     ///
-    /// Hash bytes are read straight off the backend tail prior to
-    /// advancing; the caller has just written `n` bytes ending at
-    /// the current tail position.
+    /// **Hash is NOT mutated here.** On the direct-decode path
+    /// `FrameDecoder::decode_to_slice_trusted` walks the full output
+    /// slice once at end of decode and writes the result into
+    /// `self.hash`, overwriting any incremental state. Hashing per
+    /// sequence here would be wasted work whose result the final
+    /// pass discards. The legacy decode path likewise folds bytes
+    /// into the hash via `drain_to`, not at write time.
     #[inline]
     pub(crate) fn advance_output_counter(&mut self, n: usize) {
         self.total_output_counter += n as u64;
-        #[cfg(feature = "hash")]
-        {
-            // Read the just-written tail bytes via the backend's
-            // slice view. Donor-path callers (gated by
-            // `BufferBackend::SUPPORTS_INLINE_DONOR_EXEC = true`) are
-            // currently restricted to `UserSliceBackend`, whose
-            // `as_slices()` returns `(&slice[head..tail], &[])` — a
-            // single contiguous prefix. Two-slice ring-wrap layout
-            // (`RingBuffer`) returns `false` for the const above and
-            // therefore never reaches this helper. If a future backend
-            // opts into the donor path AND uses two-slice layout,
-            // the `as_slices().0` shortcut here would miss bytes
-            // straddling the wrap — update both slices then.
-            let (front, back) = self.buffer.as_slices();
-            debug_assert!(
-                back.is_empty(),
-                "advance_output_counter assumes contiguous front slice; \
-                 only backends with single-slice layout may opt into \
-                 SUPPORTS_INLINE_DONOR_EXEC"
-            );
-            let lo = front.len().saturating_sub(n);
-            self.hash.write(&front[lo..]);
-        }
     }
 
     /// Fill `fill_length` bytes of the output with the literal `fill_with`,

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -431,17 +431,31 @@ pub enum DecodeBufferError {
     /// follow-up. Currently NOT surfaced from any production path —
     /// `extend_from_within_unchecked` on `UserSliceBackend` still
     /// panics on overshoot via its release-mode `assert!`. The
-    /// `_trusted` suffix on `decode_to_slice_trusted` is the
+    /// `_trusted` suffix on `decode_all` is the
     /// shipping contract until that follow-up wires
     /// `BufferBackend::try_extend_from_within` through
     /// `DecodeBuffer::repeat*` and maps `BackendOverflow` into
     /// `FrameDecoderError::FrameContentSizeMismatch`.
     ///
     /// The variant lives now (vs landing later with the
-    /// follow-up) so the typed conversion at the `decode_to_slice_trusted`
+    /// follow-up) so the typed conversion at the `decode_all`
     /// boundary is in place; only the constructor on the burst path
     /// is missing.
     BackendOverflow,
+    /// Repeat-side match copy would write past the writable tail of
+    /// a fixed-capacity backend (`UserSliceBackend`). Surfaced by
+    /// [`super::decode_buffer::DecodeBuffer::repeat`] / `_lookahead`
+    /// when the new `BufferBackend::try_reserve` rejects the
+    /// pre-write capacity check — keeping the safe public decode
+    /// APIs error-returning instead of panicking via the per-call
+    /// `assert!` inside `extend_from_within_unchecked`. Growable
+    /// backends (`FlatBuf`, `RingBuffer`) never produce this; their
+    /// `try_reserve` falls through to infallible `reserve`.
+    OutputBufferOverflow {
+        tail: usize,
+        requested: usize,
+        capacity: usize,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -466,6 +480,16 @@ impl core::fmt::Display for DecodeBufferError {
                 write!(
                     f,
                     "Match repeat would overflow the output buffer's fixed capacity"
+                )
+            }
+            DecodeBufferError::OutputBufferOverflow {
+                tail,
+                requested,
+                capacity,
+            } => {
+                write!(
+                    f,
+                    "Match repeat would write past fixed-capacity buffer: tail={tail}, requested={requested}, capacity={capacity}"
                 )
             }
         }
@@ -858,7 +882,7 @@ pub enum ExecuteSequencesError {
         have: usize,
     },
     ZeroOffset,
-    /// A donor-shape inline sequence (`BufferBackend::donor_exec_one_sequence`)
+    /// A donor-shape inline sequence (`BufferBackend::exec_sequence_inline`)
     /// would have written past the writable tail of a fixed-size backend
     /// (`UserSliceBackend`). Indicates the frame is corrupt — its sequences
     /// expand past the declared `frame_content_size` plus the caller-supplied
@@ -866,7 +890,7 @@ pub enum ExecuteSequencesError {
     /// post-block FCS overflow check would also catch the same shape, but the
     /// per-sequence guard is what keeps the unsafe write surface inside the
     /// user-provided slice on the way to the post-block check.
-    DonorPathBufferOverflow {
+    OutputBufferOverflow {
         tail: usize,
         requested: usize,
         capacity: usize,
@@ -888,7 +912,7 @@ impl core::fmt::Display for ExecuteSequencesError {
             ExecuteSequencesError::ZeroOffset => {
                 write!(f, "Illegal offset: 0 found")
             }
-            ExecuteSequencesError::DonorPathBufferOverflow {
+            ExecuteSequencesError::OutputBufferOverflow {
                 tail,
                 requested,
                 capacity,
@@ -915,6 +939,16 @@ impl std::error::Error for ExecuteSequencesError {
 impl From<DecodeBufferError> for ExecuteSequencesError {
     fn from(val: DecodeBufferError) -> Self {
         Self::DecodebufferError(val)
+    }
+}
+
+impl From<crate::decoding::buffer_backend::BackendOverflow> for ExecuteSequencesError {
+    fn from(val: crate::decoding::buffer_backend::BackendOverflow) -> Self {
+        Self::OutputBufferOverflow {
+            tail: val.tail,
+            requested: val.requested,
+            capacity: val.capacity,
+        }
     }
 }
 

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -853,8 +853,24 @@ impl From<HuffmanTableError> for DecompressLiteralsError {
 #[non_exhaustive]
 pub enum ExecuteSequencesError {
     DecodebufferError(DecodeBufferError),
-    NotEnoughBytesForSequence { wanted: usize, have: usize },
+    NotEnoughBytesForSequence {
+        wanted: usize,
+        have: usize,
+    },
     ZeroOffset,
+    /// A donor-shape inline sequence (`BufferBackend::donor_exec_one_sequence`)
+    /// would have written past the writable tail of a fixed-size backend
+    /// (`UserSliceBackend`). Indicates the frame is corrupt — its sequences
+    /// expand past the declared `frame_content_size` plus the caller-supplied
+    /// `WILDCOPY_OVERLENGTH` slack. The fast-path check is per-sequence; the
+    /// post-block FCS overflow check would also catch the same shape, but the
+    /// per-sequence guard is what keeps the unsafe write surface inside the
+    /// user-provided slice on the way to the post-block check.
+    DonorPathBufferOverflow {
+        tail: usize,
+        requested: usize,
+        capacity: usize,
+    },
 }
 
 impl core::fmt::Display for ExecuteSequencesError {
@@ -871,6 +887,16 @@ impl core::fmt::Display for ExecuteSequencesError {
             }
             ExecuteSequencesError::ZeroOffset => {
                 write!(f, "Illegal offset: 0 found")
+            }
+            ExecuteSequencesError::DonorPathBufferOverflow {
+                tail,
+                requested,
+                capacity,
+            } => {
+                write!(
+                    f,
+                    "Donor-path sequence would write past fixed-size buffer: tail={tail}, requested={requested}, capacity={capacity}"
+                )
             }
         }
     }

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -423,24 +423,17 @@ pub enum DecodeBufferError {
         buf_len: usize,
     },
     ZeroOffset,
-    /// Match repeat would overflow a fixed-capacity backend
-    /// (`UserSliceBackend`). Growable backends (FlatBuf/RingBuffer)
-    /// grow on demand and never produce this.
-    ///
-    /// Reserved for the Compressed-block sequence-executor hardening
-    /// follow-up. Currently NOT surfaced from any production path —
-    /// `extend_from_within_unchecked` on `UserSliceBackend` still
-    /// panics on overshoot via its release-mode `assert!`. The
-    /// `_trusted` suffix on `decode_all` is the
-    /// shipping contract until that follow-up wires
-    /// `BufferBackend::try_extend_from_within` through
-    /// `DecodeBuffer::repeat*` and maps `BackendOverflow` into
-    /// `FrameDecoderError::FrameContentSizeMismatch`.
-    ///
-    /// The variant lives now (vs landing later with the
-    /// follow-up) so the typed conversion at the `decode_all`
-    /// boundary is in place; only the constructor on the burst path
-    /// is missing.
+    /// Legacy unit variant kept for binary compatibility with earlier
+    /// snapshots of this enum. Not surfaced from any current
+    /// production path — `BufferBackend::try_extend` /
+    /// `try_extend_from_within` and the new `try_reserve` (used by
+    /// `DecodeBuffer::repeat`) carry their failures through the
+    /// richer [`Self::OutputBufferOverflow`] variant below, which
+    /// reports the offending `tail` / `requested` / `capacity`
+    /// triple. New code should pattern-match on
+    /// `OutputBufferOverflow`; this unit variant is retained to keep
+    /// the `#[non_exhaustive]` enum's existing discriminant set
+    /// stable.
     BackendOverflow,
     /// Repeat-side match copy would write past the writable tail of
     /// a fixed-capacity backend (`UserSliceBackend`). Surfaced by

--- a/zstd/src/decoding/exec_sequence_donor.rs
+++ b/zstd/src/decoding/exec_sequence_donor.rs
@@ -118,10 +118,22 @@ pub(crate) mod x86 {
                 let dec32 = DEC32_TABLE[offset] as usize;
                 let v: u32 = src.add(dec32).cast::<u32>().read_unaligned();
                 dst.add(4).cast::<u32>().write_unaligned(v);
-                // src was advanced by `dec32` to read the second u32;
-                // `sub2` rewinds it so the post-call src is at
-                // `original_src + dec32 - sub2 + 8`.
-                let src_after = src.add(dec32).offset(-(sub2 as isize)).add(8);
+                // Post-call src position is `src + (dec32 - sub2 + 8)`.
+                // Computing this as
+                // `src.add(dec32).offset(-(sub2 as isize)).add(8)`
+                // (donor's literal C transcription) produces an
+                // intermediate pointer below the allocation base
+                // when `dec32 < sub2` — true for every offset ∈ 1..=7
+                // in donor's tables — which is UB under Rust's
+                // `.offset()` provenance rules even when the final
+                // pointer lands back in-bounds. Apply the net signed
+                // offset once so no intermediate underflows.
+                let net_offset = dec32 as isize - sub2 as isize + 8;
+                debug_assert!(
+                    net_offset >= 0,
+                    "overlap_copy8 net offset is non-negative for all offset ∈ 1..=7"
+                );
+                let src_after = src.offset(net_offset);
                 (dst.add(8), src_after)
             } else {
                 // ZSTD_copy8 — straight 8-byte unaligned move.

--- a/zstd/src/decoding/exec_sequence_donor.rs
+++ b/zstd/src/decoding/exec_sequence_donor.rs
@@ -21,11 +21,15 @@
 //! on those targets, so the dispatch site dead-eliminates this code
 //! at compile time per backend monomorphisation).
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+// x86_64 only: SSE2 is the architectural baseline there (every x86_64
+// CPU has SSE2 by definition). 32-bit `x86` is excluded because the
+// SSE2 intrinsics here are emitted without a `#[target_feature]`
+// gate, and 32-bit i386 / i486 / i586 targets do not always have
+// SSE2 in their baseline. The dispatch site
+// (`UserSliceBackend::SUPPORTS_INLINE_DONOR_EXEC`) mirrors this cfg
+// so the legacy chain handles non-x86_64 targets.
+#[cfg(target_arch = "x86_64")]
 pub(crate) mod x86 {
-    #[cfg(target_arch = "x86")]
-    use core::arch::x86::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
-    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
 
     /// Donor's `ZSTD_copy16`: one unaligned 16-byte SIMD store.

--- a/zstd/src/decoding/exec_sequence_donor.rs
+++ b/zstd/src/decoding/exec_sequence_donor.rs
@@ -17,7 +17,7 @@
 //! Helpers are private SSE2-baseline x86_64 ops (all supported
 //! x86_64 targets carry SSE2). Non-x86 paths fall back through the
 //! existing `BufferBackend::extend` + `DecodeBuffer::repeat` chain
-//! (`UserSliceBackend::supports_inline_donor_exec` returns `false`
+//! (`UserSliceBackend::SUPPORTS_INLINE_DONOR_EXEC` returns `false`
 //! on those targets, so the dispatch site dead-eliminates this code
 //! at compile time per backend monomorphisation).
 

--- a/zstd/src/decoding/exec_sequence_donor.rs
+++ b/zstd/src/decoding/exec_sequence_donor.rs
@@ -1,0 +1,130 @@
+//! Verbatim port of donor zstd's `ZSTD_execSequence` body
+//! (lib/decompress/zstd_decompress_block.c:1008-1105) for the
+//! `UserSliceBackend` direct-write decode path. Bypasses the
+//! `DecodeBuffer::push` + `repeat` abstraction chain in favour of
+//! donor's straight-line shape:
+//!
+//! 1. Literal copy: unconditional 16-byte SIMD store + wildcopy tail
+//!    if `litLength > 16`. Mirrors donor's "split out litLength <= 16
+//!    since it is nearly always true" comment.
+//! 2. Match copy fast path: `offset >= 16` → single wildcopy
+//!    (`no_overlap` semantics, 16-byte SIMD loop).
+//! 3. Match copy short-offset: `offset < 16` →
+//!    [`ZSTD_overlapCopy8`] spreading then wildcopy
+//!    (`overlap_src_before_dst`, 8-byte loop while diff < 16,
+//!    16-byte once diff catches up).
+//!
+//! Helpers are private SSE2-baseline x86_64 ops (all supported
+//! x86_64 targets carry SSE2). Non-x86 paths fall back through the
+//! existing `BufferBackend::extend` + `DecodeBuffer::repeat` chain
+//! (`UserSliceBackend::supports_inline_donor_exec` returns `false`
+//! on those targets, so the dispatch site dead-eliminates this code
+//! at compile time per backend monomorphisation).
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub(crate) mod x86 {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+
+    /// Donor's `ZSTD_copy16`: one unaligned 16-byte SIMD store.
+    /// SSE2 is the x86_64 baseline (and on x86 we gate via the
+    /// module's `cfg(target_arch)`), so the intrinsics are always
+    /// available without a per-call CPU feature check.
+    #[inline(always)]
+    pub(crate) unsafe fn copy16(dst: *mut u8, src: *const u8) {
+        unsafe {
+            let v = _mm_loadu_si128(src as *const __m128i);
+            _mm_storeu_si128(dst as *mut __m128i, v);
+        }
+    }
+
+    /// Donor's `ZSTD_wildcopy(..., ZSTD_no_overlap)`: 16-byte SIMD
+    /// loop until at least `length` bytes are written. May overshoot
+    /// up to 15 bytes past `dst + length`; caller's
+    /// `WILDCOPY_OVERLENGTH` slack accommodates.
+    #[inline(always)]
+    pub(crate) unsafe fn wildcopy_no_overlap(dst: *mut u8, src: *const u8, length: usize) {
+        debug_assert!(length > 0);
+        unsafe {
+            let mut off = 0usize;
+            loop {
+                copy16(dst.add(off), src.add(off));
+                off += 16;
+                if off >= length {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Donor's `ZSTD_wildcopy(..., ZSTD_overlap_src_before_dst)` for
+    /// the `diff < WILDCOPY_VECLEN` (= < 16) arm: 8-byte unaligned
+    /// loop. Each iter reads `src + off + 8` which may be in the
+    /// just-written destination region — correct for RLE expansion
+    /// once the source/dest gap is ≥ 8.
+    #[inline(always)]
+    pub(crate) unsafe fn wildcopy_overlap_8byte_stride(
+        dst: *mut u8,
+        src: *const u8,
+        length: usize,
+    ) {
+        debug_assert!(length > 0);
+        unsafe {
+            let mut off = 0usize;
+            loop {
+                let v: u64 = src.add(off).cast::<u64>().read_unaligned();
+                dst.add(off).cast::<u64>().write_unaligned(v);
+                off += 8;
+                if off >= length {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Donor's `ZSTD_overlapCopy8`
+    /// (zstd_decompress_block.c:799-826). Copies 8 bytes from `src`
+    /// to `dst` and, when `offset < 8`, "spreads" the source/dest
+    /// distance so the following wildcopy can use the safe ≥ 8
+    /// stride.
+    ///
+    /// Returns the updated `(dst, src)` pair (caller's old pointers
+    /// are no longer valid).
+    #[inline(always)]
+    pub(crate) unsafe fn overlap_copy8(
+        dst: *mut u8,
+        src: *const u8,
+        offset: usize,
+    ) -> (*mut u8, *const u8) {
+        // dec32table / dec64table — donor's two precomputed lookup
+        // tables for the offset < 8 spread step.
+        const DEC32_TABLE: [u32; 8] = [0, 1, 2, 1, 4, 4, 4, 4];
+        const DEC64_TABLE: [i32; 8] = [8, 8, 8, 7, 8, 9, 10, 11];
+        unsafe {
+            if offset < 8 {
+                // Read 4 bytes, advance src by dec32, read 4 more bytes,
+                // then back-advance by dec64 — see donor source.
+                let sub2 = DEC64_TABLE[offset];
+                dst.add(0).write(src.add(0).read());
+                dst.add(1).write(src.add(1).read());
+                dst.add(2).write(src.add(2).read());
+                dst.add(3).write(src.add(3).read());
+                let dec32 = DEC32_TABLE[offset] as usize;
+                let v: u32 = src.add(dec32).cast::<u32>().read_unaligned();
+                dst.add(4).cast::<u32>().write_unaligned(v);
+                // src was advanced by `dec32` to read the second u32;
+                // `sub2` rewinds it so the post-call src is at
+                // `original_src + dec32 - sub2 + 8`.
+                let src_after = src.add(dec32).offset(-(sub2 as isize)).add(8);
+                (dst.add(8), src_after)
+            } else {
+                // ZSTD_copy8 — straight 8-byte unaligned move.
+                let v: u64 = src.cast::<u64>().read_unaligned();
+                dst.cast::<u64>().write_unaligned(v);
+                (dst.add(8), src.add(8))
+            }
+        }
+    }
+}

--- a/zstd/src/decoding/exec_sequence_donor.rs
+++ b/zstd/src/decoding/exec_sequence_donor.rs
@@ -144,3 +144,92 @@ pub(crate) mod x86 {
         }
     }
 }
+
+#[cfg(all(test, target_arch = "x86_64"))]
+mod donor_helper_tests {
+    use super::x86::{copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride};
+
+    #[test]
+    fn copy16_copies_exactly_16_bytes() {
+        let src: [u8; 16] = [
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD,
+            0xAE, 0xAF,
+        ];
+        let mut dst = [0u8; 16];
+        unsafe { copy16(dst.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn wildcopy_no_overlap_short_length_overshoots() {
+        // Length 1 still triggers the unconditional first 16-byte
+        // store — the wildcopy overshoots up to 15 bytes past the
+        // declared end, which is the donor contract.
+        let src: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        let mut dst = [0u8; 32];
+        unsafe { wildcopy_no_overlap(dst.as_mut_ptr(), src.as_ptr(), 1) };
+        // First 16 bytes copied from src; remaining untouched.
+        assert_eq!(&dst[..16], &src[..16]);
+        assert!(dst[16..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn wildcopy_no_overlap_length_above_16_uses_multiple_iters() {
+        // Length 24 → first 16-byte store, then one more iter that
+        // overshoots 8 bytes past the declared end.
+        let src: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        let mut dst = [0u8; 32];
+        unsafe { wildcopy_no_overlap(dst.as_mut_ptr(), src.as_ptr(), 24) };
+        // 32 bytes get written (two 16-byte stores).
+        assert_eq!(&dst[..32], &src[..32]);
+    }
+
+    #[test]
+    fn wildcopy_overlap_8byte_stride_rle_expansion_offset_8() {
+        // Offset = 8 means caller has set up src = dst - 8. Each
+        // 8-byte read picks up bytes the previous iter just wrote,
+        // expanding the seed pattern across the destination region.
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        unsafe {
+            wildcopy_overlap_8byte_stride(buf.as_mut_ptr().add(8), buf.as_ptr(), 16);
+        }
+        // Bytes 8..16 = seed; bytes 16..24 = seed again (RLE expansion).
+        assert_eq!(&buf[8..16], &[1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(&buf[16..24], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn overlap_copy8_offset_ge_8_does_plain_copy() {
+        // offset >= 8 path: straight ZSTD_copy8 (8-byte read+write).
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        let (op2, ip2) = unsafe { overlap_copy8(buf.as_mut_ptr().add(8), buf.as_ptr(), 8) };
+        // dst advances by 8 bytes, src advances by 8 bytes.
+        assert_eq!(op2, unsafe { buf.as_mut_ptr().add(16) });
+        assert_eq!(ip2, unsafe { buf.as_ptr().add(8) });
+        // bytes 8..16 = seed.
+        assert_eq!(
+            &buf[8..16],
+            &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]
+        );
+    }
+
+    #[test]
+    fn overlap_copy8_offset_lt_8_spreads_source() {
+        // offset < 8 path: uses dec32table / dec64table to spread
+        // the source-destination distance so subsequent wildcopy can
+        // use the ≥ 8 stride. Test offset = 3 (a common short-offset
+        // RLE pattern).
+        let mut buf = [0u8; 32];
+        buf[..3].copy_from_slice(&[0xAA, 0xBB, 0xCC]);
+        let (op2, _ip2) = unsafe { overlap_copy8(buf.as_mut_ptr().add(3), buf.as_ptr(), 3) };
+        // dst advanced 8 bytes.
+        assert_eq!(op2, unsafe { buf.as_mut_ptr().add(11) });
+        // First 8 bytes of the destination region are the 3-byte
+        // seed expanded — verify they're non-zero (exact spread
+        // pattern depends on the lookup tables; donor parity is the
+        // contract).
+        assert!(buf[3..11].iter().any(|&b| b != 0));
+    }
+}

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -65,9 +65,9 @@ pub(crate) mod x86 {
 
     /// Donor's `ZSTD_wildcopy(..., ZSTD_overlap_src_before_dst)` for
     /// the `diff < WILDCOPY_VECLEN` (= < 16) arm: 8-byte unaligned
-    /// loop. Each iter reads `src + off + 8` which may be in the
-    /// just-written destination region — correct for RLE expansion
-    /// once the source/dest gap is ≥ 8.
+    /// loop. Each iter reads `src + off` (8 bytes) which may be in
+    /// the just-written destination region — correct for RLE
+    /// expansion once the source/dest gap is ≥ 8.
     #[inline(always)]
     pub(crate) unsafe fn wildcopy_overlap_8byte_stride(
         dst: *mut u8,

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -17,7 +17,7 @@
 //! Helpers are private SSE2-baseline x86_64 ops (all supported
 //! x86_64 targets carry SSE2). Non-x86 paths fall back through the
 //! existing `BufferBackend::extend` + `DecodeBuffer::repeat` chain
-//! (`UserSliceBackend::SUPPORTS_INLINE_DONOR_EXEC` returns `false`
+//! (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC` returns `false`
 //! on those targets, so the dispatch site dead-eliminates this code
 //! at compile time per backend monomorphisation).
 
@@ -26,7 +26,7 @@
 // SSE2 intrinsics here are emitted without a `#[target_feature]`
 // gate, and 32-bit i386 / i486 / i586 targets do not always have
 // SSE2 in their baseline. The dispatch site
-// (`UserSliceBackend::SUPPORTS_INLINE_DONOR_EXEC`) mirrors this cfg
+// (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC`) mirrors this cfg
 // so the legacy chain handles non-x86_64 targets.
 #[cfg(target_arch = "x86_64")]
 pub(crate) mod x86 {
@@ -146,7 +146,7 @@ pub(crate) mod x86 {
 }
 
 #[cfg(all(test, target_arch = "x86_64"))]
-mod donor_helper_tests {
+mod inline_helper_tests {
     use super::x86::{copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride};
 
     #[test]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1094,7 +1094,7 @@ impl FrameDecoder {
             };
             // Per-frame direct-path dispatch. Now safe to route the
             // public `decode_all` here because
-            // `UserSliceBackend::donor_exec_one_sequence` returns
+            // `UserSliceBackend::exec_sequence_inline` returns
             // `Result<(), ExecuteSequencesError>` instead of
             // panicking on capacity overflow; the error propagates
             // up as `FrameDecoderError`. Eligibility (FCS > 0, no
@@ -1173,22 +1173,24 @@ impl FrameDecoder {
     /// `input` must contain an exact number of frames.
     ///
     /// `output` must have enough extra capacity to hold the decompressed data.
-    /// This function will not reallocate or grow the vector. If you don't know
-    /// how large the output will be, use [`FrameDecoder::decode_blocks`] instead.
+    /// This function reserves an additional [`WILDCOPY_OVERLENGTH`]
+    /// bytes on top of the caller's capacity so the per-frame direct
+    /// decode path stays eligible — that may grow the vector by up
+    /// to that fixed amount via `Vec::reserve`. It will NOT grow
+    /// further to fit the decompressed payload itself; the caller's
+    /// pre-allocated capacity must already cover the data. If you
+    /// don't know how large the output will be, use
+    /// [`FrameDecoder::decode_blocks`] instead.
     ///
     /// This calls [`FrameDecoder::init`], and all bytes currently in the decoder will be lost.
     ///
     /// The length of the output vector is updated to include the decompressed data.
-    /// The length is not changed if an error occurs.
-    ///
-    /// As an internal optimisation this method reserves an extra
-    /// [`WILDCOPY_OVERLENGTH`] bytes beyond the requested capacity
-    /// so `decode_all` can route each frame through the direct
-    /// (UserSliceBackend) decode path, which bypasses the per-block
-    /// drain copy. The slack bytes are NOT part of the returned
-    /// `output.len()` — `output` is truncated to the actual
-    /// decompressed size on return. Callers who pre-sized the Vec
-    /// with `Vec::with_capacity(fcs)` see no functional change.
+    /// The length is not changed if an error occurs. The
+    /// `WILDCOPY_OVERLENGTH` slack is internal — `output.len()` on
+    /// return is the actual decompressed size, NOT the inflated
+    /// capacity. Callers who pre-sized the Vec with
+    /// `Vec::with_capacity(fcs)` see no functional change beyond
+    /// the small one-time capacity bump.
     pub fn decode_all_to_vec(
         &mut self,
         input: &[u8],
@@ -1445,9 +1447,9 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn decode_to_slice_trusted_matches_decode_all_on_single_segment_frame() {
+    fn decode_all_matches_decode_all_on_single_segment_frame() {
         // Roundtrip a small payload through the encoder, then decode
-        // it via both `decode_all` and `decode_to_slice_trusted`. Both paths
+        // it via both `decode_all` and `decode_all`. Both paths
         // must produce identical output bytes — the only difference
         // is the internal buffer/drain shape, not the decoded
         // semantics. This is the regression gate for the
@@ -1468,13 +1470,13 @@ mod tests {
         assert_eq!(n_a, payload.len());
         assert_eq!(&out_a[..n_a], payload.as_slice());
 
-        // Direct: decode_to_slice_trusted with WILDCOPY slack.
+        // Direct: decode_all with WILDCOPY slack.
         let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
             .decode_all(compressed.as_slice(), &mut out_b)
-            .expect("decode_to_slice_trusted should succeed");
+            .expect("decode_all should succeed");
         assert_eq!(
             n_b,
             payload.len(),
@@ -1484,7 +1486,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_trusted_multi_segment_frame_decodes_correctly() {
+    fn decode_all_multi_segment_frame_decodes_correctly() {
         // Multi-segment frame: payload large enough that the
         // encoder's default frame layout has `single_segment_flag =
         // false` and `window_size < frame_content_size`. The direct
@@ -1523,7 +1525,7 @@ mod tests {
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
             .decode_all(compressed.as_slice(), &mut out_b)
-            .expect("decode_to_slice_trusted should succeed on multi-segment frame");
+            .expect("decode_all should succeed on multi-segment frame");
         assert_eq!(n_b, payload.len(), "wrong byte count on direct path");
         assert_eq!(&out_b[..n_b], payload.as_slice());
 
@@ -1547,11 +1549,11 @@ mod tests {
 
     #[cfg(feature = "hash")]
     #[test]
-    fn decode_to_slice_trusted_propagates_checksum_into_persistent_scratch() {
+    fn decode_all_propagates_checksum_into_persistent_scratch() {
         // Direct path on a checksum-flagged frame: the FrameCompressor
         // under `feature = "hash"` sets content_checksum_flag, so the
         // decoded frame has a recorded checksum. After
-        // decode_to_slice_trusted we must be able to verify it matches via
+        // decode_all we must be able to verify it matches via
         // the public get_calculated_checksum() accessor — the digest
         // is computed by walking output at end of decode and stored
         // into the persistent scratch's hasher.
@@ -1567,7 +1569,7 @@ mod tests {
         let mut out = alloc::vec![0u8; payload.len() + slack];
         let n = dec
             .decode_all(compressed.as_slice(), &mut out)
-            .expect("decode_to_slice_trusted with checksum must succeed");
+            .expect("decode_all with checksum must succeed");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
 
@@ -1588,7 +1590,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_trusted_fcs_overflow_via_corrupt_frame_returns_structured_error() {
+    fn decode_all_fcs_overflow_via_corrupt_frame_returns_structured_error() {
         // Hand-build a corrupt frame that declares
         // frame_content_size = 4 but the (last) block carries a
         // larger Raw payload. The pre-flight FCS check inside the
@@ -1639,7 +1641,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_trusted_falls_back_when_output_too_small_for_wildcopy_slack() {
+    fn decode_all_falls_back_when_output_too_small_for_wildcopy_slack() {
         // Output sized exactly to frame_content_size (no
         // WILDCOPY_OVERLENGTH slack) must NOT trigger the direct
         // path — the burst's `extend_from_within_unchecked` writes
@@ -1660,13 +1662,13 @@ mod tests {
         let mut out = alloc::vec![0u8; payload.len()];
         let n = dec
             .decode_all(compressed.as_slice(), &mut out)
-            .expect("decode_to_slice_trusted should still succeed via fallback");
+            .expect("decode_all should still succeed via fallback");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
     }
 
     #[test]
-    fn decode_to_slice_trusted_fallback_validates_fcs_against_total_output() {
+    fn decode_all_fallback_validates_fcs_against_total_output() {
         // Synthetic single-segment frame: FCS = 20 bytes, but the
         // last-block flag fires after only 4 bytes of raw payload.
         // On the direct path this would trip the post-block
@@ -1711,7 +1713,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_trusted_fallback_treats_explicit_fcs_zero_as_declared() {
+    fn decode_all_fallback_treats_explicit_fcs_zero_as_declared() {
         // Synthetic multi-segment frame with FCS_flag=2 (4-byte
         // FCS) explicitly set to 0. The header DECLARES zero
         // content, but the body carries a 5-byte raw last-block.
@@ -1765,7 +1767,7 @@ mod tests {
     }
 
     #[test]
-    fn decode_to_slice_trusted_fallback_accepts_honest_explicit_fcs_zero() {
+    fn decode_all_fallback_accepts_honest_explicit_fcs_zero() {
         // Companion to the corrupt-FCS=0 test above: an HONEST
         // empty frame with FCS_flag=2 (4-byte FCS) explicitly set
         // to 0 AND a 0-byte raw last-block. `fcs_declared()`

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1077,7 +1077,6 @@ impl FrameDecoder {
         mut output: &mut [u8],
         mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
     ) -> Result<usize, FrameDecoderError> {
-        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut total_bytes_written = 0;
         while !input.is_empty() {
             match init_frame(self, &mut input) {
@@ -1092,30 +1091,17 @@ impl FrameDecoder {
                 }
                 Err(e) => return Err(e),
             };
-            // Per-frame direct-path dispatch. Eligibility mirrors
-            // `decode_to_slice_trusted`: FCS declared and > 0, no
-            // active dictionary, and the remaining `output` slice has
-            // room for FCS + WILDCOPY_OVERLENGTH slack. When all hold
-            // the frame decodes straight into `output[..content_size]`
-            // through `UserSliceBackend`, bypassing the FlatBuf/Ring
-            // -> `read()` drain copy that dominates throughput on
-            // poorly-compressed corpora. Ineligible frames (no FCS,
-            // active dict, output too small for slack, streaming
-            // multi-frame inputs where the next frame needs the
-            // current iteration's tail) fall through to the legacy
-            // `decode_blocks` + `read` drain loop below.
-            let state_ref = self.state.as_ref().expect("init populated state");
-            let content_size = state_ref.frame_header.frame_content_size();
-            let dict_active = state_ref.using_dict.is_some();
-            let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
-            if direct_eligible {
-                let written = self.run_direct_decode(&mut input, output, content_size)?;
-                output = &mut output[written..];
-                total_bytes_written += written;
-                continue;
-            }
+            // `decode_all` MUST stay on the per-block decode + read
+            // drain path: it's the safe public API and its
+            // `Result<_, FrameDecoderError>` contract requires
+            // structured errors on malformed input. The direct path
+            // (`run_direct_decode` + `UserSliceBackend`) is gated
+            // behind the `_trusted` suffix on `decode_to_slice_trusted`
+            // because its write surface uses release-mode `assert!`
+            // for capacity checks — corrupt frames would panic
+            // mid-block instead of returning `Err(...)`. Direct-path
+            // routing for safe APIs is tracked behind the fallible
+            // `BufferBackend` refactor in issue #246.
             loop {
                 self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
                 let bytes_written = self
@@ -1752,53 +1738,6 @@ mod tests {
                 .single_segment_flag(),
             "test precondition violated: frame is single-segment, rename or resize"
         );
-    }
-
-    #[test]
-    fn decode_all_routes_eligible_frame_through_direct_path() {
-        // Regression test for the per-frame direct-path dispatch in
-        // `decode_all_impl`. With a sized-with-slack output buffer
-        // the eligibility gate (FCS > 0, no dict, output.len() >=
-        // FCS + WILDCOPY_OVERLENGTH) holds, so `decode_all` must
-        // route through `run_direct_decode` and produce the same
-        // bytes the legacy drain path would.
-        let payload: Vec<u8> = (0..8192u32).map(|i| (i & 0xFF) as u8).collect();
-        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
-        compressor.set_source(payload.as_slice());
-        let mut compressed = Vec::new();
-        compressor.set_drain(&mut compressed);
-        compressor.compress();
-
-        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
-        let mut dec = FrameDecoder::new();
-        let mut out = alloc::vec![0u8; payload.len() + slack];
-        let n = dec
-            .decode_all(compressed.as_slice(), &mut out)
-            .expect("decode_all with WILDCOPY slack should succeed via direct path");
-        assert_eq!(n, payload.len());
-        assert_eq!(&out[..n], payload.as_slice());
-    }
-
-    #[test]
-    fn decode_all_with_tight_output_routes_through_legacy_drain() {
-        // Output sized to EXACTLY content_size (no slack) must
-        // fail the direct-path eligibility gate and fall back to
-        // the per-block decode + read drain loop. This covers
-        // callers that don't / can't pre-size with WILDCOPY slack.
-        let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
-        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
-        compressor.set_source(payload.as_slice());
-        let mut compressed = Vec::new();
-        compressor.set_drain(&mut compressed);
-        compressor.compress();
-
-        let mut dec = FrameDecoder::new();
-        let mut out = alloc::vec![0u8; payload.len()];
-        let n = dec
-            .decode_all(compressed.as_slice(), &mut out)
-            .expect("decode_all with tight output must succeed via legacy drain");
-        assert_eq!(n, payload.len());
-        assert_eq!(&out[..n], payload.as_slice());
     }
 
     #[cfg(feature = "hash")]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1077,6 +1077,7 @@ impl FrameDecoder {
         mut output: &mut [u8],
         mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
     ) -> Result<usize, FrameDecoderError> {
+        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut total_bytes_written = 0;
         while !input.is_empty() {
             match init_frame(self, &mut input) {
@@ -1091,30 +1092,32 @@ impl FrameDecoder {
                 }
                 Err(e) => return Err(e),
             };
-            // `decode_all` MUST stay on the per-block decode + read
-            // drain path: it's the safe public API and its
-            // `Result<_, FrameDecoderError>` contract requires
-            // structured errors on malformed input. The direct path
-            // (`run_direct_decode` + `UserSliceBackend`) is gated
-            // behind the `_trusted` suffix on `decode_to_slice_trusted`
-            // because its write surface uses release-mode `assert!`
-            // for capacity checks — corrupt frames would panic
-            // mid-block instead of returning `Err(...)`. Direct-path
-            // routing for safe APIs is tracked behind the fallible
-            // `BufferBackend` refactor in issue #246.
+            // Per-frame direct-path dispatch. Now safe to route the
+            // public `decode_all` here because
+            // `UserSliceBackend::donor_exec_one_sequence` returns
+            // `Result<(), ExecuteSequencesError>` instead of
+            // panicking on capacity overflow; the error propagates
+            // up as `FrameDecoderError`. Eligibility (FCS > 0, no
+            // active dict, remaining `output` slice has WILDCOPY
+            // slack) puts the frame on the fast path that bypasses
+            // the FlatBuf/Ring -> `read()` drain copy. Ineligible
+            // frames (no FCS, active dict, output too small for
+            // slack) fall through to the legacy `decode_blocks` +
+            // `read` drain loop below.
+            let state_ref = self.state.as_ref().expect("init populated state");
+            let content_size = state_ref.frame_header.frame_content_size();
+            let fcs_declared = state_ref.frame_header.fcs_declared();
+            let dict_active = state_ref.using_dict.is_some();
+            let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
+            let direct_eligible =
+                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
+            if direct_eligible {
+                let written = self.run_direct_decode(&mut input, output, content_size)?;
+                output = &mut output[written..];
+                total_bytes_written += written;
+                continue;
+            }
             let frame_start_total = total_bytes_written;
-            let content_size = self
-                .state
-                .as_ref()
-                .expect("init populated state")
-                .frame_header
-                .frame_content_size();
-            let fcs_declared = self
-                .state
-                .as_ref()
-                .expect("init populated state")
-                .frame_header
-                .fcs_declared();
             loop {
                 self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
                 let bytes_written = self
@@ -1129,16 +1132,9 @@ impl FrameDecoder {
                     break;
                 }
             }
-            // Per-frame FCS validation: when the frame header
-            // declared a frame_content_size, the drained byte count
-            // for THIS frame must match it. Without this check a
-            // corrupt under-producing frame (last_block flag tripped
-            // early on a sub-FCS payload) would silently return
-            // `Ok(short_len)` here, even though
-            // `decode_single_frame_legacy_drain` maps the same
-            // shape to `FrameContentSizeMismatch`. Use
-            // `fcs_declared()` (NOT `content_size > 0`) so an empty
-            // frame with explicit FCS=0 on the wire still gets
+            // Per-frame FCS validation on the legacy fallback path.
+            // Use `fcs_declared()` (NOT `content_size > 0`) so an
+            // empty frame with explicit FCS=0 on the wire still gets
             // validated.
             if fcs_declared {
                 let produced = (total_bytes_written - frame_start_total) as u64;
@@ -1184,12 +1180,26 @@ impl FrameDecoder {
     ///
     /// The length of the output vector is updated to include the decompressed data.
     /// The length is not changed if an error occurs.
+    ///
+    /// As an internal optimisation this method reserves an extra
+    /// [`WILDCOPY_OVERLENGTH`] bytes beyond the requested capacity
+    /// so `decode_all` can route each frame through the direct
+    /// (UserSliceBackend) decode path, which bypasses the per-block
+    /// drain copy. The slack bytes are NOT part of the returned
+    /// `output.len()` — `output` is truncated to the actual
+    /// decompressed size on return. Callers who pre-sized the Vec
+    /// with `Vec::with_capacity(fcs)` see no functional change.
     pub fn decode_all_to_vec(
         &mut self,
         input: &[u8],
         output: &mut Vec<u8>,
     ) -> Result<(), FrameDecoderError> {
+        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let len = output.len();
+        // Reserve WILDCOPY slack on top of the caller's capacity so
+        // `decode_all` can land on the direct path even when the
+        // caller didn't pre-allocate slack themselves.
+        output.reserve(WILDCOPY_OVERLENGTH);
         let cap = output.capacity();
         output.resize(cap, 0);
         match self.decode_all(input, &mut output[len..]) {
@@ -1203,244 +1213,6 @@ impl FrameDecoder {
                 Err(e)
             }
         }
-    }
-
-    /// Decode a single zstd frame from `input` directly into
-    /// `output`, bypassing the internal `DecodeBuffer` -> `read()`
-    /// drain copy when the frame is eligible. Donor parity with the
-    /// `ZSTD_in_dst` litBuffer placement strategy.
-    ///
-    /// Eligibility requires all of:
-    /// - `frame_content_size` is present in the header (> 0).
-    /// - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
-    ///   (room for the SIMD wildcopy overshoot slack).
-    /// - No active dictionary on `self.state` (dict_content is not
-    ///   carried into the stack-local DecodeBuffer this method
-    ///   builds).
-    ///
-    /// `content_checksum_flag` is NOT a disqualifier: when set,
-    /// the direct path hashes the decoded `output[..content_size]`
-    /// once at the end of decode and propagates the digest into
-    /// the persistent scratch's `hash` so
-    /// [`Self::get_calculated_checksum`] returns the right value.
-    ///
-    /// Multi-segment frames are supported via a per-block
-    /// `DecodeBuffer::drop_to_window_size` call that caps the
-    /// visible buffer at `window_size` at block boundaries. The
-    /// discarded bytes stay physically in the user slice (they're
-    /// the frame's already-decoded output); only their
-    /// `BufferBackend::head` visibility moves forward.
-    ///
-    /// Note: `drop_to_window_size` runs only BETWEEN blocks, so
-    /// within a single block `buffer.len()` can temporarily exceed
-    /// `window_size`. `DecodeBuffer::repeat` validates match
-    /// offsets against `buffer.len()` (not against `window_size`),
-    /// so corrupted streams with `offset > window_size` but
-    /// `offset <= current buffer.len()` are NOT rejected by this
-    /// gate. Strict spec compliance for offsets in multi-segment
-    /// frames would require an in-block offset bound that we don't
-    /// currently enforce on either the direct or the fallback path.
-    ///
-    /// Non-eligible frames fall back transparently to the existing
-    /// `decode_blocks` + `read` drain path.
-    ///
-    /// `input` is expected to contain a single zstd frame. Bytes
-    /// past the end of that frame are NOT validated and are silently
-    /// ignored — this differs from [`Self::decode_all`], which loops
-    /// until `input` is fully consumed and will attempt to parse a
-    /// second frame (or error) on trailing bytes. Multi-frame
-    /// streams must use [`Self::decode_all`].
-    ///
-    /// On the direct path the literal pushes and
-    /// sequence-execution match copies write straight into
-    /// `output`, eliminating the FlatBuf-as-intermediate `read()`
-    /// drain that dominates poorly-compressed L-7-class corpora
-    /// (~28% of decode time on
-    /// `level_-7_fast/decodecorpus-z000033/rust_stream`). Both
-    /// single-segment and multi-segment frames take the direct
-    /// path; multi-segment frames cap the visible buffer at
-    /// `window_size` between blocks via
-    /// `DecodeBuffer::drop_to_window_size`.
-    ///
-    /// Frames that aren't eligible (zero `frame_content_size`,
-    /// active dictionary, undersized `output`) transparently fall
-    /// back to the internal block-decode + read drain loop. The
-    /// fallback is NOT [`Self::decode_all`] semantics: it decodes
-    /// exactly one frame and returns; trailing bytes past the
-    /// frame are silently ignored. Use [`Self::decode_all`] for
-    /// multi-frame input or streams that may contain skippable
-    /// frames.
-    ///
-    /// `input` is expected to contain exactly ONE non-skippable
-    /// zstd frame. **Skippable frames are rejected with
-    /// `ReadFrameHeaderError::SkipFrame` from `init`** — this
-    /// method does NOT skip them. Multi-frame input or input that
-    /// might contain skippable frames must go through
-    /// [`Self::decode_all`], which iterates `init` and handles
-    /// `SkipFrame` by advancing past the skippable payload.
-    ///
-    /// # State observability after this call
-    ///
-    /// On the direct path, decoded bytes are written into `output`
-    /// via a stack-local `DecodeBuffer<UserSliceBackend>` that is
-    /// dropped before this function returns. The persistent
-    /// `state.decoder_scratch.buffer` stays empty. Consequently,
-    /// after `decode_to_slice_trusted` returns:
-    ///
-    /// - [`Self::is_finished`] returns `true`,
-    /// - [`Self::can_collect`] returns `0`,
-    /// - [`Self::read`] (the crate's `io::Read` impl, which under
-    ///   `feature = "std"` is `std::io::Read`) reads 0 bytes,
-    /// - [`Self::collect`] returns `Some(Vec::new())`,
-    /// - [`Self::get_calculated_checksum`] returns the correct
-    ///   value when the frame had `content_checksum_flag` set —
-    ///   the direct path walks the output once at end of decode
-    ///   and propagates the digest into the persistent scratch's
-    ///   hasher so this accessor reads the right state.
-    ///
-    /// Callers must use the bytes from `output[..n]` (where `n`
-    /// is the returned count); do not mix `decode_to_slice_trusted` with
-    /// `read`/`collect` on the same `FrameDecoder`.
-    ///
-    /// When the frame is NOT eligible (no FCS in the header, or
-    /// output buffer too small for the WILDCOPY slack, or active
-    /// dictionary), this method falls back to a single-frame
-    /// `decode_blocks` + `read` drain loop, draining into the
-    /// caller's `output` slice. This is NOT `decode_all`: it
-    /// processes only one frame (no trailing-frame iteration, no
-    /// silent skippable-frame skip) and returns
-    /// [`FrameDecoderError::TargetTooSmall`] if the decoded
-    /// output does not fit in `output`.
-    ///
-    /// # Panic / DoS surface
-    ///
-    /// **For trusted input only.** On the direct path
-    /// `UserSliceBackend` uses release-mode `assert!` for capacity
-    /// checks across all three write entry points (`extend`,
-    /// `extend_and_fill`, `extend_from_within_unchecked`). A
-    /// malformed Compressed block whose payload expands past the
-    /// declared `frame_content_size` (and beyond the
-    /// `WILDCOPY_OVERLENGTH` slack the caller sized into `output`)
-    /// will panic mid-block rather than returning a structured
-    /// error. The per-block `produced > content_size` guard catches
-    /// the overshoot AFTER the block, but cannot prevent the
-    /// in-block writes from running first.
-    ///
-    /// The trade-off is deliberate for this PR. Making the writes
-    /// fallible requires extending the `BufferBackend` trait
-    /// surface, touching every backend implementation, and
-    /// propagating `Result<_, _>` through the entire sequence
-    /// executor — a refactor too large to fold into the direct
-    /// decode wiring without losing review tractability. The
-    /// follow-up issue tracking that work (referenced below in
-    /// "Fallible BufferBackend writes") is a hard prerequisite
-    /// before this entry point becomes safe to expose on
-    /// untrusted streams.
-    ///
-    /// Callers handling untrusted input must use [`Self::decode_all`]
-    /// which routes through `FlatBuf` / `RingBuffer`. Those
-    /// backends grow via `Vec::reserve` (succeeds or aborts on
-    /// alloc failure — not error-returning), but the growable Vec
-    /// capacity absorbs a malformed block's overshoot inside the
-    /// allocation; the frame-level checks then turn the size
-    /// mismatch into `FrameContentSizeMismatch` instead of OOB
-    /// writes into a fixed-size user slice. Fallible
-    /// `BufferBackend` writes that would let `decode_to_slice_trusted`
-    /// remain safe on adversarial input are tracked in issue #246.
-    // The `_trusted` suffix is part of the API contract: this
-    // entry point is for trusted input only. Adversarial /
-    // malformed input can panic via release-mode `assert!` inside
-    // `UserSliceBackend`. Callers handling untrusted data MUST use
-    // `decode_all` instead. The fallible-`BufferBackend` refactor
-    // that would let this entry point be safe on adversarial
-    // input is tracked as a follow-up.
-    #[doc(alias = "decode_to_slice")]
-    #[must_use = "decode_to_slice_trusted returns the decoded byte count; ignoring it leaves the output's effective length ambiguous"]
-    pub fn decode_to_slice_trusted(
-        &mut self,
-        mut input: &[u8],
-        output: &mut [u8],
-    ) -> Result<usize, FrameDecoderError> {
-        use super::buffer_backend::WILDCOPY_OVERLENGTH;
-        use FrameDecoderError as err;
-
-        // Parse the frame header. This populates `self.state` with
-        // the frame descriptor + resets the per-frame scratch
-        // (DecoderScratchKind::Flat for single-segment, ::Ring
-        // otherwise).
-        //
-        // Skippable frames are reported by `init` as
-        // `ReadFrameHeaderError::SkipFrame`. The direct path
-        // doesn't have a state model for "skip + decode next" since
-        // it processes a single frame at most — propagate the error
-        // unchanged so callers learn this input needs `decode_all`
-        // (which iterates init and advances past skippable
-        // payloads).
-        self.init(&mut input)?;
-
-        let state = self.state.as_ref().ok_or(err::NotYetInitialized)?;
-        let content_size = state.frame_header.frame_content_size();
-        let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        let dict_active = state.using_dict.is_some();
-        let eligible = content_size > 0 && !dict_active && (output.len() as u64) >= needed;
-
-        if !eligible {
-            // Frame doesn't qualify for direct decode (empty
-            // frame_content_size — header lacks FCS — or output too
-            // small for the WILDCOPY slack, or active dict). Fall
-            // through to the per-block decode + drain path. `init`
-            // already populated `self.state`, so `decode_blocks` +
-            // `read` pick up from there.
-            return self.decode_single_frame_legacy_drain(&mut input, output, content_size);
-        }
-
-        self.run_direct_decode(&mut input, output, content_size)
-    }
-
-    /// Single-frame legacy drain path: per-block decode + `read()`
-    /// drain into `output`. Used as fallback by
-    /// [`Self::decode_to_slice_trusted`] when direct-decode
-    /// eligibility fails (no FCS, active dict, output too small for
-    /// WILDCOPY slack). Not invoked from `decode_all_impl` since
-    /// that has its own multi-frame loop.
-    fn decode_single_frame_legacy_drain(
-        &mut self,
-        input: &mut &[u8],
-        output: &mut [u8],
-        content_size: u64,
-    ) -> Result<usize, FrameDecoderError> {
-        use FrameDecoderError as err;
-
-        let mut output_tail: &mut [u8] = output;
-        let mut total_bytes_written = 0;
-        loop {
-            self.decode_blocks(&mut *input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
-            let bytes_written = self
-                .read(output_tail)
-                .map_err(err::FailedToDrainDecodebuffer)?;
-            output_tail = &mut output_tail[bytes_written..];
-            total_bytes_written += bytes_written;
-            if self.can_collect() != 0 {
-                return Err(err::TargetTooSmall);
-            }
-            if self.is_finished() {
-                break;
-            }
-        }
-        // Use `fcs_declared()` (NOT `content_size > 0`) as the
-        // "is FCS on the wire" gate. The two diverge on an empty
-        // frame with explicit FCS=0: `content_size` is 0 in both
-        // "absent" and "explicitly zero" cases, while
-        // `fcs_declared()` returns false only in the truly absent
-        // case.
-        let state = self.state.as_ref().expect("state populated by init");
-        if state.frame_header.fcs_declared() && (total_bytes_written as u64) != content_size {
-            return Err(err::FrameContentSizeMismatch {
-                declared: content_size,
-                produced: total_bytes_written as u64,
-            });
-        }
-        Ok(total_bytes_written)
     }
 
     /// Single-frame direct-decode path. Decodes one zstd frame into
@@ -1701,7 +1473,7 @@ mod tests {
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
-            .decode_to_slice_trusted(compressed.as_slice(), &mut out_b)
+            .decode_all(compressed.as_slice(), &mut out_b)
             .expect("decode_to_slice_trusted should succeed");
         assert_eq!(
             n_b,
@@ -1750,7 +1522,7 @@ mod tests {
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
-            .decode_to_slice_trusted(compressed.as_slice(), &mut out_b)
+            .decode_all(compressed.as_slice(), &mut out_b)
             .expect("decode_to_slice_trusted should succeed on multi-segment frame");
         assert_eq!(n_b, payload.len(), "wrong byte count on direct path");
         assert_eq!(&out_b[..n_b], payload.as_slice());
@@ -1794,7 +1566,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; payload.len() + slack];
         let n = dec
-            .decode_to_slice_trusted(compressed.as_slice(), &mut out)
+            .decode_all(compressed.as_slice(), &mut out)
             .expect("decode_to_slice_trusted with checksum must succeed");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
@@ -1854,7 +1626,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; 4 + slack];
         let err = dec
-            .decode_to_slice_trusted(&frame, &mut out)
+            .decode_all(&frame, &mut out)
             .expect_err("FCS-overflow frame must fail decode");
         assert!(
             matches!(
@@ -1887,7 +1659,7 @@ mod tests {
         // Exactly payload.len(), no slack — direct path is gated out.
         let mut out = alloc::vec![0u8; payload.len()];
         let n = dec
-            .decode_to_slice_trusted(compressed.as_slice(), &mut out)
+            .decode_all(compressed.as_slice(), &mut out)
             .expect("decode_to_slice_trusted should still succeed via fallback");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
@@ -1924,7 +1696,7 @@ mod tests {
         // so the eligibility check gates the direct path out.
         let mut out = alloc::vec![0u8; 20];
         let err = dec
-            .decode_to_slice_trusted(wire.as_slice(), &mut out)
+            .decode_all(wire.as_slice(), &mut out)
             .expect_err("fallback must reject corrupt FCS underflow");
         match err {
             crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
@@ -1978,7 +1750,7 @@ mod tests {
         // give it some room so `read()` can drain the block.
         let mut out = alloc::vec![0u8; 16];
         let err = dec
-            .decode_to_slice_trusted(wire.as_slice(), &mut out)
+            .decode_all(wire.as_slice(), &mut out)
             .expect_err("corrupt FCS=0 + 5-byte block must error");
         match err {
             crate::decoding::errors::FrameDecoderError::FrameContentSizeMismatch {
@@ -2027,7 +1799,7 @@ mod tests {
         let mut dec = FrameDecoder::new();
         let mut out = alloc::vec![0u8; 16];
         let n = dec
-            .decode_to_slice_trusted(wire.as_slice(), &mut out)
+            .decode_all(wire.as_slice(), &mut out)
             .expect("honest FCS=0 + empty block must succeed");
         assert_eq!(n, 0);
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1102,6 +1102,19 @@ impl FrameDecoder {
             // mid-block instead of returning `Err(...)`. Direct-path
             // routing for safe APIs is tracked behind the fallible
             // `BufferBackend` refactor in issue #246.
+            let frame_start_total = total_bytes_written;
+            let content_size = self
+                .state
+                .as_ref()
+                .expect("init populated state")
+                .frame_header
+                .frame_content_size();
+            let fcs_declared = self
+                .state
+                .as_ref()
+                .expect("init populated state")
+                .frame_header
+                .fcs_declared();
             loop {
                 self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
                 let bytes_written = self
@@ -1114,6 +1127,26 @@ impl FrameDecoder {
                 }
                 if self.is_finished() {
                     break;
+                }
+            }
+            // Per-frame FCS validation: when the frame header
+            // declared a frame_content_size, the drained byte count
+            // for THIS frame must match it. Without this check a
+            // corrupt under-producing frame (last_block flag tripped
+            // early on a sub-FCS payload) would silently return
+            // `Ok(short_len)` here, even though
+            // `decode_single_frame_legacy_drain` maps the same
+            // shape to `FrameContentSizeMismatch`. Use
+            // `fcs_declared()` (NOT `content_size > 0`) so an empty
+            // frame with explicit FCS=0 on the wire still gets
+            // validated.
+            if fcs_declared {
+                let produced = (total_bytes_written - frame_start_total) as u64;
+                if produced != content_size {
+                    return Err(FrameDecoderError::FrameContentSizeMismatch {
+                        declared: content_size,
+                        produced,
+                    });
                 }
             }
         }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1077,6 +1077,7 @@ impl FrameDecoder {
         mut output: &mut [u8],
         mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
     ) -> Result<usize, FrameDecoderError> {
+        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut total_bytes_written = 0;
         while !input.is_empty() {
             match init_frame(self, &mut input) {
@@ -1091,6 +1092,30 @@ impl FrameDecoder {
                 }
                 Err(e) => return Err(e),
             };
+            // Per-frame direct-path dispatch. Eligibility mirrors
+            // `decode_to_slice_trusted`: FCS declared and > 0, no
+            // active dictionary, and the remaining `output` slice has
+            // room for FCS + WILDCOPY_OVERLENGTH slack. When all hold
+            // the frame decodes straight into `output[..content_size]`
+            // through `UserSliceBackend`, bypassing the FlatBuf/Ring
+            // -> `read()` drain copy that dominates throughput on
+            // poorly-compressed corpora. Ineligible frames (no FCS,
+            // active dict, output too small for slack, streaming
+            // multi-frame inputs where the next frame needs the
+            // current iteration's tail) fall through to the legacy
+            // `decode_blocks` + `read` drain loop below.
+            let state_ref = self.state.as_ref().expect("init populated state");
+            let content_size = state_ref.frame_header.frame_content_size();
+            let dict_active = state_ref.using_dict.is_some();
+            let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
+            let direct_eligible =
+                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
+            if direct_eligible {
+                let written = self.run_direct_decode(&mut input, output, content_size)?;
+                output = &mut output[written..];
+                total_bytes_written += written;
+                continue;
+            }
             loop {
                 self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
                 let bytes_written = self
@@ -1317,12 +1342,7 @@ impl FrameDecoder {
         mut input: &[u8],
         output: &mut [u8],
     ) -> Result<usize, FrameDecoderError> {
-        use super::block_decoder;
         use super::buffer_backend::WILDCOPY_OVERLENGTH;
-        use super::decode_buffer::DecodeBuffer;
-        use super::scratch::DirectScratch;
-        use super::user_slice_buf::UserSliceBackend;
-        use crate::io::Read;
         use FrameDecoderError as err;
 
         // Parse the frame header. This populates `self.state` with
@@ -1339,111 +1359,115 @@ impl FrameDecoder {
         // payloads).
         self.init(&mut input)?;
 
-        let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
+        let state = self.state.as_ref().ok_or(err::NotYetInitialized)?;
         let content_size = state.frame_header.frame_content_size();
         let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-        // Eligibility independent of `single_segment_flag`:
-        // multi-segment frames work via a coarse, block-boundary
-        // cap on the visible buffer. The post-block
-        // `drop_to_window_size` call in the loop below advances the
-        // backend's `head` so `buffer.len()` doesn't grow past
-        // `window_size` between blocks — bytes physically remain
-        // in the user slice, just leave `len()`'s visible range so
-        // a subsequent block's match-offset cannot reach back
-        // arbitrarily far via stale history.
-        //
-        // This is NOT strict spec enforcement of
-        // `offset <= window_size`: within a single block
-        // `buffer.len()` can temporarily exceed `window_size` and
-        // `DecodeBuffer::repeat` validates against `buffer.len()`
-        // (not `window_size`), so an in-block match with
-        // `offset > window_size` but `offset <= current
-        // buffer.len()` is accepted on both direct and fallback
-        // paths. See the `decode_to_slice_trusted` doc for the full
-        // limitation note.
-        //
-        // Disabled when a dictionary is active: the persistent
-        // `DecoderScratch::buffer.dict_content` seeded by
-        // `init_from_dict` is NOT carried into the stack-local
-        // `DecodeBuffer<UserSliceBackend>` we build below, so any
-        // match that reaches into the external dictionary would
-        // decode against an empty prefix. Fall back to the regular
-        // path which keeps the dict in the persistent buffer.
         let dict_active = state.using_dict.is_some();
-        // `content_checksum_flag` is no longer a disqualifier. The
-        // direct path writes the decoded bytes into the user's
-        // `output` slice, and we hash that slice once at the end of
-        // decode (single sequential pass over cache-hot data). The
-        // computed digest is then propagated into the persistent
-        // `state.decoder_scratch.buffer.hash` so the public
-        // `get_calculated_checksum()` accessor reads the correct
-        // value just like on the `decode_all` path.
         let eligible = content_size > 0 && !dict_active && (output.len() as u64) >= needed;
 
         if !eligible {
             // Frame doesn't qualify for direct decode (empty
             // frame_content_size — header lacks FCS — or output too
-            // small for the WILDCOPY slack). Fall through to the
-            // existing per-block decode + drain path — `init`
+            // small for the WILDCOPY slack, or active dict). Fall
+            // through to the per-block decode + drain path. `init`
             // already populated `self.state`, so `decode_blocks` +
             // `read` pick up from there.
-            let mut output_tail: &mut [u8] = output;
-            let mut total_bytes_written = 0;
-            loop {
-                self.decode_blocks(&mut input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
-                let bytes_written = self
-                    .read(output_tail)
-                    .map_err(err::FailedToDrainDecodebuffer)?;
-                output_tail = &mut output_tail[bytes_written..];
-                total_bytes_written += bytes_written;
-                if self.can_collect() != 0 {
-                    return Err(err::TargetTooSmall);
-                }
-                if self.is_finished() {
-                    break;
-                }
-            }
-            // When the frame header declares a `frame_content_size`,
-            // ensure the drained byte count actually matches it.
-            // Without this check a corrupt frame that sets FCS but
-            // ends early (e.g. last-block flag on a sub-FCS payload)
-            // would silently return success here, while the
-            // eligible-frame direct path catches the same condition
-            // via `FrameContentSizeMismatch`. The fallback path now
-            // matches that behaviour.
-            //
-            // Use `fcs_declared()` (NOT `content_size > 0`) as the
-            // "is FCS on the wire" gate. The two diverge on the
-            // legitimate edge case of an empty frame with an
-            // EXPLICIT FCS=0 on the wire (FCS_flag>=1 with bytes
-            // reading 0, or single_segment+FCS_flag=0 with the
-            // 1-byte FCS=0): `content_size` is 0 in BOTH the
-            // "absent" and "explicitly zero" cases, while
-            // `fcs_declared()` returns false only in the truly
-            // absent case.
-            let state = self.state.as_ref().expect("state populated by init");
-            if state.frame_header.fcs_declared() && (total_bytes_written as u64) != content_size {
-                return Err(err::FrameContentSizeMismatch {
-                    declared: content_size,
-                    produced: total_bytes_written as u64,
-                });
-            }
-            return Ok(total_bytes_written);
+            return self.decode_single_frame_legacy_drain(&mut input, output, content_size);
         }
 
-        // Direct decode path. Borrow the persistent fields
-        // (HUF/FSE tables, offset_hist, scratch Vecs) out of the
-        // existing single-segment Flat scratch; we keep them
-        // populated across `decode_to_slice_trusted` calls (HUF table reuse
-        // is the main scratch-reuse win on small frames). Then
-        // construct a stack-local DecodeBuffer<UserSliceBackend<'o>>
-        // over `output` and bundle into a `DirectScratch`.
+        self.run_direct_decode(&mut input, output, content_size)
+    }
+
+    /// Single-frame legacy drain path: per-block decode + `read()`
+    /// drain into `output`. Used as fallback by
+    /// [`Self::decode_to_slice_trusted`] when direct-decode
+    /// eligibility fails (no FCS, active dict, output too small for
+    /// WILDCOPY slack). Not invoked from `decode_all_impl` since
+    /// that has its own multi-frame loop.
+    fn decode_single_frame_legacy_drain(
+        &mut self,
+        input: &mut &[u8],
+        output: &mut [u8],
+        content_size: u64,
+    ) -> Result<usize, FrameDecoderError> {
+        use FrameDecoderError as err;
+
+        let mut output_tail: &mut [u8] = output;
+        let mut total_bytes_written = 0;
+        loop {
+            self.decode_blocks(&mut *input, BlockDecodingStrategy::UptoBytes(1024 * 1024))?;
+            let bytes_written = self
+                .read(output_tail)
+                .map_err(err::FailedToDrainDecodebuffer)?;
+            output_tail = &mut output_tail[bytes_written..];
+            total_bytes_written += bytes_written;
+            if self.can_collect() != 0 {
+                return Err(err::TargetTooSmall);
+            }
+            if self.is_finished() {
+                break;
+            }
+        }
+        // Use `fcs_declared()` (NOT `content_size > 0`) as the
+        // "is FCS on the wire" gate. The two diverge on an empty
+        // frame with explicit FCS=0: `content_size` is 0 in both
+        // "absent" and "explicitly zero" cases, while
+        // `fcs_declared()` returns false only in the truly absent
+        // case.
+        let state = self.state.as_ref().expect("state populated by init");
+        if state.frame_header.fcs_declared() && (total_bytes_written as u64) != content_size {
+            return Err(err::FrameContentSizeMismatch {
+                declared: content_size,
+                produced: total_bytes_written as u64,
+            });
+        }
+        Ok(total_bytes_written)
+    }
+
+    /// Single-frame direct-decode path. Decodes one zstd frame into
+    /// `output[..content_size]` via a stack-local
+    /// `DecodeBuffer<UserSliceBackend>`, bypassing the per-block
+    /// FlatBuf/Ring -> `read()` drain copy.
+    ///
+    /// # Preconditions (caller-enforced)
+    ///
+    /// - `self.init` (or `init_with_dict_handle`) was called for
+    ///   this frame so `self.state` is populated.
+    /// - `content_size` matches `self.state.frame_header
+    ///   .frame_content_size()` and is `> 0` (caller already passed
+    ///   the eligibility gate).
+    /// - `output.len() >= content_size + WILDCOPY_OVERLENGTH`.
+    /// - No active dictionary
+    ///   (`self.state.using_dict.is_none()`).
+    ///
+    /// On return, `input` points at the byte immediately after the
+    /// frame's checksum (or after the last block, when the frame
+    /// has `content_checksum_flag = 0`). `self.state.frame_finished`
+    /// is set so [`Self::is_finished`] reports `true`.
+    fn run_direct_decode(
+        &mut self,
+        input: &mut &[u8],
+        output: &mut [u8],
+        content_size: u64,
+    ) -> Result<usize, FrameDecoderError> {
+        use super::block_decoder;
+        use super::decode_buffer::DecodeBuffer;
+        use super::scratch::DirectScratch;
+        use super::user_slice_buf::UserSliceBackend;
+        use crate::io::Read;
+        use FrameDecoderError as err;
+
+        let state = self
+            .state
+            .as_mut()
+            .expect("caller ensures init populated state");
+
         // Borrow persistent fields out of whichever scratch variant
         // `init` produced (Flat for single_segment, Ring for
-        // multi-segment) — both expose the same set of HUF/FSE/Vec
+        // multi-segment) — both expose the same HUF/FSE/Vec
         // fields; only `buffer` differs and we don't use that here.
-        // Macro-style binding to avoid the closure / generic
-        // gymnastics of returning multiple &mut from a match arm.
+        // Macro-style binding avoids the closure / generic
+        // gymnastics of returning multiple `&mut` from a match arm.
         let (huf, fse, offset_hist, literals_buffer, sequences, block_content_buffer, window_size) =
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => (
@@ -1495,7 +1519,7 @@ impl FrameDecoder {
         let mut produced: u64 = 0;
         loop {
             let (block_header, hsize) = block_dec
-                .read_block_header(&mut input)
+                .read_block_header(&mut *input)
                 .map_err(err::FailedToReadBlockHeader)?;
             state.bytes_read_counter += u64::from(hsize);
             // Pre-flight FCS check ONLY for Raw / RLE blocks where
@@ -1506,9 +1530,7 @@ impl FrameDecoder {
             let block_upper = u64::from(block_header.decompressed_size);
             if block_upper > 0 && produced + block_upper > content_size {
                 // Frame is corrupt — Raw/RLE block headers claim
-                // more output than the FCS allows. Caller's buffer
-                // was sized against FCS, so this is decoder-side
-                // corruption, not user sizing.
+                // more output than the FCS allows.
                 return Err(err::FrameContentSizeMismatch {
                     declared: content_size,
                     produced: produced + block_upper,
@@ -1521,33 +1543,22 @@ impl FrameDecoder {
             let body_consumed = match block_dec.decode_block_content_from_slice(
                 &block_header,
                 &mut direct,
-                &mut input,
+                &mut *input,
             ) {
                 Ok(n) => n,
                 // Defense-in-depth: RLE / Raw block whose declared
                 // `decompressed_size` slipped past the per-block
-                // pre-flight above (e.g. due to overflow arithmetic)
-                // and tripped the backend's fallible write surface.
-                // The pre-flight catches this case via
-                // `FrameContentSizeMismatch` already; convert here
-                // for the residual paths to keep the public surface
-                // panic-free.
+                // pre-flight above and tripped the backend's
+                // fallible write surface.
                 Err(crate::decoding::errors::DecodeBlockContentError::BackendOverflow {
                     ..
                 }) => {
-                    // Use saturating_add on the `produced (u64) +
-                    // decompressed_size (u32 → u64)` sum. Each block's
-                    // `decompressed_size` is bounded by 128 KiB
-                    // (`MAX_BLOCK_SIZE`, smaller than u32::MAX let
-                    // alone u64::MAX), but accumulated `produced`
-                    // across many adversarial frames can grow toward
-                    // u64::MAX. Saturating avoids a panic-in-debug /
-                    // wrap-in-release on the error path itself, which
-                    // would undermine the defense-in-depth this
-                    // conversion exists for. The cap value
-                    // (`u64::MAX`) is informative enough for the
-                    // caller — they only care that `produced` exceeds
-                    // declared `content_size`.
+                    // Use saturating_add on the
+                    // `produced + decompressed_size` sum. Each block
+                    // is bounded by 128 KiB (MAX_BLOCK_SIZE), but
+                    // accumulated `produced` can grow toward
+                    // u64::MAX across adversarial frames. Saturating
+                    // avoids a panic on the error path itself.
                     return Err(err::FrameContentSizeMismatch {
                         declared: content_size,
                         produced: produced
@@ -1557,32 +1568,19 @@ impl FrameDecoder {
                 Err(e) => return Err(err::FailedToReadBlockBody(e)),
             };
             produced = direct.buffer.total_produced();
-            // Post-decode FCS overflow check. Works uniformly for
-            // Raw/RLE/Compressed since it reads the actual bytes
-            // written by the backend rather than the header's
-            // (possibly zero) `decompressed_size`.
+            // Post-decode FCS overflow check.
             if produced > content_size {
                 return Err(err::FrameContentSizeMismatch {
                     declared: content_size,
                     produced,
                 });
             }
-            // Silence unused-binding warning when this delta isn't
-            // consulted — it's there so future debug builds can
-            // assert (produced - before) <= MAX_BLOCK_SIZE if the
-            // spec invariant ever needs an explicit gate.
             let _ = before;
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
             // Cap the visible buffer at window_size between blocks
             // so the next block's match-offset validation matches
-            // the spec's `offset <= window_size` rule. Bytes
-            // physically stay in the user slice; we just narrow
-            // the visible range via `head`. For single-segment
-            // frames `content_size <= window_size` so this is a
-            // no-op on every iteration; for multi-segment frames
-            // it advances `head` once `tail - head` outgrows the
-            // window.
+            // the spec's `offset <= window_size` rule.
             direct.buffer.drop_to_window_size();
             if block_header.last_block {
                 if state.frame_header.descriptor.content_checksum_flag() {
@@ -1596,11 +1594,7 @@ impl FrameDecoder {
                 break;
             }
         }
-        // Final sanity: blocks summed to exactly `content_size`. A
-        // malformed frame with `last_block` set early (or one whose
-        // block headers under-count) would land here. Distinct from
-        // TargetTooSmall — the caller did their part, the frame
-        // itself is corrupt.
+        // Final sanity: blocks summed to exactly `content_size`.
         if produced != content_size {
             return Err(err::FrameContentSizeMismatch {
                 declared: content_size,
@@ -1608,17 +1602,11 @@ impl FrameDecoder {
             });
         }
 
-        // `direct.buffer.len()` would only show the visible (post
-        // head-advance) range, not the total bytes physically
-        // written into the user slice. The decode succeeded so
-        // `content_size` is the authoritative byte count — the
-        // backend wrote exactly that many bytes starting at
-        // `output[0]`.
         let written = content_size as usize;
         state.frame_finished = true;
         // Drop the stack-local DirectScratch (and its DecodeBuffer
         // borrow on `output`) so we can re-borrow `output` for the
-        // hash pass below. After this point `direct` is gone.
+        // hash pass below.
         drop(direct);
         #[cfg(feature = "hash")]
         {
@@ -1628,15 +1616,7 @@ impl FrameDecoder {
             // Walk the decoded output once and propagate the
             // resulting hasher state into the persistent scratch's
             // buffer so `get_calculated_checksum()` returns the
-            // right value. Cost: ~330 us / MiB at xxhash's
-            // ~3 GB/s throughput on x86_64, against cache-hot data.
-            //
-            // Done unconditionally for every successful direct
-            // decode (not just frames with `content_checksum_flag`)
-            // so `get_calculated_checksum()` returns the running
-            // digest path-independently — matches what
-            // `decode_all`'s drain-time hashing produces on
-            // checksumless frames too.
+            // right value path-independently.
             use core::hash::Hasher;
             let mut hasher = twox_hash::XxHash64::with_seed(0);
             hasher.write(&output[..written]);
@@ -1772,6 +1752,53 @@ mod tests {
                 .single_segment_flag(),
             "test precondition violated: frame is single-segment, rename or resize"
         );
+    }
+
+    #[test]
+    fn decode_all_routes_eligible_frame_through_direct_path() {
+        // Regression test for the per-frame direct-path dispatch in
+        // `decode_all_impl`. With a sized-with-slack output buffer
+        // the eligibility gate (FCS > 0, no dict, output.len() >=
+        // FCS + WILDCOPY_OVERLENGTH) holds, so `decode_all` must
+        // route through `run_direct_decode` and produce the same
+        // bytes the legacy drain path would.
+        let payload: Vec<u8> = (0..8192u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len() + slack];
+        let n = dec
+            .decode_all(compressed.as_slice(), &mut out)
+            .expect("decode_all with WILDCOPY slack should succeed via direct path");
+        assert_eq!(n, payload.len());
+        assert_eq!(&out[..n], payload.as_slice());
+    }
+
+    #[test]
+    fn decode_all_with_tight_output_routes_through_legacy_drain() {
+        // Output sized to EXACTLY content_size (no slack) must
+        // fail the direct-path eligibility gate and fall back to
+        // the per-block decode + read drain loop. This covers
+        // callers that don't / can't pre-size with WILDCOPY slack.
+        let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len()];
+        let n = dec
+            .decode_all(compressed.as_slice(), &mut out)
+            .expect("decode_all with tight output must succeed via legacy drain");
+        assert_eq!(n, payload.len());
+        assert_eq!(&out[..n], payload.as_slice());
     }
 
     #[cfg(feature = "hash")]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1447,12 +1447,17 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn decode_all_matches_decode_all_on_single_segment_frame() {
+    fn decode_all_legacy_drain_matches_direct_path_on_single_segment_frame() {
         // Roundtrip a small payload through the encoder, then decode
-        // it via both `decode_all` and `decode_all`. Both paths
-        // must produce identical output bytes — the only difference
-        // is the internal buffer/drain shape, not the decoded
-        // semantics. This is the regression gate for the
+        // it via `decode_all` on two output shapes that select
+        // different internal paths:
+        //   1. Tight output (no WILDCOPY_OVERLENGTH slack) → legacy
+        //      `decode_blocks` + `read()` drain path.
+        //   2. Output with WILDCOPY slack → direct
+        //      `run_direct_decode` + `UserSliceBackend` path.
+        // Both paths must produce identical output bytes — the only
+        // difference is the internal buffer/drain shape, not the
+        // decoded semantics. This is the regression gate for the
         // direct-decode wiring.
         let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
@@ -1461,22 +1466,22 @@ mod tests {
         compressor.set_drain(&mut compressed);
         compressor.compress();
 
-        // Baseline: decode_all.
+        // Baseline: tight output → legacy drain path.
         let mut dec_a = FrameDecoder::new();
         let mut out_a = alloc::vec![0u8; payload.len()];
         let n_a = dec_a
             .decode_all(compressed.as_slice(), &mut out_a)
-            .expect("decode_all should succeed");
+            .expect("decode_all (legacy drain) should succeed");
         assert_eq!(n_a, payload.len());
         assert_eq!(&out_a[..n_a], payload.as_slice());
 
-        // Direct: decode_all with WILDCOPY slack.
+        // Direct: output with WILDCOPY slack → direct path.
         let slack = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut dec_b = FrameDecoder::new();
         let mut out_b = alloc::vec![0u8; payload.len() + slack];
         let n_b = dec_b
             .decode_all(compressed.as_slice(), &mut out_b)
-            .expect("decode_all should succeed");
+            .expect("decode_all (direct path) should succeed");
         assert_eq!(
             n_b,
             payload.len(),

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -41,6 +41,7 @@ pub(crate) mod block_decoder;
 pub(crate) mod buffer_backend;
 pub(crate) mod decode_buffer;
 pub(crate) mod dictionary;
+pub(crate) mod exec_sequence_donor;
 // FlatBuf is the compile-time-monomorphised "frame fits in window"
 // backend selected via `DecodeBuffer<FlatBuf>`. `FrameDecoder`'s
 // `DecoderScratchKind` picks it when the frame header has

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -41,7 +41,7 @@ pub(crate) mod block_decoder;
 pub(crate) mod buffer_backend;
 pub(crate) mod decode_buffer;
 pub(crate) mod dictionary;
-pub(crate) mod exec_sequence_donor;
+pub(crate) mod exec_sequence_inline;
 // FlatBuf is the compile-time-monomorphised "frame fits in window"
 // backend selected via `DecodeBuffer<FlatBuf>`. `FrameDecoder`'s
 // `DecoderScratchKind` picks it when the frame header has
@@ -60,7 +60,7 @@ pub(crate) mod sequence_section_decoder;
 pub(crate) mod simd_copy;
 // `UserSliceBackend` is the compile-time-monomorphised backend that
 // writes directly into the caller's `&mut [u8]` output slice, used
-// by the `FrameDecoder::decode_to_slice_trusted` direct-decode path. It
+// by the `FrameDecoder::decode_all` direct-decode path. It
 // eliminates the `FlatBuf` drain copy + anonymous-page-fault cost
 // on large literal sections. Wiring happens via
 // `DecodeBuffer<UserSliceBackend<'a>>`; the lifetime binds the

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -107,7 +107,7 @@ impl<B: BufferBackend> Workspace for DecoderScratch<B> {
 /// that the owned-buffer path performs, by writing decoded bytes
 /// straight into the caller-provided output slice.
 ///
-/// Constructed inside `FrameDecoder::decode_to_slice_trusted` and dropped
+/// Constructed inside `FrameDecoder::decode_all` and dropped
 /// at function exit; never persisted across calls.
 pub struct DirectScratch<'o, 'p> {
     pub huf: &'p mut HuffmanScratch,

--- a/zstd/src/decoding/sequence_execution.rs
+++ b/zstd/src/decoding/sequence_execution.rs
@@ -33,7 +33,13 @@ pub(crate) fn execute_sequences_fields<B: super::buffer_backend::BufferBackend>(
         // SAFETY: literals_copy_counter <= high <= literals_buffer_len.
         let literals = unsafe { literals_buffer.get_unchecked(literals_copy_counter..high) };
         literals_copy_counter = high;
-        buffer.push(literals);
+        // `try_push` routes a fixed-capacity backend overshoot
+        // (UserSliceBackend) into a structured
+        // `ExecuteSequencesError::OutputBufferOverflow` instead of
+        // panicking via the per-call `assert!` inside
+        // `BufferBackend::extend`. Growable backends accept the write
+        // infallibly via the default trait impl.
+        buffer.try_push(literals)?;
 
         let actual_offset = do_offset_history(seq.of, seq.ll, offset_hist);
         if actual_offset == 0 {
@@ -45,7 +51,7 @@ pub(crate) fn execute_sequences_fields<B: super::buffer_backend::BufferBackend>(
     }
     if literals_copy_counter < literals_buffer_len {
         let rest_literals = &literals_buffer[literals_copy_counter..];
-        buffer.push(rest_literals);
+        buffer.try_push(rest_literals)?;
         seq_sum = seq_sum.wrapping_add(rest_literals.len() as u32);
     }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -525,19 +525,23 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     // past the end of the literals buffer slice — UB even when the
     // bytes happen to be valid memory inside the backing `Vec`.
     // Donor guards with `iLitEnd > litLimit` → slow path. We mirror
-    // the same gate. For `lit_length <= 16` the over-read is from the
-    // first unconditional `ZSTD_copy16` (16 bytes from `lit_cur_before`).
-    // For `lit_length > 16` the wildcopy_no_overlap tail loop's final
-    // 16-byte chunk loads bytes
-    // `lits.as_ptr() + (lit_length - 16) .. + lit_length`. Both cases
-    // are covered by `high + 15 <= lit_len`
-    // (`high = lit_cur_before + lit_length`): the over-read past the
-    // declared literal end is bounded by 15 bytes, and `high + 15`
-    // staying inside `lit_len` proves the load is in-bounds. The
-    // final few sequences of a block fall through to the legacy
-    // `push`/`repeat` chain which handles short literals exactly
-    // (no over-read).
-    if B::SUPPORTS_INLINE_DONOR_EXEC && high + 15 <= lit_len {
+    // the same gate. The donor inline path issues two distinct reads
+    // past the declared literal end:
+    //   (1) Unconditional first `ZSTD_copy16` from `lit_cur_before`
+    //       — needs `lit_cur_before + 16 <= lit_len`. THIS GATE
+    //       MATTERS EVEN WHEN `seq.ll == 0`: the copy still happens,
+    //       overwriting the dst region the match copy will rewrite.
+    //   (2) Tail wildcopy's final 16-byte chunk at offset
+    //       `(lit_length - 16) .. lit_length` — needs
+    //       `lit_cur_before + lit_length + 15 <= lit_len`, i.e.
+    //       `high + 15 <= lit_len`.
+    // For `lit_length == 0` only (1) fires. For `lit_length ∈ 1..=16`
+    // (1) is tighter than (2). For `lit_length > 16` (2) is tighter.
+    // Take both as guards. `checked_add` covers adversarial overflow.
+    let donor_path_safe = B::SUPPORTS_INLINE_DONOR_EXEC
+        && lit_cur_before.checked_add(16).is_some_and(|b| b <= lit_len)
+        && high.checked_add(15).is_some_and(|b| b <= lit_len);
+    if donor_path_safe {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path
         // gate). Donor inline path stays on the prefix-resident

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -531,16 +531,19 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     //       — needs `lit_cur_before + 16 <= lit_len`. THIS GATE
     //       MATTERS EVEN WHEN `seq.ll == 0`: the copy still happens,
     //       overwriting the dst region the match copy will rewrite.
-    //   (2) Tail wildcopy's final 16-byte chunk at offset
-    //       `(lit_length - 16) .. lit_length` — needs
-    //       `lit_cur_before + lit_length + 15 <= lit_len`, i.e.
-    //       `high + 15 <= lit_len`.
-    // For `lit_length == 0` only (1) fires. For `lit_length ∈ 1..=16`
-    // (1) is tighter than (2). For `lit_length > 16` (2) is tighter.
-    // Take both as guards. `checked_add` covers adversarial overflow.
+    //   (2) Tail wildcopy's final 16-byte chunk — ONLY when
+    //       `lit_length > 16` (the donor inline path gates the
+    //       wildcopy call on that same threshold). Reads up to
+    //       `lit_cur_before + lit_length + 15`, i.e. `high + 15`.
+    // For `lit_length ∈ 0..=16` only (1) fires; gate (2) would
+    // unnecessarily reject short-literal-tail sequences near
+    // `lit_len` whose `copy16` over-read fits inside the buffer
+    // (`lit_cur_before + 16 <= lit_len`) but whose `high + 15`
+    // exceeds it. Apply (2) only in the wildcopy regime.
+    // `checked_add` covers adversarial overflow.
     let donor_path_safe = B::SUPPORTS_INLINE_DONOR_EXEC
         && lit_cur_before.checked_add(16).is_some_and(|b| b <= lit_len)
-        && high.checked_add(15).is_some_and(|b| b <= lit_len);
+        && (seq.ll as usize <= 16 || high.checked_add(15).is_some_and(|b| b <= lit_len));
     if donor_path_safe {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -492,7 +492,8 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     seq: Sequence,
     resolved_offset: u32,
 ) -> Result<(), DecompressBlockError> {
-    let high = *lit_cur + seq.ll as usize;
+    let lit_cur_before = *lit_cur;
+    let high = lit_cur_before + seq.ll as usize;
     if high > lit_len {
         return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
             wanted: high,
@@ -501,22 +502,35 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         .into());
     }
     // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
-    let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
+    let lits = unsafe { literals.get_unchecked(lit_cur_before..high) };
     *lit_cur = high;
 
     if resolved_offset == 0 {
         return Err(ExecuteSequencesError::ZeroOffset.into());
     }
 
-    // Donor-shape inline dispatch — when the backend opts in (only
-    // `UserSliceBackend` on x86/x86_64 today, per its
+    // Donor-shape inline dispatch — when the backend opts in
+    // (`UserSliceBackend` on x86_64 today, per its
     // `SUPPORTS_INLINE_DONOR_EXEC = true` const) we collapse the
     // literal copy + match copy into a single straight-line body
     // that mirrors donor `ZSTD_execSequence`
     // (zstd_decompress_block.c:1008-1105). The const branch is
     // compile-time per backend monomorphisation, so the dead arm
     // carries no runtime cost on either side.
-    if B::SUPPORTS_INLINE_DONOR_EXEC {
+    //
+    // **Literal-source slack guard** (the read-side donor-port
+    // safety contract): donor's `ZSTD_copy16` reads 16 bytes
+    // unconditionally regardless of `litLength`; on truncated
+    // literals (the closing sequences of a block) that would read
+    // past the end of the literals buffer slice — UB even when the
+    // bytes happen to be valid memory inside the backing `Vec`.
+    // Donor guards with `iLitEnd > litLimit` → slow path. We mirror
+    // the same gate: only take the donor inline arm when the source
+    // window has ≥ 16 bytes left from `lit_cur_before`. The final
+    // few sequences of a block fall through to the legacy
+    // `push`/`repeat` chain which handles short literals exactly
+    // (no over-read).
+    if B::SUPPORTS_INLINE_DONOR_EXEC && lit_cur_before + 16 <= lit_len {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path
         // gate). Donor inline path stays on the prefix-resident
@@ -535,17 +549,27 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
                 .map_err(ExecuteSequencesError::from)?;
             return Ok(());
         }
-        // SAFETY: backend opted in (compile-time const), `lits` is a
-        // non-aliased slice of the literal block, `offset` is within
-        // the live region (prefix-resident, asserted above),
-        // `match_length >= 1` is enforced by the
-        // `resolved_offset == 0` check above (offset > 0 implies
-        // match exists; degenerate `ml = 0` is benign — donor copies
-        // zero bytes through the wildcopy's `do/while` body once).
-        // Caller's upfront `reserve(MAX_BLOCK_SIZE)` guarantees the
-        // writable tail has room for `lit_length + match_length`
-        // plus the wildcopy overshoot slack
-        // (`WILDCOPY_OVERLENGTH = 32`).
+        // SAFETY:
+        // - Backend opted in (compile-time const).
+        // - `lits` is a non-aliased slice of the literals block.
+        // - Source-side slack: `lit_cur_before + 16 <= lit_len`
+        //   (gated above), so `lits.as_ptr().add(16)` reads stay
+        //   inside the literals buffer. Donor unconditional
+        //   `ZSTD_copy16` over-read of up to 16 bytes past
+        //   `lits.len()` is bounded by the slack we just asserted.
+        // - Offset is within the live region (prefix-resident,
+        //   asserted above), so the match-copy source pointer
+        //   `base + tail + lit_length - offset` is in-bounds.
+        // - Match length is `>= 1` by zstd spec invariant (a
+        //   sequence with `matchLength = 0` is malformed; the FSE
+        //   decode produces baseline values starting at 3 for ml
+        //   codes 0..3, so `seq.ml >= 3` for any valid sequence).
+        //   The wildcopy helpers assert this in debug builds.
+        // - Caller's upfront `reserve(MAX_BLOCK_SIZE)` plus the
+        //   `WILDCOPY_OVERLENGTH = 32` slack on the user slice
+        //   guarantees the writable tail has room for
+        //   `lit_length + match_length + 15` (max wildcopy
+        //   overshoot is 15 bytes past the declared end).
         unsafe {
             buffer
                 .buffer_mut()

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -45,9 +45,19 @@ const _: () = assert!(
 /// `cfg(target_feature)` under `no_std` — then dispatches to a
 /// kernel-monomorphised body so the inner pipeline's
 /// `BitReaderReversed<K>` resolves `K::mask_lower_bits` at compile
-/// time, bypassing the runtime `use_pext_triple` branch. The per-call
-/// dispatch cost is one `OnceLock::get` (std) or zero (no_std) plus a
-/// small `match` — amortised over the whole block.
+/// time (one BMI2 `bzhi` codegen per bit-mask call, no per-call
+/// kernel-selection dispatch). The per-call dispatch cost is one
+/// `OnceLock::get` (std) or zero (no_std) plus a small `match` —
+/// amortised over the whole block.
+///
+/// (Note: `BitReaderReversed::peek_bits_triple` still carries a
+/// per-call `if self.use_pext_triple` branch under
+/// `feature = "std"` + `target_arch = "x86_64"`, choosing between
+/// scalar mask and PEXT extract. That branch is **independent** of
+/// the kernel cascade and is left as-is — folding it into the
+/// kernel type would force VBMI2/Avx2/Bmi2 to commit to PEXT-only
+/// codegen, which is not always the fastest choice on the FSE
+/// state-update extracts.)
 ///
 /// The BMI2/AVX2/VBMI2 arms route through `#[target_feature]`-wrapped
 /// trampolines so LLVM can inline the kernel's `_bzhi_u64` / pext
@@ -759,7 +769,14 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         // back to the layered path below.
         let buf_len = buffer.len();
         let offset = resolved_offset as usize;
-        if offset > buf_len + lits.len() {
+        // `checked_add` against adversarial input: if `buf_len +
+        // lits.len()` would wrap `usize`, treat the offset as
+        // out-of-range and fall back to the layered path. Without
+        // the check, wrapping addition could classify a wildly
+        // out-of-range `offset` as in-range and feed the donor
+        // inline path an OOB match-source pointer.
+        let prefix_end = buf_len.checked_add(lits.len()).filter(|end| offset <= *end);
+        if prefix_end.is_none() {
             // Match source reaches outside what's been written in this
             // frame — donor's `extDict` arm. Punt back to the slow
             // `repeat()` path; that path already routes through

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -525,12 +525,19 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     // past the end of the literals buffer slice — UB even when the
     // bytes happen to be valid memory inside the backing `Vec`.
     // Donor guards with `iLitEnd > litLimit` → slow path. We mirror
-    // the same gate: only take the donor inline arm when the source
-    // window has ≥ 16 bytes left from `lit_cur_before`. The final
-    // few sequences of a block fall through to the legacy
+    // the same gate. For `lit_length <= 16` the over-read is from the
+    // first unconditional `ZSTD_copy16` (16 bytes from `lit_cur_before`).
+    // For `lit_length > 16` the wildcopy_no_overlap tail loop's final
+    // 16-byte chunk loads bytes
+    // `lits.as_ptr() + (lit_length - 16) .. + lit_length`. Both cases
+    // are covered by `high + 15 <= lit_len`
+    // (`high = lit_cur_before + lit_length`): the over-read past the
+    // declared literal end is bounded by 15 bytes, and `high + 15`
+    // staying inside `lit_len` proves the load is in-bounds. The
+    // final few sequences of a block fall through to the legacy
     // `push`/`repeat` chain which handles short literals exactly
     // (no over-read).
-    if B::SUPPORTS_INLINE_DONOR_EXEC && lit_cur_before + 16 <= lit_len {
+    if B::SUPPORTS_INLINE_DONOR_EXEC && high + 15 <= lit_len {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path
         // gate). Donor inline path stays on the prefix-resident

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -294,6 +294,14 @@ fn decode_and_execute_sequences_impl<
     // the source maintenance for zero observed wins.
     if fse.ll_rle.is_some() || fse.ml_rle.is_some() || fse.of_rle.is_some() {
         decode_sequences_with_rle(section, &mut br, fse, rle_fallback_sequences)?;
+        // `execute_sequences_fields` routes literal-pushes through
+        // `DecodeBuffer::try_push` (and match-repeats through
+        // `BufferBackend::try_reserve` inside `repeat_inner`), so a
+        // malformed RLE-driven sequence stream whose literal or match
+        // length overshoots a fixed-capacity backend (UserSliceBackend)
+        // surfaces as `ExecuteSequencesError::OutputBufferOverflow`
+        // rather than panicking via UserSliceBackend::extend's
+        // release-mode `assert!`.
         execute_sequences_fields(buffer, literals_buffer, offset_hist, rle_fallback_sequences)?;
         return Ok(());
     }

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -40,7 +40,211 @@ const _: () = assert!(
 /// Falls back to the legacy two-pass pipeline (`decode_sequences` +
 /// `execute_sequences`) when any of LL/ML/OF is in RLE mode — that path
 /// is rare on perf-relevant corpora and not worth duplicating.
+/// Public entry. Resolves the CPU kernel — `OnceLock`-cached
+/// runtime detect under `feature = "std"`, compile-time
+/// `cfg(target_feature)` under `no_std` — then dispatches to a
+/// kernel-monomorphised body so the inner pipeline's
+/// `BitReaderReversed<K>` resolves `K::mask_lower_bits` at compile
+/// time, bypassing the runtime `use_pext_triple` branch. The per-call
+/// dispatch cost is one `OnceLock::get` (std) or zero (no_std) plus a
+/// small `match` — amortised over the whole block.
+///
+/// The BMI2/AVX2/VBMI2 arms route through `#[target_feature]`-wrapped
+/// trampolines so LLVM can inline the kernel's `_bzhi_u64` / pext
+/// instructions across the `K::mask_lower_bits` call boundary inside
+/// the impl body — otherwise the per-call target_feature boundary
+/// would keep a function-call trampoline at every BitReader op.
 pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    use crate::cpu_kernel::{CpuKernelTag, ScalarKernel, detect_cpu_kernel};
+    #[cfg(target_arch = "aarch64")]
+    use crate::cpu_kernel::{NeonKernel, SveKernel};
+
+    match detect_cpu_kernel() {
+        CpuKernelTag::Scalar => decode_and_execute_sequences_impl::<B, ScalarKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Bmi2 => {
+            // SAFETY: `detect_cpu_kernel()` only returns Bmi2 when
+            // `is_x86_feature_detected!("bmi2")` confirmed BMI2 is
+            // available. The `#[target_feature(enable = "bmi2")]`
+            // wrapper lets LLVM emit `bzhi` directly at every
+            // `K::mask_lower_bits` call site inside the impl,
+            // bypassing the per-call target_feature trampoline that
+            // would otherwise survive.
+            unsafe {
+                decode_and_execute_sequences_bmi2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Avx2 => {
+            // SAFETY: detect confirmed BMI2 + AVX2.
+            unsafe {
+                decode_and_execute_sequences_avx2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Vbmi2 => {
+            // SAFETY: detect confirmed AVX-512 VBMI2 + AVX2 + BMI2
+            // (see `select_x86_kernel` precedence rules).
+            unsafe {
+                decode_and_execute_sequences_vbmi2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        CpuKernelTag::Neon => decode_and_execute_sequences_impl::<B, NeonKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "aarch64")]
+        CpuKernelTag::Sve => decode_and_execute_sequences_impl::<B, SveKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+    }
+}
+
+/// `#[target_feature(enable = "bmi2")]` trampoline for the BMI2 arm
+/// — wraps `decode_and_execute_sequences_impl::<B, Bmi2Kernel>` so
+/// LLVM can inline `_bzhi_u64` at every `K::mask_lower_bits` call
+/// across the target_feature boundary.
+///
+/// # Safety
+/// Caller must ensure BMI2 is available on the runtime CPU; the
+/// dispatcher above gates on `detect_cpu_kernel() == Bmi2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+unsafe fn decode_and_execute_sequences_bmi2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Bmi2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
+}
+
+/// `#[target_feature(enable = "bmi2,avx2")]` trampoline for the
+/// Avx2 arm. Same shape as the BMI2 trampoline; the AVX2 enable
+/// piles onto the BMI2 feature set so any AVX2-gated codegen
+/// (chunked SIMD copy via `_mm256_*`) also benefits.
+///
+/// # Safety
+/// Caller must ensure BMI2 + AVX2 are available; gated by
+/// `detect_cpu_kernel() == Avx2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2,avx2")]
+unsafe fn decode_and_execute_sequences_avx2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Avx2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
+}
+
+/// `#[target_feature(enable = "...AVX-512 VBMI2 family + BMI2 + AVX2")]`
+/// trampoline for the Vbmi2 arm. Enables the full feature set the
+/// `select_x86_kernel` precedence requires.
+///
+/// # Safety
+/// Caller must ensure the entire feature set is available; gated by
+/// `detect_cpu_kernel() == Vbmi2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2,avx2,avx512vbmi2,avx512f,avx512vl,avx512bw")]
+unsafe fn decode_and_execute_sequences_vbmi2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Vbmi2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
+}
+
+fn decode_and_execute_sequences_impl<
+    B: super::buffer_backend::BufferBackend,
+    K: crate::cpu_kernel::CpuKernel,
+>(
     section: &SequencesHeader,
     source: &[u8],
     fse: &mut FSEScratch,
@@ -59,7 +263,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     vprintln!("Updating tables used {} bytes", bytes_read);
 
     let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::new(bit_stream);
+    let mut br = BitReaderReversed::<K>::new(bit_stream);
 
     // Skip the 0-padding at the end of the last byte and consume the
     // start-of-stream `1` bit.
@@ -326,8 +530,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
 /// Grouping into a struct would push pressure off the argument
 /// registers and onto memory loads, undoing the extraction's win.
 #[allow(clippy::too_many_arguments)]
-fn run_pipelined_sequence_loop<B: super::buffer_backend::BufferBackend>(
-    br: &mut BitReaderReversed<'_>,
+fn run_pipelined_sequence_loop<
+    B: super::buffer_backend::BufferBackend,
+    K: crate::cpu_kernel::CpuKernel,
+>(
+    br: &mut BitReaderReversed<'_, K>,
     ll_dec: &mut FSEDecoder<'_>,
     ml_dec: &mut FSEDecoder<'_>,
     of_dec: &mut FSEDecoder<'_>,
@@ -606,11 +813,11 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
 /// `decode_sequences_without_rle` — separate copy because Rust does not
 /// let us share a private fn-item across two outer functions cleanly.
 #[inline(always)]
-fn decode_one_sequence_inline(
+fn decode_one_sequence_inline<K: crate::cpu_kernel::CpuKernel>(
     ll_dec: &mut FSEDecoder<'_>,
     ml_dec: &mut FSEDecoder<'_>,
     of_dec: &mut FSEDecoder<'_>,
-    br: &mut BitReaderReversed<'_>,
+    br: &mut BitReaderReversed<'_, K>,
 ) -> Sequence {
     // Read base/extra-bits directly off the active FSE state's
     // `Entry`. LL / ML are populated by `enrich_with_packed_seq_meta`
@@ -652,9 +859,9 @@ fn decode_one_sequence_inline(
     }
 }
 
-fn decode_sequences_with_rle(
+fn decode_sequences_with_rle<K: crate::cpu_kernel::CpuKernel>(
     section: &SequencesHeader,
-    br: &mut BitReaderReversed<'_>,
+    br: &mut BitReaderReversed<'_, K>,
     scratch: &FSEScratch,
     target: &mut Vec<Sequence>,
 ) -> Result<(), DecodeSequenceError> {

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -808,12 +808,25 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         //   guarantees the writable tail has room for
         //   `lit_length + match_length + 15` (max wildcopy
         //   overshoot is 15 bytes past the declared end).
+        // SAFETY: `literals.as_ptr().add(lit_cur_before)` has the
+        // provenance of the FULL `literals` slice (not `lits`, the
+        // sub-slice). The 16-byte unconditional `copy16` inside the
+        // donor body reads up to `lit_cur_before + 16` bytes from
+        // the parent buffer, which the `donor_path_safe` gate above
+        // bounded by `lit_cur_before + 16 <= lit_len`. Passing
+        // `lits.as_ptr()` directly would be UB when `lits.len() <
+        // 16` because the sub-slice's provenance ends at its own
+        // `len()` regardless of the backing buffer's extra capacity.
+        let lit_src = unsafe { literals.as_ptr().add(lit_cur_before) };
         unsafe {
-            buffer
-                .buffer_mut()
-                .donor_exec_one_sequence(lits, offset, seq.ml as usize);
+            buffer.buffer_mut().donor_exec_one_sequence(
+                lit_src,
+                seq.ll as usize,
+                offset,
+                seq.ml as usize,
+            );
         }
-        buffer.advance_output_counter(lits.len() + seq.ml as usize);
+        buffer.advance_output_counter(seq.ll as usize + seq.ml as usize);
         return Ok(());
     }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -678,7 +678,7 @@ fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
     // (high = lit_cur + seq.ll, seq.ll >= 0).
     let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
     *lit_cur = high;
-    buffer.push(lits);
+    buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
 
     let actual = do_offset_history(seq.of, seq.ll, offset_hist);
     if actual == 0 {
@@ -728,7 +728,7 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
 
     // Donor-shape inline dispatch — when the backend opts in
     // (`UserSliceBackend` on x86_64 today, per its
-    // `SUPPORTS_INLINE_DONOR_EXEC = true` const) we collapse the
+    // `SUPPORTS_INLINE_SEQUENCE_EXEC = true` const) we collapse the
     // literal copy + match copy into a single straight-line body
     // that mirrors donor `ZSTD_execSequence`
     // (zstd_decompress_block.c:1008-1105). The const branch is
@@ -764,13 +764,13 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     // over-counts by `15 - ((seq.ll - 1) % 16)` whenever `seq.ll %
     // 16 != 1` — keeping the donor inline path active on more
     // sequences near the end of the literals buffer.
-    let donor_path_safe = B::SUPPORTS_INLINE_DONOR_EXEC
+    let inline_path_safe = B::SUPPORTS_INLINE_SEQUENCE_EXEC
         && lit_cur_before.checked_add(16).is_some_and(|b| b <= lit_len)
         && (seq.ll as usize <= 16
             || lit_cur_before
                 .checked_add((seq.ll as usize).next_multiple_of(16))
                 .is_some_and(|b| b <= lit_len));
-    if donor_path_safe {
+    if inline_path_safe {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path
         // gate). Donor inline path stays on the prefix-resident
@@ -790,7 +790,7 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
             // frame — donor's `extDict` arm. Punt back to the slow
             // `repeat()` path; that path already routes through
             // `repeat_from_dict` for these offsets.
-            buffer.push(lits);
+            buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
             buffer
                 .repeat_lookahead_prefetched(offset, seq.ml as usize)
                 .map_err(ExecuteSequencesError::from)?;
@@ -821,7 +821,7 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         // provenance of the FULL `literals` slice (not `lits`, the
         // sub-slice). The 16-byte unconditional `copy16` inside the
         // donor body reads up to `lit_cur_before + 16` bytes from
-        // the parent buffer, which the `donor_path_safe` gate above
+        // the parent buffer, which the `inline_path_safe` gate above
         // bounded by `lit_cur_before + 16 <= lit_len`. Passing
         // `lits.as_ptr()` directly would be UB when `lits.len() <
         // 16` because the sub-slice's provenance ends at its own
@@ -830,7 +830,7 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         unsafe {
             buffer
                 .buffer_mut()
-                .donor_exec_one_sequence(lit_src, seq.ll as usize, offset, seq.ml as usize)
+                .exec_sequence_inline(lit_src, seq.ll as usize, offset, seq.ml as usize)
                 .map_err(DecompressBlockError::ExecuteSequencesError)?;
         }
         buffer.advance_output_counter(seq.ll as usize + seq.ml as usize);
@@ -838,7 +838,7 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     }
 
     // Fallback: the legacy push + repeat chain.
-    buffer.push(lits);
+    buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
     buffer
         .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
         .map_err(ExecuteSequencesError::from)?;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -507,10 +507,15 @@ fn decode_and_execute_sequences_impl<
     }
 
     // Tail literals: any bytes in the literals_buffer that no sequence
-    // claimed get pushed after the last sequence.
+    // claimed get pushed after the last sequence. Routed through
+    // `try_push` so a malformed block whose tail-literal length
+    // overshoots the fixed-capacity backend (UserSliceBackend) surfaces
+    // as `OutputBufferOverflow` instead of panicking via the per-call
+    // `assert!` inside `BufferBackend::extend`. Growable backends
+    // (FlatBuf, RingBuffer) accept the write infallibly.
     if lit_cur < literals_buffer_len {
         let rest = &literals_buffer[lit_cur..];
-        buffer.push(rest);
+        buffer.try_push(rest).map_err(ExecuteSequencesError::from)?;
         seq_sum = seq_sum.wrapping_add(rest.len() as u32);
     }
 
@@ -666,16 +671,20 @@ fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
     offset_hist: &mut [u32; 3],
     seq: Sequence,
 ) -> Result<(), DecompressBlockError> {
-    let high = *lit_cur + seq.ll as usize;
-    if high > lit_len {
-        return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
-            wanted: high,
+    // `checked_add` on the literal cursor + sequence ll. On 32-bit
+    // targets a malformed stream can push `*lit_cur + seq.ll as usize`
+    // past `usize::MAX`; without the checked path the wrap would
+    // produce `high < *lit_cur` and the subsequent `get_unchecked`
+    // would slice into arbitrary memory (UB).
+    let high = (*lit_cur)
+        .checked_add(seq.ll as usize)
+        .filter(|&h| h <= lit_len)
+        .ok_or(ExecuteSequencesError::NotEnoughBytesForSequence {
+            wanted: (*lit_cur).saturating_add(seq.ll as usize),
             have: lit_len,
-        }
-        .into());
-    }
-    // SAFETY: high <= lit_len (just verified) and *lit_cur <= high
-    // (high = lit_cur + seq.ll, seq.ll >= 0).
+        })?;
+    // SAFETY: high <= lit_len (verified by the `filter` above) and
+    // *lit_cur <= high (the `checked_add` succeeded, so no wrap).
     let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
     *lit_cur = high;
     buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
@@ -710,15 +719,19 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     resolved_offset: u32,
 ) -> Result<(), DecompressBlockError> {
     let lit_cur_before = *lit_cur;
-    let high = lit_cur_before + seq.ll as usize;
-    if high > lit_len {
-        return Err(ExecuteSequencesError::NotEnoughBytesForSequence {
-            wanted: high,
+    // `checked_add` guards against `usize` wrap on 32-bit targets
+    // when a malformed stream pushes `lit_cur_before + seq.ll` past
+    // `usize::MAX`; without it the wrap produces `high < lit_cur_before`
+    // and the subsequent `get_unchecked` would slice OOB (UB).
+    let high = lit_cur_before
+        .checked_add(seq.ll as usize)
+        .filter(|&h| h <= lit_len)
+        .ok_or(ExecuteSequencesError::NotEnoughBytesForSequence {
+            wanted: lit_cur_before.saturating_add(seq.ll as usize),
             have: lit_len,
-        }
-        .into());
-    }
-    // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
+        })?;
+    // SAFETY: high <= lit_len (verified above) and lit_cur_before <= high
+    // (the `checked_add` succeeded, so no wrap).
     let lits = unsafe { literals.get_unchecked(lit_cur_before..high) };
     *lit_cur = high;
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -503,11 +503,60 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     // SAFETY: high <= lit_len (just verified) and *lit_cur <= high.
     let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
     *lit_cur = high;
-    buffer.push(lits);
 
     if resolved_offset == 0 {
         return Err(ExecuteSequencesError::ZeroOffset.into());
     }
+
+    // Donor-shape inline dispatch — when the backend opts in (only
+    // `UserSliceBackend` on x86/x86_64 today, per its
+    // `SUPPORTS_INLINE_DONOR_EXEC = true` const) we collapse the
+    // literal copy + match copy into a single straight-line body
+    // that mirrors donor `ZSTD_execSequence`
+    // (zstd_decompress_block.c:1008-1105). The const branch is
+    // compile-time per backend monomorphisation, so the dead arm
+    // carries no runtime cost on either side.
+    if B::SUPPORTS_INLINE_DONOR_EXEC {
+        // Validate match-copy offset against the live region
+        // (matches `repeat()`'s `offset > buffer.len()` → dict path
+        // gate). Donor inline path stays on the prefix-resident
+        // case; offsets that step into dict / extDict territory fall
+        // back to the layered path below.
+        let buf_len = buffer.len();
+        let offset = resolved_offset as usize;
+        if offset > buf_len + lits.len() {
+            // Match source reaches outside what's been written in this
+            // frame — donor's `extDict` arm. Punt back to the slow
+            // `repeat()` path; that path already routes through
+            // `repeat_from_dict` for these offsets.
+            buffer.push(lits);
+            buffer
+                .repeat_lookahead_prefetched(offset, seq.ml as usize)
+                .map_err(ExecuteSequencesError::from)?;
+            return Ok(());
+        }
+        // SAFETY: backend opted in (compile-time const), `lits` is a
+        // non-aliased slice of the literal block, `offset` is within
+        // the live region (prefix-resident, asserted above),
+        // `match_length >= 1` is enforced by the
+        // `resolved_offset == 0` check above (offset > 0 implies
+        // match exists; degenerate `ml = 0` is benign — donor copies
+        // zero bytes through the wildcopy's `do/while` body once).
+        // Caller's upfront `reserve(MAX_BLOCK_SIZE)` guarantees the
+        // writable tail has room for `lit_length + match_length`
+        // plus the wildcopy overshoot slack
+        // (`WILDCOPY_OVERLENGTH = 32`).
+        unsafe {
+            buffer
+                .buffer_mut()
+                .donor_exec_one_sequence(lits, offset, seq.ml as usize);
+        }
+        buffer.advance_output_counter(lits.len() + seq.ml as usize);
+        return Ok(());
+    }
+
+    // Fallback: the legacy push + repeat chain.
+    buffer.push(lits);
     buffer
         .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
         .map_err(ExecuteSequencesError::from)?;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -828,12 +828,10 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         // `len()` regardless of the backing buffer's extra capacity.
         let lit_src = unsafe { literals.as_ptr().add(lit_cur_before) };
         unsafe {
-            buffer.buffer_mut().donor_exec_one_sequence(
-                lit_src,
-                seq.ll as usize,
-                offset,
-                seq.ml as usize,
-            );
+            buffer
+                .buffer_mut()
+                .donor_exec_one_sequence(lit_src, seq.ll as usize, offset, seq.ml as usize)
+                .map_err(DecompressBlockError::ExecuteSequencesError)?;
         }
         buffer.advance_output_counter(seq.ll as usize + seq.ml as usize);
         return Ok(());

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -758,9 +758,18 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     // (`lit_cur_before + 16 <= lit_len`) but whose `high + 15`
     // exceeds it. Apply (2) only in the wildcopy regime.
     // `checked_add` covers adversarial overflow.
+    // For seq.ll > 16 the wildcopy tail's final 16-byte iteration
+    // reads through `lit_cur_before + seq.ll.next_multiple_of(16)
+    // - 1`. Use that exact bound rather than `high + 15`, which
+    // over-counts by `15 - ((seq.ll - 1) % 16)` whenever `seq.ll %
+    // 16 != 1` — keeping the donor inline path active on more
+    // sequences near the end of the literals buffer.
     let donor_path_safe = B::SUPPORTS_INLINE_DONOR_EXEC
         && lit_cur_before.checked_add(16).is_some_and(|b| b <= lit_len)
-        && (seq.ll as usize <= 16 || high.checked_add(15).is_some_and(|b| b <= lit_len));
+        && (seq.ll as usize <= 16
+            || lit_cur_before
+                .checked_add((seq.ll as usize).next_multiple_of(16))
+                .is_some_and(|b| b <= lit_len));
     if donor_path_safe {
         // Validate match-copy offset against the live region
         // (matches `repeat()`'s `offset > buffer.len()` → dict path

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -985,6 +985,20 @@ mod tests {
     fn donor_exec_one_sequence_short_offset_match_uses_overlap_copy() {
         // offset < 16 takes the overlapCopy8 + 8-byte stride path
         // (vs. the offset >= 16 wildcopy_no_overlap path).
+        // Cross-validate the donor inline path's offset < 16 branch
+        // against the reference legacy `extend`/`repeat_in_chunks`
+        // chain. Both backends decode the same sequence to the same
+        // bytes — donor parity holds when their outputs agree byte
+        // for byte. This is more robust than asserting a hand-derived
+        // pattern: the donor literal `copy16` may overshoot into the
+        // match-destination region, and the subsequent match copy
+        // reads from positions that include those overshoot bytes —
+        // the resulting output legitimately mixes literal-overshoot
+        // bytes with match-source bytes in a way that depends on
+        // ordering. The legacy path doesn't do the literal overshoot
+        // so it produces the "expected" RLE pattern. The cross-check
+        // therefore needs to compare two donor-path runs against
+        // each other, not against a hand-derived RLE expansion.
         const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut buf = vec![0u8; 256 + WILDCOPY];
         // Seed last 8 bytes of history with a recognisable pattern.
@@ -995,27 +1009,25 @@ mod tests {
 
         let lits: [u8; 16] = [0xFF; 16];
         // litLength=4, offset=8, matchLength=12. offset<16 → short
-        // path. RLE expansion: match copies bytes [seed; seed[..4]]
-        // since matchLength > offset.
+        // path (overlapCopy8 + 8-byte stride).
         unsafe {
             b.donor_exec_one_sequence(lits.as_ptr(), 4, 8, 12);
         }
         // tail = 32 + 4 + 12 = 48.
         assert_eq!(b.tail, 48);
+        // Literal copy: bytes 32..36 are the literal payload.
         assert_eq!(&buf[32..36], &lits[..4]);
-        // Match output bytes 36..48: should be 12 bytes derived from
-        // the seed at offset 8 from the post-literal cursor (= 36).
-        // Source position = 28 (= 36 - 8). bytes[28..32] = seed[4..8],
-        // then expansion continues as `seed[4..8]` repeats then
-        // `seed[0..4]` (RLE-style).
-        // The exact spread pattern depends on overlap_copy8's table
-        // lookups; just verify all 12 output bytes lie in the
-        // expected seed-byte set.
-        for &b_val in &buf[36..48] {
-            assert!(
-                seed.contains(&b_val),
-                "match output byte {b_val:#x} not in seed set"
-            );
-        }
+        // Match copy: the first 4 output bytes (positions 36..40)
+        // are the FIRST 4 source bytes (positions 28..32), which the
+        // literal copy16 has NOT overwritten (it wrote at 32..48, so
+        // 28..32 remain as the seed tail). Verify those.
+        assert_eq!(&buf[36..40], &seed[4..8]);
+        // The remaining 8 match bytes (40..48) get fed by the
+        // 8-byte-stride wildcopy reading from positions inside the
+        // match-destination region, which the literal copy16 already
+        // overwrote with 0xFF. That's the donor invariant — the
+        // overshoot is consumed correctly. We don't pin the exact
+        // bytes (they're a function of overlap_copy8's spread
+        // tables) but the output length must be right.
     }
 }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -190,19 +190,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // unsafe pointer math go out of bounds.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.slice.len();
-        let cap_required = lit_length
-            .checked_add(match_length)
-            .and_then(|total| self.tail.checked_add(total))
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        let cap_required = match cap_required {
-            Some(v) if v <= cap => v,
-            Some(v) => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: v - self.tail,
-                    capacity: cap,
-                });
-            }
+        // `requested` reports the LOGICAL write length
+        // (`lit_length + match_length`) to stay consistent with
+        // `BackendOverflow.requested` on the `try_*` paths. The
+        // capacity check itself uses `tail + total + overshoot`
+        // because the unconditional 16-byte `copy16` over-reaches
+        // `tail + total` by up to 15 bytes — but that overshoot is
+        // an artefact of the SIMD copy shape, NOT a value the
+        // caller can act on, so it doesn't belong in the diagnostic.
+        let total = match lit_length.checked_add(match_length) {
+            Some(v) => v,
             None => {
                 return Err(ExecuteSequencesError::OutputBufferOverflow {
                     tail: self.tail,
@@ -211,8 +208,21 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
                 });
             }
         };
+        let cap_required = self
+            .tail
+            .checked_add(total)
+            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
+        let cap_required = match cap_required {
+            Some(v) if v <= cap => v,
+            _ => {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
+                    tail: self.tail,
+                    requested: total,
+                    capacity: cap,
+                });
+            }
+        };
         let _ = cap_required;
-        let total = lit_length + match_length;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -56,7 +56,7 @@
 //! parameter). The lifetime parameter binds the backend to the
 //! user-provided slice — the backing
 //! `DecodeBuffer<UserSliceBackend<'a>>` is stack-local in
-//! `decode_to_slice_trusted` and does not survive across calls. Persistent
+//! `decode_all` and does not survive across calls. Persistent
 //! decoder state (HUF/FSE tables, offset_hist, sequence cache)
 //! lives in `FrameDecoder` and is borrowed in by reference for the
 //! call's duration via [`super::scratch::DirectScratch`].
@@ -98,7 +98,7 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// Compressed block whose payload expands to more than the declared
 /// size — the burst's per-symbol writes can reach past `slice.len()`
 /// and panic via the `assert!` failure instead of returning a
-/// structured error. The frame-level `decode_to_slice_trusted` checks
+/// structured error. The frame-level `decode_all` checks
 /// `produced > content_size` AFTER each block; within a single block
 /// the panic-on-overshoot is the only stop.
 ///
@@ -113,7 +113,7 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// FCS mismatch and return `FrameContentSizeMismatch`.
 ///
 /// Replacing the panics with `Result<_, _>`-returning writes (so
-/// `decode_to_slice_trusted` itself can stay safe on adversarial input) is
+/// `decode_all` itself can stay safe on adversarial input) is
 /// tracked in issue #246 — it requires extending the
 /// `BufferBackend` trait surface and would gate the direct path on
 /// the new fallible signatures.
@@ -148,7 +148,7 @@ impl<'a> UserSliceBackend<'a> {
 impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// Donor-shape inline `ZSTD_execSequence` is available on
     /// `x86_64`, where SSE2 is the architectural baseline and the
-    /// helpers in [`super::exec_sequence_donor::x86`] emit
+    /// helpers in [`super::exec_sequence_inline::x86`] emit
     /// `_mm_loadu_si128` / `_mm_storeu_si128` without needing a
     /// `#[target_feature]` gate. 32-bit `x86` is excluded — its
     /// pre-SSE2 baseline (i386 / i486 / i586) would SIGILL on the
@@ -156,13 +156,13 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// existing `extend` + `repeat` chain — those paths already
     /// emit the architecture's best-available SIMD via
     /// `copy_bytes_overshooting`'s runtime detect.
-    const SUPPORTS_INLINE_DONOR_EXEC: bool = cfg!(target_arch = "x86_64");
+    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = cfg!(target_arch = "x86_64");
 
     /// Donor `ZSTD_execSequence` body — see trait doc for
     /// preconditions / contract.
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
-    unsafe fn donor_exec_one_sequence(
+    unsafe fn exec_sequence_inline(
         &mut self,
         lit_src: *const u8,
         lit_length: usize,
@@ -170,7 +170,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
         use super::errors::ExecuteSequencesError;
-        use super::exec_sequence_donor::x86::{
+        use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
         // Fallible capacity check — covers the literal+match copies
@@ -179,7 +179,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // `WILDCOPY_OVERLENGTH = 32` slack on the user slice absorbs
         // it; on a malformed frame whose sequences overproduce past
         // `frame_content_size`, the check returns
-        // `ExecuteSequencesError::DonorPathBufferOverflow` so the
+        // `ExecuteSequencesError::OutputBufferOverflow` so the
         // safe public decode APIs (`decode_all`, `decode_all_to_vec`)
         // surface a structured `FrameDecoderError` rather than
         // panic on the unsafe write surface.
@@ -197,14 +197,14 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let cap_required = match cap_required {
             Some(v) if v <= cap => v,
             Some(v) => {
-                return Err(ExecuteSequencesError::DonorPathBufferOverflow {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
                     tail: self.tail,
                     requested: v - self.tail,
                     capacity: cap,
                 });
             }
             None => {
-                return Err(ExecuteSequencesError::DonorPathBufferOverflow {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
                     tail: self.tail,
                     requested: usize::MAX,
                     capacity: cap,
@@ -227,7 +227,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             live_len
                 .checked_add(lit_length)
                 .is_some_and(|end| offset <= end),
-            "donor_exec_one_sequence: offset ({}) exceeds live window (len={} + lit={}, head={}, tail={})",
+            "exec_sequence_inline: offset ({}) exceeds live window (len={} + lit={}, head={}, tail={})",
             offset,
             live_len,
             lit_length,
@@ -311,6 +311,22 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     }
 
     #[inline]
+    fn try_reserve(&mut self, n: usize) -> Result<(), super::buffer_backend::BackendOverflow> {
+        // Fixed-capacity backend: linear `tail + n <= slice.len()`
+        // check. Lets safe public decode APIs catch a malformed-frame
+        // overshoot here instead of via the `assert!` inside
+        // `extend_from_within_unchecked` further down the call chain.
+        match self.tail.checked_add(n) {
+            Some(new_tail) if new_tail <= self.slice.len() => Ok(()),
+            _ => Err(super::buffer_backend::BackendOverflow {
+                tail: self.tail,
+                requested: n,
+                capacity: self.slice.len(),
+            }),
+        }
+    }
+
+    #[inline]
     fn reserve(&mut self, _n: usize) {
         // No-op: capacity is fixed at construction (slice length).
         // The decoder's sequence-execution path issues
@@ -379,11 +395,11 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // `BufferBackend` trait surface, touching every backend
         // implementation, and threading `Result<_, _>` through the
         // sequence executor. That refactor lives in a dedicated
-        // follow-up (the docstring on `decode_to_slice_trusted` names it as
+        // follow-up (the docstring on `decode_all` names it as
         // a hard prerequisite before this entry point becomes safe
         // on untrusted streams). Until then the contract is
         // documented at the safe-API surface and enforced by
-        // `#[must_use]` + `#[doc(alias = "decode_to_slice_trusted_trusted")]`.
+        // `#[must_use]` + `#[doc(alias = "decode_all_trusted")]`.
         // Re-flagging without addressing the trade-off documented at
         // the call site does not move the work forward.
         assert!(
@@ -922,16 +938,16 @@ mod tests {
         assert_eq!(b.tail(), 3);
     }
 
-    /// Direct tests for `donor_exec_one_sequence` — exercise the
+    /// Direct tests for `exec_sequence_inline` — exercise the
     /// x86_64 inline body so coverage attributes its 40 lines to
-    /// these tests, not through the deep `decode_to_slice_trusted`
+    /// these tests, not through the deep `decode_all`
     /// pipeline where `cargo llvm-cov` sometimes loses the inlined
     /// callee. Tests cover: short-literal + short-match, long
     /// literal (wildcopy tail), short-offset match (overlapCopy8 +
     /// 8-byte stride), long-offset match (wildcopy_no_overlap).
     #[cfg(target_arch = "x86_64")]
     #[test]
-    fn donor_exec_one_sequence_short_literal_plus_long_offset_match() {
+    fn exec_sequence_inline_short_literal_plus_long_offset_match() {
         // Layout: pre-fill `tail = 8` with a "history" region so
         // a match copy at offset 16 reaches inside the slice. Then
         // bump tail past that history and exercise donor_exec.
@@ -953,7 +969,7 @@ mod tests {
             0x10, 0x20,
         ];
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 8, 16, 8).unwrap();
+            b.exec_sequence_inline(lits.as_ptr(), 8, 16, 8).unwrap();
         }
         // tail advanced by 8 lit + 8 match = 16.
         assert_eq!(b.tail, 48);
@@ -967,7 +983,7 @@ mod tests {
 
     #[cfg(target_arch = "x86_64")]
     #[test]
-    fn donor_exec_one_sequence_long_literal_uses_wildcopy_tail() {
+    fn exec_sequence_inline_long_literal_uses_wildcopy_tail() {
         // litLength > 16 path: unconditional copy16 + wildcopy tail
         // for the remaining literal bytes.
         const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
@@ -983,7 +999,7 @@ mod tests {
         // 16-byte load.
         let lits: Vec<u8> = (0..40 + 16).map(|i| 0x80 + i as u8).collect();
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 40, 16, 8).unwrap();
+            b.exec_sequence_inline(lits.as_ptr(), 40, 16, 8).unwrap();
         }
         assert_eq!(b.tail, 80);
         assert_eq!(&buf[32..72], &lits[..40]);
@@ -994,7 +1010,7 @@ mod tests {
 
     #[cfg(target_arch = "x86_64")]
     #[test]
-    fn donor_exec_one_sequence_short_offset_match_uses_overlap_copy() {
+    fn exec_sequence_inline_short_offset_match_uses_overlap_copy() {
         // offset < 16 takes the overlapCopy8 + 8-byte stride path
         // (vs. the offset >= 16 wildcopy_no_overlap path).
         //
@@ -1027,7 +1043,7 @@ mod tests {
         // litLength=4, offset=8, matchLength=12. offset<16 → short
         // path (overlapCopy8 + 8-byte stride).
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 4, 8, 12).unwrap();
+            b.exec_sequence_inline(lits.as_ptr(), 4, 8, 12).unwrap();
         }
         // tail = 32 + 4 + 12 = 48.
         assert_eq!(b.tail, 48);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -159,11 +159,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// preconditions / contract.
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
-    unsafe fn donor_exec_one_sequence(&mut self, lits: &[u8], offset: usize, match_length: usize) {
+    unsafe fn donor_exec_one_sequence(
+        &mut self,
+        lit_src: *const u8,
+        lit_length: usize,
+        offset: usize,
+        match_length: usize,
+    ) {
         use super::exec_sequence_donor::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
-        let lit_length = lits.len();
         // Release-mode capacity assert — covers the literal+match
         // copies INCLUDING the wildcopy overshoot tail (up to 15
         // bytes past `tail + total`). The caller-side
@@ -191,9 +196,11 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         assert!(
             cap_required <= self.slice.len(),
             "UserSliceBackend::donor_exec_one_sequence overflows slice \
-             (tail+={} + {} overshoot, cap={}) — corrupt frame or missing WILDCOPY_OVERLENGTH slack",
+             (tail={} + total={} + {} overshoot = {}, cap={}) — corrupt frame or missing WILDCOPY_OVERLENGTH slack",
+            self.tail,
             total,
             MAX_WILDCOPY_OVERSHOOT,
+            cap_required,
             self.slice.len()
         );
         debug_assert!(offset >= 1);
@@ -211,10 +218,13 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // SAFETY: capacity asserted above; pointer arithmetic stays
         // within `self.slice` for the writes (tail + total <=
         // slice.len()) and reads (match src = tail + lit_length -
-        // offset, bounded by `offset <= tail + lit_length`).
+        // offset, bounded by `offset <= tail + lit_length`). Literal
+        // reads use the caller-provided `lit_src` whose provenance
+        // covers the parent literals buffer (NOT a sub-slice), so
+        // the unconditional 16-byte load stays in-bounds even when
+        // `lit_length < 16`.
         unsafe {
             let base_mut = self.slice.as_mut_ptr();
-            let lit_src = lits.as_ptr();
 
             // ── Literal copy ──
             // Donor: ZSTD_copy16(op, *litPtr); if (litLength > 16)

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -994,20 +994,24 @@ mod tests {
     fn donor_exec_one_sequence_short_offset_match_uses_overlap_copy() {
         // offset < 16 takes the overlapCopy8 + 8-byte stride path
         // (vs. the offset >= 16 wildcopy_no_overlap path).
-        // Cross-validate the donor inline path's offset < 16 branch
-        // against the reference legacy `extend`/`repeat_in_chunks`
-        // chain. Both backends decode the same sequence to the same
-        // bytes — donor parity holds when their outputs agree byte
-        // for byte. This is more robust than asserting a hand-derived
-        // pattern: the donor literal `copy16` may overshoot into the
-        // match-destination region, and the subsequent match copy
-        // reads from positions that include those overshoot bytes —
-        // the resulting output legitimately mixes literal-overshoot
-        // bytes with match-source bytes in a way that depends on
-        // ordering. The legacy path doesn't do the literal overshoot
-        // so it produces the "expected" RLE pattern. The cross-check
-        // therefore needs to compare two donor-path runs against
-        // each other, not against a hand-derived RLE expansion.
+        //
+        // What we actually assert here:
+        //   1. `tail` advances by `lit_length + match_length`.
+        //   2. The literal payload lands at `buf[tail..tail+ll]`.
+        //   3. The FIRST 4 match-output bytes match seed[4..8] —
+        //      that prefix of the match copy reads source bytes
+        //      that the literal `copy16` overshoot did NOT
+        //      overwrite (the donor `copy16` writes 16 bytes at
+        //      `tail`, so source bytes BEFORE `tail` survive).
+        //
+        // We do NOT cross-validate against the legacy `extend` +
+        // `repeat_in_chunks` chain: those paths don't perform the
+        // 16-byte literal overshoot, so they produce a different
+        // output for the same logical sequence (different bytes in
+        // positions where the donor's overshoot is consumed by the
+        // match copy). End-to-end parity is covered by the higher
+        // level `roundtrip_integrity::*` tests in lib.rs which
+        // decode whole frames and compare to the encoder input.
         const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut buf = vec![0u8; 256 + WILDCOPY];
         // Seed last 8 bytes of history with a recognisable pattern.

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -898,4 +898,113 @@ mod tests {
         assert_eq!(err.capacity, 4);
         assert_eq!(b.tail(), 3);
     }
+
+    /// Direct tests for `donor_exec_one_sequence` — exercise the
+    /// x86_64 inline body so coverage attributes its 40 lines to
+    /// these tests, not through the deep `decode_to_slice_trusted`
+    /// pipeline where `cargo llvm-cov` sometimes loses the inlined
+    /// callee. Tests cover: short-literal + short-match, long
+    /// literal (wildcopy tail), short-offset match (overlapCopy8 +
+    /// 8-byte stride), long-offset match (wildcopy_no_overlap).
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn donor_exec_one_sequence_short_literal_plus_long_offset_match() {
+        // Layout: pre-fill `tail = 8` with a "history" region so
+        // a match copy at offset 16 reaches inside the slice. Then
+        // bump tail past that history and exercise donor_exec.
+        // Buffer sized with WILDCOPY_OVERLENGTH slack at the end.
+        const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut buf = vec![0u8; 256 + WILDCOPY];
+        // Seed history: bytes 0..32 = ascending values, so a later
+        // match at offset 16 picks up bytes 16..32.
+        for i in 0..32 {
+            buf[i] = i as u8;
+        }
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.tail = 32; // Pretend 32 history bytes are already written.
+
+        // 8-byte literals to write (donor's litLength <= 16 fast
+        // path — no wildcopy tail). Match length 8 at offset 16.
+        let lits: [u8; 16] = [
+            0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22, 0xA1, 0xB1, 0xC1, 0xD1, 0xE1, 0xF1,
+            0x10, 0x20,
+        ];
+        unsafe {
+            b.donor_exec_one_sequence(lits.as_ptr(), 8, 16, 8);
+        }
+        // tail advanced by 8 lit + 8 match = 16.
+        assert_eq!(b.tail, 48);
+        // Literals landed at tail = 32..40.
+        assert_eq!(&buf[32..40], &lits[..8]);
+        // Match: at output position 40..48, source = tail + lit_len -
+        // offset = 32 + 8 - 16 = 24. So buf[40..48] == buf[24..32]
+        // (history bytes 24..32 = [24, 25, 26, 27, 28, 29, 30, 31]).
+        assert_eq!(&buf[40..48], &[24u8, 25, 26, 27, 28, 29, 30, 31]);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn donor_exec_one_sequence_long_literal_uses_wildcopy_tail() {
+        // litLength > 16 path: unconditional copy16 + wildcopy tail
+        // for the remaining literal bytes.
+        const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut buf = vec![0u8; 256 + WILDCOPY];
+        for i in 0..32 {
+            buf[i] = i as u8;
+        }
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.tail = 32;
+
+        // 40-byte literals (forces wildcopy tail) — needs 40-byte
+        // source buffer with extra read slack for the final
+        // 16-byte load.
+        let lits: Vec<u8> = (0..40 + 16).map(|i| 0x80 + i as u8).collect();
+        unsafe {
+            b.donor_exec_one_sequence(lits.as_ptr(), 40, 16, 8);
+        }
+        assert_eq!(b.tail, 80);
+        assert_eq!(&buf[32..72], &lits[..40]);
+        // Match at offset 16: src = 32 + 40 - 16 = 56. buf[72..80]
+        // == buf[56..64] (which we just wrote = lits[24..32]).
+        assert_eq!(&buf[72..80], &lits[24..32]);
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn donor_exec_one_sequence_short_offset_match_uses_overlap_copy() {
+        // offset < 16 takes the overlapCopy8 + 8-byte stride path
+        // (vs. the offset >= 16 wildcopy_no_overlap path).
+        const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
+        let mut buf = vec![0u8; 256 + WILDCOPY];
+        // Seed last 8 bytes of history with a recognisable pattern.
+        let seed = [0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7];
+        buf[24..32].copy_from_slice(&seed);
+        let mut b = UserSliceBackend::from_slice(&mut buf);
+        b.tail = 32;
+
+        let lits: [u8; 16] = [0xFF; 16];
+        // litLength=4, offset=8, matchLength=12. offset<16 → short
+        // path. RLE expansion: match copies bytes [seed; seed[..4]]
+        // since matchLength > offset.
+        unsafe {
+            b.donor_exec_one_sequence(lits.as_ptr(), 4, 8, 12);
+        }
+        // tail = 32 + 4 + 12 = 48.
+        assert_eq!(b.tail, 48);
+        assert_eq!(&buf[32..36], &lits[..4]);
+        // Match output bytes 36..48: should be 12 bytes derived from
+        // the seed at offset 8 from the post-literal cursor (= 36).
+        // Source position = 28 (= 36 - 8). bytes[28..32] = seed[4..8],
+        // then expansion continues as `seed[4..8]` repeats then
+        // `seed[0..4]` (RLE-style).
+        // The exact spread pattern depends on overlap_copy8's table
+        // lookups; just verify all 12 output bytes lie in the
+        // expected seed-byte set.
+        for &b_val in &buf[36..48] {
+            assert!(
+                seed.contains(&b_val),
+                "match output byte {b_val:#x} not in seed set"
+            );
+        }
+    }
 }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -164,8 +164,6 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
         let lit_length = lits.len();
-        let total = lit_length + match_length;
-        let new_tail = self.tail + total;
         // Release-mode capacity assert — covers the literal+match
         // copies INCLUDING the wildcopy overshoot tail (up to 15
         // bytes past `tail + total`). The caller-side
@@ -174,9 +172,24 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // explicit so a future caller that supplies a smaller slice
         // fails immediately with a clear diagnostic instead of
         // silently corrupting memory past the declared tail.
+        //
+        // All sums use `checked_*` so adversarial / corrupt input
+        // that would wrap `usize` ends up as `None` → assert fires
+        // with a clean error instead of wrapping past the slice
+        // length and letting the subsequent unsafe pointer math go
+        // out of bounds.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
+        let total = lit_length
+            .checked_add(match_length)
+            .expect("UserSliceBackend::donor_exec_one_sequence: lit+ml overflow on corrupt frame");
+        let new_tail = self.tail.checked_add(total).expect(
+            "UserSliceBackend::donor_exec_one_sequence: tail+total overflow on corrupt frame",
+        );
+        let cap_required = new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT).expect(
+            "UserSliceBackend::donor_exec_one_sequence: overshoot bound overflow on corrupt frame",
+        );
         assert!(
-            new_tail + MAX_WILDCOPY_OVERSHOOT <= self.slice.len(),
+            cap_required <= self.slice.len(),
             "UserSliceBackend::donor_exec_one_sequence overflows slice \
              (tail+={} + {} overshoot, cap={}) — corrupt frame or missing WILDCOPY_OVERLENGTH slack",
             total,
@@ -186,13 +199,13 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
         debug_assert!(
-            offset <= self.tail + lit_length,
-            "donor_exec_one_sequence: offset ({}) exceeds output start \
-             ({} + lit {} = {})",
+            self.tail
+                .checked_add(lit_length)
+                .is_some_and(|end| offset <= end),
+            "donor_exec_one_sequence: offset ({}) exceeds output start (tail={} + lit={})",
             offset,
             self.tail,
             lit_length,
-            self.tail + lit_length
         );
 
         // SAFETY: capacity asserted above; pointer arithmetic stays

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -143,18 +143,21 @@ impl<'a> UserSliceBackend<'a> {
 }
 
 impl<'a> BufferBackend for UserSliceBackend<'a> {
-    /// Donor-shape inline `ZSTD_execSequence` is available on x86 /
-    /// x86_64 where the SSE2 baseline gives us 16-byte SIMD store/load
-    /// for free. On other arches (aarch64 NEON, riscv, etc.) the
-    /// dispatch site falls back to the existing `extend` + `repeat`
-    /// chain — those paths already emit the architecture's
-    /// best-available SIMD via `copy_bytes_overshooting`'s runtime
-    /// detect.
-    const SUPPORTS_INLINE_DONOR_EXEC: bool = cfg!(any(target_arch = "x86", target_arch = "x86_64"));
+    /// Donor-shape inline `ZSTD_execSequence` is available on
+    /// `x86_64`, where SSE2 is the architectural baseline and the
+    /// helpers in [`super::exec_sequence_donor::x86`] emit
+    /// `_mm_loadu_si128` / `_mm_storeu_si128` without needing a
+    /// `#[target_feature]` gate. 32-bit `x86` is excluded — its
+    /// pre-SSE2 baseline (i386 / i486 / i586) would SIGILL on the
+    /// SSE2 intrinsics. aarch64 NEON, riscv etc. fall back to the
+    /// existing `extend` + `repeat` chain — those paths already
+    /// emit the architecture's best-available SIMD via
+    /// `copy_bytes_overshooting`'s runtime detect.
+    const SUPPORTS_INLINE_DONOR_EXEC: bool = cfg!(target_arch = "x86_64");
 
     /// Donor `ZSTD_execSequence` body — see trait doc for
     /// preconditions / contract.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn donor_exec_one_sequence(&mut self, lits: &[u8], offset: usize, match_length: usize) {
         use super::exec_sequence_donor::x86::{
@@ -164,15 +167,20 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let total = lit_length + match_length;
         let new_tail = self.tail + total;
         // Release-mode capacity assert — covers the literal+match
-        // copies together. The wildcopy bodies overshoot up to 15
-        // bytes past `tail + total`; the caller-side
-        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice
-        // accommodates that.
+        // copies INCLUDING the wildcopy overshoot tail (up to 15
+        // bytes past `tail + total`). The caller-side
+        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice covers
+        // any value ≤ 32; the assert here makes the requirement
+        // explicit so a future caller that supplies a smaller slice
+        // fails immediately with a clear diagnostic instead of
+        // silently corrupting memory past the declared tail.
+        const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         assert!(
-            new_tail <= self.slice.len(),
+            new_tail + MAX_WILDCOPY_OVERSHOOT <= self.slice.len(),
             "UserSliceBackend::donor_exec_one_sequence overflows slice \
-             (tail+={}, cap={}) — corrupt frame",
+             (tail+={} + {} overshoot, cap={}) — corrupt frame or missing WILDCOPY_OVERLENGTH slack",
             total,
+            MAX_WILDCOPY_OVERSHOOT,
             self.slice.len()
         );
         debug_assert!(offset >= 1);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -205,14 +205,23 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         );
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
+        // Match against the LIVE window (tail - head) per the trait
+        // contract, not `tail`. On single-segment frames head stays
+        // at 0 so the two are equivalent; on multi-segment frames
+        // `drop_to_window_size` advances `head` and asserting
+        // against raw `tail` would mask offsets that reach past the
+        // window boundary into dropped history.
+        let live_len = self.tail - self.head;
         debug_assert!(
-            self.tail
+            live_len
                 .checked_add(lit_length)
                 .is_some_and(|end| offset <= end),
-            "donor_exec_one_sequence: offset ({}) exceeds output start (tail={} + lit={})",
+            "donor_exec_one_sequence: offset ({}) exceeds live window (len={} + lit={}, head={}, tail={})",
             offset,
-            self.tail,
+            live_len,
             lit_length,
+            self.head,
+            self.tail,
         );
 
         // SAFETY: capacity asserted above; pointer arithmetic stays
@@ -676,6 +685,8 @@ mod tests {
     extern crate alloc;
     use super::*;
     use alloc::vec;
+    #[cfg(target_arch = "x86_64")]
+    use alloc::vec::Vec;
 
     #[test]
     fn extend_writes_at_tail() {

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -1,8 +1,11 @@
 //! User-slice-backed output buffer for the "decode straight into the
 //! caller's output slice" fast path.
 //!
-//! Selected by [`crate::decoding::FrameDecoder::decode_to_slice_trusted`]
-//! when ALL of the following hold:
+//! Selected automatically by
+//! [`crate::decoding::FrameDecoder::decode_all`] (and
+//! [`crate::decoding::FrameDecoder::decode_all_to_vec`], which
+//! reserves the extra slack internally) when ALL of the following
+//! hold:
 //! - `frame_content_size > 0` — the header-derived content size
 //!   is non-zero. This is the actual eligibility condition (NOT
 //!   "FCS present"): an empty frame with an explicit FCS=0
@@ -950,7 +953,7 @@ mod tests {
             0x10, 0x20,
         ];
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 8, 16, 8);
+            b.donor_exec_one_sequence(lits.as_ptr(), 8, 16, 8).unwrap();
         }
         // tail advanced by 8 lit + 8 match = 16.
         assert_eq!(b.tail, 48);
@@ -980,7 +983,7 @@ mod tests {
         // 16-byte load.
         let lits: Vec<u8> = (0..40 + 16).map(|i| 0x80 + i as u8).collect();
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 40, 16, 8);
+            b.donor_exec_one_sequence(lits.as_ptr(), 40, 16, 8).unwrap();
         }
         assert_eq!(b.tail, 80);
         assert_eq!(&buf[32..72], &lits[..40]);
@@ -1024,7 +1027,7 @@ mod tests {
         // litLength=4, offset=8, matchLength=12. offset<16 → short
         // path (overlapCopy8 + 8-byte stride).
         unsafe {
-            b.donor_exec_one_sequence(lits.as_ptr(), 4, 8, 12);
+            b.donor_exec_one_sequence(lits.as_ptr(), 4, 8, 12).unwrap();
         }
         // tail = 32 + 4 + 12 = 48.
         assert_eq!(b.tail, 48);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -89,34 +89,34 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 /// allocation. The dispatch site in [`crate::decoding::FrameDecoder`]
 /// validates this precondition.
 ///
-/// # DoS surface on malformed Compressed blocks
+/// # Safety contract on malformed Compressed blocks
 ///
-/// The bounds checks on write entry points are uniformly
-/// release-mode `assert!` (for `extend`, `extend_and_fill`, and
-/// `extend_from_within_unchecked`). On adversarial input — a frame
-/// header that declares a small `frame_content_size` AND a
-/// Compressed block whose payload expands to more than the declared
-/// size — the burst's per-symbol writes can reach past `slice.len()`
-/// and panic via the `assert!` failure instead of returning a
-/// structured error. The frame-level `decode_all` checks
-/// `produced > content_size` AFTER each block; within a single block
-/// the panic-on-overshoot is the only stop.
+/// The safe public decode APIs ([`crate::decoding::FrameDecoder::decode_all`]
+/// and [`crate::decoding::FrameDecoder::decode_all_to_vec`]) route
+/// through the FALLIBLE write surface:
+/// [`Self::try_extend`] / [`Self::try_extend_and_fill`] /
+/// [`Self::try_extend_from_within`] for direct writes,
+/// [`super::buffer_backend::BufferBackend::try_reserve`] for the
+/// match-repeat pre-check inside `DecodeBuffer::repeat_inner`, and
+/// `exec_sequence_inline` (which returns
+/// `Result<(), ExecuteSequencesError>`). A malformed Compressed
+/// block whose payload expands past the declared
+/// `frame_content_size` surfaces as
+/// `ExecuteSequencesError::OutputBufferOverflow` (literal-push /
+/// donor-inline path) or `DecodeBufferError::OutputBufferOverflow`
+/// (match-repeat path), both of which propagate up the call stack
+/// as a structured `FrameDecoderError` instead of panicking.
 ///
-/// Callers handling untrusted input should use
-/// [`crate::decoding::FrameDecoder::decode_all`] which routes
-/// through `FlatBuf` / `RingBuffer` backends. Those backends grow
-/// via `Vec::reserve` — growth doesn't return errors (it succeeds
-/// or aborts on alloc failure), but the growable Vec capacity
-/// means a malformed block whose decompressed output exceeds FCS
-/// stays inside the allocation instead of writing OOB into a
-/// fixed-size user slice. The frame-level checks then catch the
-/// FCS mismatch and return `FrameContentSizeMismatch`.
-///
-/// Replacing the panics with `Result<_, _>`-returning writes (so
-/// `decode_all` itself can stay safe on adversarial input) is
-/// tracked in issue #246 — it requires extending the
-/// `BufferBackend` trait surface and would gate the direct path on
-/// the new fallible signatures.
+/// The INFALLIBLE entry points (`extend`, `extend_and_fill`,
+/// `extend_from_within_unchecked`) remain on the type as defense in
+/// depth and as the call shape for inner unsafe blocks where
+/// capacity has already been validated by the wrapping `try_*` call.
+/// Each retains a release-mode `assert!` so a future caller that
+/// invokes the infallible entry point directly with an OOB length
+/// fails with a clear diagnostic rather than letting the subsequent
+/// unsafe pointer math reach past `slice.len()`. The safe public
+/// APIs never reach these `assert!`s on malformed input — the
+/// fallible dispatch catches the overshoot one layer up.
 pub(crate) struct UserSliceBackend<'a> {
     slice: &'a mut [u8],
     /// Bytes in `slice[..head]` have been drained to the output

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -2,11 +2,7 @@
 //! caller's output slice" fast path.
 //!
 //! Selected by [`crate::decoding::FrameDecoder::decode_to_slice_trusted`]
-//! and by [`crate::decoding::FrameDecoder::decode_all`] (the latter
-//! routes per-frame through the same `run_direct_decode` helper when
-//! the frame is eligible; ineligible frames in a `decode_all` stream
-//! transparently fall through to the legacy `decode_blocks` +
-//! `read()` drain loop) when ALL of the following hold:
+//! when ALL of the following hold:
 //! - `frame_content_size > 0` — the header-derived content size
 //!   is non-zero. This is the actual eligibility condition (NOT
 //!   "FCS present"): an empty frame with an explicit FCS=0

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -165,44 +165,52 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         lit_length: usize,
         offset: usize,
         match_length: usize,
-    ) {
+    ) -> Result<(), super::errors::ExecuteSequencesError> {
+        use super::errors::ExecuteSequencesError;
         use super::exec_sequence_donor::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
-        // Release-mode capacity assert — covers the literal+match
-        // copies INCLUDING the wildcopy overshoot tail (up to 15
-        // bytes past `tail + total`). The caller-side
-        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice covers
-        // any value ≤ 32; the assert here makes the requirement
-        // explicit so a future caller that supplies a smaller slice
-        // fails immediately with a clear diagnostic instead of
-        // silently corrupting memory past the declared tail.
+        // Fallible capacity check — covers the literal+match copies
+        // INCLUDING the wildcopy overshoot tail (up to 15 bytes past
+        // `tail + total`). On a well-formed frame the caller-side
+        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice absorbs
+        // it; on a malformed frame whose sequences overproduce past
+        // `frame_content_size`, the check returns
+        // `ExecuteSequencesError::DonorPathBufferOverflow` so the
+        // safe public decode APIs (`decode_all`, `decode_all_to_vec`)
+        // surface a structured `FrameDecoderError` rather than
+        // panic on the unsafe write surface.
         //
-        // All sums use `checked_*` so adversarial / corrupt input
-        // that would wrap `usize` ends up as `None` → assert fires
-        // with a clean error instead of wrapping past the slice
-        // length and letting the subsequent unsafe pointer math go
-        // out of bounds.
+        // All sums use `checked_*` so adversarial input that would
+        // wrap `usize` produces the same error variant instead of
+        // wrapping past the slice length and letting the subsequent
+        // unsafe pointer math go out of bounds.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
-        let total = lit_length
+        let cap = self.slice.len();
+        let cap_required = lit_length
             .checked_add(match_length)
-            .expect("UserSliceBackend::donor_exec_one_sequence: lit+ml overflow on corrupt frame");
-        let new_tail = self.tail.checked_add(total).expect(
-            "UserSliceBackend::donor_exec_one_sequence: tail+total overflow on corrupt frame",
-        );
-        let cap_required = new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT).expect(
-            "UserSliceBackend::donor_exec_one_sequence: overshoot bound overflow on corrupt frame",
-        );
-        assert!(
-            cap_required <= self.slice.len(),
-            "UserSliceBackend::donor_exec_one_sequence overflows slice \
-             (tail={} + total={} + {} overshoot = {}, cap={}) — corrupt frame or missing WILDCOPY_OVERLENGTH slack",
-            self.tail,
-            total,
-            MAX_WILDCOPY_OVERSHOOT,
-            cap_required,
-            self.slice.len()
-        );
+            .and_then(|total| self.tail.checked_add(total))
+            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
+        let cap_required = match cap_required {
+            Some(v) if v <= cap => v,
+            Some(v) => {
+                return Err(ExecuteSequencesError::DonorPathBufferOverflow {
+                    tail: self.tail,
+                    requested: v - self.tail,
+                    capacity: cap,
+                });
+            }
+            None => {
+                return Err(ExecuteSequencesError::DonorPathBufferOverflow {
+                    tail: self.tail,
+                    requested: usize::MAX,
+                    capacity: cap,
+                });
+            }
+        };
+        let _ = cap_required;
+        let total = lit_length + match_length;
+        let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
         // Match against the LIVE window (tail - head) per the trait
@@ -266,6 +274,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             }
         }
         self.tail = new_tail;
+        Ok(())
     }
 
     /// `new()` exists for trait conformance but is not used on the

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -2,7 +2,11 @@
 //! caller's output slice" fast path.
 //!
 //! Selected by [`crate::decoding::FrameDecoder::decode_to_slice_trusted`]
-//! when ALL of the following hold:
+//! and by [`crate::decoding::FrameDecoder::decode_all`] (the latter
+//! routes per-frame through the same `run_direct_decode` helper when
+//! the frame is eligible; ineligible frames in a `decode_all` stream
+//! transparently fall through to the legacy `decode_blocks` +
+//! `read()` drain loop) when ALL of the following hold:
 //! - `frame_content_size > 0` — the header-derived content size
 //!   is non-zero. This is the actual eligibility condition (NOT
 //!   "FCS present"): an empty frame with an explicit FCS=0

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -928,8 +928,8 @@ mod tests {
         let mut buf = vec![0u8; 256 + WILDCOPY];
         // Seed history: bytes 0..32 = ascending values, so a later
         // match at offset 16 picks up bytes 16..32.
-        for i in 0..32 {
-            buf[i] = i as u8;
+        for (i, slot) in buf.iter_mut().take(32).enumerate() {
+            *slot = i as u8;
         }
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.tail = 32; // Pretend 32 history bytes are already written.
@@ -960,8 +960,8 @@ mod tests {
         // for the remaining literal bytes.
         const WILDCOPY: usize = super::super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut buf = vec![0u8; 256 + WILDCOPY];
-        for i in 0..32 {
-            buf[i] = i as u8;
+        for (i, slot) in buf.iter_mut().take(32).enumerate() {
+            *slot = i as u8;
         }
         let mut b = UserSliceBackend::from_slice(&mut buf);
         b.tail = 32;

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -386,22 +386,20 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // builds and turn the unchecked copy into UB. Cost: one
         // compare on the literal-push path — same magnitude as
         // the surrounding bounds-already-baked-in writes.
-        // The `assert!` below panics on adversarial / malformed input
-        // (a Compressed block whose payload expands past declared FCS).
-        // This is the deliberate trade-off for the trusted-input
-        // direct-decode path: switching the write surface to fallible
-        // `Result` writes — so the panic becomes a structured
-        // `FrameContentSizeMismatch` — requires extending the
-        // `BufferBackend` trait surface, touching every backend
-        // implementation, and threading `Result<_, _>` through the
-        // sequence executor. That refactor lives in a dedicated
-        // follow-up (the docstring on `decode_all` names it as
-        // a hard prerequisite before this entry point becomes safe
-        // on untrusted streams). Until then the contract is
-        // documented at the safe-API surface and enforced by
-        // `#[must_use]` + `#[doc(alias = "decode_all_trusted")]`.
-        // Re-flagging without addressing the trade-off documented at
-        // the call site does not move the work forward.
+        //
+        // This is the INFALLIBLE entry point. The safe public APIs
+        // (`decode_all`, `decode_all_to_vec`) never reach it on
+        // malformed input: their dispatch routes through
+        // [`Self::try_extend`] (and via `DecodeBuffer::try_push` /
+        // `try_reserve` for the match-repeat path), which return
+        // `BackendOverflow` and convert into
+        // `FrameDecoderError::ExecuteSequencesError` /
+        // `FrameContentSizeMismatch`. The `assert!` here covers
+        // the case where a future caller wires the infallible
+        // entry point into a hot path that doesn't go through the
+        // dispatch — the panic message points at the corrupt-frame
+        // root cause rather than letting the subsequent unsafe
+        // pointer math go OOB.
         assert!(
             new_tail <= self.slice.len(),
             "UserSliceBackend::extend overflows slice (tail+={}, cap={}) — corrupt frame",

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -143,6 +143,91 @@ impl<'a> UserSliceBackend<'a> {
 }
 
 impl<'a> BufferBackend for UserSliceBackend<'a> {
+    /// Donor-shape inline `ZSTD_execSequence` is available on x86 /
+    /// x86_64 where the SSE2 baseline gives us 16-byte SIMD store/load
+    /// for free. On other arches (aarch64 NEON, riscv, etc.) the
+    /// dispatch site falls back to the existing `extend` + `repeat`
+    /// chain — those paths already emit the architecture's
+    /// best-available SIMD via `copy_bytes_overshooting`'s runtime
+    /// detect.
+    const SUPPORTS_INLINE_DONOR_EXEC: bool = cfg!(any(target_arch = "x86", target_arch = "x86_64"));
+
+    /// Donor `ZSTD_execSequence` body — see trait doc for
+    /// preconditions / contract.
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[inline(always)]
+    unsafe fn donor_exec_one_sequence(&mut self, lits: &[u8], offset: usize, match_length: usize) {
+        use super::exec_sequence_donor::x86::{
+            copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
+        };
+        let lit_length = lits.len();
+        let total = lit_length + match_length;
+        let new_tail = self.tail + total;
+        // Release-mode capacity assert — covers the literal+match
+        // copies together. The wildcopy bodies overshoot up to 15
+        // bytes past `tail + total`; the caller-side
+        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice
+        // accommodates that.
+        assert!(
+            new_tail <= self.slice.len(),
+            "UserSliceBackend::donor_exec_one_sequence overflows slice \
+             (tail+={}, cap={}) — corrupt frame",
+            total,
+            self.slice.len()
+        );
+        debug_assert!(offset >= 1);
+        debug_assert!(match_length >= 1);
+        debug_assert!(
+            offset <= self.tail + lit_length,
+            "donor_exec_one_sequence: offset ({}) exceeds output start \
+             ({} + lit {} = {})",
+            offset,
+            self.tail,
+            lit_length,
+            self.tail + lit_length
+        );
+
+        // SAFETY: capacity asserted above; pointer arithmetic stays
+        // within `self.slice` for the writes (tail + total <=
+        // slice.len()) and reads (match src = tail + lit_length -
+        // offset, bounded by `offset <= tail + lit_length`).
+        unsafe {
+            let base_mut = self.slice.as_mut_ptr();
+            let lit_src = lits.as_ptr();
+
+            // ── Literal copy ──
+            // Donor: ZSTD_copy16(op, *litPtr); if (litLength > 16)
+            //         wildcopy(op+16, *litPtr+16, litLength-16, no_overlap)
+            //
+            // The unconditional first copy16 may overshoot up to 15
+            // bytes past `op + lit_length` into the match-destination
+            // region — those bytes are about to be overwritten by the
+            // match copy below, so the overshoot is harmless.
+            let op_lit = base_mut.add(self.tail);
+            copy16(op_lit, lit_src);
+            if lit_length > 16 {
+                wildcopy_no_overlap(op_lit.add(16), lit_src.add(16), lit_length - 16);
+            }
+
+            // ── Match copy ──
+            // Donor uses `oLitEnd = op + litLength` as the match
+            // destination; the match source is `oLitEnd - offset`.
+            let op_match = base_mut.add(self.tail + lit_length);
+            let match_src = base_mut.cast_const().add(self.tail + lit_length - offset);
+
+            if offset >= 16 {
+                wildcopy_no_overlap(op_match, match_src, match_length);
+            } else {
+                // overlap_copy8 + wildcopy(overlap) tail.
+                let (op2, ip2) = overlap_copy8(op_match, match_src, offset);
+                if match_length > 8 {
+                    wildcopy_overlap_8byte_stride(op2, ip2, match_length - 8);
+                }
+            }
+        }
+        self.tail = new_tail;
+    }
+
     /// `new()` exists for trait conformance but is not used on the
     /// direct-decode path — the slice is always provided up-front via
     /// [`Self::from_slice`]. Returns an empty backend wrapping an

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -1,4 +1,5 @@
 use crate::bit_io::{BitReader, BitReaderReversed};
+use crate::cpu_kernel::CpuKernel;
 use crate::decoding::errors::{FSEDecoderError, FSETableError};
 use alloc::vec::Vec;
 
@@ -31,7 +32,10 @@ impl<'t> FSEDecoder<'t> {
 
     /// Initialize internal state and prepare for decoding. After this, `decode_symbol` can be called
     /// to read the first symbol and `update_state` can be called to prepare to read the next symbol.
-    pub fn init_state(&mut self, bits: &mut BitReaderReversed<'_>) -> Result<(), FSEDecoderError> {
+    pub fn init_state<K: CpuKernel>(
+        &mut self,
+        bits: &mut BitReaderReversed<'_, K>,
+    ) -> Result<(), FSEDecoderError> {
         if self.table.accuracy_log == 0 {
             return Err(FSEDecoderError::TableIsUninitialized);
         }
@@ -91,7 +95,7 @@ impl<'t> FSEDecoder<'t> {
     /// unchecked indexing in `read_entry`) into a clear fail-fast
     /// panic that surfaces the API misuse immediately instead of
     /// leaving the bitstream and decode state silently desynchronised.
-    pub fn update_state(&mut self, bits: &mut BitReaderReversed<'_>) {
+    pub fn update_state<K: CpuKernel>(&mut self, bits: &mut BitReaderReversed<'_, K>) {
         // Public-API safety guard: `FSEDecoder::new` builds a decoder
         // with a zero-default `state` (Entry { new_state: 0, num_bits:
         // 0, symbol: 0 }) regardless of whether the table was actually
@@ -183,7 +187,7 @@ impl<'t> FSEDecoder<'t> {
     /// [`init_state`]: Self::init_state
     /// [`update_state`]: Self::update_state
     #[inline(always)]
-    pub(crate) fn update_state_fast(&mut self, bits: &mut BitReaderReversed<'_>) {
+    pub(crate) fn update_state_fast<K: CpuKernel>(&mut self, bits: &mut BitReaderReversed<'_, K>) {
         let num_bits = self.state.num_bits;
         let add = bits.get_bits_unchecked(num_bits);
         let next_state = usize::from(self.state.new_state) + add as usize;

--- a/zstd/src/fse/mod.rs
+++ b/zstd/src/fse/mod.rs
@@ -243,7 +243,7 @@ pub fn round_trip(data: &[u8]) {
 
     check_tables(&dec_table, &enc_table);
 
-    let mut br = BitReaderReversed::new(encoded);
+    let mut br = BitReaderReversed::<crate::cpu_kernel::ScalarKernel>::new(encoded);
     let mut skipped_bits = 0;
     loop {
         let val = br.get_bits(1);

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -149,7 +149,7 @@ pub mod testing {
 /// matches that contract.
 ///
 /// Public so callers sizing an output slice for
-/// [`crate::decoding::FrameDecoder::decode_to_slice_trusted`] can size
+/// [`crate::decoding::FrameDecoder::decode_all`] can size
 /// `frame_content_size + WILDCOPY_OVERLENGTH` symbolically without
 /// duplicating the value. Use the const reference rather than a
 /// hardcoded literal — `simd_copy::copy_bytes_overshooting` already


### PR DESCRIPTION
## Summary

Verbatim port of the C zstd `ZSTD_execSequence` body (zstd_decompress_block.c:1008-1105) into a new inline sequence-execution path on `UserSliceBackend`, plus follow-on refactors that:

1. Unify all `FrameDecoder` decode entry points onto one internal code path (one direct fast path + one legacy fallback by per-frame eligibility).
2. Make the direct path's write surface fully fallible — safe public decode APIs (`decode_all`, `decode_all_to_vec`) surface `FrameDecoderError` on malformed input instead of panicking.
3. Auto-reserve `WILDCOPY_OVERLENGTH` slack in `decode_all_to_vec` so the direct path is reachable without callers having to know about the slack contract.

The inline-execution body bypasses the `DecodeBuffer::push` + `repeat` abstraction chain (5+ layer dispatch through `extend_from_within_unchecked` → `copy_bytes_overshooting` → `single_op_copy_16` etc.) in favour of a straight-line shape:

1. **Literal copy** — unconditional `_mm_storeu_si128` 16-byte SSE2 store followed by a 16-byte SIMD wildcopy loop for the `litLength > 16` tail. For the typical 1..=16 byte litLength the second copy never fires.

2. **Match copy fast path** (offset ≥ 16) — single wildcopy with `no_overlap` semantics, 16-byte SIMD loop.

3. **Match copy short-offset** (offset 1..=15) — `overlap_copy8` spreading (dec32table / dec64table for offset < 8, plain `copy8` for 8..15) followed by `wildcopy(overlap_src_before_dst)` 8-byte stride for the remaining `matchLength - 8` bytes.

Dispatched at compile time via a const `SUPPORTS_INLINE_SEQUENCE_EXEC: bool` on the `BufferBackend` trait — `UserSliceBackend` returns `true` on `x86_64` (SSE2 is the architectural baseline there), every other backend (FlatBuf, RingBuffer) and target falls through to the existing legacy chain. 32-bit `x86` (i586/i686) is excluded because the SSE2 intrinsics are emitted without a `#[target_feature]` gate and those targets don't always carry SSE2 in their baseline.

## Safety: fallible writes on every direct-path entry

After the routing landed, two paths still went through release-mode `assert!` on `UserSliceBackend` overflow:
1. The donor inline body itself (`exec_sequence_inline`) had `assert!` on per-sequence capacity.
2. The fallback path used by ineligible sequences (`buffer.push` + `repeat_inner` → `extend_from_within_unchecked`) had `assert!` too.

Both are now fallible:

- `BufferBackend::exec_sequence_inline` returns `Result<(), ExecuteSequencesError>`. The new `OutputBufferOverflow` variant carries the (`tail`, `requested`, `capacity`) triple.
- A new fallible `BufferBackend::try_reserve(n)` method. Default impl (growable backends) delegates to `reserve()` infallibly. `UserSliceBackend` overrides with a linear `tail + n <= cap` check.
- `DecodeBuffer::repeat_inner` calls `try_reserve` and propagates `BackendOverflow` → `DecodeBufferError::OutputBufferOverflow`.
- The fallback `buffer.push(lits)` callsites in `execute_one_sequence_pipelined` move to `buffer.try_push(lits)?`.

Net effect: a malformed-frame corrupted sequence whose match or literal length overshoots the user's slice surfaces as `FrameDecoderError` instead of a panic.

## Path unification

With safety closed, `decode_all` and `decode_all_to_vec` now route through the direct (`UserSliceBackend`) path automatically when the per-frame eligibility gate holds (FCS > 0, no active dict, remaining output has `WILDCOPY_OVERLENGTH` slack). Ineligible frames keep falling through to the per-block decode + read drain loop.

`decode_all_to_vec` reserves the `WILDCOPY_OVERLENGTH` slack internally so callers don't need to know about it — `output.len()` on return is the actual decompressed size, NOT the inflated capacity. The slack costs at most 32 bytes of one-time `Vec::reserve`.

The previously-public `decode_to_slice_trusted` (and its private `decode_single_frame_legacy_drain` helper) are dropped — `decode_all`'s internal dispatch produces identical output through the same `run_direct_decode` helper. The `pure_rust_direct` decompress bench arm is dropped too — `pure_rust` now allocates with `WILDCOPY_OVERLENGTH` slack and exercises the same direct path, making the two arms identical.

## Bench (i9-9900K, `886a35de` vs pre-PR `main`)

`pure_rust` (decode_all) hits the direct path automatically across all eligible fixtures:

| fixture | `main` (pre-PR) | `886a35de` | change | × donor |
|---|---|---|---|---|
| `decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust` | 2.034 ms | **1.553 ms** | **−23.6%** | 2.40× (was 3.14×) |
| `decompress/level_-1_fast/high-entropy-1m/c_stream/matrix/pure_rust` | 147.0 µs | **101.4 µs** | **−31.0%** | **1.03× (parity)** |
| `decompress/level_-1_fast/low-entropy-1m/c_stream/matrix/pure_rust` | 355.3 µs | **213.7 µs** | **−39.9%** | 1.45× (was 2.42×) |

The 24-40 % wall-clock reduction reaches all `decode_all` / `decode_all_to_vec` callers automatically without their having to know about WILDCOPY slack.

## Why this layer wins

Earlier attempts (#256 libc fallback replacement, #262 8-byte stride, this branch's earlier chunk-cap=16) all targeted micro-optimisations INSIDE `copy_bytes_overshooting`'s dispatch tree and either lost to Intel ERMS or to the existing 16-byte SSE2 path our `single_op_copy_16` already emits. The bottleneck is not the per-byte SIMD width — it's the dispatch tree itself.

This port collapses the entire literal+match-copy work into one inlined unsafe block per sequence with NO trait dispatch, NO `copy_bytes_overshooting` compare chain, NO `single_op_copy_16` indirection. The SIMD store is the same 16-byte SSE2 `_mm_storeu_si128` either way; the saving is the surrounding compare/branch chain folded out.

## Testing

- `cargo nextest run -p structured-zstd --release` — 636/637 pass (1 pre-existing release-mode debug_assert test, unrelated).
- `cargo clippy --all-targets -- -D warnings` clean.
- Direct-decode regression tests (the `decode_all_*` family in `frame_decoder.rs`) cover the literal-copy + match-copy contract — the inline executor produces byte-identical output to the legacy `push + repeat` chain.
- SIMD helpers (`copy16`, `wildcopy_no_overlap`, `wildcopy_overlap_8byte_stride`, `overlap_copy8`) covered by unit tests in `exec_sequence_inline.rs`.
- `UserSliceBackend::exec_sequence_inline` body covered by direct unit tests in `user_slice_buf.rs` (short-literal + long-offset, long-literal wildcopy tail, short-offset overlap-copy).

Part of #247.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster decompression on x86_64 via a new inline sequence execution path for literal + match copying.
* **Stability / Correctness**
  * Direct-path writes are now fully fallible — malformed frames surface structured errors instead of panicking.
  * Rolling frame-hash state is now snapshot and restored during speculative decoding, preventing failed paths from affecting final frame digests.
* **Compatibility**
  * Non-x86_64 platforms continue using the existing decode path; optimized path is enabled only where supported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
