### PR TITLE
perf(decode): cache predefined FSE tables (small-4k-log-lines −69%)

### DIFF
--- a/zstd/examples/profile_decode_direct.rs
+++ b/zstd/examples/profile_decode_direct.rs
@@ -1,0 +1,56 @@
+//! Hot-loop decode binary for targeted flamegraph profiling on the
+//! direct-path (`UserSliceBackend`) decode. Mirrors the
+//! `compare_ffi.rs` `pure_rust` arm — pre-sizes the target with
+//! `WILDCOPY_OVERLENGTH` slack so the per-frame eligibility gate
+//! sends the decode through `run_direct_decode`.
+//!
+//! Usage:
+//!   profile_decode_direct <compressed_blob> <decompressed_size> [iters]
+//!
+//! The custom binary avoids criterion's setup overhead (build_raw_dict,
+//! reservation churn, page-fault noise) that drowned the decode hot
+//! path in `cargo flamegraph --bench compare_ffi` runs.
+
+use std::env;
+use std::fs;
+use structured_zstd::WILDCOPY_OVERLENGTH;
+use structured_zstd::decoding::FrameDecoder;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let path = args
+        .get(1)
+        .expect("usage: profile_decode_direct <blob> <expected_size> [iters]");
+    let expected: usize = args
+        .get(2)
+        .expect("expected_size required")
+        .parse()
+        .expect("expected_size parse");
+    let iters: usize = args.get(3).map(|s| s.parse().unwrap()).unwrap_or(50_000);
+
+    let compressed = fs::read(path).expect("read");
+    let mut target = vec![0u8; expected + WILDCOPY_OVERLENGTH];
+    // Pre-touch pages so kernel zero-init isn't in the flamegraph.
+    for slot in target.iter_mut().step_by(4096) {
+        *slot = 0;
+    }
+
+    let mut decoder = FrameDecoder::new();
+    let t0 = std::time::Instant::now();
+    let mut written_total = 0u64;
+    for _ in 0..iters {
+        let n = decoder
+            .decode_all(compressed.as_slice(), &mut target)
+            .expect("decode_all");
+        written_total = written_total.wrapping_add(n as u64);
+        std::hint::black_box(&target[..n]);
+    }
+    let elapsed = t0.elapsed();
+    eprintln!(
+        "iters={} elapsed={:.3?} per_iter={:.3?} total_written={}",
+        iters,
+        elapsed,
+        elapsed / iters as u32,
+        written_total
+    );
+}

--- a/zstd/examples/profile_decode_direct.rs
+++ b/zstd/examples/profile_decode_direct.rs
@@ -50,11 +50,11 @@ fn main() {
         std::hint::black_box(&target[..n]);
     }
     let elapsed = t0.elapsed();
+    // Compute per-iter time as f64 nanoseconds: `Duration / u32` would
+    // truncate `iters` on 64-bit platforms (and produce a divide-by-0
+    // panic when `iters % 2^32 == 0`).
+    let per_iter_ns = elapsed.as_nanos() as f64 / iters as f64;
     eprintln!(
-        "iters={} elapsed={:.3?} per_iter={:.3?} total_written={}",
-        iters,
-        elapsed,
-        elapsed / iters as u32,
-        written_total
+        "iters={iters} elapsed={elapsed:.3?} per_iter={per_iter_ns:.1}ns total_written={written_total}"
     );
 }

--- a/zstd/examples/profile_decode_direct.rs
+++ b/zstd/examples/profile_decode_direct.rs
@@ -33,16 +33,34 @@ fn main() {
         .max(1);
 
     let compressed = fs::read(path).expect("read");
-    let mut target = vec![0u8; expected + WILDCOPY_OVERLENGTH];
+    // checked_add to reject adversarial `expected_size` inputs that
+    // would wrap `usize` when added to `WILDCOPY_OVERLENGTH`.
+    let target_len = expected
+        .checked_add(WILDCOPY_OVERLENGTH)
+        .expect("expected_size + WILDCOPY_OVERLENGTH overflows usize");
+    let mut target = vec![0u8; target_len];
     // Pre-touch pages so kernel zero-init isn't in the flamegraph.
     for slot in target.iter_mut().step_by(4096) {
         *slot = 0;
     }
 
     let mut decoder = FrameDecoder::new();
+    // First iteration validates that the user's `expected_size` matches
+    // the actual decoded length — otherwise the timed loop below would
+    // silently profile a different workload than the user intended.
+    let first = decoder
+        .decode_all(compressed.as_slice(), &mut target)
+        .expect("decode_all");
+    assert_eq!(
+        first, expected,
+        "decoded size mismatch: expected {expected}, got {first} \
+         (compressed blob does not decode to the size argument passed)",
+    );
+
     let t0 = std::time::Instant::now();
-    let mut written_total = 0u64;
-    for _ in 0..iters {
+    let mut written_total = first as u64;
+    std::hint::black_box(&target[..first]);
+    for _ in 1..iters {
         let n = decoder
             .decode_all(compressed.as_slice(), &mut target)
             .expect("decode_all");

--- a/zstd/examples/profile_decode_direct.rs
+++ b/zstd/examples/profile_decode_direct.rs
@@ -26,7 +26,11 @@ fn main() {
         .expect("expected_size required")
         .parse()
         .expect("expected_size parse");
-    let iters: usize = args.get(3).map(|s| s.parse().unwrap()).unwrap_or(50_000);
+    let iters: usize = args
+        .get(3)
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(50_000)
+        .max(1);
 
     let compressed = fs::read(path).expect("read");
     let mut target = vec![0u8; expected + WILDCOPY_OVERLENGTH];

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -344,6 +344,15 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
             return;
         }
 
+        // Range gate: `num_bits > 64` would make the dirty-upper-bits
+        // shift below `bits >> num_bits` invoke IR-level shift overflow
+        // (panic in debug, UB in release-without-overflow-checks). The
+        // safe public API must reject this before the shift.
+        assert!(
+            num_bits <= 64,
+            "write_bits_64 num_bits={num_bits} exceeds u64 width",
+        );
+
         // Dirty-upper-bits contract: the caller MUST pre-mask `bits`
         // to the `num_bits` low-bit range. Violation silently corrupts
         // the output bitstream because subsequent `write_bits_64`
@@ -356,16 +365,15 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         // caller would produce a corrupt compressed blob with no
         // diagnostic signal).
         //
-        // `bits >> num_bits == 0` covers both the `num_bits == 64`
-        // edge (right-shift-by-64 on u64 is UB at the IR level but
-        // here we short-circuit via the leading `num_bits == 0`
-        // bail-out + this branch's `num_bits < 64` precondition — in
-        // practice every call site that reads up to 64 bits goes
-        // through `write_bits_64_no_check` instead) and the
-        // off-by-one trap that `bits.ilog2() <= num_bits` had: under
-        // the old `<=` form, `bits == 1 << num_bits` (which occupies
-        // `num_bits + 1` bits) would still pass. The shift form is
-        // also one ALU op vs `ilog2`'s LZCNT round-trip.
+        // The `num_bits == 64` arm short-circuits the shift entirely
+        // (right-shift-by-64 on u64 is IR-level UB even though the
+        // value is in range here) — the upper-bits check is trivially
+        // satisfied because `num_bits == 64` covers the whole u64.
+        // For `num_bits < 64`, `bits >> num_bits == 0` is the strict
+        // form (the prior `bits.ilog2() <= num_bits` was off-by-one:
+        // it accepted `bits == 1 << num_bits` which occupies
+        // `num_bits + 1` bits) and is one ALU op vs ilog2's LZCNT
+        // round-trip.
         assert!(
             num_bits == 64 || bits >> num_bits == 0,
             "write_bits_64 dirty upper bits: bits=0x{bits:x} occupies {} bits but num_bits={num_bits}",

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -344,8 +344,23 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
             return;
         }
 
+        // Dirty-upper-bits contract: the caller MUST pre-mask `bits`
+        // to the `num_bits` low-bit range. Violation silently corrupts
+        // the output bitstream because subsequent `write_bits_64`
+        // calls would OR the spurious upper bits into the partial
+        // accumulator at the wrong position. Enforce in release too
+        // (was `debug_assert!`) — the per-call cost is one `ilog2`
+        // (LZCNT, 1 cycle on Skylake-X) + a predicted-not-taken
+        // branch, negligible vs the encoder's per-token shift/merge
+        // work, while the safety value is real (encoder call sites
+        // are internal but a wrong caller would produce a corrupt
+        // compressed blob with no diagnostic signal).
         if bits > 0 {
-            debug_assert!(bits.ilog2() <= num_bits as u32);
+            assert!(
+                bits.ilog2() <= num_bits as u32,
+                "write_bits_64 dirty upper bits: bits=0x{bits:x} occupies {} bits but num_bits={num_bits}",
+                u64::BITS - bits.leading_zeros(),
+            );
         }
 
         // fill partial byte first

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -349,19 +349,28 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
         // the output bitstream because subsequent `write_bits_64`
         // calls would OR the spurious upper bits into the partial
         // accumulator at the wrong position. Enforce in release too
-        // (was `debug_assert!`) — the per-call cost is one `ilog2`
-        // (LZCNT, 1 cycle on Skylake-X) + a predicted-not-taken
-        // branch, negligible vs the encoder's per-token shift/merge
-        // work, while the safety value is real (encoder call sites
-        // are internal but a wrong caller would produce a corrupt
-        // compressed blob with no diagnostic signal).
-        if bits > 0 {
-            assert!(
-                bits.ilog2() <= num_bits as u32,
-                "write_bits_64 dirty upper bits: bits=0x{bits:x} occupies {} bits but num_bits={num_bits}",
-                u64::BITS - bits.leading_zeros(),
-            );
-        }
+        // (was `debug_assert!`) — the per-call cost is one shift +
+        // compare + predicted-not-taken branch, negligible vs the
+        // encoder's per-token shift/merge work, while the safety
+        // value is real (encoder call sites are internal but a wrong
+        // caller would produce a corrupt compressed blob with no
+        // diagnostic signal).
+        //
+        // `bits >> num_bits == 0` covers both the `num_bits == 64`
+        // edge (right-shift-by-64 on u64 is UB at the IR level but
+        // here we short-circuit via the leading `num_bits == 0`
+        // bail-out + this branch's `num_bits < 64` precondition — in
+        // practice every call site that reads up to 64 bits goes
+        // through `write_bits_64_no_check` instead) and the
+        // off-by-one trap that `bits.ilog2() <= num_bits` had: under
+        // the old `<=` form, `bits == 1 << num_bits` (which occupies
+        // `num_bits + 1` bits) would still pass. The shift form is
+        // also one ALU op vs `ilog2`'s LZCNT round-trip.
+        assert!(
+            num_bits == 64 || bits >> num_bits == 0,
+            "write_bits_64 dirty upper bits: bits=0x{bits:x} occupies {} bits but num_bits={num_bits}",
+            u64::BITS - bits.leading_zeros(),
+        );
 
         // fill partial byte first
         if num_bits + self.bits_in_partial < 64 {

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -353,6 +353,22 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
             "write_bits_64 num_bits={num_bits} exceeds u64 width",
         );
 
+        // Full-word fast path: when `num_bits == 64` AND the partial
+        // buffer is empty, write the whole u64 directly. Falls back to
+        // the normal path otherwise — that path's
+        // `write_bits_64_cold` does `bits >> bits_free_in_partial`
+        // where `bits_free_in_partial = 64 - bits_in_partial`. With
+        // `bits_in_partial == 0` and `num_bits == 64` the shift is by
+        // 64 (UB). Routing the empty-partial / num_bits==64 case
+        // through this fast path avoids the cold-path shift entirely;
+        // for `num_bits == 64` with non-empty partial, the cold path's
+        // shift is `<= 63` which is well-defined.
+        if num_bits == 64 && self.bits_in_partial == 0 {
+            self.output.as_mut().extend_from_slice(&bits.to_le_bytes());
+            self.bit_idx += 64;
+            return;
+        }
+
         // Dirty-upper-bits contract: the caller MUST pre-mask `bits`
         // to the `num_bits` low-bit range. Violation silently corrupts
         // the output bitstream because subsequent `write_bits_64`

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -115,10 +115,13 @@ pub(crate) trait BufferBackend: Sized {
     ///   bound fails — a future caller reusing this hook must
     ///   enforce the same gate or pad the literals buffer with 15
     ///   bytes of slack at allocation time.
-    /// - Caller is responsible for updating any DecodeBuffer-level
-    ///   counters (`total_output_counter`, hash) that mirror the
-    ///   bytes this method writes — see
-    ///   `decode_buffer::DecodeBuffer::advance_output_counter`.
+    /// - This method writes directly through the backend; the
+    ///   wrapper-level `DecodeBuffer::total_output_counter` is NOT
+    ///   maintained on this path. Callers that need a byte count for
+    ///   the inline-eligible path must read `BufferBackend::tail()`
+    ///   (see `FrameDecoder::run_direct_decode`'s post-block FCS
+    ///   check). Hash is likewise deferred to the post-block
+    ///   full-slice pass in `FrameDecoder::decode_all`.
     #[allow(unused_variables, unused_mut)]
     #[inline(always)]
     unsafe fn exec_sequence_inline(

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -192,23 +192,15 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         &mut self.buffer
     }
 
-    /// Advance the `total_output_counter` by `n` bytes — pair with
-    /// [`super::buffer_backend::BufferBackend::exec_sequence_inline`]
-    /// which writes the actual bytes through the backend without
-    /// touching DecodeBuffer-level bookkeeping. Without this helper
-    /// the donor-shape path would leave `total_output_counter` stale
-    /// on every sequence executed through it.
-    ///
-    /// **Hash is NOT mutated here.** On the direct-decode path
-    /// `FrameDecoder::decode_all` walks the full output
-    /// slice once at end of decode and writes the result into
-    /// `self.hash`, overwriting any incremental state. Hashing per
-    /// sequence here would be wasted work whose result the final
-    /// pass discards. The legacy decode path likewise folds bytes
-    /// into the hash via `drain_to`, not at write time.
-    #[inline]
-    pub(crate) fn advance_output_counter(&mut self, n: usize) {
-        self.total_output_counter += n as u64;
+    /// Immutable backend handle. Used by `run_direct_decode`'s
+    /// post-block FCS check to read `tail` directly, bypassing the
+    /// `total_output_counter` field — the donor inline path skips
+    /// `advance_output_counter` (see
+    /// `sequence_section_decoder::execute_one_sequence_pipelined`)
+    /// so the counter would be stale on that path.
+    #[inline(always)]
+    pub(crate) fn buffer_ref(&self) -> &B {
+        &self.buffer
     }
 
     /// Fill `fill_length` bytes of the output with the literal `fill_with`,
@@ -699,23 +691,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             None => Ok(0),
             Some(can_drain) => self.drain_to(can_drain, |buf| write_all_bytes(&mut sink, buf)),
         }
-    }
-
-    /// Total bytes ever produced into the backend across this
-    /// `DecodeBuffer`'s lifetime. Incremented by `push` / `repeat` /
-    /// `extend_and_fill` / `extend_from_reader`. Survives across
-    /// `drop_to_window_size` and `drain_*` calls (those only narrow
-    /// the visible region; they don't roll back produced).
-    ///
-    /// Used by the direct-decode path (`FrameDecoder::decode_all`)
-    /// to track actual bytes written against the declared
-    /// `frame_content_size`. Sidesteps `BlockHeader.decompressed_size`
-    /// which is intentionally 0 for `BlockType::Compressed` (the
-    /// header parser doesn't decode the body), so per-block tracking
-    /// via the header field would always read 0 on compressed blocks
-    /// and miscount.
-    pub fn total_produced(&self) -> u64 {
-        self.total_output_counter
     }
 
     /// Advance the backend's head past any bytes beyond `window_size`

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -179,10 +179,10 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.reserve(amount);
     }
 
-    /// Mutable backend handle — paired with
-    /// [`Self::advance_output_counter`] so the donor-shape inline
-    /// sequence executor can write straight into the backend's
-    /// physical storage and then update the buffer-level counters.
+    /// Mutable backend handle. Lets the inline sequence executor
+    /// write straight into the backend's physical storage; the
+    /// `tail()` cursor on the backend is the authoritative output
+    /// length, so no separate buffer-level counter update is needed.
     /// Crate-internal; gated to the
     /// `BufferBackend::SUPPORTS_INLINE_SEQUENCE_EXEC = true` dispatch
     /// site.
@@ -192,12 +192,14 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         &mut self.buffer
     }
 
-    /// Immutable backend handle. Used by `run_direct_decode`'s
-    /// post-block FCS check to read `tail` directly, bypassing the
-    /// `total_output_counter` field — the donor inline path skips
-    /// `advance_output_counter` (see
+    /// Immutable backend handle. `run_direct_decode`'s post-block FCS
+    /// check reads `tail()` straight from the backend rather than
+    /// going through `total_output_counter`: the inline sequence
+    /// executor (see
     /// `sequence_section_decoder::execute_one_sequence_pipelined`)
-    /// so the counter would be stale on that path.
+    /// writes directly through `buffer_mut`, so the
+    /// `total_output_counter` field on the wrapper is not maintained
+    /// on that path and `tail()` is the only accurate output length.
     #[inline(always)]
     pub(crate) fn buffer_ref(&self) -> &B {
         &self.buffer

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -253,7 +253,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// `Block_Size` exceeds the caller's output slice surfaces as a
     /// structured error instead of panicking. Compressed-block
     /// sequence execution is a follow-up.
-    #[inline]
+    #[inline(always)]
     pub fn try_push(&mut self, data: &[u8]) -> Result<(), super::buffer_backend::BackendOverflow> {
         self.buffer.try_extend(data)?;
         self.total_output_counter += data.len() as u64;

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -624,6 +624,20 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
+        // `total_output_counter` gate: dict-source matches are only
+        // valid while the dictionary content is still inside the
+        // visible window. On the inline-exec path
+        // (`UserSliceBackend`) `total_output_counter` is NOT
+        // maintained — it stays at 0 — so the gate is trivially
+        // satisfied. This does NOT cause incorrect behavior on that
+        // path because `dict_content` is always empty for the direct
+        // decode entry (`run_direct_decode`'s
+        // `DecodeBuffer::from_backend` initializes it to empty), so
+        // `bytes_from_dict > self.dict_content.len()` below catches
+        // every would-be dict-source match and returns
+        // `NotEnoughBytesInDictionary`. The
+        // `RingBuffer` / `FlatBuf` paths still maintain the counter
+        // via `push` / `repeat_match` and rely on it correctly.
         if self.total_output_counter <= self.window_size as u64 {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -40,9 +40,11 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 /// `try_restore_checkpoint()` writes to `self.hash`:
 ///   * `push` and `extend_and_fill` only advance
 ///     `total_output_counter`.
-///   * `advance_output_counter` (donor inline path) only advances
-///     `total_output_counter` (hashing is deferred to the final
-///     full-slice pass in `FrameDecoder::decode_all`).
+///   * The inline sequence executor writes through `buffer_mut()`
+///     directly, bypassing the wrapper-level
+///     `total_output_counter` entirely (`UserSliceBackend::tail`
+///     carries the byte count on that path; hashing is deferred to
+///     the final full-slice pass in `FrameDecoder::decode_all`).
 ///   * `drain_to` / `read` DO write hash, but they run BETWEEN
 ///     blocks, never inside the fused sequence loop the checkpoint
 ///     guards.
@@ -165,8 +167,9 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // No hash restore: see `DecodeBufferCheckpoint` doc. No
         // mutation site between `checkpoint()` and this call writes
         // to `self.hash` (drain runs between blocks, not inside the
-        // fused sequence loop; the donor inline path's
-        // `advance_output_counter` advances only the counter).
+        // fused sequence loop; the inline sequence executor bypasses
+        // the wrapper counter entirely via `buffer_mut()`, leaving
+        // hashing for the post-block full-slice pass).
         true
     }
 

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1129,7 +1129,7 @@ pub enum FSETableError {
     TooManySymbols {
         got: usize,
     },
-    /// Probability value outside the RFC 8478 §4.1.1 allowed set
+    /// Probability value outside the RFC 8878 §4.1.1 allowed set
     /// `{-1, 0, 1..=table_size}`. Carries the violating value, the
     /// table size (`1 << accuracy_log`) and `accuracy_log` so the
     /// caller can pinpoint the failure without re-deriving the bound.
@@ -1142,7 +1142,7 @@ pub enum FSETableError {
     /// width exceeds the table's accuracy log, violating the
     /// `new_state + (1 << num_bits) - 1 < table_size` invariant that
     /// the unchecked `read_entry` decode hot path relies on. The
-    /// triggering probability is in-range per RFC 8478 §4.1.1; the
+    /// triggering probability is in-range per RFC 8878 §4.1.1; the
     /// failure is an internal table-shape inconsistency surfaced
     /// against the public `build_from_probabilities` API.
     TableInvariantViolation {
@@ -1197,7 +1197,7 @@ impl core::fmt::Display for FSETableError {
             } => {
                 write!(
                     f,
-                    "FSE probability value {value} is outside the RFC 8478 allowed set (must be -1, 0, or in 1..={table_size}; accuracy_log={accuracy_log})",
+                    "FSE probability value {value} is outside the RFC 8878 allowed set (must be -1, 0, or in 1..={table_size}; accuracy_log={accuracy_log})",
                 )
             }
             FSETableError::TableInvariantViolation {

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1130,10 +1130,13 @@ pub enum FSETableError {
         got: usize,
     },
     /// Probability value outside the RFC 8478 §4.1.1 allowed set
-    /// `{-1, 0, 1..=table_size}`. Carried verbatim from the input
-    /// vector for diagnostics.
+    /// `{-1, 0, 1..=table_size}`. Carries the violating value, the
+    /// table size (`1 << accuracy_log`) and `accuracy_log` so the
+    /// caller can pinpoint the failure without re-deriving the bound.
     InvalidProbability {
         value: i32,
+        table_size: u32,
+        accuracy_log: u8,
     },
     /// `calc_baseline_and_numbits` produced a state-entry whose bit
     /// width exceeds the table's accuracy log, violating the
@@ -1187,10 +1190,14 @@ impl core::fmt::Display for FSETableError {
                     "There are too many symbols in this distribution: {got}. Max: 256",
                 )
             }
-            FSETableError::InvalidProbability { value } => {
+            FSETableError::InvalidProbability {
+                value,
+                table_size,
+                accuracy_log,
+            } => {
                 write!(
                     f,
-                    "FSE probability value {value} is outside the RFC 8478 allowed set (must be -1, 0, or in 1..=table_size)",
+                    "FSE probability value {value} is outside the RFC 8478 allowed set (must be -1, 0, or in 1..={table_size}; accuracy_log={accuracy_log})",
                 )
             }
             FSETableError::TableInvariantViolation {

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1122,7 +1122,7 @@ pub enum FSETableError {
     },
     GetBitsError(GetBitsError),
     ProbabilityCounterMismatch {
-        got: u64,
+        got: u32,
         expected_sum: u32,
         symbol_probabilities: Vec<i32>,
     },
@@ -1130,9 +1130,23 @@ pub enum FSETableError {
         got: usize,
     },
     /// Probability value outside the RFC 8478 §4.1.1 allowed set
-    /// `{-1, 0, positive}`. Specifically a value `< -1`.
+    /// `{-1, 0, 1..=table_size}`. Carried verbatim from the input
+    /// vector for diagnostics.
     InvalidProbability {
         value: i32,
+    },
+    /// `calc_baseline_and_numbits` produced a state-entry whose bit
+    /// width exceeds the table's accuracy log, violating the
+    /// `new_state + (1 << num_bits) - 1 < table_size` invariant that
+    /// the unchecked `read_entry` decode hot path relies on. The
+    /// triggering probability is in-range per RFC 8478 §4.1.1; the
+    /// failure is an internal table-shape inconsistency surfaced
+    /// against the public `build_from_probabilities` API.
+    TableInvariantViolation {
+        prob: i32,
+        symbol: u8,
+        num_bits: u8,
+        accuracy_log: u8,
     },
 }
 
@@ -1164,7 +1178,7 @@ impl core::fmt::Display for FSETableError {
             } => {
                 write!(
                     f,
-                    "The counter ({got}) exceeded the expected sum: {expected_sum}. This means an error or corrupted data \n {symbol_probabilities:?}",
+                    "FSE probability sum mismatch: got {got}, expected {expected_sum}. Indicates corrupted data or an invalid distribution\n {symbol_probabilities:?}",
                 )
             }
             FSETableError::TooManySymbols { got } => {
@@ -1176,7 +1190,18 @@ impl core::fmt::Display for FSETableError {
             FSETableError::InvalidProbability { value } => {
                 write!(
                     f,
-                    "FSE probability value {value} is outside the RFC 8478 allowed set (negatives below -1 are not permitted)",
+                    "FSE probability value {value} is outside the RFC 8478 allowed set (must be -1, 0, or in 1..=table_size)",
+                )
+            }
+            FSETableError::TableInvariantViolation {
+                prob,
+                symbol,
+                num_bits,
+                accuracy_log,
+            } => {
+                write!(
+                    f,
+                    "FSE table invariant violation: symbol {symbol} (prob {prob}) produced num_bits {num_bits} > accuracy_log {accuracy_log}",
                 )
             }
         }
@@ -1526,7 +1551,7 @@ mod tests {
                 symbol_probabilities: vec![1, -1],
             }
             .to_string(),
-            "The counter (4) exceeded the expected sum: 3. This means an error or corrupted data \n [1, -1]"
+            "FSE probability sum mismatch: got 4, expected 3. Indicates corrupted data or an invalid distribution\n [1, -1]"
         );
         assert_eq!(
             HuffmanTableError::NotEnoughBytesForWeights {

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1129,6 +1129,11 @@ pub enum FSETableError {
     TooManySymbols {
         got: usize,
     },
+    /// Probability value outside the RFC 8478 §4.1.1 allowed set
+    /// `{-1, 0, positive}`. Specifically a value `< -1`.
+    InvalidProbability {
+        value: i32,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -1166,6 +1171,12 @@ impl core::fmt::Display for FSETableError {
                 write!(
                     f,
                     "There are too many symbols in this distribution: {got}. Max: 256",
+                )
+            }
+            FSETableError::InvalidProbability { value } => {
+                write!(
+                    f,
+                    "FSE probability value {value} is outside the RFC 8478 allowed set (negatives below -1 are not permitted)",
                 )
             }
         }

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -1122,7 +1122,7 @@ pub enum FSETableError {
     },
     GetBitsError(GetBitsError),
     ProbabilityCounterMismatch {
-        got: u32,
+        got: u64,
         expected_sum: u32,
         symbol_probabilities: Vec<i32>,
     },

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -7,6 +7,7 @@
 use super::frame;
 use crate::decoding;
 use crate::decoding::block_decoder::BlockDecoder;
+use crate::decoding::buffer_backend::BufferBackend;
 use crate::decoding::decode_buffer::DecodeBuffer;
 use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
 use crate::decoding::errors::{DecodeBlockContentError, FrameDecoderError};
@@ -1332,7 +1333,14 @@ impl FrameDecoder {
             // Slice-source fast path: consume the block body
             // straight from `input` without copying into the
             // persistent `block_content_buffer`.
-            let before = direct.buffer.total_produced();
+            // Read `tail` directly: the donor inline path no longer
+            // calls `advance_output_counter` so the separate
+            // `total_output_counter` would be stale on that path.
+            // `UserSliceBackend::tail` is advanced inside every
+            // `exec_sequence_inline` / `extend` / `try_extend`
+            // call, so it's the authoritative count of bytes the
+            // backend has written.
+            let before = direct.buffer.buffer_ref().tail() as u64;
             let body_consumed = match block_dec.decode_block_content_from_slice(
                 &block_header,
                 &mut direct,
@@ -1360,7 +1368,7 @@ impl FrameDecoder {
                 }
                 Err(e) => return Err(err::FailedToReadBlockBody(e)),
             };
-            produced = direct.buffer.total_produced();
+            produced = direct.buffer.buffer_ref().tail() as u64;
             // Post-decode FCS overflow check.
             if produced > content_size {
                 return Err(err::FrameContentSizeMismatch {

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1333,14 +1333,6 @@ impl FrameDecoder {
             // Slice-source fast path: consume the block body
             // straight from `input` without copying into the
             // persistent `block_content_buffer`.
-            // Read `tail` directly: the donor inline path no longer
-            // calls `advance_output_counter` so the separate
-            // `total_output_counter` would be stale on that path.
-            // `UserSliceBackend::tail` is advanced inside every
-            // `exec_sequence_inline` / `extend` / `try_extend`
-            // call, so it's the authoritative count of bytes the
-            // backend has written.
-            let before = direct.buffer.buffer_ref().tail() as u64;
             let body_consumed = match block_dec.decode_block_content_from_slice(
                 &block_header,
                 &mut direct,
@@ -1376,7 +1368,6 @@ impl FrameDecoder {
                     produced,
                 });
             }
-            let _ = before;
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
             // Cap the visible buffer at window_size between blocks

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1258,7 +1258,7 @@ fn maybe_update_fse_tables(
             {
                 scratch.literal_lengths.build_from_probabilities(
                     LL_DEFAULT_ACC_LOG,
-                    &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
+                    &LITERALS_LENGTH_DEFAULT_DISTRIBUTION,
                 )?;
                 scratch
                     .literal_lengths
@@ -1306,10 +1306,9 @@ fn maybe_update_fse_tables(
             }
             #[cfg(not(feature = "std"))]
             {
-                scratch.offsets.build_from_probabilities(
-                    OF_DEFAULT_ACC_LOG,
-                    &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
-                )?;
+                scratch
+                    .offsets
+                    .build_from_probabilities(OF_DEFAULT_ACC_LOG, &OFFSET_DEFAULT_DISTRIBUTION)?;
                 scratch.offsets.enrich_for_offsets();
                 scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
             }
@@ -1354,7 +1353,7 @@ fn maybe_update_fse_tables(
             {
                 scratch.match_lengths.build_from_probabilities(
                     ML_DEFAULT_ACC_LOG,
-                    &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
+                    &MATCH_LENGTH_DEFAULT_DISTRIBUTION,
                 )?;
                 scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
             }
@@ -1430,10 +1429,7 @@ fn predefined_ll_table()
         return Ok(t);
     }
     let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
-    t.build_from_probabilities(
-        LL_DEFAULT_ACC_LOG,
-        &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
-    )?;
+    t.build_from_probabilities(LL_DEFAULT_ACC_LOG, &LITERALS_LENGTH_DEFAULT_DISTRIBUTION)?;
     t.enrich_with_packed_seq_meta(&LL_META);
     let _ = CACHED.set(t);
     Ok(CACHED.get().expect("just set"))
@@ -1448,10 +1444,7 @@ fn predefined_ml_table()
         return Ok(t);
     }
     let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
-    t.build_from_probabilities(
-        ML_DEFAULT_ACC_LOG,
-        &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
-    )?;
+    t.build_from_probabilities(ML_DEFAULT_ACC_LOG, &MATCH_LENGTH_DEFAULT_DISTRIBUTION)?;
     t.enrich_with_packed_seq_meta(&ML_META);
     let _ = CACHED.set(t);
     Ok(CACHED.get().expect("just set"))
@@ -1466,10 +1459,7 @@ fn predefined_of_table()
         return Ok((&cache.0, cache.1));
     }
     let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
-    t.build_from_probabilities(
-        OF_DEFAULT_ACC_LOG,
-        &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
-    )?;
+    t.build_from_probabilities(OF_DEFAULT_ACC_LOG, &OFFSET_DEFAULT_DISTRIBUTION)?;
     t.enrich_for_offsets();
     let share = compute_offsets_long_share(&t);
     let _ = CACHED.set((t, share));

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1252,7 +1252,7 @@ fn maybe_update_fse_tables(
             // Default LL distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.literal_lengths.clone_from(predefined_ll_table());
+                scratch.literal_lengths.reinit_from(predefined_ll_table());
             }
             #[cfg(not(feature = "std"))]
             {
@@ -1301,7 +1301,7 @@ fn maybe_update_fse_tables(
             #[cfg(feature = "std")]
             {
                 let (cached, long_share) = predefined_of_table();
-                scratch.offsets.clone_from(cached);
+                scratch.offsets.reinit_from(cached);
                 scratch.offsets_long_share = long_share;
             }
             #[cfg(not(feature = "std"))]
@@ -1347,7 +1347,7 @@ fn maybe_update_fse_tables(
             // Default ML distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.match_lengths.clone_from(predefined_ml_table());
+                scratch.match_lengths.reinit_from(predefined_ml_table());
             }
             #[cfg(not(feature = "std"))]
             {

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1224,13 +1224,21 @@ fn maybe_update_fse_tables(
         }
         ModeType::Predefined => {
             vprintln!("Use predefined ll table");
-            scratch.literal_lengths.build_from_probabilities(
-                LL_DEFAULT_ACC_LOG,
-                &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
-            )?;
-            scratch
-                .literal_lengths
-                .enrich_with_packed_seq_meta(&LL_META);
+            // Default LL distribution → cached table memcpy.
+            #[cfg(feature = "std")]
+            {
+                scratch.literal_lengths.clone_from(predefined_ll_table());
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                scratch.literal_lengths.build_from_probabilities(
+                    LL_DEFAULT_ACC_LOG,
+                    &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
+                )?;
+                scratch
+                    .literal_lengths
+                    .enrich_with_packed_seq_meta(&LL_META);
+            }
             scratch.ll_rle = None;
         }
         ModeType::Repeat => {
@@ -1264,13 +1272,23 @@ fn maybe_update_fse_tables(
         }
         ModeType::Predefined => {
             vprintln!("Use predefined of table");
-            scratch.offsets.build_from_probabilities(
-                OF_DEFAULT_ACC_LOG,
-                &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
-            )?;
-            scratch.offsets.enrich_for_offsets();
+            // Default OF distribution → cached table + cached long-share.
+            #[cfg(feature = "std")]
+            {
+                let (cached, long_share) = predefined_of_table();
+                scratch.offsets.clone_from(cached);
+                scratch.offsets_long_share = long_share;
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                scratch.offsets.build_from_probabilities(
+                    OF_DEFAULT_ACC_LOG,
+                    &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
+                )?;
+                scratch.offsets.enrich_for_offsets();
+                scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
+            }
             scratch.of_rle = None;
-            scratch.offsets_long_share = compute_offsets_long_share(&scratch.offsets);
         }
         ModeType::Repeat => {
             vprintln!("Repeat of table");
@@ -1302,11 +1320,19 @@ fn maybe_update_fse_tables(
         }
         ModeType::Predefined => {
             vprintln!("Use predefined ml table");
-            scratch.match_lengths.build_from_probabilities(
-                ML_DEFAULT_ACC_LOG,
-                &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
-            )?;
-            scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
+            // Default ML distribution → cached table memcpy.
+            #[cfg(feature = "std")]
+            {
+                scratch.match_lengths.clone_from(predefined_ml_table());
+            }
+            #[cfg(not(feature = "std"))]
+            {
+                scratch.match_lengths.build_from_probabilities(
+                    ML_DEFAULT_ACC_LOG,
+                    &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
+                )?;
+                scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
+            }
             scratch.ml_rle = None;
         }
         ModeType::Repeat => {
@@ -1328,6 +1354,85 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
     4, 3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 2, 1, 1, 1, 1, 1,
     -1, -1, -1, -1,
 ];
+
+// =====================================================================
+//                   Predefined FSE table cache
+// =====================================================================
+//
+// ModeType::Predefined fires whenever the encoder declares that an
+// LL / OF / ML symbol stream follows the RFC 8478 default
+// distribution (§3.1.1.3.2.1.1). On small-block fixtures this can
+// dominate the decode budget: building the table costs O(table_size)
+// per axis plus several `Vec::resize` round-trips, while the symbol
+// stream itself is only a few hundred bytes.
+//
+// Flamegraph on `small-4k-log-lines/c_stream/pure_rust` (i9, post
+// PR #263 merge) showed 66.72% of decode time in
+// `FSETable::build_decoding_table`, all of it inside the Predefined
+// branches.
+//
+// The default distributions are static — the tables they produce
+// are byte-identical across calls. Pre-build once via OnceLock,
+// then `clone_from` the cached table into the per-frame scratch.
+// `Vec::clone_from` reuses the existing scratch allocation when the
+// capacity already fits (it does, the scratch is re-used across
+// frames), so each call is a fixed-size memcpy plus a few scalar
+// field copies.
+//
+// `no_std` builds keep the original per-call rebuild path because
+// `std::sync::OnceLock` isn't available without `std`. Replacing it
+// with a portable `OnceBox` would require pulling in `once_cell` —
+// not worth a dep for a build that doesn't share the hot path with
+// the `std` benches anyway.
+#[cfg(feature = "std")]
+fn predefined_ll_table() -> &'static crate::fse::FSETable {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
+    CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
+        t.build_from_probabilities(
+            LL_DEFAULT_ACC_LOG,
+            &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
+        )
+        .expect("predefined LL distribution is well-formed");
+        t.enrich_with_packed_seq_meta(&LL_META);
+        t
+    })
+}
+
+#[cfg(feature = "std")]
+fn predefined_ml_table() -> &'static crate::fse::FSETable {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
+    CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
+        t.build_from_probabilities(
+            ML_DEFAULT_ACC_LOG,
+            &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
+        )
+        .expect("predefined ML distribution is well-formed");
+        t.enrich_with_packed_seq_meta(&ML_META);
+        t
+    })
+}
+
+#[cfg(feature = "std")]
+fn predefined_of_table() -> (&'static crate::fse::FSETable, u32) {
+    use std::sync::OnceLock;
+    static CACHED: OnceLock<(crate::fse::FSETable, u32)> = OnceLock::new();
+    let cache = CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
+        t.build_from_probabilities(
+            OF_DEFAULT_ACC_LOG,
+            &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
+        )
+        .expect("predefined OF distribution is well-formed");
+        t.enrich_for_offsets();
+        let share = compute_offsets_long_share(&t);
+        (t, share)
+    });
+    (&cache.0, cache.1)
+}
 
 // The default Match Length decoding table uses an accuracy logarithm of 6 bits.
 const ML_DEFAULT_ACC_LOG: u8 = 6;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1242,7 +1242,7 @@ fn maybe_update_fse_tables(
             {
                 scratch.literal_lengths.clone_from(predefined_ll_table()?);
             }
-            #[cfg(not(target_has_atomic = "ptr"))]
+            #[cfg(not(feature = "std"))]
             {
                 scratch.literal_lengths.build_from_probabilities(
                     LL_DEFAULT_ACC_LOG,
@@ -1292,7 +1292,7 @@ fn maybe_update_fse_tables(
                 scratch.offsets.clone_from(cached);
                 scratch.offsets_long_share = long_share;
             }
-            #[cfg(not(target_has_atomic = "ptr"))]
+            #[cfg(not(feature = "std"))]
             {
                 scratch.offsets.build_from_probabilities(
                     OF_DEFAULT_ACC_LOG,
@@ -1338,7 +1338,7 @@ fn maybe_update_fse_tables(
             {
                 scratch.match_lengths.clone_from(predefined_ml_table()?);
             }
-            #[cfg(not(target_has_atomic = "ptr"))]
+            #[cfg(not(feature = "std"))]
             {
                 scratch.match_lengths.build_from_probabilities(
                     ML_DEFAULT_ACC_LOG,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1398,11 +1398,13 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
 //
 // The default distributions are static — the tables they produce
 // are byte-identical across calls. Pre-build once via OnceLock,
-// then `clone_from` the cached table into the per-frame scratch.
-// `Vec::clone_from` reuses the existing scratch allocation when the
+// then `reinit_from` the cached table into the per-frame scratch.
+// `reinit_from` reuses the existing `decode` Vec allocation when the
 // capacity already fits (it does, the scratch is re-used across
-// frames), so each call is a fixed-size memcpy plus a few scalar
-// field copies.
+// frames), copying only the `decode` entries + `accuracy_log` +
+// `symbol_probabilities` content. The build-only `symbol_spread_buffer`
+// is NOT copied — `reinit_from` only `reserve`s capacity for it —
+// shaving the spread-buffer memcpy that the prior `clone_from` did.
 //
 // Std-only because `OnceLock` lives in `std::sync` — there is no
 // `core::sync::OnceLock` (the only stable OnceLock-style API

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -900,16 +900,14 @@ fn decode_one_sequence_inline<K: crate::cpu_kernel::CpuKernel>(
     // Reading `state` directly drops the previous `lookup_ll_code` /
     // `lookup_ml_code` indirections (those did a second cache touch
     // on the separate meta tables per sequence) — the active entry
-    // is already cache-hot.
-    //
-    // OF intentionally keeps the closed-form `1u32 << of_code`
-    // baseline computation instead of reading `of_dec.state.base_value`:
-    // the shift is a single ALU op vs a 4-byte memory load, both
-    // produce identical codegen with `obits + ...` add, and `of_code`
-    // is still required for `get_bits_triple` and the
-    // `debug_assert!(of_code <= MAX_OFFSET_CODE)` precondition. The
-    // 12-byte Entry layout still pays off here through LL / ML's
-    // base_value / num_additional_bits reads.
+    // is already cache-hot. OF reads from the same Entry layout via
+    // `base_value` / `num_additional_bits` written by
+    // `enrich_for_offsets` at build time; on x86_64 the codegen
+    // matches the prior `1u32 << of_code` shift form (both share the
+    // already-touched bit-count cache line) and the uniform read
+    // shape unblocks dropping `state.symbol` from the hot path so
+    // the 12-byte Entry can shrink to donor's 8-byte ZSTD_seqSymbol
+    // in a follow-up tightening of the FSE table cache footprint.
     let ll_state = ll_dec.state;
     let ml_state = ml_dec.state;
     let of_state = of_dec.state;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -909,17 +909,29 @@ fn decode_one_sequence_inline<K: crate::cpu_kernel::CpuKernel>(
     // base_value / num_additional_bits reads.
     let ll_state = ll_dec.state;
     let ml_state = ml_dec.state;
-    let of_code = of_dec.state.symbol;
+    let of_state = of_dec.state;
 
     let ll_value = ll_state.base_value;
     let ll_num_bits = ll_state.num_additional_bits;
     let ml_value = ml_state.base_value;
     let ml_num_bits = ml_state.num_additional_bits;
+    // Donor-shape uniform read: OF uses `base_value` + `num_additional_bits`
+    // like LL/ML, dropping the `entry.symbol → 1 << symbol` shift. Both
+    // fields are already populated by `enrich_for_offsets` (`base_value
+    // = 1 << code`, `num_additional_bits = code`). On x86_64 the memory
+    // load is wash vs the shift since both fields share the same Entry
+    // cache line that was already touched for the bit-count read; the
+    // win is that the hot path no longer reads `state.symbol`, which
+    // unblocks dropping the field from `Entry` (donor's ZSTD_seqSymbol
+    // is 8 bytes vs our 12 — that would tighten the FSE table cache
+    // footprint by 4 bytes / entry).
+    let of_num_bits = of_state.num_additional_bits;
+    let of_base = of_state.base_value;
 
-    debug_assert!(of_code <= MAX_OFFSET_CODE);
+    debug_assert!(of_num_bits <= MAX_OFFSET_CODE);
 
-    let (obits, ml_add, ll_add) = br.get_bits_triple(of_code, ml_num_bits, ll_num_bits);
-    let offset = obits as u32 + (1u32 << of_code);
+    let (obits, ml_add, ll_add) = br.get_bits_triple(of_num_bits, ml_num_bits, ll_num_bits);
+    let offset = obits as u32 + of_base;
 
     debug_assert_ne!(offset, 0);
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -891,9 +891,12 @@ fn decode_one_sequence_inline<K: crate::cpu_kernel::CpuKernel>(
     br: &mut BitReaderReversed<'_, K>,
 ) -> Sequence {
     // Read base/extra-bits directly off the active FSE state's
-    // `Entry`. LL / ML are populated by `enrich_with_packed_seq_meta`
-    // from the packed `LL_META` / `ML_META` tables during build;
-    // OF is enriched closed-form (`1 << code`) by `enrich_for_offsets`.
+    // `Entry`. LL / ML / OF all use the same uniform shape: the
+    // build-time enrichment populates `state.base_value` and
+    // `state.num_additional_bits` for each axis (LL/ML via
+    // `enrich_with_packed_seq_meta` from the packed `LL_META` /
+    // `ML_META` tables; OF via `enrich_for_offsets` which writes
+    // `base_value = 1 << code` and `num_additional_bits = code`).
     // Reading `state` directly drops the previous `lookup_ll_code` /
     // `lookup_ml_code` indirections (those did a second cache touch
     // on the separate meta tables per sequence) — the active entry

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1385,7 +1385,7 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
 // =====================================================================
 //
 // ModeType::Predefined fires whenever the encoder declares that an
-// LL / OF / ML symbol stream follows the RFC 8478 default
+// LL / OF / ML symbol stream follows the RFC 8878 default
 // distribution (§3.1.1.3.2.1.1). On small-block fixtures this can
 // dominate the decode budget: building the table costs O(table_size)
 // per axis plus several `Vec::resize` round-trips, while the symbol
@@ -1416,7 +1416,7 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
 //
 // The build step is infallible by construction: the source
 // distribution slices are compile-time constants verified against
-// the RFC 8478 reference, and `build_from_probabilities` only fails
+// the RFC 8878 reference, and `build_from_probabilities` only fails
 // on malformed input (sum mismatch, oversized acc_log, symbol >
 // max). Treating a failure here as a panic is correct — it would
 // mean a static array literal is mathematically broken, which is a
@@ -1431,7 +1431,7 @@ fn predefined_ll_table() -> &'static crate::fse::FSETable {
     CACHED.get_or_init(|| {
         let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
         t.build_from_probabilities(LL_DEFAULT_ACC_LOG, &LITERALS_LENGTH_DEFAULT_DISTRIBUTION)
-            .expect("LITERALS_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+            .expect("LITERALS_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8878 constant");
         t.enrich_with_packed_seq_meta(&LL_META);
         t
     })
@@ -1444,7 +1444,7 @@ fn predefined_ml_table() -> &'static crate::fse::FSETable {
     CACHED.get_or_init(|| {
         let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
         t.build_from_probabilities(ML_DEFAULT_ACC_LOG, &MATCH_LENGTH_DEFAULT_DISTRIBUTION)
-            .expect("MATCH_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+            .expect("MATCH_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8878 constant");
         t.enrich_with_packed_seq_meta(&ML_META);
         t
     })
@@ -1457,7 +1457,7 @@ fn predefined_of_table() -> (&'static crate::fse::FSETable, u32) {
     let cache = CACHED.get_or_init(|| {
         let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
         t.build_from_probabilities(OF_DEFAULT_ACC_LOG, &OFFSET_DEFAULT_DISTRIBUTION)
-            .expect("OFFSET_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+            .expect("OFFSET_DEFAULT_DISTRIBUTION is a static RFC 8878 constant");
         t.enrich_for_offsets();
         let share = compute_offsets_long_share(&t);
         (t, share)

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -854,7 +854,20 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
                 .exec_sequence_inline(lit_src, seq.ll as usize, offset, seq.ml as usize)
                 .map_err(DecompressBlockError::ExecuteSequencesError)?;
         }
-        buffer.advance_output_counter(seq.ll as usize + seq.ml as usize);
+        // No `advance_output_counter` here: the donor inline path
+        // advances `UserSliceBackend::tail` directly inside
+        // `exec_sequence_inline`, and the post-block FCS check in
+        // `run_direct_decode` now reads `tail` (via
+        // `buffer_ref().tail() as u64`) instead of the separately
+        // maintained `DecodeBuffer::total_output_counter`. Skipping
+        // the per-sequence RMW drops the ~9% of decode time
+        // measured at `addq <ll+ml>, 0x40(%r9)` on z000033
+        // (perf annotate on
+        // `decode_and_execute_sequences_avx2`). The legacy
+        // push+repeat fallback below still goes through
+        // `DecodeBuffer::try_push` / `repeat_lookahead_prefetched`,
+        // which keep `total_output_counter` in sync for backends
+        // that need it.
         return Ok(());
     }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1252,7 +1252,7 @@ fn maybe_update_fse_tables(
             // Default LL distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.literal_lengths.clone_from(predefined_ll_table()?);
+                scratch.literal_lengths.clone_from(predefined_ll_table());
             }
             #[cfg(not(feature = "std"))]
             {
@@ -1300,7 +1300,7 @@ fn maybe_update_fse_tables(
             // Default OF distribution → cached table + cached long-share.
             #[cfg(feature = "std")]
             {
-                let (cached, long_share) = predefined_of_table()?;
+                let (cached, long_share) = predefined_of_table();
                 scratch.offsets.clone_from(cached);
                 scratch.offsets_long_share = long_share;
             }
@@ -1347,7 +1347,7 @@ fn maybe_update_fse_tables(
             // Default ML distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.match_lengths.clone_from(predefined_ml_table()?);
+                scratch.match_lengths.clone_from(predefined_ml_table());
             }
             #[cfg(not(feature = "std"))]
             {
@@ -1411,60 +1411,55 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
 // is the planned route to extend the cache to no-atomic targets
 // without pulling in `once_cell`.
 //
-// Errors from `build_from_probabilities` are propagated through a
-// manual `get` / `set` race pattern (`OnceLock::get_or_try_init` is
-// still unstable on the current MSRV). If two threads attempt the
-// first init concurrently both build the table, but only one wins
-// the `set` — the other observes the winner via the trailing
-// `get()`. The cost of the redundant build is paid at most once
-// per process and only under contention, so the race-write is
-// preferable to the unstable API or to a `Mutex` round-trip on
-// every call.
+// The build step is infallible by construction: the source
+// distribution slices are compile-time constants verified against
+// the RFC 8478 reference, and `build_from_probabilities` only fails
+// on malformed input (sum mismatch, oversized acc_log, symbol >
+// max). Treating a failure here as a panic is correct — it would
+// mean a static array literal is mathematically broken, which is a
+// compile-time bug, not a runtime data condition. Returning
+// `&'static FSETable` (infallible) lets `OnceLock::get_or_init`
+// handle the cache primitive directly without a fallible-init
+// shim.
 #[cfg(feature = "std")]
-fn predefined_ll_table()
--> Result<&'static crate::fse::FSETable, crate::decoding::errors::FSETableError> {
+fn predefined_ll_table() -> &'static crate::fse::FSETable {
     use std::sync::OnceLock;
     static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
-    if let Some(t) = CACHED.get() {
-        return Ok(t);
-    }
-    let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
-    t.build_from_probabilities(LL_DEFAULT_ACC_LOG, &LITERALS_LENGTH_DEFAULT_DISTRIBUTION)?;
-    t.enrich_with_packed_seq_meta(&LL_META);
-    let _ = CACHED.set(t);
-    Ok(CACHED.get().expect("just set"))
+    CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
+        t.build_from_probabilities(LL_DEFAULT_ACC_LOG, &LITERALS_LENGTH_DEFAULT_DISTRIBUTION)
+            .expect("LITERALS_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+        t.enrich_with_packed_seq_meta(&LL_META);
+        t
+    })
 }
 
 #[cfg(feature = "std")]
-fn predefined_ml_table()
--> Result<&'static crate::fse::FSETable, crate::decoding::errors::FSETableError> {
+fn predefined_ml_table() -> &'static crate::fse::FSETable {
     use std::sync::OnceLock;
     static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
-    if let Some(t) = CACHED.get() {
-        return Ok(t);
-    }
-    let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
-    t.build_from_probabilities(ML_DEFAULT_ACC_LOG, &MATCH_LENGTH_DEFAULT_DISTRIBUTION)?;
-    t.enrich_with_packed_seq_meta(&ML_META);
-    let _ = CACHED.set(t);
-    Ok(CACHED.get().expect("just set"))
+    CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
+        t.build_from_probabilities(ML_DEFAULT_ACC_LOG, &MATCH_LENGTH_DEFAULT_DISTRIBUTION)
+            .expect("MATCH_LENGTH_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+        t.enrich_with_packed_seq_meta(&ML_META);
+        t
+    })
 }
 
 #[cfg(feature = "std")]
-fn predefined_of_table()
--> Result<(&'static crate::fse::FSETable, u32), crate::decoding::errors::FSETableError> {
+fn predefined_of_table() -> (&'static crate::fse::FSETable, u32) {
     use std::sync::OnceLock;
     static CACHED: OnceLock<(crate::fse::FSETable, u32)> = OnceLock::new();
-    if let Some(cache) = CACHED.get() {
-        return Ok((&cache.0, cache.1));
-    }
-    let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
-    t.build_from_probabilities(OF_DEFAULT_ACC_LOG, &OFFSET_DEFAULT_DISTRIBUTION)?;
-    t.enrich_for_offsets();
-    let share = compute_offsets_long_share(&t);
-    let _ = CACHED.set((t, share));
-    let cache = CACHED.get().expect("just set");
-    Ok((&cache.0, cache.1))
+    let cache = CACHED.get_or_init(|| {
+        let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
+        t.build_from_probabilities(OF_DEFAULT_ACC_LOG, &OFFSET_DEFAULT_DISTRIBUTION)
+            .expect("OFFSET_DEFAULT_DISTRIBUTION is a static RFC 8478 constant");
+        t.enrich_for_offsets();
+        let share = compute_offsets_long_share(&t);
+        (t, share)
+    });
+    (&cache.0, cache.1)
 }
 
 // The default Match Length decoding table uses an accuracy logarithm of 6 bits.
@@ -1510,7 +1505,7 @@ fn predefined_fse_caches_match_rebuild_output() {
         )
         .unwrap();
     ll_rebuild.enrich_with_packed_seq_meta(&LL_META);
-    let ll_cached = predefined_ll_table().unwrap();
+    let ll_cached = predefined_ll_table();
     assert_eq!(ll_rebuild.accuracy_log, ll_cached.accuracy_log);
     assert_eq!(ll_rebuild.decode.len(), ll_cached.decode.len());
     for (i, (a, b)) in ll_rebuild
@@ -1540,7 +1535,7 @@ fn predefined_fse_caches_match_rebuild_output() {
         )
         .unwrap();
     ml_rebuild.enrich_with_packed_seq_meta(&ML_META);
-    let ml_cached = predefined_ml_table().unwrap();
+    let ml_cached = predefined_ml_table();
     assert_eq!(ml_rebuild.accuracy_log, ml_cached.accuracy_log);
     assert_eq!(ml_rebuild.decode.len(), ml_cached.decode.len());
     for (i, (a, b)) in ml_rebuild
@@ -1571,7 +1566,7 @@ fn predefined_fse_caches_match_rebuild_output() {
         .unwrap();
     of_rebuild.enrich_for_offsets();
     let of_rebuild_share = compute_offsets_long_share(&of_rebuild);
-    let (of_cached, of_cached_share) = predefined_of_table().unwrap();
+    let (of_cached, of_cached_share) = predefined_of_table();
     assert_eq!(of_rebuild.accuracy_log, of_cached.accuracy_log);
     assert_eq!(of_rebuild.decode.len(), of_cached.decode.len());
     assert_eq!(

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1227,9 +1227,9 @@ fn maybe_update_fse_tables(
             // Default LL distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.literal_lengths.clone_from(predefined_ll_table());
+                scratch.literal_lengths.clone_from(predefined_ll_table()?);
             }
-            #[cfg(not(feature = "std"))]
+            #[cfg(not(target_has_atomic = "ptr"))]
             {
                 scratch.literal_lengths.build_from_probabilities(
                     LL_DEFAULT_ACC_LOG,
@@ -1275,11 +1275,11 @@ fn maybe_update_fse_tables(
             // Default OF distribution → cached table + cached long-share.
             #[cfg(feature = "std")]
             {
-                let (cached, long_share) = predefined_of_table();
+                let (cached, long_share) = predefined_of_table()?;
                 scratch.offsets.clone_from(cached);
                 scratch.offsets_long_share = long_share;
             }
-            #[cfg(not(feature = "std"))]
+            #[cfg(not(target_has_atomic = "ptr"))]
             {
                 scratch.offsets.build_from_probabilities(
                     OF_DEFAULT_ACC_LOG,
@@ -1323,9 +1323,9 @@ fn maybe_update_fse_tables(
             // Default ML distribution → cached table memcpy.
             #[cfg(feature = "std")]
             {
-                scratch.match_lengths.clone_from(predefined_ml_table());
+                scratch.match_lengths.clone_from(predefined_ml_table()?);
             }
-            #[cfg(not(feature = "std"))]
+            #[cfg(not(target_has_atomic = "ptr"))]
             {
                 scratch.match_lengths.build_from_probabilities(
                     ML_DEFAULT_ACC_LOG,
@@ -1379,59 +1379,77 @@ const LITERALS_LENGTH_DEFAULT_DISTRIBUTION: [i32; 36] = [
 // frames), so each call is a fixed-size memcpy plus a few scalar
 // field copies.
 //
-// `no_std` builds keep the original per-call rebuild path because
-// `std::sync::OnceLock` isn't available without `std`. Replacing it
-// with a portable `OnceBox` would require pulling in `once_cell` —
-// not worth a dep for a build that doesn't share the hot path with
-// the `std` benches anyway.
+// Std-only because `OnceLock` lives in `std::sync` — there is no
+// `core::sync::OnceLock` (the only stable OnceLock-style API
+// requires std). `no_std` builds fall back to the per-call rebuild
+// path via the `#[cfg(feature = "std")]` gate. The
+// `critical-section` Cargo feature already flagged in the manifest
+// is the planned route to extend the cache to no-atomic targets
+// without pulling in `once_cell`.
+//
+// Errors from `build_from_probabilities` are propagated through a
+// manual `get` / `set` race pattern (`OnceLock::get_or_try_init` is
+// still unstable on the current MSRV). If two threads attempt the
+// first init concurrently both build the table, but only one wins
+// the `set` — the other observes the winner via the trailing
+// `get()`. The cost of the redundant build is paid at most once
+// per process and only under contention, so the race-write is
+// preferable to the unstable API or to a `Mutex` round-trip on
+// every call.
 #[cfg(feature = "std")]
-fn predefined_ll_table() -> &'static crate::fse::FSETable {
+fn predefined_ll_table()
+-> Result<&'static crate::fse::FSETable, crate::decoding::errors::FSETableError> {
     use std::sync::OnceLock;
     static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
-    CACHED.get_or_init(|| {
-        let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
-        t.build_from_probabilities(
-            LL_DEFAULT_ACC_LOG,
-            &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
-        )
-        .expect("predefined LL distribution is well-formed");
-        t.enrich_with_packed_seq_meta(&LL_META);
-        t
-    })
+    if let Some(t) = CACHED.get() {
+        return Ok(t);
+    }
+    let mut t = crate::fse::FSETable::new(MAX_LITERAL_LENGTH_CODE);
+    t.build_from_probabilities(
+        LL_DEFAULT_ACC_LOG,
+        &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
+    )?;
+    t.enrich_with_packed_seq_meta(&LL_META);
+    let _ = CACHED.set(t);
+    Ok(CACHED.get().expect("just set"))
 }
 
 #[cfg(feature = "std")]
-fn predefined_ml_table() -> &'static crate::fse::FSETable {
+fn predefined_ml_table()
+-> Result<&'static crate::fse::FSETable, crate::decoding::errors::FSETableError> {
     use std::sync::OnceLock;
     static CACHED: OnceLock<crate::fse::FSETable> = OnceLock::new();
-    CACHED.get_or_init(|| {
-        let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
-        t.build_from_probabilities(
-            ML_DEFAULT_ACC_LOG,
-            &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
-        )
-        .expect("predefined ML distribution is well-formed");
-        t.enrich_with_packed_seq_meta(&ML_META);
-        t
-    })
+    if let Some(t) = CACHED.get() {
+        return Ok(t);
+    }
+    let mut t = crate::fse::FSETable::new(MAX_MATCH_LENGTH_CODE);
+    t.build_from_probabilities(
+        ML_DEFAULT_ACC_LOG,
+        &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
+    )?;
+    t.enrich_with_packed_seq_meta(&ML_META);
+    let _ = CACHED.set(t);
+    Ok(CACHED.get().expect("just set"))
 }
 
 #[cfg(feature = "std")]
-fn predefined_of_table() -> (&'static crate::fse::FSETable, u32) {
+fn predefined_of_table()
+-> Result<(&'static crate::fse::FSETable, u32), crate::decoding::errors::FSETableError> {
     use std::sync::OnceLock;
     static CACHED: OnceLock<(crate::fse::FSETable, u32)> = OnceLock::new();
-    let cache = CACHED.get_or_init(|| {
-        let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
-        t.build_from_probabilities(
-            OF_DEFAULT_ACC_LOG,
-            &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
-        )
-        .expect("predefined OF distribution is well-formed");
-        t.enrich_for_offsets();
-        let share = compute_offsets_long_share(&t);
-        (t, share)
-    });
-    (&cache.0, cache.1)
+    if let Some(cache) = CACHED.get() {
+        return Ok((&cache.0, cache.1));
+    }
+    let mut t = crate::fse::FSETable::new(MAX_OFFSET_CODE);
+    t.build_from_probabilities(
+        OF_DEFAULT_ACC_LOG,
+        &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
+    )?;
+    t.enrich_for_offsets();
+    let share = compute_offsets_long_share(&t);
+    let _ = CACHED.set((t, share));
+    let cache = CACHED.get().expect("just set");
+    Ok((&cache.0, cache.1))
 }
 
 // The default Match Length decoding table uses an accuracy logarithm of 6 bits.
@@ -1454,6 +1472,116 @@ const OF_DEFAULT_ACC_LOG: u8 = 5;
 const OFFSET_DEFAULT_DISTRIBUTION: [i32; 29] = [
     1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1,
 ];
+
+/// Regression gate for the predefined FSE table cache: every cached
+/// table must be byte-identical to the table the rebuild path would
+/// produce on the next call. If the cache ever drifts from the
+/// rebuild output (different `decode` entries, different
+/// `accuracy_log`, different `offsets_long_share` for OF) the
+/// dispatch in `maybe_update_fse_tables` would silently decode
+/// against a stale table — the bench delta would still look fine
+/// but cross-validation against the donor would diverge on the
+/// next ratio gate.
+#[cfg(feature = "std")]
+#[test]
+fn predefined_fse_caches_match_rebuild_output() {
+    use crate::fse::FSETable;
+
+    let mut ll_rebuild = FSETable::new(MAX_LITERAL_LENGTH_CODE);
+    ll_rebuild
+        .build_from_probabilities(
+            LL_DEFAULT_ACC_LOG,
+            &Vec::from(&LITERALS_LENGTH_DEFAULT_DISTRIBUTION[..]),
+        )
+        .unwrap();
+    ll_rebuild.enrich_with_packed_seq_meta(&LL_META);
+    let ll_cached = predefined_ll_table().unwrap();
+    assert_eq!(ll_rebuild.accuracy_log, ll_cached.accuracy_log);
+    assert_eq!(ll_rebuild.decode.len(), ll_cached.decode.len());
+    for (i, (a, b)) in ll_rebuild
+        .decode
+        .iter()
+        .zip(ll_cached.decode.iter())
+        .enumerate()
+    {
+        assert_eq!(a.symbol, b.symbol, "LL entry {i} symbol mismatch");
+        assert_eq!(a.num_bits, b.num_bits, "LL entry {i} num_bits mismatch");
+        assert_eq!(a.new_state, b.new_state, "LL entry {i} new_state mismatch");
+        assert_eq!(
+            a.base_value, b.base_value,
+            "LL entry {i} base_value mismatch"
+        );
+        assert_eq!(
+            a.num_additional_bits, b.num_additional_bits,
+            "LL entry {i} num_additional_bits mismatch"
+        );
+    }
+
+    let mut ml_rebuild = FSETable::new(MAX_MATCH_LENGTH_CODE);
+    ml_rebuild
+        .build_from_probabilities(
+            ML_DEFAULT_ACC_LOG,
+            &Vec::from(&MATCH_LENGTH_DEFAULT_DISTRIBUTION[..]),
+        )
+        .unwrap();
+    ml_rebuild.enrich_with_packed_seq_meta(&ML_META);
+    let ml_cached = predefined_ml_table().unwrap();
+    assert_eq!(ml_rebuild.accuracy_log, ml_cached.accuracy_log);
+    assert_eq!(ml_rebuild.decode.len(), ml_cached.decode.len());
+    for (i, (a, b)) in ml_rebuild
+        .decode
+        .iter()
+        .zip(ml_cached.decode.iter())
+        .enumerate()
+    {
+        assert_eq!(a.symbol, b.symbol, "ML entry {i} symbol mismatch");
+        assert_eq!(a.num_bits, b.num_bits, "ML entry {i} num_bits mismatch");
+        assert_eq!(a.new_state, b.new_state, "ML entry {i} new_state mismatch");
+        assert_eq!(
+            a.base_value, b.base_value,
+            "ML entry {i} base_value mismatch"
+        );
+        assert_eq!(
+            a.num_additional_bits, b.num_additional_bits,
+            "ML entry {i} num_additional_bits mismatch"
+        );
+    }
+
+    let mut of_rebuild = FSETable::new(MAX_OFFSET_CODE);
+    of_rebuild
+        .build_from_probabilities(
+            OF_DEFAULT_ACC_LOG,
+            &Vec::from(&OFFSET_DEFAULT_DISTRIBUTION[..]),
+        )
+        .unwrap();
+    of_rebuild.enrich_for_offsets();
+    let of_rebuild_share = compute_offsets_long_share(&of_rebuild);
+    let (of_cached, of_cached_share) = predefined_of_table().unwrap();
+    assert_eq!(of_rebuild.accuracy_log, of_cached.accuracy_log);
+    assert_eq!(of_rebuild.decode.len(), of_cached.decode.len());
+    assert_eq!(
+        of_rebuild_share, of_cached_share,
+        "OF offsets_long_share mismatch"
+    );
+    for (i, (a, b)) in of_rebuild
+        .decode
+        .iter()
+        .zip(of_cached.decode.iter())
+        .enumerate()
+    {
+        assert_eq!(a.symbol, b.symbol, "OF entry {i} symbol mismatch");
+        assert_eq!(a.num_bits, b.num_bits, "OF entry {i} num_bits mismatch");
+        assert_eq!(a.new_state, b.new_state, "OF entry {i} new_state mismatch");
+        assert_eq!(
+            a.base_value, b.base_value,
+            "OF entry {i} base_value mismatch"
+        );
+        assert_eq!(
+            a.num_additional_bits, b.num_additional_bits,
+            "OF entry {i} num_additional_bits mismatch"
+        );
+    }
+}
 
 #[test]
 fn test_ll_default() {

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -320,7 +320,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         self.tail = 0;
     }
 
-    #[inline]
+    #[inline(always)]
     fn try_reserve(&mut self, n: usize) -> Result<(), super::buffer_backend::BackendOverflow> {
         // Fixed-capacity backend: linear `tail + n <= slice.len()`
         // check. Lets safe public decode APIs catch a malformed-frame
@@ -573,7 +573,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     // backend: a fixed-capacity output slice that cannot grow on
     // demand, so any overshoot must be reported instead of aborting.
 
-    #[inline]
+    #[inline(always)]
     fn try_extend(&mut self, data: &[u8]) -> Result<(), super::buffer_backend::BackendOverflow> {
         let len = data.len();
         // Use `checked_add` to catch adversarial input where
@@ -615,7 +615,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         Ok(())
     }
 
-    #[inline]
+    #[inline(always)]
     fn try_extend_and_fill(
         &mut self,
         fill_with: u8,
@@ -645,7 +645,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         Ok(())
     }
 
-    #[inline]
+    #[inline(always)]
     fn try_extend_from_within(
         &mut self,
         start: usize,

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -39,17 +39,17 @@ impl<'t> FSEDecoder<'t> {
         if self.table.accuracy_log == 0 {
             return Err(FSEDecoderError::TableIsUninitialized);
         }
-        // Externally-constructible-table guard: `FSETable::decode`
-        // and `FSETable::accuracy_log` are `pub` fields, so safe
-        // external callers (not just `fuzz_exports` harnesses) can
-        // hand the decoder a table whose `decode.len()` doesn't match
-        // `1 << accuracy_log`. Validate the shape invariant up-front
-        // and surface as a typed `InvalidTableShape` error (distinct
-        // from `TableIsUninitialized` to keep error triage
-        // unambiguous) — without this, `read_entry`'s unchecked
-        // indexing (the `cfg(not(fuzz_exports))` arm) hits UB in
-        // release builds on a malformed table. `checked_shl` covers
-        // the pathological case where `accuracy_log >= usize::BITS`.
+        // Defense-in-depth internal-invariant guard: in normal builds
+        // `crate::fse` is not externally reachable, but malformed
+        // tables can still arise from internal misuse, future
+        // `feature = "fuzz_exports"`. Validate up-front that
+        // `decode.len() == 1 << accuracy_log` and surface a typed
+        // `InvalidTableShape` error (distinct from
+        // `TableIsUninitialized` to keep error triage unambiguous).
+        // Without this, `read_entry`'s unchecked indexing (the
+        // `cfg(not(fuzz_exports))` arm) could hit UB on a malformed
+        // table in release builds. `checked_shl` covers the
+        // pathological case where `accuracy_log >= usize::BITS`.
         // Branch cost is a single per-call check; the per-sequence
         // hot path (`update_state_fast`) is unaffected.
         let accuracy_log = self.table.accuracy_log;

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -233,9 +233,6 @@ pub struct FSETable {
     /// If a symbol probability is set to `-1`, it means that the probability of a symbol
     /// occurring in the data is less than one.
     pub symbol_probabilities: Vec<i32>, //used while building the decode Vector
-    /// The number of times each symbol occurs (The first entry being 0x0, the second being 0x1) and so on
-    /// up until the highest possible symbol (255).
-    symbol_counter: Vec<u32>,
 }
 
 impl FSETable {
@@ -244,7 +241,6 @@ impl FSETable {
         FSETable {
             max_symbol,
             symbol_probabilities: Vec::with_capacity(256), //will never be more than 256 symbols because u8
-            symbol_counter: Vec::with_capacity(256), //will never be more than 256 symbols because u8
             symbol_spread_buffer: Vec::new(),
             decode: Vec::new(), //depending on acc_log.
             accuracy_log: 0,
@@ -254,7 +250,6 @@ impl FSETable {
     /// Reset `self` and update `self`'s state to mirror the provided table.
     pub fn reinit_from(&mut self, other: &Self) {
         self.reset();
-        self.symbol_counter.extend_from_slice(&other.symbol_counter);
         self.symbol_probabilities
             .extend_from_slice(&other.symbol_probabilities);
         self.symbol_spread_buffer
@@ -265,7 +260,6 @@ impl FSETable {
 
     /// Empty the table and clear all internal state.
     pub fn reset(&mut self) {
-        self.symbol_counter.clear();
         self.symbol_probabilities.clear();
         self.symbol_spread_buffer.clear();
         self.decode.clear();
@@ -386,133 +380,109 @@ impl FSETable {
         self.build_decoding_table()
     }
 
-    /// Build the actual decoding table after probabilities have been read into the table.
-    /// After this function is called, the decoding process can begin.
+    /// Build the actual decoding table after probabilities have been
+    /// read. Donor-shape single-pass build: spread symbols into the
+    /// scratch buffer, then write `decode` entries in one linear pass
+    /// — no intermediate zero-init Vec::resize, no per-call heap
+    /// allocation for the symbol counter (stack-allocated since the
+    /// max symbol count is bounded by `u8::MAX + 1 = 256`).
     fn build_decoding_table(&mut self) -> Result<(), FSETableError> {
-        if self.symbol_probabilities.len() > self.max_symbol as usize + 1 {
-            return Err(FSETableError::TooManySymbols {
-                got: self.symbol_probabilities.len(),
-            });
+        let nb_symbols = self.symbol_probabilities.len();
+        if nb_symbols > self.max_symbol as usize + 1 {
+            return Err(FSETableError::TooManySymbols { got: nb_symbols });
         }
-
-        self.decode.clear();
 
         let table_size = 1 << self.accuracy_log;
-        // After clear(), len == 0, so reserve(table_size) guarantees capacity
-        // ≥ table_size. The matching `set_len` runs later, right before
-        // `copy_symbols_into_decode`, so that any panic in the intervening
-        // table_symbols / symbol_spread_buffer allocations unwinds with
-        // `self.decode.len() == 0` instead of leaving uninitialized Entry
-        // slots reachable through `&mut self.decode[..]` on the next call.
-        self.decode.reserve(table_size);
 
-        let mut table_symbols = core::mem::take(&mut self.symbol_spread_buffer);
-        table_symbols.clear();
-        table_symbols.resize(table_size, 0);
-        let negative_idx = {
-            let table_symbols = &mut table_symbols;
-            let mut negative_idx = table_size; //will point to the highest index with is already occupied by a negative-probability-symbol
+        // === Spread step ===
+        // Reuse the persistent scratch buffer; clear then resize to
+        // table_size. The resize is the ONLY zero-init in the entire
+        // build path now (previous impl also zero-init'd `decode`
+        // through `Vec::resize` with a default `Entry`, doubling the
+        // write traffic on the build path).
+        let mut spread = core::mem::take(&mut self.symbol_spread_buffer);
+        spread.clear();
+        spread.resize(table_size, 0);
 
-            //first scan for all -1 probabilities and place them at the top of the table
-            for symbol in 0..self.symbol_probabilities.len() {
-                if self.symbol_probabilities[symbol] == -1 {
-                    negative_idx -= 1;
-                    table_symbols[negative_idx] = symbol as u8;
-                }
+        // Pass 1: place -1 probability symbols at the top of the table.
+        let mut negative_idx = table_size;
+        for symbol in 0..nb_symbols {
+            if self.symbol_probabilities[symbol] == -1 {
+                negative_idx -= 1;
+                spread[negative_idx] = symbol as u8;
             }
+        }
 
-            //then place in a semi-random order all of the other symbols
-            let mut position = 0;
-            for idx in 0..self.symbol_probabilities.len() {
-                let symbol = idx as u8;
-                if self.symbol_probabilities[idx] <= 0 {
-                    continue;
-                }
-
-                //for each probability point the symbol gets on slot
-                let prob = self.symbol_probabilities[idx];
-                for _ in 0..prob {
-                    table_symbols[position] = symbol;
-
+        // Pass 2: distribute positive-probability symbols across the
+        // [0, negative_idx) range using the donor's `next_position`
+        // walker.
+        let mut position = 0usize;
+        for symbol in 0..nb_symbols {
+            let prob = self.symbol_probabilities[symbol];
+            if prob <= 0 {
+                continue;
+            }
+            let symbol_u8 = symbol as u8;
+            for _ in 0..prob {
+                spread[position] = symbol_u8;
+                position = next_position(position, table_size);
+                while position >= negative_idx {
                     position = next_position(position, table_size);
-                    while position >= negative_idx {
-                        position = next_position(position, table_size);
-                        //everything above negative_idx is already taken
-                    }
                 }
             }
-            negative_idx
-        };
-
-        // `copy_symbols_into_decode` is responsible for sizing
-        // `self.decode` AND writing every slot in 0..table_size before
-        // it returns. Keeping the set_len call adjacent to the init
-        // loop (rather than pre-extending here) is what guarantees no
-        // panic-able code can run between "tell Vec the length is
-        // table_size" and "every slot has a fully-initialized Entry".
-        // capacity is reserved earlier in this function.
-        self.copy_symbols_into_decode(&table_symbols, table_size);
-        self.symbol_spread_buffer = table_symbols;
-        for idx in negative_idx..table_size {
-            self.decode[idx].num_bits = self.accuracy_log;
         }
 
-        // baselines and num_bits can only be calculated when all symbols have been spread
-        self.symbol_counter.clear();
-        self.symbol_counter
-            .resize(self.symbol_probabilities.len(), 0);
-        for idx in 0..negative_idx {
-            let entry = &mut self.decode[idx];
-            let symbol = entry.symbol;
-            let prob = self.symbol_probabilities[symbol as usize];
+        // === Build step ===
+        // Stack-allocated counter (max 256 symbols since the symbol
+        // alphabet is bounded by `u8`). Replaces the previous
+        // `Vec<u32>` field that was cleared + resized per call —
+        // about 200 bytes of heap-alloc churn dropped from the hot
+        // build path. Zero-init at declaration covers every slot.
+        let mut counter = [0u32; 256];
+        let accuracy_log = self.accuracy_log;
 
-            let symbol_count = self.symbol_counter[symbol as usize];
-            let (bl, nb) = calc_baseline_and_numbits(table_size as u32, prob as u32, symbol_count);
-
-            //println!("symbol: {:2}, table: {}, prob: {:3}, count: {:3}, bl: {:3}, nb: {:2}", symbol, table_size, prob, symbol_count, bl, nb);
-
-            assert!(nb <= self.accuracy_log);
-            self.symbol_counter[symbol as usize] += 1;
-
-            entry.new_state = u16::try_from(bl).map_err(|_| FSETableError::AccLogTooBig {
-                got: self.accuracy_log,
-                max: ENTRY_MAX_ACCURACY_LOG,
-            })?;
-            entry.num_bits = nb;
+        // Single linear pass: write every entry exactly once. The
+        // previous impl had three passes (zero-init resize, symbol
+        // copy, build), all touching the same `Vec<Entry>` cache
+        // line — now collapsed into one.
+        self.decode.clear();
+        self.decode.reserve(table_size);
+        for (idx, &symbol) in spread.iter().enumerate().take(table_size) {
+            if idx < negative_idx {
+                // Positive-probability slot.
+                let prob = self.symbol_probabilities[symbol as usize];
+                let symbol_count = counter[symbol as usize];
+                counter[symbol as usize] = symbol_count + 1;
+                let (bl, nb) =
+                    calc_baseline_and_numbits(table_size as u32, prob as u32, symbol_count);
+                debug_assert!(nb <= accuracy_log);
+                let new_state = u16::try_from(bl).map_err(|_| FSETableError::AccLogTooBig {
+                    got: accuracy_log,
+                    max: ENTRY_MAX_ACCURACY_LOG,
+                })?;
+                self.decode.push(Entry {
+                    new_state,
+                    symbol,
+                    num_bits: nb,
+                    base_value: 0,
+                    num_additional_bits: 0,
+                });
+            } else {
+                // -1 probability slot: no baseline, num_bits =
+                // accuracy_log (decoder takes the full state width on
+                // these slots, by zstd FSE spec).
+                self.decode.push(Entry {
+                    new_state: 0,
+                    symbol,
+                    num_bits: accuracy_log,
+                    base_value: 0,
+                    num_additional_bits: 0,
+                });
+            }
         }
+
+        self.symbol_spread_buffer = spread;
         Ok(())
-    }
-
-    fn copy_symbols_into_decode(&mut self, table_symbols: &[u8], table_size: usize) {
-        debug_assert_eq!(table_symbols.len(), table_size);
-        debug_assert!(table_size <= self.decode.capacity());
-
-        // Entry is now 12 bytes (header + base_value + num_additional_bits
-        // + tail padding). The previous LE fast path that packed two
-        // 4-byte entries into a single u64 store no longer applies.
-        // Zero-init through `resize` and then set per-slot `.symbol`
-        // — the per-block table build is not on the per-sequence hot
-        // path (this runs once per FSE-mode block, not per emit), so
-        // dropping the byte-packed write here keeps the layout change
-        // contained without measurable cost.
-        //
-        // The `base_value` / `num_additional_bits` fields stay at
-        // their zero default here; per-table enrichment for LL / ML /
-        // OF runs in `enrich_for_*` after the baseline / num_bits
-        // computation below populates the rest of each entry.
-        self.decode.resize(
-            table_size,
-            Entry {
-                new_state: 0,
-                symbol: 0,
-                num_bits: 0,
-                base_value: 0,
-                num_additional_bits: 0,
-            },
-        );
-        for (entry, symbol) in self.decode.iter_mut().zip(table_symbols.iter().copied()) {
-            entry.symbol = symbol;
-        }
     }
 
     /// Read the accuracy log and the probability table from the source and return the number of bytes

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -770,6 +770,22 @@ mod tests {
     }
 
     #[test]
+    fn build_from_probabilities_rejects_overflow_in_sum() {
+        // DoS-shaped exploit: two i32::MAX values + 0x42 cast to u32
+        // and summed wrapping wraps to 0x40 = 64 = 1 << acc_log. The
+        // pre-fix u32 sum check would accept the input, then
+        // build_decoding_table would run `for _ in 0..prob` against
+        // prob = i32::MAX, looping 2^31-1 times per such symbol.
+        let mut t = FSETable::new(8);
+        let probs: [i32; 3] = [i32::MAX, i32::MAX, 0x42];
+        let result = t.build_from_probabilities(6, &probs);
+        assert!(
+            matches!(result, Err(FSETableError::InvalidProbability { .. })),
+            "expected InvalidProbability for overflow-shaped exploit, got {result:?}",
+        );
+    }
+
+    #[test]
     fn build_from_probabilities_rejects_negative_below_minus_one() {
         // RFC 8478 §4.1.1: probability values are in {-1, 0, positive}.
         // p = -2 is outside the spec; clamping to 0 silently is wrong.

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -407,8 +407,9 @@ impl FSETable {
         //      2^31-1 times per such symbol (worst case: spread-array
         //      out-of-bounds panic, best case: minutes of CPU).
         //
-        // Reject any `p > table_size` upfront and compute the sum in
-        // `u64` so wrap is impossible.
+        // Reject any `p > table_size` upfront so the subsequent u32
+        // sum is bounded (see the sum's own comment for the
+        // wrap-impossibility argument).
         let table_size = 1u32 << acc_log;
         for &p in probs {
             if p < -1 || p > table_size as i32 {

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -678,3 +678,64 @@ fn calc_baseline_and_numbits(
         ((index_shifted * slice_width), num_bits as u8)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decoding::errors::FSETableError;
+
+    #[test]
+    fn build_from_probabilities_rejects_sum_too_small() {
+        // acc_log=4 → table_size=16. Valid sum (treating -1 as 1)
+        // is 16. Use a distribution that sums to 8 (probs sum 8,
+        // no -1s).
+        let mut t = FSETable::new(8);
+        let probs: [i32; 4] = [4, 2, 1, 1];
+        let result = t.build_from_probabilities(4, &probs);
+        assert!(
+            matches!(
+                result,
+                Err(FSETableError::ProbabilityCounterMismatch { .. })
+            ),
+            "expected ProbabilityCounterMismatch for sum=8 vs expected=16, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn build_from_probabilities_rejects_sum_too_large() {
+        // acc_log=4 → table_size=16. Probs summing to 20 (>16)
+        // would over-fill the spread.
+        let mut t = FSETable::new(8);
+        let probs: [i32; 4] = [8, 6, 4, 2];
+        let result = t.build_from_probabilities(4, &probs);
+        assert!(
+            matches!(
+                result,
+                Err(FSETableError::ProbabilityCounterMismatch { .. })
+            ),
+            "expected ProbabilityCounterMismatch for sum=20 vs expected=16, got {result:?}",
+        );
+    }
+
+    #[test]
+    fn build_from_probabilities_accepts_negative_one_in_sum() {
+        // acc_log=4 → table_size=16. Probs: 12 positive + 4 × -1
+        // (counted as 1 each) sum to 16. Should succeed.
+        let mut t = FSETable::new(8);
+        let probs: [i32; 6] = [8, 4, -1, -1, -1, -1];
+        let result = t.build_from_probabilities(4, &probs);
+        assert!(
+            result.is_ok(),
+            "expected Ok for sum=16 with -1s, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_probabilities_accepts_exact_sum() {
+        // Sum 4+4+4+4 = 16 = 1 << 4. No -1s.
+        let mut t = FSETable::new(8);
+        let probs: [i32; 4] = [4, 4, 4, 4];
+        let result = t.build_from_probabilities(4, &probs);
+        assert!(result.is_ok(), "expected Ok for exact sum, got {result:?}");
+    }
+}

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -387,7 +387,7 @@ impl FSETable {
         // overshoot `decode.len()` on the unchecked `read_entry`
         // hot path. Surface as a typed error so the caller can
         // distinguish a malformed input from an internal failure.
-        // Strict probability range validation: RFC 8478 §4.1.1 admits
+        // Strict probability range validation: RFC 8878 §4.1.1 admits
         // only `{-1, 0, 1..=table_size}` as probability values. The
         // wire-format parser never emits anything else, but
         // `build_from_probabilities` is a public entry point reachable
@@ -851,7 +851,7 @@ mod tests {
 
     #[test]
     fn build_from_probabilities_rejects_negative_below_minus_one() {
-        // RFC 8478 §4.1.1: probability values are in {-1, 0, positive}.
+        // RFC 8878 §4.1.1: probability values are in {-1, 0, positive}.
         // p = -2 is outside the spec; clamping to 0 silently is wrong.
         let mut t = FSETable::new(8);
         let probs: [i32; 4] = [-2, 8, 4, 4];

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -389,10 +389,23 @@ impl FSETable {
         // overshoot `decode.len()` on the unchecked `read_entry`
         // hot path. Surface as a typed error so the caller can
         // distinguish a malformed input from an internal failure.
+        // Strict probability validation: RFC 8478 §4.1.1 admits only
+        // {-1, 0, positive} as probability values. The wire-format
+        // parser never emits anything else, but `build_from_probabilities`
+        // is a public entry point reachable from fuzz harnesses and
+        // external users — rejecting `p < -1` here keeps the API
+        // contract tight (clamping silently to 0 would let `[-2, ...]`
+        // satisfy a sum check whose remaining terms happen to add up
+        // to `table_size`, producing a quietly malformed table).
+        for &p in probs {
+            if p < -1 {
+                return Err(FSETableError::InvalidProbability { value: p });
+            }
+        }
         let table_size = 1u32 << acc_log;
         let probability_sum: u32 = probs
             .iter()
-            .map(|&p| if p == -1 { 1 } else { p.max(0) as u32 })
+            .map(|&p| if p == -1 { 1 } else { p as u32 })
             .sum();
         if probability_sum != table_size {
             return Err(FSETableError::ProbabilityCounterMismatch {

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -757,6 +757,19 @@ mod tests {
     }
 
     #[test]
+    fn build_from_probabilities_rejects_negative_below_minus_one() {
+        // RFC 8478 §4.1.1: probability values are in {-1, 0, positive}.
+        // p = -2 is outside the spec; clamping to 0 silently is wrong.
+        let mut t = FSETable::new(8);
+        let probs: [i32; 4] = [-2, 8, 4, 4];
+        let result = t.build_from_probabilities(4, &probs);
+        assert!(
+            matches!(result, Err(FSETableError::InvalidProbability { value: -2 })),
+            "expected InvalidProbability{{-2}}, got {result:?}",
+        );
+    }
+
+    #[test]
     fn build_from_probabilities_accepts_exact_sum() {
         // Sum 4+4+4+4 = 16 = 1 << 4. No -1s.
         let mut t = FSETable::new(8);

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -389,25 +389,37 @@ impl FSETable {
         // overshoot `decode.len()` on the unchecked `read_entry`
         // hot path. Surface as a typed error so the caller can
         // distinguish a malformed input from an internal failure.
-        // Strict probability validation: RFC 8478 §4.1.1 admits only
-        // {-1, 0, positive} as probability values. The wire-format
-        // parser never emits anything else, but `build_from_probabilities`
-        // is a public entry point reachable from fuzz harnesses and
-        // external users — rejecting `p < -1` here keeps the API
-        // contract tight (clamping silently to 0 would let `[-2, ...]`
-        // satisfy a sum check whose remaining terms happen to add up
-        // to `table_size`, producing a quietly malformed table).
+        // Strict probability range validation: RFC 8478 §4.1.1 admits
+        // only `{-1, 0, 1..=table_size}` as probability values. The
+        // wire-format parser never emits anything else, but
+        // `build_from_probabilities` is a public entry point reachable
+        // from fuzz harnesses and external users — leaving the gate
+        // open invites two attack shapes:
+        //
+        //   1. Silent malformed table: clamping `p < -1` to 0 (the
+        //      previous `p.max(0)`) lets `[-2, ...]` satisfy a sum
+        //      check whose remaining terms happen to add up to
+        //      `table_size`, producing a quietly broken table.
+        //   2. DoS via probability-sum overflow: `[i32::MAX, i32::MAX,
+        //      0x42] as u32` wraps to `0x40 = 64 = 1 << 6`, satisfies
+        //      the sum check, then `build_decoding_table` runs
+        //      `for _ in 0..prob` against `prob = i32::MAX`, looping
+        //      2^31-1 times per such symbol (worst case: spread-array
+        //      out-of-bounds panic, best case: minutes of CPU).
+        //
+        // Reject any `p > table_size` upfront and compute the sum in
+        // `u64` so wrap is impossible.
+        let table_size = 1u32 << acc_log;
         for &p in probs {
-            if p < -1 {
+            if p < -1 || p > table_size as i32 {
                 return Err(FSETableError::InvalidProbability { value: p });
             }
         }
-        let table_size = 1u32 << acc_log;
-        let probability_sum: u32 = probs
+        let probability_sum: u64 = probs
             .iter()
-            .map(|&p| if p == -1 { 1 } else { p as u32 })
+            .map(|&p| if p == -1 { 1u64 } else { p as u64 })
             .sum();
-        if probability_sum != table_size {
+        if probability_sum != u64::from(table_size) {
             return Err(FSETableError::ProbabilityCounterMismatch {
                 got: probability_sum,
                 expected_sum: table_size,
@@ -597,7 +609,7 @@ impl FSETable {
 
         if probability_counter != probability_sum {
             return Err(FSETableError::ProbabilityCounterMismatch {
-                got: probability_counter,
+                got: u64::from(probability_counter),
                 expected_sum: probability_sum,
                 symbol_probabilities: self.symbol_probabilities.clone(),
             });

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -415,11 +415,18 @@ impl FSETable {
                 return Err(FSETableError::InvalidProbability { value: p });
             }
         }
-        let probability_sum: u64 = probs
+        // Sum the validated probs in u32. Per-element validation
+        // above bounds each non-`-1` value by `table_size <= 1 << 16`,
+        // and `probs.len() <= 256`, so the worst-case sum
+        // `256 * 65536 = 16M` fits u32 with 8 bits of headroom — no
+        // wrap possible. Keeps the public
+        // `ProbabilityCounterMismatch.got` field at u32 (no public
+        // API break).
+        let probability_sum: u32 = probs
             .iter()
-            .map(|&p| if p == -1 { 1u64 } else { p as u64 })
+            .map(|&p| if p == -1 { 1u32 } else { p as u32 })
             .sum();
-        if probability_sum != u64::from(table_size) {
+        if probability_sum != table_size {
             return Err(FSETableError::ProbabilityCounterMismatch {
                 got: probability_sum,
                 expected_sum: table_size,
@@ -437,7 +444,20 @@ impl FSETable {
     /// — no intermediate zero-init Vec::resize, no per-call heap
     /// allocation for the symbol counter (stack-allocated since the
     /// max symbol count is bounded by `u8::MAX + 1 = 256`).
+    ///
+    /// Wraps `build_decoding_table_inner` so the `symbol_spread_buffer`
+    /// scratch is unconditionally restored to `self` on every exit
+    /// path (success OR error) — otherwise an early `Err` from the
+    /// inner pass would drop the taken buffer and force a fresh
+    /// allocation on the next build.
     fn build_decoding_table(&mut self) -> Result<(), FSETableError> {
+        let mut spread = core::mem::take(&mut self.symbol_spread_buffer);
+        let result = self.build_decoding_table_inner(&mut spread);
+        self.symbol_spread_buffer = spread;
+        result
+    }
+
+    fn build_decoding_table_inner(&mut self, spread: &mut Vec<u8>) -> Result<(), FSETableError> {
         let nb_symbols = self.symbol_probabilities.len();
         if nb_symbols > self.max_symbol as usize + 1 {
             return Err(FSETableError::TooManySymbols { got: nb_symbols });
@@ -451,7 +471,6 @@ impl FSETable {
         // build path now (previous impl also zero-init'd `decode`
         // through `Vec::resize` with a default `Entry`, doubling the
         // write traffic on the build path).
-        let mut spread = core::mem::take(&mut self.symbol_spread_buffer);
         spread.clear();
         spread.resize(table_size, 0);
 
@@ -518,7 +537,12 @@ impl FSETable {
                 // Reject at build time so the unchecked indexing
                 // contract holds in release as well as debug.
                 if nb > accuracy_log {
-                    return Err(FSETableError::InvalidProbability { value: prob });
+                    return Err(FSETableError::TableInvariantViolation {
+                        prob,
+                        symbol,
+                        num_bits: nb,
+                        accuracy_log,
+                    });
                 }
                 let new_state = u16::try_from(bl).map_err(|_| FSETableError::AccLogTooBig {
                     got: accuracy_log,
@@ -545,7 +569,6 @@ impl FSETable {
             }
         }
 
-        self.symbol_spread_buffer = spread;
         Ok(())
     }
 
@@ -622,7 +645,7 @@ impl FSETable {
 
         if probability_counter != probability_sum {
             return Err(FSETableError::ProbabilityCounterMismatch {
-                got: u64::from(probability_counter),
+                got: probability_counter,
                 expected_sum: probability_sum,
                 symbol_probabilities: self.symbol_probabilities.clone(),
             });

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -39,35 +39,33 @@ impl<'t> FSEDecoder<'t> {
         if self.table.accuracy_log == 0 {
             return Err(FSEDecoderError::TableIsUninitialized);
         }
-        // Externally-constructible-table guard: when
-        // `feature = "fuzz_exports"` is on, `FSETable.decode` /
-        // `FSETable.accuracy_log` are settable from outside the crate,
-        // so a fuzz harness can hand the decoder a mis-shaped table
-        // that skips `build_decoding_table`'s invariants. Validate the
-        // table-shape invariant `decode.len() == 1 << accuracy_log`
-        // up-front and surface as a typed `InvalidTableShape` error
-        // (distinct from `TableIsUninitialized` to keep fuzz triage
-        // unambiguous) — without this, `read_entry`'s bounds-checked
-        // indexing under the same cfg would panic on a malformed
-        // table, which fuzz harnesses cannot distinguish from a
-        // legitimate decoder failure. `checked_shl` covers the
-        // pathological case where `accuracy_log >= usize::BITS`.
-        #[cfg(feature = "fuzz_exports")]
-        {
-            let accuracy_log = self.table.accuracy_log;
-            let decode_len = self.table.decode.len();
-            let expected = 1usize.checked_shl(accuracy_log.into()).ok_or(
-                FSEDecoderError::InvalidTableShape {
+        // Externally-constructible-table guard: `FSETable::decode`
+        // and `FSETable::accuracy_log` are `pub` fields, so safe
+        // external callers (not just `fuzz_exports` harnesses) can
+        // hand the decoder a table whose `decode.len()` doesn't match
+        // `1 << accuracy_log`. Validate the shape invariant up-front
+        // and surface as a typed `InvalidTableShape` error (distinct
+        // from `TableIsUninitialized` to keep error triage
+        // unambiguous) — without this, `read_entry`'s unchecked
+        // indexing (the `cfg(not(fuzz_exports))` arm) hits UB in
+        // release builds on a malformed table. `checked_shl` covers
+        // the pathological case where `accuracy_log >= usize::BITS`.
+        // Branch cost is a single per-call check; the per-sequence
+        // hot path (`update_state_fast`) is unaffected.
+        let accuracy_log = self.table.accuracy_log;
+        let decode_len = self.table.decode.len();
+        let expected =
+            1usize
+                .checked_shl(accuracy_log.into())
+                .ok_or(FSEDecoderError::InvalidTableShape {
                     decode_len,
                     accuracy_log,
-                },
-            )?;
-            if decode_len != expected {
-                return Err(FSEDecoderError::InvalidTableShape {
-                    decode_len,
-                    accuracy_log,
-                });
-            }
+                })?;
+        if decode_len != expected {
+            return Err(FSEDecoderError::InvalidTableShape {
+                decode_len,
+                accuracy_log,
+            });
         }
         let new_state = bits.get_bits(self.table.accuracy_log);
         // SAFETY: `accuracy_log` bits read from the bitstream produce
@@ -455,10 +453,23 @@ impl FSETable {
     /// path (success OR error) — otherwise an early `Err` from the
     /// inner pass would drop the taken buffer and force a fresh
     /// allocation on the next build.
+    ///
+    /// On `Err` the table is also fully `reset()` after the buffer
+    /// restore: the inner pass mutates `self.decode` (partial push)
+    /// while `self.accuracy_log` / `self.symbol_probabilities` were
+    /// already set by the caller (`build_from_probabilities`); leaving
+    /// that inconsistency in place would let a subsequent `init_state`
+    /// pass the `accuracy_log != 0` gate and read from a partial
+    /// `decode` vec — UB. After `reset()` the table is in the same
+    /// well-defined empty state a freshly-constructed `FSETable` has;
+    /// any subsequent `init_state` returns `TableIsUninitialized`.
     fn build_decoding_table(&mut self) -> Result<(), FSETableError> {
         let mut spread = core::mem::take(&mut self.symbol_spread_buffer);
         let result = self.build_decoding_table_inner(&mut spread);
         self.symbol_spread_buffer = spread;
+        if result.is_err() {
+            self.reset();
+        }
         result
     }
 

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -506,7 +506,20 @@ impl FSETable {
                 counter[symbol as usize] = symbol_count + 1;
                 let (bl, nb) =
                     calc_baseline_and_numbits(table_size as u32, prob as u32, symbol_count);
-                debug_assert!(nb <= accuracy_log);
+                // FSE invariant gate (release-mode safety): the
+                // decoder's unchecked `read_entry` path relies on
+                // `new_state + (1 << num_bits) - 1 < table_size`,
+                // which factors through `nb <= accuracy_log`. The
+                // wire-format `parse_wire` path establishes this by
+                // construction, but `build_from_probabilities` is a
+                // public surface — a crafted but in-range probability
+                // vector could theoretically drive
+                // `calc_baseline_and_numbits` to violate the invariant.
+                // Reject at build time so the unchecked indexing
+                // contract holds in release as well as debug.
+                if nb > accuracy_log {
+                    return Err(FSETableError::InvalidProbability { value: prob });
+                }
                 let new_state = u16::try_from(bl).map_err(|_| FSETableError::AccLogTooBig {
                     got: accuracy_log,
                     max: ENTRY_MAX_ACCURACY_LOG,

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -375,6 +375,32 @@ impl FSETable {
                 max: ENTRY_MAX_ACCURACY_LOG,
             });
         }
+        // Probability sum check: `build_decoding_table` assumes the
+        // sum of positive probabilities plus the count of `-1`
+        // entries (each contributing one slot at the top of the
+        // table) equals exactly `1 << acc_log`. Without this guard
+        // the wire-format `parse_wire` path validates the sum
+        // upstream, but callers entering through
+        // `build_from_probabilities` directly (the Predefined cache
+        // and any fuzz / external user) would silently produce a
+        // table where `calc_baseline_and_numbits` is given
+        // `symbol_count` values exceeding the symbol's actual
+        // `prob`, yielding `new_state` / `num_bits` pairs that can
+        // overshoot `decode.len()` on the unchecked `read_entry`
+        // hot path. Surface as a typed error so the caller can
+        // distinguish a malformed input from an internal failure.
+        let table_size = 1u32 << acc_log;
+        let probability_sum: u32 = probs
+            .iter()
+            .map(|&p| if p == -1 { 1 } else { p.max(0) as u32 })
+            .sum();
+        if probability_sum != table_size {
+            return Err(FSETableError::ProbabilityCounterMismatch {
+                got: probability_sum,
+                expected_sum: table_size,
+                symbol_probabilities: probs.to_vec(),
+            });
+        }
         self.symbol_probabilities = probs.to_vec();
         self.accuracy_log = acc_log;
         self.build_decoding_table()

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -413,7 +413,11 @@ impl FSETable {
         let table_size = 1u32 << acc_log;
         for &p in probs {
             if p < -1 || p > table_size as i32 {
-                return Err(FSETableError::InvalidProbability { value: p });
+                return Err(FSETableError::InvalidProbability {
+                    value: p,
+                    table_size,
+                    accuracy_log: acc_log,
+                });
             }
         }
         // Sum the validated probs in u32. Per-element validation
@@ -842,8 +846,11 @@ mod tests {
         let probs: [i32; 4] = [-2, 8, 4, 4];
         let result = t.build_from_probabilities(4, &probs);
         assert!(
-            matches!(result, Err(FSETableError::InvalidProbability { value: -2 })),
-            "expected InvalidProbability{{-2}}, got {result:?}",
+            matches!(
+                result,
+                Err(FSETableError::InvalidProbability { value: -2, .. })
+            ),
+            "expected InvalidProbability{{value: -2, ..}}, got {result:?}",
         );
     }
 


### PR DESCRIPTION
## Summary

Flamegraph on `decompress/level_-1_fast/small-4k-log-lines/c_stream/matrix/pure_rust` (i9, post-PR-#263 merge) showed **66.72% of decode time in `FSETable::build_decoding_table`** — all of it inside the `ModeType::Predefined` branches.

The RFC 8478 §3.1.1.3.2.1.1 default LL / OF / ML distributions are static constants; the tables they produce are byte-identical across every call. Yet the decoder was running the full table-construction loop (O(table_size) with several `Vec::resize` round-trips per axis) every time the encoder declared Predefined mode.

This PR adds three `OnceLock<FSETable>` caches (LL / OF / ML, with OF carrying its precomputed `offsets_long_share` too). The `ModeType::Predefined` arms now `clone_from` the cached table instead of rebuilding. Per-frame scratch reuses its allocation, so each `clone_from` is a fixed-size memcpy + a few scalar field copies — measured ~3 orders of magnitude faster than the rebuild path on small-block fixtures.

## Bench (i9-9900K, vs `origin/main` baseline)

| fixture | `origin/main` | this branch | change | × donor |
|---|---|---|---|---|
| `small-4k-log-lines/c_stream` | 2.85 µs | **874 ns** | **−69.4%** | 1.62× (was 5.28×) |
| `large-log-stream/c_stream` | 16.85 ms | **15.28 ms** | **−9.3%** | 1.16× (was 1.28×) |
| `low-entropy-1m/c_stream` | 218.2 µs | **207.6 µs** | **−4.9%** | 1.41× (was 1.49×) |
| `small-1k-random/c_stream` | 135 ns | **130 ns** | **−3.7%** | 1.17× (was 1.21×) |
| `small-10k-random/c_stream` | 745 ns | 749 ns | flat (noise) | 0.99× |
| `high-entropy-1m/c_stream` | 101.6 µs | 101.8 µs | +0.17% (noise) | 1.05× |
| `decodecorpus-z000033/c_stream` | 1.50 ms | 1.50 ms | flat | 2.31× |

The win lands on every fixture where the encoder uses the default LL/OF/ML distribution, which is dominantly the small-block case. Random / high-entropy fixtures rarely hit Predefined (those use FSECompressed custom tables), so the cache is dead code on their hot path — zero overhead.

`small-4k-log-lines` was the worst outlier in the post-#263 baseline (5.28× donor); this PR brings it to **1.62× donor**, the same band as the rest of the structured corpora.

## Implementation

- Three `OnceLock<FSETable>` statics keyed by axis (LL / OF / ML).
- OF cache also stores the precomputed `offsets_long_share` so the downstream call on the hot path is replaced by a load from cache.
- `ModeType::Predefined` arms call the cache helper and `clone_from` into per-frame scratch.
- `no_std` builds keep the per-call rebuild path (matches the existing pattern used by `cpu_kernel::detect_cpu_kernel` and the bit-reader BMI2 dispatch — `OnceLock` requires `std`).

## Testing

- `cargo nextest run -p structured-zstd --release` — 636/637 pass (1 pre-existing release-mode debug_assert).
- `cargo clippy --all-targets -- -D warnings` clean.

Closes #265.