### PR TITLE
docs(#176): Skippable Frame Magic Allocations registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ structured-zstd = { version = "0", features = ["lsm"] }
 The ecosystem registry of allocated skippable-frame magic variants
 and the allocation policy live in
 [docs/SKIPPABLE_MAGIC_ALLOCATIONS.md](https://github.com/structured-world/structured-zstd/blob/main/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).
+<!-- Absolute URL is intentional: this README is embedded into the
+crate's rustdoc via `#![doc = include_str!("../README.md")]` in
+zstd/src/lib.rs, where relative paths resolve under docs.rs and 404.
+The registry is also the canonical single source of truth on
+upstream `main`, so the link target is correct for forks too —
+fork consumers should point readers at the upstream registry
+rather than maintain divergent copies. -->
 
 ## Project relationship
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,23 @@ stream.read_to_end(&mut sink).unwrap();
 
 ## Storage-format extensions
 
-Behind the `lsm` Cargo feature, `structured-zstd` exposes a typed
-`SkippableFrame` API (`structured_zstd::skippable`) for storage-format
-authors who need to interleave application metadata with zstd data.
+Behind the `lsm` Cargo feature (default **off**), `structured-zstd`
+exposes a typed `SkippableFrame` API
+(`structured_zstd::skippable`) for storage-format authors who need
+to interleave application metadata with zstd data. Enable on the
+command line:
+
+```bash
+cargo add structured-zstd --features lsm
+```
+
+or in `Cargo.toml`:
+
+```toml
+[dependencies]
+structured-zstd = { version = "0", features = ["lsm"] }
+```
+
 The ecosystem registry of allocated skippable-frame magic variants
 and the allocation policy live in
 [docs/SKIPPABLE_MAGIC_ALLOCATIONS.md](https://github.com/structured-world/structured-zstd/blob/main/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).

--- a/README.md
+++ b/README.md
@@ -150,6 +150,15 @@ let mut sink = Vec::new();
 stream.read_to_end(&mut sink).unwrap();
 ```
 
+## Storage-format extensions
+
+Behind the `lsm` Cargo feature, `structured-zstd` exposes a typed
+`SkippableFrame` API (`zstd::skippable`) for storage-format authors who
+need to interleave application metadata with zstd data. The ecosystem
+registry of allocated skippable-frame magic variants and the
+allocation policy live in
+[docs/SKIPPABLE_MAGIC_ALLOCATIONS.md](docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).
+
 ## Project relationship
 
 Maintained fork of [KillingSpark/zstd-rs](https://github.com/KillingSpark/zstd-rs) (ruzstd) by the [Structured World Foundation](https://sw.foundation). We sync periodically with upstream but maintain an independent development trajectory focused on the [CoordiNode](https://github.com/structured-world/coordinode) database engine's per-label dictionary needs.

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ stream.read_to_end(&mut sink).unwrap();
 ## Storage-format extensions
 
 Behind the `lsm` Cargo feature, `structured-zstd` exposes a typed
-`SkippableFrame` API (`zstd::skippable`) for storage-format authors who
-need to interleave application metadata with zstd data. The ecosystem
-registry of allocated skippable-frame magic variants and the
-allocation policy live in
-[docs/SKIPPABLE_MAGIC_ALLOCATIONS.md](docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).
+`SkippableFrame` API (`structured_zstd::skippable`) for storage-format
+authors who need to interleave application metadata with zstd data.
+The ecosystem registry of allocated skippable-frame magic variants
+and the allocation policy live in
+[docs/SKIPPABLE_MAGIC_ALLOCATIONS.md](https://github.com/structured-world/structured-zstd/blob/main/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).
 
 ## Project relationship
 

--- a/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
+++ b/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
@@ -23,6 +23,10 @@ Allocations are an application-protocol concern. Downstream consumers
 embedding metadata in zstd streams should register their variants here
 to prevent collisions.
 
+<!-- The variant table below uses single leading pipes per
+GitHub Flavored Markdown. Render-checked on github.com — does not
+produce a spurious empty column. -->
+
 ## Allocated variants
 
 | Variant | Magic        | Consumer                    | Purpose                                                                       | Spec |

--- a/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
+++ b/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
@@ -1,10 +1,10 @@
 # Skippable Frame Magic Allocations
 
-RFC 8878 reserves 16 magic numbers (`0x184D2A50..0x184D2A5F`) for "skippable
-frames" — opaque user-defined payloads that compliant zstd decoders skip
-past. The `structured-zstd` crate provides a typed `SkippableFrame` API
-(`zstd::skippable` module) for emitting and parsing these but **does not
-allocate any variant**.
+RFC 8878 reserves 16 magic numbers (`0x184D2A50..=0x184D2A5F`) for
+"skippable frames" — opaque user-defined payloads that compliant zstd
+decoders skip past. The `structured-zstd` crate provides a typed
+`SkippableFrame` API (`structured_zstd::skippable` module) for emitting
+and parsing these but **does not allocate any variant**.
 
 > **Feature gate:** the typed `SkippableFrame` API and adjacent
 > storage-format extensions require enabling the `lsm` Cargo feature:
@@ -25,21 +25,23 @@ to prevent collisions.
 
 ## Allocated variants
 
-| Variant | Magic        | Consumer                    | Purpose                                        | Spec |
-|---------|--------------|-----------------------------|------------------------------------------------|------|
-| 0       | `0x184D2A50` | lsm-tree wire format v1     | MetadataFrame (AEAD header for encrypted blocks)| [LSM-T1](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
-| 1       | `0x184D2A51` | lsm-tree wire format v1     | BodyFrame (encrypted payload)                  | [LSM-T1](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
-| 2       | `0x184D2A52` | lsm-tree wire format v1     | EccFrame (reserved for future ECC layer)       | [LSM-T5](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
-| 3–15    | `0x184D2A53..5F` | reserved by lsm-tree v1 | future versions / extensions                   | — |
+| Variant | Magic        | Consumer                    | Purpose                                                                       | Spec |
+|---------|--------------|-----------------------------|-------------------------------------------------------------------------------|------|
+| 0       | `0x184D2A50` | lsm-tree wire format v1     | MetadataFrame (AEAD header for encrypted blocks); spec phase LSM-T1           | [lsm-tree #250](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 1       | `0x184D2A51` | lsm-tree wire format v1     | BodyFrame (encrypted payload); spec phase LSM-T1                              | [lsm-tree #250](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 2       | `0x184D2A52` | lsm-tree wire format v1     | EccFrame (reserved for future ECC layer); spec phase LSM-T5                   | [lsm-tree #250](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 3–15    | `0x184D2A53..=0x184D2A5F` | reserved by lsm-tree v1 | future versions / extensions                                                  | — |
+
+`LSM-Tn` identifiers are spec-phase tags inside the parent lsm-tree wire-format issue; all three active variants are described in the same parent spec.
 
 ## Allocation policy
 
 - A consumer wishing to use a previously-unallocated variant SHOULD file
   a PR against this table referencing the downstream wire-format spec.
 - Variants allocated to a consumer are reserved as a contiguous range
-  owned by that consumer (e.g. lsm-tree owns `0x50..5F` in v1); the
-  consumer may sub-allocate inside that range without coordinating with
-  `structured-zstd`.
+  owned by that consumer (e.g. lsm-tree owns `0x184D2A50..=0x184D2A5F`
+  in v1); the consumer may sub-allocate inside that range without
+  coordinating with `structured-zstd`.
 - If a consumer abandons or supersedes a variant allocation, file a PR
   to release it back to the unallocated pool.
 - `structured-zstd` is the registry steward but does not validate or

--- a/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
+++ b/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md
@@ -1,0 +1,46 @@
+# Skippable Frame Magic Allocations
+
+RFC 8878 reserves 16 magic numbers (`0x184D2A50..0x184D2A5F`) for "skippable
+frames" — opaque user-defined payloads that compliant zstd decoders skip
+past. The `structured-zstd` crate provides a typed `SkippableFrame` API
+(`zstd::skippable` module) for emitting and parsing these but **does not
+allocate any variant**.
+
+> **Feature gate:** the typed `SkippableFrame` API and adjacent
+> storage-format extensions require enabling the `lsm` Cargo feature:
+>
+> ```toml
+> [dependencies]
+> structured-zstd = { version = "0", features = ["lsm"] }
+> ```
+>
+> The C FFI `cdylib` build remains strict drop-in for donor `libzstd`
+> v1.5.7 regardless of which Rust features are enabled — magic-variant
+> allocations affect only Rust-side typed wrappers, not the cdylib
+> symbol surface.
+
+Allocations are an application-protocol concern. Downstream consumers
+embedding metadata in zstd streams should register their variants here
+to prevent collisions.
+
+## Allocated variants
+
+| Variant | Magic        | Consumer                    | Purpose                                        | Spec |
+|---------|--------------|-----------------------------|------------------------------------------------|------|
+| 0       | `0x184D2A50` | lsm-tree wire format v1     | MetadataFrame (AEAD header for encrypted blocks)| [LSM-T1](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 1       | `0x184D2A51` | lsm-tree wire format v1     | BodyFrame (encrypted payload)                  | [LSM-T1](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 2       | `0x184D2A52` | lsm-tree wire format v1     | EccFrame (reserved for future ECC layer)       | [LSM-T5](https://github.com/structured-world/coordinode-lsm-tree/issues/250) |
+| 3–15    | `0x184D2A53..5F` | reserved by lsm-tree v1 | future versions / extensions                   | — |
+
+## Allocation policy
+
+- A consumer wishing to use a previously-unallocated variant SHOULD file
+  a PR against this table referencing the downstream wire-format spec.
+- Variants allocated to a consumer are reserved as a contiguous range
+  owned by that consumer (e.g. lsm-tree owns `0x50..5F` in v1); the
+  consumer may sub-allocate inside that range without coordinating with
+  `structured-zstd`.
+- If a consumer abandons or supersedes a variant allocation, file a PR
+  to release it back to the unallocated pool.
+- `structured-zstd` is the registry steward but does not validate or
+  enforce semantics — that is the consumer's responsibility.

--- a/zstd/src/skippable.rs
+++ b/zstd/src/skippable.rs
@@ -39,6 +39,10 @@
 //! per-variant constants are baked into the source — applications are
 //! responsible for documenting which variants they claim and
 //! coordinating with other ecosystem consumers to avoid collisions.
+//!
+//! The ecosystem registry of known allocations and the policy for
+//! claiming new ones lives in
+//! [`docs/SKIPPABLE_MAGIC_ALLOCATIONS.md`](https://github.com/structured-world/structured-zstd/blob/main/docs/SKIPPABLE_MAGIC_ALLOCATIONS.md).
 
 extern crate alloc;
 


### PR DESCRIPTION
## Summary

Adds `docs/SKIPPABLE_MAGIC_ALLOCATIONS.md` — the ecosystem registry of
skippable-frame magic variants (RFC 8878 `0x184D2A50..0x184D2A5F`) and the
allocation policy for downstream consumers. The `structured-zstd` crate
accepts any `magic_variant: u8` in `0..=15` and does **not** bake variant
constants into the source; the registry file is the human-readable record
of who claimed what.

## Initial table

- Variants 0/1/2: lsm-tree wire format v1 (Metadata / Body / Ecc frames)
- Variants 3–15: reserved by lsm-tree v1 for future extensions

The 0x184D2A50..5F range is fully claimed by lsm-tree in v1 — the table
documents that reservation and the policy for releasing or sub-allocating
within it.

## Discoverability paths

- README has a one-line pointer in a new "Storage-format extensions"
  section linking to the registry file.
- `zstd::skippable` rustdoc cross-links to the registry file at the
  "Magic variant allocation policy" subsection.

Either entry point (browsing the repo OR reading rustdoc) finds the
registry.

## Feature gate

`structured-zstd` keeps the typed `SkippableFrame` API behind the `lsm`
Cargo feature (default off). The registry file documents this so
consumers know they need `cargo add structured-zstd --features lsm` to
use the typed wrappers. The C FFI `cdylib` symbol surface is unaffected
regardless of feature state.

## Test plan

- [x] \`cargo check -p structured-zstd\`: passes
- [x] \`cargo test --doc -p structured-zstd skippable\`: passes (doctest cross-link compiles)
- [x] No code changes — pure documentation

Closes #176.