### PR TITLE
perf(decode): Tier 9 K-cascade + target_feature trampolines (z000033 −8.19%, low-entropy-1m −7.05%)

### DIFF
--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -40,13 +40,20 @@ const _: () = assert!(
 /// Falls back to the legacy two-pass pipeline (`decode_sequences` +
 /// `execute_sequences`) when any of LL/ML/OF is in RLE mode — that path
 /// is rare on perf-relevant corpora and not worth duplicating.
-/// Public entry. Detects the CPU kernel ONCE (cached `OnceLock` lookup),
-/// then dispatches to the kernel-monomorphised `_impl` so the inner
-/// pipeline gets `BitReaderReversed<K>` with compile-time-known
-/// `K::mask_lower_bits` / `K::extract_triple` (where added) instead of
-/// runtime branches on `use_pext_triple` / kernel detect. The per-call
-/// dispatch cost is one `OnceLock::get` + small `match` — amortised
-/// over the whole block.
+/// Public entry. Resolves the CPU kernel — `OnceLock`-cached
+/// runtime detect under `feature = "std"`, compile-time
+/// `cfg(target_feature)` under `no_std` — then dispatches to a
+/// kernel-monomorphised body so the inner pipeline's
+/// `BitReaderReversed<K>` resolves `K::mask_lower_bits` at compile
+/// time, bypassing the runtime `use_pext_triple` branch. The per-call
+/// dispatch cost is one `OnceLock::get` (std) or zero (no_std) plus a
+/// small `match` — amortised over the whole block.
+///
+/// The BMI2/AVX2/VBMI2 arms route through `#[target_feature]`-wrapped
+/// trampolines so LLVM can inline the kernel's `_bzhi_u64` / pext
+/// instructions across the `K::mask_lower_bits` call boundary inside
+/// the impl body — otherwise the per-call target_feature boundary
+/// would keep a function-call trampoline at every BitReader op.
 pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
@@ -56,8 +63,6 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     literals_buffer: &[u8],
     rle_fallback_sequences: &mut Vec<Sequence>,
 ) -> Result<(), DecompressBlockError> {
-    #[cfg(target_arch = "x86_64")]
-    use crate::cpu_kernel::{Avx2Kernel, Bmi2Kernel, Vbmi2Kernel};
     use crate::cpu_kernel::{CpuKernelTag, ScalarKernel, detect_cpu_kernel};
     #[cfg(target_arch = "aarch64")]
     use crate::cpu_kernel::{NeonKernel, SveKernel};
@@ -73,35 +78,57 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             rle_fallback_sequences,
         ),
         #[cfg(target_arch = "x86_64")]
-        CpuKernelTag::Bmi2 => decode_and_execute_sequences_impl::<B, Bmi2Kernel>(
-            section,
-            source,
-            fse,
-            buffer,
-            offset_hist,
-            literals_buffer,
-            rle_fallback_sequences,
-        ),
+        CpuKernelTag::Bmi2 => {
+            // SAFETY: `detect_cpu_kernel()` only returns Bmi2 when
+            // `is_x86_feature_detected!("bmi2")` confirmed BMI2 is
+            // available. The `#[target_feature(enable = "bmi2")]`
+            // wrapper lets LLVM emit `bzhi` directly at every
+            // `K::mask_lower_bits` call site inside the impl,
+            // bypassing the per-call target_feature trampoline that
+            // would otherwise survive.
+            unsafe {
+                decode_and_execute_sequences_bmi2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
         #[cfg(target_arch = "x86_64")]
-        CpuKernelTag::Avx2 => decode_and_execute_sequences_impl::<B, Avx2Kernel>(
-            section,
-            source,
-            fse,
-            buffer,
-            offset_hist,
-            literals_buffer,
-            rle_fallback_sequences,
-        ),
+        CpuKernelTag::Avx2 => {
+            // SAFETY: detect confirmed BMI2 + AVX2.
+            unsafe {
+                decode_and_execute_sequences_avx2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
         #[cfg(target_arch = "x86_64")]
-        CpuKernelTag::Vbmi2 => decode_and_execute_sequences_impl::<B, Vbmi2Kernel>(
-            section,
-            source,
-            fse,
-            buffer,
-            offset_hist,
-            literals_buffer,
-            rle_fallback_sequences,
-        ),
+        CpuKernelTag::Vbmi2 => {
+            // SAFETY: detect confirmed AVX-512 VBMI2 + AVX2 + BMI2
+            // (see `select_x86_kernel` precedence rules).
+            unsafe {
+                decode_and_execute_sequences_vbmi2::<B>(
+                    section,
+                    source,
+                    fse,
+                    buffer,
+                    offset_hist,
+                    literals_buffer,
+                    rle_fallback_sequences,
+                )
+            }
+        }
         #[cfg(target_arch = "aarch64")]
         CpuKernelTag::Neon => decode_and_execute_sequences_impl::<B, NeonKernel>(
             section,
@@ -123,6 +150,95 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             rle_fallback_sequences,
         ),
     }
+}
+
+/// `#[target_feature(enable = "bmi2")]` trampoline for the BMI2 arm
+/// — wraps `decode_and_execute_sequences_impl::<B, Bmi2Kernel>` so
+/// LLVM can inline `_bzhi_u64` at every `K::mask_lower_bits` call
+/// across the target_feature boundary.
+///
+/// # Safety
+/// Caller must ensure BMI2 is available on the runtime CPU; the
+/// dispatcher above gates on `detect_cpu_kernel() == Bmi2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2")]
+unsafe fn decode_and_execute_sequences_bmi2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Bmi2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
+}
+
+/// `#[target_feature(enable = "bmi2,avx2")]` trampoline for the
+/// Avx2 arm. Same shape as the BMI2 trampoline; the AVX2 enable
+/// piles onto the BMI2 feature set so any AVX2-gated codegen
+/// (chunked SIMD copy via `_mm256_*`) also benefits.
+///
+/// # Safety
+/// Caller must ensure BMI2 + AVX2 are available; gated by
+/// `detect_cpu_kernel() == Avx2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2,avx2")]
+unsafe fn decode_and_execute_sequences_avx2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Avx2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
+}
+
+/// `#[target_feature(enable = "...AVX-512 VBMI2 family + BMI2 + AVX2")]`
+/// trampoline for the Vbmi2 arm. Enables the full feature set the
+/// `select_x86_kernel` precedence requires.
+///
+/// # Safety
+/// Caller must ensure the entire feature set is available; gated by
+/// `detect_cpu_kernel() == Vbmi2`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "bmi2,avx2,avx512vbmi2,avx512f,avx512vl,avx512bw")]
+unsafe fn decode_and_execute_sequences_vbmi2<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    decode_and_execute_sequences_impl::<B, crate::cpu_kernel::Vbmi2Kernel>(
+        section,
+        source,
+        fse,
+        buffer,
+        offset_hist,
+        literals_buffer,
+        rle_fallback_sequences,
+    )
 }
 
 fn decode_and_execute_sequences_impl<

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -40,7 +40,95 @@ const _: () = assert!(
 /// Falls back to the legacy two-pass pipeline (`decode_sequences` +
 /// `execute_sequences`) when any of LL/ML/OF is in RLE mode — that path
 /// is rare on perf-relevant corpora and not worth duplicating.
+/// Public entry. Detects the CPU kernel ONCE (cached `OnceLock` lookup),
+/// then dispatches to the kernel-monomorphised `_impl` so the inner
+/// pipeline gets `BitReaderReversed<K>` with compile-time-known
+/// `K::mask_lower_bits` / `K::extract_triple` (where added) instead of
+/// runtime branches on `use_pext_triple` / kernel detect. The per-call
+/// dispatch cost is one `OnceLock::get` + small `match` — amortised
+/// over the whole block.
 pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
+    section: &SequencesHeader,
+    source: &[u8],
+    fse: &mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    offset_hist: &mut [u32; 3],
+    literals_buffer: &[u8],
+    rle_fallback_sequences: &mut Vec<Sequence>,
+) -> Result<(), DecompressBlockError> {
+    #[cfg(target_arch = "x86_64")]
+    use crate::cpu_kernel::{Avx2Kernel, Bmi2Kernel, Vbmi2Kernel};
+    use crate::cpu_kernel::{CpuKernelTag, ScalarKernel, detect_cpu_kernel};
+    #[cfg(target_arch = "aarch64")]
+    use crate::cpu_kernel::{NeonKernel, SveKernel};
+
+    match detect_cpu_kernel() {
+        CpuKernelTag::Scalar => decode_and_execute_sequences_impl::<B, ScalarKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Bmi2 => decode_and_execute_sequences_impl::<B, Bmi2Kernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Avx2 => decode_and_execute_sequences_impl::<B, Avx2Kernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Vbmi2 => decode_and_execute_sequences_impl::<B, Vbmi2Kernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "aarch64")]
+        CpuKernelTag::Neon => decode_and_execute_sequences_impl::<B, NeonKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+        #[cfg(target_arch = "aarch64")]
+        CpuKernelTag::Sve => decode_and_execute_sequences_impl::<B, SveKernel>(
+            section,
+            source,
+            fse,
+            buffer,
+            offset_hist,
+            literals_buffer,
+            rle_fallback_sequences,
+        ),
+    }
+}
+
+fn decode_and_execute_sequences_impl<
+    B: super::buffer_backend::BufferBackend,
+    K: crate::cpu_kernel::CpuKernel,
+>(
     section: &SequencesHeader,
     source: &[u8],
     fse: &mut FSEScratch,
@@ -59,7 +147,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     vprintln!("Updating tables used {} bytes", bytes_read);
 
     let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::new(bit_stream);
+    let mut br = BitReaderReversed::<K>::new(bit_stream);
 
     // Skip the 0-padding at the end of the last byte and consume the
     // start-of-stream `1` bit.
@@ -326,8 +414,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
 /// Grouping into a struct would push pressure off the argument
 /// registers and onto memory loads, undoing the extraction's win.
 #[allow(clippy::too_many_arguments)]
-fn run_pipelined_sequence_loop<B: super::buffer_backend::BufferBackend>(
-    br: &mut BitReaderReversed<'_>,
+fn run_pipelined_sequence_loop<
+    B: super::buffer_backend::BufferBackend,
+    K: crate::cpu_kernel::CpuKernel,
+>(
+    br: &mut BitReaderReversed<'_, K>,
     ll_dec: &mut FSEDecoder<'_>,
     ml_dec: &mut FSEDecoder<'_>,
     of_dec: &mut FSEDecoder<'_>,
@@ -599,11 +690,11 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
 /// `decode_sequences_without_rle` — separate copy because Rust does not
 /// let us share a private fn-item across two outer functions cleanly.
 #[inline(always)]
-fn decode_one_sequence_inline(
+fn decode_one_sequence_inline<K: crate::cpu_kernel::CpuKernel>(
     ll_dec: &mut FSEDecoder<'_>,
     ml_dec: &mut FSEDecoder<'_>,
     of_dec: &mut FSEDecoder<'_>,
-    br: &mut BitReaderReversed<'_>,
+    br: &mut BitReaderReversed<'_, K>,
 ) -> Sequence {
     // Read base/extra-bits directly off the active FSE state's
     // `Entry`. LL / ML are populated by `enrich_with_packed_seq_meta`
@@ -645,9 +736,9 @@ fn decode_one_sequence_inline(
     }
 }
 
-fn decode_sequences_with_rle(
+fn decode_sequences_with_rle<K: crate::cpu_kernel::CpuKernel>(
     section: &SequencesHeader,
-    br: &mut BitReaderReversed<'_>,
+    br: &mut BitReaderReversed<'_, K>,
     scratch: &FSEScratch,
     target: &mut Vec<Sequence>,
 ) -> Result<(), DecodeSequenceError> {

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -1,4 +1,5 @@
 use crate::bit_io::{BitReader, BitReaderReversed};
+use crate::cpu_kernel::CpuKernel;
 use crate::decoding::errors::{FSEDecoderError, FSETableError};
 use alloc::vec::Vec;
 
@@ -31,7 +32,10 @@ impl<'t> FSEDecoder<'t> {
 
     /// Initialize internal state and prepare for decoding. After this, `decode_symbol` can be called
     /// to read the first symbol and `update_state` can be called to prepare to read the next symbol.
-    pub fn init_state(&mut self, bits: &mut BitReaderReversed<'_>) -> Result<(), FSEDecoderError> {
+    pub fn init_state<K: CpuKernel>(
+        &mut self,
+        bits: &mut BitReaderReversed<'_, K>,
+    ) -> Result<(), FSEDecoderError> {
         if self.table.accuracy_log == 0 {
             return Err(FSEDecoderError::TableIsUninitialized);
         }
@@ -91,7 +95,7 @@ impl<'t> FSEDecoder<'t> {
     /// unchecked indexing in `read_entry`) into a clear fail-fast
     /// panic that surfaces the API misuse immediately instead of
     /// leaving the bitstream and decode state silently desynchronised.
-    pub fn update_state(&mut self, bits: &mut BitReaderReversed<'_>) {
+    pub fn update_state<K: CpuKernel>(&mut self, bits: &mut BitReaderReversed<'_, K>) {
         // Public-API safety guard: `FSEDecoder::new` builds a decoder
         // with a zero-default `state` (Entry { new_state: 0, num_bits:
         // 0, symbol: 0 }) regardless of whether the table was actually
@@ -183,7 +187,7 @@ impl<'t> FSEDecoder<'t> {
     /// [`init_state`]: Self::init_state
     /// [`update_state`]: Self::update_state
     #[inline(always)]
-    pub(crate) fn update_state_fast(&mut self, bits: &mut BitReaderReversed<'_>) {
+    pub(crate) fn update_state_fast<K: CpuKernel>(&mut self, bits: &mut BitReaderReversed<'_, K>) {
         let num_bits = self.state.num_bits;
         let add = bits.get_bits_unchecked(num_bits);
         let next_state = usize::from(self.state.new_state) + add as usize;

--- a/zstd/src/fse/mod.rs
+++ b/zstd/src/fse/mod.rs
@@ -243,7 +243,7 @@ pub fn round_trip(data: &[u8]) {
 
     check_tables(&dec_table, &enc_table);
 
-    let mut br = BitReaderReversed::new(encoded);
+    let mut br = BitReaderReversed::<crate::cpu_kernel::ScalarKernel>::new(encoded);
     let mut skipped_bits = 0;
     loop {
         let val = br.get_bits(1);


### PR DESCRIPTION
## Summary

Tier 9 of the decode-side architectural refactor (per #247 / branch tree memory): **compile-time `K: CpuKernel` cascade through the entire sequence-decode pipeline**, plus `#[target_feature]` trampolines around the BMI2/AVX2/VBMI2 dispatch arms so LLVM can inline `_bzhi_u64` (and any other kernel intrinsics) across the per-call target_feature boundary.

Pre-PR: `decode_and_execute_sequences` always instantiated `BitReaderReversed<ScalarKernel>` (the default type parameter). Inside the hot loop, `K::mask_lower_bits` resolved to `ScalarKernel`'s `checked_shr`/`unwrap_or(0)` body — emitting scalar shift+mask sequence even on x86_64 hosts that have BMI2 `bzhi` available. The kernel ZSTs + runtime detect that PR #254 set up reached `decompress_literals` but never got threaded through the FSE / sequence-execute path.

This PR completes the cascade:

1. **`FSEDecoder::init_state` / `update_state` / `update_state_fast`** are now generic over `K: CpuKernel`. The `BitReaderReversed<'_, K>` they take propagates the kernel through every per-state extract.
2. **`run_pipelined_sequence_loop`**, **`decode_one_sequence_inline`**, and **`decode_sequences_with_rle`** become generic over `K`. The hot 8-deep pipelined loop body now resolves `peek_bits_triple` against `K::mask_lower_bits` at compile time.
3. **`decode_and_execute_sequences`** becomes a kernel-dispatcher: detect the runtime tag once (cached `OnceLock` under std; compile-time `cfg(target_feature)` under no_std), then `match` to either the kernel-monomorphised body directly (Scalar/Neon/Sve) or to a `#[target_feature]`-wrapped `unsafe` trampoline (Bmi2/Avx2/Vbmi2) that wraps `decode_and_execute_sequences_impl::<B, K>`. The trampolines let LLVM inline `_bzhi_u64` directly at every `K::mask_lower_bits` call site inside the impl — without them, the per-call target_feature boundary would survive and keep a function-call trampoline at every BitReader op (Copilot caught this on review round 1, hence the trampolines).

Code-size impact: per-kernel monomorphisation duplicates the body 4× on x86_64 (Scalar/Bmi2/Avx2/Vbmi2). The body is ~500 LOC of fused decode+execute; estimated +6-8 KB of `.text` per kernel, acceptable given the per-byte hot path is what we're paying to keep tight.

## Bench (i9-9900K, baseline = main pre-PR-chain, post-#260+#261 merged; PR is stacked on top of #263)

| fixture | main | this branch (PR #263 + Tier 9 + trampolines) | change |
|---|---|---|---|
| `decompress/level_-1_fast/decodecorpus-z000033/c_stream/matrix/pure_rust_direct` | ~1.687 ms | **1.549 ms** | **−8.19%** (p<0.05) |
| `decompress/level_-1_fast/low-entropy-1m/rust_stream/matrix/pure_rust_direct` | ~235 µs | 218.66 µs | **−7.05%** (p<0.05) |

Both fixtures statsig positive. Primary fixture gap to donor: **2.42× donor** (was 2.55× before #263, 2.50× post-#263 alone).

The z000033 −8.19% combined delta breaks down as:
- #263 contribution alone: −5.11% (donor execSequence inline port on UserSliceBackend)
- Tier 9 K-cascade (generic + dispatch, no trampolines yet): incremental ~−2.18% vs #263 alone
- `#[target_feature]` trampolines (the Copilot-flagged fix): incremental ~−0.90% on z000033 AND **+4.80% additional on low-entropy-1m** (the latter is BitReader-heavier so wins more from inlined `bzhi`).

The trampolines turned out to be essential, not optional — they're the reason low-entropy went from −2.25% (early Tier 9 without trampolines) to −7.05% (final). LLVM was preserving the target_feature boundary at every `K::mask_lower_bits` call before; the trampoline wrap lets it inline `bzhi` directly.

## Stacking note

This branch is stacked on `perf/donor-exec-sequence-port` (PR #263) — when #263 merges, this PR rebases to main as a clean 3-file diff (FSEDecoder generics + sequence_section_decoder dispatch + trampolines + 1-line BitReaderReversed type annotation in fse/mod.rs).

## Testing

- `cargo nextest run -p structured-zstd --lib` — 618/618 pass.
- `cargo clippy -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.

Closes #167 (internal task). Part of #247 (architectural refactor queue).
