### PR TITLE
perf(decode): route short-block fallback through inline executor (z000033 −25%)

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -637,7 +637,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // every would-be dict-source match and returns
         // `NotEnoughBytesInDictionary`. The
         // `RingBuffer` / `FlatBuf` paths still maintain the counter
-        // via `push` / `repeat_match` and rely on it correctly.
+        // via `push` / `repeat_inner` and rely on it correctly.
         if self.total_output_counter <= self.window_size as u64 {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -711,47 +711,6 @@ fn run_pipelined_sequence_loop<
     Ok(())
 }
 
-/// Per-sequence executor for the non-pipelined (short-block) fallback
-/// path. Mutates the real `offset_hist` in lockstep with the sequence
-/// being executed — preserving the legacy "Err leaves partial output +
-/// pre-mutation hist" rollback contract.
-#[inline(always)]
-fn execute_one_sequence<B: super::buffer_backend::BufferBackend>(
-    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
-    literals: &[u8],
-    lit_cur: &mut usize,
-    lit_len: usize,
-    offset_hist: &mut [u32; 3],
-    seq: Sequence,
-) -> Result<(), DecompressBlockError> {
-    // `checked_add` on the literal cursor + sequence ll. On 32-bit
-    // targets a malformed stream can push `*lit_cur + seq.ll as usize`
-    // past `usize::MAX`; without the checked path the wrap would
-    // produce `high < *lit_cur` and the subsequent `get_unchecked`
-    // would slice into arbitrary memory (UB).
-    let high = (*lit_cur)
-        .checked_add(seq.ll as usize)
-        .filter(|&h| h <= lit_len)
-        .ok_or(ExecuteSequencesError::NotEnoughBytesForSequence {
-            wanted: (*lit_cur).saturating_add(seq.ll as usize),
-            have: lit_len,
-        })?;
-    // SAFETY: high <= lit_len (verified by the `filter` above) and
-    // *lit_cur <= high (the `checked_add` succeeded, so no wrap).
-    let lits = unsafe { literals.get_unchecked(*lit_cur..high) };
-    *lit_cur = high;
-    buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
-
-    let actual = do_offset_history(seq.of, seq.ll, offset_hist);
-    if actual == 0 {
-        return Err(ExecuteSequencesError::ZeroOffset.into());
-    }
-    buffer
-        .repeat(actual as usize, seq.ml as usize)
-        .map_err(ExecuteSequencesError::from)?;
-    Ok(())
-}
-
 /// Pipelined-path executor variant: takes the offset already resolved
 /// by the decode-ahead `shadow_hist` walk, so `do_offset_history` is
 /// NOT called here (caller mutated only the shadow). Routes the match
@@ -905,14 +864,20 @@ fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
         // `run_direct_decode` now reads `tail` (via
         // `buffer_ref().tail() as u64`) instead of the separately
         // maintained `DecodeBuffer::total_output_counter`. Skipping
-        // the per-sequence RMW drops the ~9% of decode time
-        // measured at `addq <ll+ml>, 0x40(%r9)` on z000033
-        // (perf annotate on
-        // `decode_and_execute_sequences_avx2`). The legacy
-        // push+repeat fallback below still goes through
-        // `DecodeBuffer::try_push` / `repeat_lookahead_prefetched`,
-        // which keep `total_output_counter` in sync for backends
-        // that need it.
+        // the per-sequence RMW drops the ~9% of decode time measured
+        // at `addq <ll+ml>, 0x40(%r9)` on z000033 (perf annotate on
+        // `decode_and_execute_sequences_avx2`).
+        //
+        // `total_output_counter` is intentionally NOT maintained on
+        // the inline-exec path. Once any sequence in a block takes
+        // this path, the wrapper-level counter is stale for the
+        // remainder of the block — the legacy
+        // `try_push`/`repeat_lookahead_prefetched` arm below only
+        // accounts for its own bytes, NOT a running total. The
+        // authoritative byte count for the inline-eligible path is
+        // `UserSliceBackend::tail()`; any caller that previously
+        // read `total_output_counter` on this path is migrated to
+        // `buffer_ref().tail()` (see `run_direct_decode`).
         return Ok(());
     }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -345,19 +345,20 @@ fn decode_and_execute_sequences_impl<
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
 
-    // `offset_hist` mutation on the in-band success path:
-    //   * Pipelined branch (long pipeline): real `offset_hist` is NOT
-    //     touched per-sequence — repcodes are resolved against the
-    //     local `shadow_hist`, and the resolved offset is stored in
-    //     the ring alongside the decoded sequence. After successful
-    //     drain we copy `shadow_hist` back into `*offset_hist` once.
-    //   * Non-pipelined branch (short-block fallback): real
-    //     `offset_hist` IS mutated inline via `do_offset_history` in
-    //     `execute_one_sequence`.
-    //   * Rollback path (post-loop bitstream check fails): restore
-    //     `*offset_hist = saved_offset_hist`. Cheap no-op on the
-    //     pipelined branch (real hist was never touched mid-loop),
-    //     correct rewind on the non-pipelined branch.
+    // `offset_hist` mutation on the in-band success path: both
+    // pipelined and short-block fallback resolve repcodes against a
+    // local `shadow_hist` and commit `*offset_hist = shadow_hist`
+    // ONLY after the last sequence executes successfully. Mid-loop
+    // mutation of the real `offset_hist` would leak partial state on
+    // an `Err` from `execute_one_sequence*` (literal bounds check,
+    // inline-exec offset gate), and the `?`-shaped early returns in
+    // the fallback path bypass the post-loop rollback below — the
+    // shadow + commit-on-success shape mirrors the pipelined branch
+    // exactly so an `Err` ANYWHERE in the loop leaves the caller's
+    // offset_hist untouched. The post-loop `*offset_hist =
+    // saved_offset_hist` rollback handler still fires if the
+    // bitstream-tail validation fails, covering the edge case where
+    // every sequence succeeds but the bitstream has leftover bits.
 
     let num_sequences = section.num_sequences as usize;
 
@@ -462,7 +463,7 @@ fn decode_and_execute_sequences_impl<
         // mid-block stays at zero.
         //
         // Routes through `execute_one_sequence_pipelined` (resolving
-        // the actual offset against `offset_hist` upfront) so the
+        // the actual offset against a `shadow_hist` upfront) so the
         // inline donor-shape writer fires on backends that opt in
         // (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC = true`).
         // The legacy `execute_one_sequence` path went through
@@ -474,17 +475,30 @@ fn decode_and_execute_sequences_impl<
         // the wrapper-level counter is bypassed entirely on this
         // path; the post-block FCS check in `run_direct_decode`
         // reads `tail()` instead.
+        //
+        // `shadow_hist` mirrors the pipelined-branch pattern: the
+        // real `offset_hist` is NOT mutated mid-loop, so an early
+        // `Err` from `execute_one_sequence_pipelined` (literal bounds
+        // check, inline-exec offset gate, etc.) propagating through
+        // the explicit Err arm below leaves the caller's offset_hist
+        // untouched. On the success path we commit `shadow_hist`
+        // back to `*offset_hist` once, after the loop.
+        let mut shadow_hist = *offset_hist;
+        let mut fallback_err: Option<DecompressBlockError> = None;
         for i in 0..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let resolved_offset = do_offset_history(seq.of, seq.ll, offset_hist);
-            execute_one_sequence_pipelined(
+            let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+            if let Err(e) = execute_one_sequence_pipelined(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
                 seq,
                 resolved_offset,
-            )?;
+            ) {
+                fallback_err = Some(e);
+                break;
+            }
             seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
 
             if i + 1 < num_sequences {
@@ -494,6 +508,22 @@ fn decode_and_execute_sequences_impl<
                 of_dec.update_state_fast(&mut br);
             }
         }
+        if let Some(e) = fallback_err {
+            // Mirrors the pipelined branch's Err handler: roll the
+            // buffer back to the pre-loop checkpoint; offset_hist
+            // was never mutated mid-loop (shadow only), so no
+            // restore needed there. Buffer might have absorbed
+            // literal pushes / partial inline writes from the
+            // failing sequence — try_restore_checkpoint handles
+            // both cases via the captured tail snapshot.
+            if buffer.try_restore_checkpoint(buffer_checkpoint) {
+                // offset_hist intentionally NOT touched here: it
+                // still holds the pre-loop value because shadow_hist
+                // received all the in-band mutations.
+            }
+            return Err(e);
+        }
+        *offset_hist = shadow_hist;
     }
 
     // Post-loop bitstream validation. On failure roll back the buffer

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -467,10 +467,11 @@ fn decode_and_execute_sequences_impl<
         // inline donor-shape writer fires on backends that opt in
         // (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC = true`).
         // The legacy `execute_one_sequence` path went through
-        // `DecodeBuffer::repeat_match` → `total_output_counter +=
-        // match_length` (decode_buffer.rs:357), which perf annotate
-        // on z000033 L-3 fast attributed ~6% of decode time to (the
-        // RMW at `0x40(r8)` of the wrapper struct). The inline
+        // `DecodeBuffer::repeat_inner` which incremented
+        // `total_output_counter += match_length` on every sequence —
+        // perf annotate on z000033 L-3 fast attributed ~6% of decode
+        // time to that RMW at offset `0x40(r8)` of the wrapper
+        // struct. The inline
         // executor advances `tail` directly inside the backend, so
         // the wrapper-level counter is bypassed entirely on this
         // path; the post-block FCS check in `run_direct_decode`

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -517,11 +517,18 @@ fn decode_and_execute_sequences_impl<
             // literal pushes / partial inline writes from the
             // failing sequence — try_restore_checkpoint handles
             // both cases via the captured tail snapshot.
-            if buffer.try_restore_checkpoint(buffer_checkpoint) {
-                // offset_hist intentionally NOT touched here: it
-                // still holds the pre-loop value because shadow_hist
-                // received all the in-band mutations.
-            }
+            //
+            // offset_hist intentionally NOT touched here regardless
+            // of the rollback outcome: it still holds the pre-loop
+            // value because shadow_hist absorbed all the in-band
+            // mutations. The bool return from `try_restore_checkpoint`
+            // is therefore irrelevant on this path — `false` means
+            // an intervening reallocation invalidated the captured
+            // tail, in which case the frame is already corrupted and
+            // the caller surfaces the original `Err` below. We drop
+            // the return value via `let _` to make the
+            // intentional-discard explicit.
+            let _ = buffer.try_restore_checkpoint(buffer_checkpoint);
             return Err(e);
         }
         *offset_hist = shadow_hist;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -460,15 +460,30 @@ fn decode_and_execute_sequences_impl<
         // simpler shape wins. Inlined here (rather than a separate
         // function) so the cold tail-call cost of swapping decoders
         // mid-block stays at zero.
+        //
+        // Routes through `execute_one_sequence_pipelined` (resolving
+        // the actual offset against `offset_hist` upfront) so the
+        // inline donor-shape writer fires on backends that opt in
+        // (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC = true`).
+        // The legacy `execute_one_sequence` path went through
+        // `DecodeBuffer::repeat_match` → `total_output_counter +=
+        // match_length` (decode_buffer.rs:357), which perf annotate
+        // on z000033 L-3 fast attributed ~6% of decode time to (the
+        // RMW at `0x40(r8)` of the wrapper struct). The inline
+        // executor advances `tail` directly inside the backend, so
+        // the wrapper-level counter is bypassed entirely on this
+        // path; the post-block FCS check in `run_direct_decode`
+        // reads `tail()` instead.
         for i in 0..num_sequences {
             let seq = decode_one_sequence_inline(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            execute_one_sequence(
+            let resolved_offset = do_offset_history(seq.of, seq.ll, offset_hist);
+            execute_one_sequence_pipelined(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
-                offset_hist,
                 seq,
+                resolved_offset,
             )?;
             seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
 


### PR DESCRIPTION
## Summary

This PR's primary win is routing the short-block fallback through the inline executor (z000033 −25% time), but the rebase on top of the parent #268 work also carries through several FSE / encoder / decoder safety fixes added during review. Reviewers should evaluate all of:

1. **Primary perf change** — short-block fallback path now resolves the offset via a local `shadow_hist` and calls `execute_one_sequence_pipelined` (inline executor), instead of routing through `DecodeBuffer::repeat_match` which hits the `total_output_counter += match_length` RMW at offset `0x40` of the wrapper struct (~6% of `decode_and_execute_sequences_avx2` time on z000033 L-3 fast per perf annotate).
2. **Err safety** — `shadow_hist` + commit-on-success mirrors the pipelined branch's pattern: an Err from `execute_one_sequence_pipelined` propagates through an explicit Err arm that restores the buffer checkpoint and leaves the caller's `offset_hist` untouched (previously the per-iter mutation leaked through the `?` short-circuit).
3. **Predefined FSE table cache** (`OnceLock`, std-only) for LL / ML / OF default distributions — skips per-block table rebuilds (~70% time on small-4k-log-lines).
4. **`build_from_probabilities` validation** — public-API guard against:
   - probabilities outside RFC 8478 §4.1.1 range `{-1, 0, 1..=table_size}` (rejects `-2` clamping, `> table_size` DoS shapes)
   - probability sum overflow (`[i32::MAX, i32::MAX, 0x42] as u32` wrapping to `table_size`)
   - the internal `nb > accuracy_log` table-shape invariant that the decoder's unchecked `read_entry` path relies on
5. **Distinct error variants** for input-range failures vs internal-invariant failures (`InvalidProbability` vs `TableInvariantViolation`) so diagnostics carry actionable context.
6. **Encoder bit-writer dirty-upper-bits assert** — was a debug_assert (stripped in release, silent stream corruption on caller misuse); upgraded to runtime check with the off-by-one corrected (`bits >> num_bits == 0`).
7. **Predefined cache copy** — switched `clone_from` → `reinit_from` so the build-only `symbol_spread_buffer` scratch isn't memcpy'd into per-block decoder state.
8. **Err-safe scratch buffer in `build_decoding_table`** — `mem::take` of the persistent `symbol_spread_buffer` is now restored on every exit path (success and error).

## Measurements (i9-9900K, criterion 10 samples, 1s warmup, 5s measure)

### z000033 (decodecorpus 1 MiB fixture, c_stream)

All 10 levels covered (L-3 fast through L15 lazy):

| Level | Time change |
|---|---|
| L-3 fast | **−25.91%** (p=0.00) |
| L1 fast | −25.95% |
| L3 dfast | −26.03% |
| L7 lazy2 | −26.21% |
| L15 lazy | −26.11% |

Average: **−25.95% time, +35% throughput.**

### Cross-fixture L-3 fast

| Fixture / stream | rust_stream | c_stream |
|---|---|---|
| high-entropy-1m | −1.96% ✓ | −3.40% ✓ |
| low-entropy-1m | −0.21% (≈) | −0.14% (p>0.05, noise) |
| large-log-stream | −0.35% ✓ | −0.28% (verified on longer 8s run; initial 5s run showed +2.63% which did not reproduce) |
| small-4k-log-lines | n/a | +0.45% (≈ noise) |

**No confirmed regressions.** The large-log-stream c_stream initial outlier (+2.63%) was first-run noise — the longer 8s confirmation run produced −0.28%.

## Test plan

- [x] Full nextest suite: **644/644 pass** (release mode, no skipped failures)
- [x] No-default-features check: passes
- [x] z000033 multi-level bench on i9 (decode-dominated decompression path)
- [x] Cross-fixture bench on i9 (verify no regressions)

Closes #265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal decoder consistency by standardizing error handling across different decompression code paths, enhancing overall robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->