### PR TITLE
feat(encoding+decoding): FrameEmitInfo + opt-in per-block XXH64 sidecar

### DIFF
--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -253,7 +253,12 @@ pub(crate) enum CpuKernelTag {
     Vbmi2,
     #[cfg(target_arch = "aarch64")]
     Neon,
-    #[cfg(target_arch = "aarch64")]
+    // Both constructors of `Sve` need a reachable feature: runtime
+    // detection via `std::arch::is_aarch64_feature_detected!` (so
+    // `feature = "std"`) or compile-time `target_feature = "sve"` in
+    // RUSTFLAGS. Without either, the variant is unreachable and a
+    // `match` arm referencing it warns as dead.
+    #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
     Sve,
 }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -122,6 +122,26 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.len()
     }
 
+    /// Return the last `n` bytes of the visible buffer as two
+    /// contiguous slices (`(s1, s2)` matching the wrap semantics of
+    /// the underlying backend). `n` must be `<= self.len()`. Used by
+    /// the per-block checksum path to hash bytes that were appended
+    /// during the most recent block decode without copying.
+    ///
+    /// Returns empty slices if `n == 0`.
+    #[cfg(feature = "lsm")]
+    pub(crate) fn last_n_as_slices(&self, n: usize) -> (&[u8], &[u8]) {
+        let (s1, s2) = self.buffer.as_slices();
+        let total = s1.len() + s2.len();
+        debug_assert!(n <= total);
+        let start = total - n;
+        if start >= s1.len() {
+            (&[][..], &s2[start - s1.len()..])
+        } else {
+            (&s1[start..], s2)
+        }
+    }
+
     /// Capture a rollback point covering the buffer's write cursor and the
     /// total-output counter. Pair with [`restore_checkpoint`] to undo
     /// speculative pushes/repeats made after the capture — used by the fused

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -129,7 +129,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// during the most recent block decode without copying.
     ///
     /// Returns empty slices if `n == 0`.
-    #[cfg(feature = "lsm")]
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     pub(crate) fn last_n_as_slices(&self, n: usize) -> (&[u8], &[u8]) {
         let (s1, s2) = self.buffer.as_slices();
         let total = s1.len() + s2.len();

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -700,6 +700,12 @@ impl FrameDecoder {
         dict: &DictionaryHandle,
     ) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        // Fresh frame → drop the previous frame's per-block checksum
+        // digests so the next decode starts with an empty vec.
+        // Mirrors the same clear in `reset()`; reset_with_dict_handle
+        // is a parallel entry point so it needs its own call.
+        #[cfg(all(feature = "lsm", feature = "hash"))]
+        self.computed_block_checksums.clear();
         Self::validate_registered_dictionary(dict.as_dict())?;
         let magicless = self.magicless;
         // Scope the &mut borrow of `self.state` to the header parse
@@ -1263,8 +1269,20 @@ impl FrameDecoder {
             let fcs_declared = state_ref.frame_header.fcs_declared();
             let dict_active = state_ref.using_dict.is_some();
             let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
+            // Per-block checksum collection lives in `decode_blocks`;
+            // the direct decode fast path writes through
+            // `UserSliceBackend` directly and never enters that loop.
+            // Force the legacy drain path when the caller has opted in
+            // to per-block checksums so the digests vector stays
+            // consistent regardless of output-slice slack.
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            let per_block_checksums_on = self.per_block_checksums_enabled;
+            #[cfg(not(all(feature = "lsm", feature = "hash")))]
+            let per_block_checksums_on = false;
+            let direct_eligible = content_size > 0
+                && !dict_active
+                && (output.len() as u64) >= needed
+                && !per_block_checksums_on;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -904,7 +904,11 @@ impl FrameDecoder {
             );
 
             #[cfg(all(feature = "lsm", feature = "hash"))]
-            let len_before_block = state.decoder_scratch.buffer_len();
+            let len_before_block: Option<usize> = if self.per_block_checksums_enabled {
+                Some(state.decoder_scratch.buffer_len())
+            } else {
+                None
+            };
             let bytes_read_in_block_body = state
                 .decoder_scratch
                 .decode_block_content(&mut block_dec, &block_header, &mut source)
@@ -913,9 +917,9 @@ impl FrameDecoder {
 
             // Per-block XXH64 (low 32 bits) of the just-decompressed
             // bytes. Hashed from `last_n_as_slices` so RingBuffer wrap
-            // is handled in-place — no extra copy.
+            // is handled in-place, no extra copy.
             #[cfg(all(feature = "lsm", feature = "hash"))]
-            if self.per_block_checksums_enabled {
+            if let Some(len_before_block) = len_before_block {
                 let added = state.decoder_scratch.buffer_len() - len_before_block;
                 let (s1, s2) = state.decoder_scratch.last_n_as_slices(added);
                 let mut h = twox_hash::XxHash64::with_seed(0);
@@ -1590,11 +1594,18 @@ impl FrameDecoder {
         // `self.computed_block_checksums`, so the digests vector
         // stays consistent with the legacy `decode_blocks` path
         // regardless of which dispatch the frame took.
+        // `Vec::new()` does not allocate, so this stays free when
+        // `per_block_checksums_enabled` is false: the `push` and the
+        // post-loop hashing loop are both gated by the same flag.
         #[cfg(all(feature = "lsm", feature = "hash"))]
         let mut block_ranges: alloc::vec::Vec<(usize, usize)> = alloc::vec::Vec::new();
         loop {
             #[cfg(all(feature = "lsm", feature = "hash"))]
-            let produced_before = produced as usize;
+            let produced_before: Option<usize> = if self.per_block_checksums_enabled {
+                Some(produced as usize)
+            } else {
+                None
+            };
             let (block_header, hsize) = block_dec
                 .read_block_header(&mut *input)
                 .map_err(err::FailedToReadBlockHeader)?;
@@ -1654,7 +1665,7 @@ impl FrameDecoder {
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
             #[cfg(all(feature = "lsm", feature = "hash"))]
-            if self.per_block_checksums_enabled {
+            if let Some(produced_before) = produced_before {
                 block_ranges.push((produced_before, produced as usize));
             }
             // Cap the visible buffer at window_size between blocks

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1269,20 +1269,15 @@ impl FrameDecoder {
             let fcs_declared = state_ref.frame_header.fcs_declared();
             let dict_active = state_ref.using_dict.is_some();
             let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
-            // Per-block checksum collection lives in `decode_blocks`;
-            // the direct decode fast path writes through
-            // `UserSliceBackend` directly and never enters that loop.
-            // Force the legacy drain path when the caller has opted in
-            // to per-block checksums so the digests vector stays
-            // consistent regardless of output-slice slack.
-            #[cfg(all(feature = "lsm", feature = "hash"))]
-            let per_block_checksums_on = self.per_block_checksums_enabled;
-            #[cfg(not(all(feature = "lsm", feature = "hash")))]
-            let per_block_checksums_on = false;
-            let direct_eligible = content_size > 0
-                && !dict_active
-                && (output.len() as u64) >= needed
-                && !per_block_checksums_on;
+            // Per-block checksums collected inside `run_direct_decode`
+            // post-loop (over recorded (start, end) ranges of `output`)
+            // so the direct path stays eligible AND keeps the
+            // window-size cap (`drop_to_window_size`) between blocks
+            // that the spec relies on for `offset <= window_size`
+            // validation. Path choice no longer alters checksum
+            // semantics.
+            let direct_eligible =
+                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -1589,7 +1584,17 @@ impl FrameDecoder {
         // tracking would always count 0 for those blocks and
         // miscount frames that aren't pure Raw/RLE.
         let mut produced: u64 = 0;
+        // Per-block output ranges captured during the direct-path
+        // loop. After the loop we re-borrow `output` (post-drop of
+        // `direct`) and XXH64 each range into
+        // `self.computed_block_checksums`, so the digests vector
+        // stays consistent with the legacy `decode_blocks` path
+        // regardless of which dispatch the frame took.
+        #[cfg(all(feature = "lsm", feature = "hash"))]
+        let mut block_ranges: alloc::vec::Vec<(usize, usize)> = alloc::vec::Vec::new();
         loop {
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            let produced_before = produced as usize;
             let (block_header, hsize) = block_dec
                 .read_block_header(&mut *input)
                 .map_err(err::FailedToReadBlockHeader)?;
@@ -1648,6 +1653,10 @@ impl FrameDecoder {
             }
             state.bytes_read_counter += body_consumed;
             state.block_counter += 1;
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            if self.per_block_checksums_enabled {
+                block_ranges.push((produced_before, produced as usize));
+            }
             // Cap the visible buffer at window_size between blocks
             // so the next block's match-offset validation matches
             // the spec's `offset <= window_size` rule.
@@ -1678,6 +1687,21 @@ impl FrameDecoder {
         // borrow on `output`) so we can re-borrow `output` for the
         // hash pass below.
         drop(direct);
+        // Per-block XXH64 (low 32 bits) over the captured ranges.
+        // Mirrors `decode_blocks`' per-block hashing so the digests
+        // vector stays identical regardless of which dispatch path
+        // the frame took. Ranges were recorded inside the loop while
+        // `direct` held a mutable borrow on `output`; now that the
+        // borrow is dropped we can read the slices directly.
+        #[cfg(all(feature = "lsm", feature = "hash"))]
+        if self.per_block_checksums_enabled {
+            use core::hash::Hasher;
+            for (start, end) in &block_ranges {
+                let mut h = twox_hash::XxHash64::with_seed(0);
+                h.write(&output[*start..*end]);
+                self.computed_block_checksums.push(h.finish() as u32);
+            }
+        }
         #[cfg(feature = "hash")]
         {
             // Direct path bypasses the per-write hash accounting

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -2571,11 +2571,12 @@ mod tests {
     #[test]
     fn per_block_checksum_round_trip() {
         // Encode with per-block checksums enabled. Decode with
-        // per-block verification. Encoder produces 1 checksum per
-        // input chunk; decoder produces 1 checksum per physical
-        // block. For levels without post-split (Default = L3, no
-        // multi-physical-block path) the two should match
-        // element-wise.
+        // per-block verification. Both sides emit exactly 1
+        // checksum per physical block written to / read from the
+        // wire (encoder hashes per emission site, including each
+        // post-split partition; decoder hashes each decoded block).
+        // Cardinality and element-wise contents must match
+        // round-trip.
         let payload: Vec<u8> = (0..200_000u32).map(|i| (i & 0xFF) as u8).collect();
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
         compressor.set_source(payload.as_slice());

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -103,6 +103,17 @@ pub struct FrameDecoder {
     /// with `found: None`.
     #[cfg(feature = "lsm")]
     expect_window_descriptor: Option<u8>,
+    /// When `true`, the per-block decode loop XXH64-hashes each
+    /// block's decompressed bytes and stores the low-32-bit digest in
+    /// [`Self::computed_block_checksums`]. Default `false` (zero
+    /// cost). Set via [`Self::enable_per_block_checksums`].
+    #[cfg(feature = "lsm")]
+    per_block_checksums_enabled: bool,
+    /// Per-block XXH64 (low 32 bits) digests captured during the
+    /// current frame's decode when `per_block_checksums_enabled` is
+    /// set. Reset at the start of every new frame.
+    #[cfg(feature = "lsm")]
+    computed_block_checksums: alloc::vec::Vec<u32>,
 }
 
 /// Backend-tagged decode scratch — chosen at frame-reset time based
@@ -177,6 +188,16 @@ impl DecoderScratchKind {
         match self {
             Self::Ring(s) => s.buffer.len(),
             Self::Flat(s) => s.buffer.len(),
+        }
+    }
+
+    /// Last `n` bytes of the visible buffer as `(s1, s2)` (wrap-aware).
+    /// Routes through whichever backend the current scratch holds.
+    #[cfg(feature = "lsm")]
+    fn last_n_as_slices(&self, n: usize) -> (&[u8], &[u8]) {
+        match self {
+            Self::Ring(s) => s.buffer.last_n_as_slices(n),
+            Self::Flat(s) => s.buffer.last_n_as_slices(n),
         }
     }
 
@@ -370,7 +391,38 @@ impl FrameDecoder {
             expect_dict_id: None,
             #[cfg(feature = "lsm")]
             expect_window_descriptor: None,
+            #[cfg(feature = "lsm")]
+            per_block_checksums_enabled: false,
+            #[cfg(feature = "lsm")]
+            computed_block_checksums: alloc::vec::Vec::new(),
         }
+    }
+
+    /// Opt in to per-block XXH64 verification during decode.
+    /// Default off; zero cost when disabled. Each block's decompressed
+    /// bytes are XXH64-hashed (low 32 bits) and appended to
+    /// [`Self::computed_block_checksums`] as the decode progresses.
+    /// Callers compare the captured digests against externally-stored
+    /// expected values (e.g. from a per-block sidecar in the
+    /// containing application protocol).
+    ///
+    /// Behind the `lsm` Cargo feature.
+    #[cfg(feature = "lsm")]
+    pub fn enable_per_block_checksums(&mut self) {
+        self.per_block_checksums_enabled = true;
+    }
+
+    /// Per-block XXH64 (low 32 bits) digests captured during the
+    /// current frame's decode. Empty unless
+    /// [`Self::enable_per_block_checksums`] was called before
+    /// [`Self::decode_all`] / [`Self::reset`].
+    ///
+    /// Reset at the start of every new frame.
+    ///
+    /// Behind the `lsm` Cargo feature.
+    #[cfg(feature = "lsm")]
+    pub fn computed_block_checksums(&self) -> &[u32] {
+        &self.computed_block_checksums
     }
 
     /// Pin the expected `Dictionary_ID` for the next frame.
@@ -567,6 +619,11 @@ impl FrameDecoder {
     /// equivalent to init()
     pub fn reset(&mut self, source: impl Read) -> Result<(), FrameDecoderError> {
         use FrameDecoderError as err;
+        // Fresh frame → start with an empty per-block checksum vec so
+        // the values for the next frame don't carry over from the
+        // previous one.
+        #[cfg(feature = "lsm")]
+        self.computed_block_checksums.clear();
         let magicless = self.magicless;
         let dict_id = match &mut self.state {
             Some(s) => {
@@ -835,11 +892,27 @@ impl FrameDecoder {
                 block_header.decompressed_size
             );
 
+            #[cfg(feature = "lsm")]
+            let len_before_block = state.decoder_scratch.buffer_len();
             let bytes_read_in_block_body = state
                 .decoder_scratch
                 .decode_block_content(&mut block_dec, &block_header, &mut source)
                 .map_err(err::FailedToReadBlockBody)?;
             state.bytes_read_counter += bytes_read_in_block_body;
+
+            // Per-block XXH64 (low 32 bits) of the just-decompressed
+            // bytes. Hashed from `last_n_as_slices` so RingBuffer wrap
+            // is handled in-place — no extra copy.
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            if self.per_block_checksums_enabled {
+                let added = state.decoder_scratch.buffer_len() - len_before_block;
+                let (s1, s2) = state.decoder_scratch.last_n_as_slices(added);
+                let mut h = twox_hash::XxHash64::with_seed(0);
+                use core::hash::Hasher;
+                h.write(s1);
+                h.write(s2);
+                self.computed_block_checksums.push(h.finish() as u32);
+            }
 
             state.block_counter += 1;
 
@@ -2360,5 +2433,100 @@ mod tests {
             .expect("decode_all should succeed on skippable + zstd stream");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn frame_emit_info_describes_emitted_block_layout() {
+        // Encode a payload large enough to force >1 block, fetch
+        // FrameEmitInfo, walk blocks[] and verify each block's
+        // (offset_in_frame, header_size, body_size) matches the bytes
+        // actually emitted into the drain buffer.
+        let payload: Vec<u8> = (0..200_000u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let info = compressor
+            .last_frame_emit_info()
+            .expect("last_frame_emit_info populated after compress")
+            .clone();
+        drop(compressor);
+
+        // Frame header range starts at 0 and is non-empty.
+        assert_eq!(info.frame_header_range.start, 0);
+        assert!(info.frame_header_range.end > 0);
+        // Total size matches what was written to the drain.
+        assert_eq!(info.total_size as usize, compressed.len());
+        // At least one block, and the last entry has last_block=true.
+        assert!(!info.blocks.is_empty());
+        assert!(info.blocks.last().unwrap().last_block);
+        // All non-final blocks have last_block=false.
+        for b in &info.blocks[..info.blocks.len() - 1] {
+            assert!(!b.last_block);
+        }
+        // Walk and verify each block's header bytes match the
+        // recorded type / size by re-decoding the 3-byte header.
+        for b in &info.blocks {
+            let off = b.offset_in_frame as usize;
+            assert_eq!(b.header_size, 3);
+            let mut hdr = [0u8; 4];
+            hdr[..3].copy_from_slice(&compressed[off..off + 3]);
+            let raw = u32::from_le_bytes(hdr);
+            let last = (raw & 1) != 0;
+            let ty = (raw >> 1) & 0b11;
+            let sz = raw >> 3;
+            assert_eq!(last, b.last_block);
+            assert_eq!(sz, b.body_size);
+            let expected_ty = match b.block_type {
+                crate::encoding::frame_emit_info::BlockType::Raw => 0,
+                crate::encoding::frame_emit_info::BlockType::RLE => 1,
+                crate::encoding::frame_emit_info::BlockType::Compressed => 2,
+                crate::encoding::frame_emit_info::BlockType::Reserved => 3,
+            };
+            assert_eq!(ty, expected_ty);
+        }
+        // Checksum range present iff `feature = "hash"` is enabled.
+        assert_eq!(info.checksum_range.is_some(), cfg!(feature = "hash"));
+    }
+
+    #[cfg(all(feature = "lsm", feature = "hash"))]
+    #[test]
+    fn per_block_checksum_round_trip() {
+        // Encode with per-block checksums enabled. Decode with
+        // per-block verification. Encoder produces 1 checksum per
+        // input chunk; decoder produces 1 checksum per physical
+        // block. For levels without post-split (Default = L3, no
+        // multi-physical-block path) the two should match
+        // element-wise.
+        let payload: Vec<u8> = (0..200_000u32).map(|i| (i & 0xFF) as u8).collect();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        compressor.enable_per_block_checksums();
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let encoder_checksums = compressor
+            .last_frame_block_checksums()
+            .expect("checksums populated after enable + compress")
+            .to_vec();
+        drop(compressor);
+        assert!(!encoder_checksums.is_empty());
+
+        // Decode side: enable verification, decode, compare.
+        let mut decoder = FrameDecoder::new();
+        decoder.enable_per_block_checksums();
+        let mut output = alloc::vec![0u8; payload.len()];
+        let n = decoder
+            .decode_all(compressed.as_slice(), &mut output)
+            .expect("decode_all should succeed");
+        assert_eq!(n, payload.len());
+        assert_eq!(&output[..n], payload.as_slice());
+
+        let decoder_checksums = decoder.computed_block_checksums();
+        assert_eq!(decoder_checksums, encoder_checksums.as_slice());
     }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -106,13 +106,16 @@ pub struct FrameDecoder {
     /// When `true`, the per-block decode loop XXH64-hashes each
     /// block's decompressed bytes and stores the low-32-bit digest in
     /// [`Self::computed_block_checksums`]. Default `false` (zero
-    /// cost). Set via [`Self::enable_per_block_checksums`].
-    #[cfg(feature = "lsm")]
+    /// cost). Set via [`Self::enable_per_block_checksums`]. Gated on
+    /// `all(lsm, hash)` because XXH64 lives behind the `hash`
+    /// feature.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     per_block_checksums_enabled: bool,
     /// Per-block XXH64 (low 32 bits) digests captured during the
     /// current frame's decode when `per_block_checksums_enabled` is
-    /// set. Reset at the start of every new frame.
-    #[cfg(feature = "lsm")]
+    /// set. Reset at the start of every new frame. Gated on
+    /// `all(lsm, hash)` (see `per_block_checksums_enabled`).
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     computed_block_checksums: alloc::vec::Vec<u32>,
 }
 
@@ -193,7 +196,7 @@ impl DecoderScratchKind {
 
     /// Last `n` bytes of the visible buffer as `(s1, s2)` (wrap-aware).
     /// Routes through whichever backend the current scratch holds.
-    #[cfg(feature = "lsm")]
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     fn last_n_as_slices(&self, n: usize) -> (&[u8], &[u8]) {
         match self {
             Self::Ring(s) => s.buffer.last_n_as_slices(n),
@@ -391,9 +394,9 @@ impl FrameDecoder {
             expect_dict_id: None,
             #[cfg(feature = "lsm")]
             expect_window_descriptor: None,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             per_block_checksums_enabled: false,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             computed_block_checksums: alloc::vec::Vec::new(),
         }
     }
@@ -406,8 +409,10 @@ impl FrameDecoder {
     /// expected values (e.g. from a per-block sidecar in the
     /// containing application protocol).
     ///
-    /// Behind the `lsm` Cargo feature.
-    #[cfg(feature = "lsm")]
+    /// Behind `all(feature = "lsm", feature = "hash")` — the XXH64
+    /// primitive lives behind the `hash` feature, so this method
+    /// only compiles when both are enabled.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     pub fn enable_per_block_checksums(&mut self) {
         self.per_block_checksums_enabled = true;
     }
@@ -419,8 +424,8 @@ impl FrameDecoder {
     ///
     /// Reset at the start of every new frame.
     ///
-    /// Behind the `lsm` Cargo feature.
-    #[cfg(feature = "lsm")]
+    /// Behind `all(feature = "lsm", feature = "hash")`.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     pub fn computed_block_checksums(&self) -> &[u32] {
         &self.computed_block_checksums
     }
@@ -622,7 +627,7 @@ impl FrameDecoder {
         // Fresh frame → start with an empty per-block checksum vec so
         // the values for the next frame don't carry over from the
         // previous one.
-        #[cfg(feature = "lsm")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         self.computed_block_checksums.clear();
         let magicless = self.magicless;
         let dict_id = match &mut self.state {
@@ -892,7 +897,7 @@ impl FrameDecoder {
                 block_header.decompressed_size
             );
 
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             let len_before_block = state.decoder_scratch.buffer_len();
             let bytes_read_in_block_body = state
                 .decoder_scratch
@@ -2469,7 +2474,10 @@ mod tests {
         }
         // Walk and verify each block's header bytes match the
         // recorded type / size by re-decoding the 3-byte header.
-        for b in &info.blocks {
+        // Walking arithmetic: offset_in_frame + header_size + body_size
+        // must land exactly on the next block's offset_in_frame (or,
+        // for the last block, on the checksum / end of frame).
+        for (i, b) in info.blocks.iter().enumerate() {
             let off = b.offset_in_frame as usize;
             assert_eq!(b.header_size, 3);
             let mut hdr = [0u8; 4];
@@ -2479,7 +2487,14 @@ mod tests {
             let ty = (raw >> 1) & 0b11;
             let sz = raw >> 3;
             assert_eq!(last, b.last_block);
-            assert_eq!(sz, b.body_size);
+            assert_eq!(sz, b.block_size_field);
+            // body_size is the PHYSICAL length on the wire: spec's
+            // Block_Size for Raw/Compressed, always 1 for RLE.
+            let expected_physical = match b.block_type {
+                crate::encoding::frame_emit_info::BlockType::RLE => 1,
+                _ => sz,
+            };
+            assert_eq!(b.body_size, expected_physical);
             let expected_ty = match b.block_type {
                 crate::encoding::frame_emit_info::BlockType::Raw => 0,
                 crate::encoding::frame_emit_info::BlockType::RLE => 1,
@@ -2487,6 +2502,24 @@ mod tests {
                 crate::encoding::frame_emit_info::BlockType::Reserved => 3,
             };
             assert_eq!(ty, expected_ty);
+            // Walking-arithmetic invariant.
+            let next_off = b.offset_in_frame + b.header_size as u32 + b.body_size;
+            if let Some(next) = info.blocks.get(i + 1) {
+                assert_eq!(
+                    next_off, next.offset_in_frame,
+                    "block {i} body_size doesn't reach next block's offset_in_frame",
+                );
+            } else if let Some(cs) = info.checksum_range.as_ref() {
+                assert_eq!(
+                    next_off, cs.start,
+                    "last block body_size doesn't reach checksum_range.start",
+                );
+            } else {
+                assert_eq!(
+                    next_off, info.total_size,
+                    "last block body_size doesn't reach total_size",
+                );
+            }
         }
         // Checksum range present iff `feature = "hash"` is enabled.
         assert_eq!(info.checksum_range.is_some(), cfg!(feature = "hash"));

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1332,6 +1332,7 @@ impl FrameDecoder {
     /// the visitor (when `Some`) on the borrowed payload before
     /// advancing past it.
     #[cfg(feature = "lsm")]
+    #[allow(clippy::type_complexity)]
     fn decode_all_impl(
         &mut self,
         mut input: &[u8],

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -295,12 +295,12 @@ pub struct FSEScratch {
     /// resulting frame engages the pipelined prefetch decoder
     /// regardless of long-offset share, then clears the flag so
     /// subsequent blocks fall back to the `offsets_long_share`
-    /// heuristic. The sequence-count guard `num_sequences >= ADVANCE
-    /// * 2` still applies: blocks too small to fill the lookahead
-    /// pipeline take the short-block fallback in both the cold-dict
-    /// and warm cases. Without a dictionary the flag stays `false`
-    /// (cache state of the predefined / repeat tables is not
-    /// considered "cold" in the donor model).
+    /// heuristic. The `num_sequences >= ADVANCE * 2` guard still
+    /// applies: blocks too small to fill the lookahead pipeline take
+    /// the short-block fallback in both the cold-dict and warm cases.
+    /// Without a dictionary the flag stays `false` (cache state of the
+    /// predefined and repeat tables is not considered "cold" in the
+    /// donor model).
     pub ddict_is_cold: bool,
 }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -73,9 +73,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     literals_buffer: &[u8],
     rle_fallback_sequences: &mut Vec<Sequence>,
 ) -> Result<(), DecompressBlockError> {
-    use crate::cpu_kernel::{CpuKernelTag, ScalarKernel, detect_cpu_kernel};
     #[cfg(target_arch = "aarch64")]
-    use crate::cpu_kernel::{NeonKernel, SveKernel};
+    use crate::cpu_kernel::NeonKernel;
+    #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
+    use crate::cpu_kernel::SveKernel;
+    use crate::cpu_kernel::{CpuKernelTag, ScalarKernel, detect_cpu_kernel};
 
     match detect_cpu_kernel() {
         CpuKernelTag::Scalar => decode_and_execute_sequences_impl::<B, ScalarKernel>(
@@ -149,7 +151,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             literals_buffer,
             rle_fallback_sequences,
         ),
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
         CpuKernelTag::Sve => decode_and_execute_sequences_impl::<B, SveKernel>(
             section,
             source,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -255,6 +255,12 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     collect_block_parts(state, &mut scratch.parts);
     if scratch.parts.sequences.len() <= 4 {
         let source_len = state.matcher.get_last_space().len();
+        // `block_checksums: Option<&mut Vec<u32>>`; `as_deref_mut` unwraps
+        // exactly one level of `&mut`, yielding `Option<&mut Vec<u32>>` here
+        // (the blanket `impl<T: ?Sized> Deref for &mut T` has
+        // `Target = T`, so the deref chain does NOT cascade into
+        // `Vec<u32>::Target = [u32]`). Hence `sink: &mut Vec<u32>` and
+        // `Vec::push` is in scope.
         #[cfg(feature = "hash")]
         if let Some(sink) = block_checksums.as_deref_mut() {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -249,11 +249,20 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     state: &mut CompressState<M>,
     last_block: bool,
     output: &mut Vec<u8>,
+    mut block_checksums: Option<&mut Vec<u32>>,
 ) {
     let mut scratch = core::mem::take(&mut state.block_scratch);
     collect_block_parts(state, &mut scratch.parts);
     if scratch.parts.sequences.len() <= 4 {
         let source_len = state.matcher.get_last_space().len();
+        #[cfg(feature = "hash")]
+        if let Some(sink) = block_checksums.as_deref_mut() {
+            sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
+                state.matcher.get_last_space(),
+            ));
+        }
+        #[cfg(not(feature = "hash"))]
+        let _ = block_checksums.as_deref_mut();
         scratch.compressed.clear();
         let mut emit_buffers = SingleSequenceEmitBuffers {
             output,
@@ -321,6 +330,12 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         } else {
             chunk_lit_len + chunk_match_len
         };
+        #[cfg(feature = "hash")]
+        if let Some(sink) = block_checksums.as_deref_mut() {
+            sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
+                &state.matcher.get_last_space()[src_start..src_start + src_size],
+            ));
+        }
         let mut emit_buffers = SingleSequenceEmitBuffers {
             output,
             compressed: &mut scratch.compressed,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -249,7 +249,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     state: &mut CompressState<M>,
     last_block: bool,
     output: &mut Vec<u8>,
-    mut block_checksums: Option<&mut Vec<u32>>,
+    #[cfg(all(feature = "lsm", feature = "hash"))] mut block_checksums: Option<&mut Vec<u32>>,
 ) {
     let mut scratch = core::mem::take(&mut state.block_scratch);
     collect_block_parts(state, &mut scratch.parts);
@@ -261,14 +261,12 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         // `Target = T`, so the deref chain does NOT cascade into
         // `Vec<u32>::Target = [u32]`). Hence `sink: &mut Vec<u32>` and
         // `Vec::push` is in scope.
-        #[cfg(feature = "hash")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums.as_deref_mut() {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
                 state.matcher.get_last_space(),
             ));
         }
-        #[cfg(not(feature = "hash"))]
-        let _ = block_checksums.as_deref_mut();
         scratch.compressed.clear();
         let mut emit_buffers = SingleSequenceEmitBuffers {
             output,
@@ -336,7 +334,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         } else {
             chunk_lit_len + chunk_match_len
         };
-        #[cfg(feature = "hash")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums.as_deref_mut() {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
                 &state.matcher.get_last_space()[src_start..src_start + src_size],

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -375,8 +375,11 @@ fn donor_pre_split_level(level: CompressionLevel) -> Option<usize> {
 
 /// XXH64 (low 32 bits, seed 0) over `data`. Shared helper for the
 /// per-physical-block checksum sidecar so encoder and decoder hash
-/// the exact same byte ranges with the exact same parameters.
-#[cfg(feature = "hash")]
+/// the exact same byte ranges with the exact same parameters. Gated
+/// at `all(lsm, hash)` because the only consumer is the lsm-side
+/// `block_checksums` sidecar; non-lsm builds carry no reference to
+/// this helper at all.
+#[cfg(all(feature = "lsm", feature = "hash"))]
 #[inline]
 pub(crate) fn xxh64_block_low32(data: &[u8]) -> u32 {
     let mut h = XxHash64::with_seed(0);
@@ -833,17 +836,14 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | CompressionLevel::Level(_) => {
                     let before_len = all_blocks.len();
                     let block_len = uncompressed_data.len();
-                    #[cfg(all(feature = "lsm", feature = "hash"))]
-                    let checksum_sink = self.block_checksums.as_mut();
-                    #[cfg(not(all(feature = "lsm", feature = "hash")))]
-                    let checksum_sink: Option<&mut Vec<u32>> = None;
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
                         last_block,
                         uncompressed_data,
                         &mut all_blocks,
-                        checksum_sink,
+                        #[cfg(all(feature = "lsm", feature = "hash"))]
+                        self.block_checksums.as_mut(),
                     );
                     savings += block_len as i64 - (all_blocks.len() - before_len) as i64;
                 }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -52,6 +52,21 @@ pub struct FrameCompressor<R: Read, W: Write, M: Matcher> {
     magicless: bool,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
+    /// Block-layout introspection populated at the end of every
+    /// successful `compress()`. `None` until the first call.
+    /// Behind the `lsm` feature gate.
+    #[cfg(feature = "lsm")]
+    frame_emit_info: Option<crate::encoding::frame_emit_info::FrameEmitInfo>,
+    /// When `true`, `compress()` XXH64-hashes each block's
+    /// uncompressed bytes and appends the low-32-bit digest to
+    /// `block_checksums`. Default `false` (zero cost).
+    #[cfg(feature = "lsm")]
+    per_block_checksums_enabled: bool,
+    /// Per-block XXH64 (low 32 bits) digests captured during
+    /// `compress()` when `per_block_checksums_enabled` is set. Ordered
+    /// by block-emit order. `None` until the first call after enabling.
+    #[cfg(feature = "lsm")]
+    block_checksums: Option<alloc::vec::Vec<u32>>,
 }
 
 #[derive(Clone, Default)]
@@ -464,6 +479,12 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             magicless: false,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
+            #[cfg(feature = "lsm")]
+            frame_emit_info: None,
+            #[cfg(feature = "lsm")]
+            per_block_checksums_enabled: false,
+            #[cfg(feature = "lsm")]
+            block_checksums: None,
         }
     }
 }
@@ -491,6 +512,12 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             magicless: false,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
+            #[cfg(feature = "lsm")]
+            frame_emit_info: None,
+            #[cfg(feature = "lsm")]
+            per_block_checksums_enabled: false,
+            #[cfg(feature = "lsm")]
+            block_checksums: None,
         }
     }
 
@@ -542,6 +569,17 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// To avoid endlessly encoding from a potentially endless source (like a network socket) you can use the
     /// [Read::take] function
     pub fn compress(&mut self) {
+        // Reset per-frame introspection state so a re-used compressor
+        // doesn't carry over the previous frame's layout/checksums.
+        #[cfg(feature = "lsm")]
+        {
+            self.frame_emit_info = None;
+            if self.per_block_checksums_enabled {
+                self.block_checksums = Some(alloc::vec::Vec::new());
+            } else {
+                self.block_checksums = None;
+            }
+        }
         let initial_size_hint = self.source_size_hint;
         let source_size_hint_known = initial_size_hint.is_some();
         let use_dictionary_state =
@@ -733,6 +771,20 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // As we read, hash that data too
             #[cfg(feature = "hash")]
             self.hasher.write(&uncompressed_data);
+            // Per-input-chunk XXH64 (low 32 bits) for the optional
+            // per-block checksum sidecar. Chunk-level granularity
+            // matches the forensic-ECC use case (one digest per input
+            // chunk passed to the block emitter); see
+            // `enable_per_block_checksums` rustdoc for the post-split
+            // semantics. Hashed BEFORE the block-emit call below so
+            // we capture the input bytes regardless of which physical
+            // block type (Raw / RLE / Compressed) the emitter chooses.
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            if let Some(checksums) = self.block_checksums.as_mut() {
+                let mut h = XxHash64::with_seed(0);
+                h.write(&uncompressed_data);
+                checksums.push(h.finish() as u32);
+            }
             // Special handling is needed for compression of a totally empty file
             if uncompressed_data.is_empty() {
                 let header = BlockHeader {
@@ -819,6 +871,109 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 .write_all(&(content_checksum as u32).to_le_bytes())
                 .unwrap();
         }
+
+        // FrameEmitInfo population (lsm feature): walk all_blocks to
+        // recover per-block layout. Each Block_Header is 3 bytes LE
+        // packing `(block_size << 3) | (block_type << 1) | last_block`.
+        // Physical body size differs by type: RLE bodies are always 1
+        // byte (the repeated byte), Raw/Compressed bodies span
+        // `block_size` bytes.
+        #[cfg(feature = "lsm")]
+        {
+            use crate::blocks::block::BlockType as BT;
+            use crate::encoding::frame_emit_info::{FrameBlock, FrameEmitInfo};
+            let frame_header_len = header_buf.len() as u32;
+            let mut blocks: Vec<FrameBlock> = Vec::new();
+            let mut cursor: usize = 0;
+            while cursor + 3 <= all_blocks.len() {
+                let mut header_u32 = [0u8; 4];
+                header_u32[..3].copy_from_slice(&all_blocks[cursor..cursor + 3]);
+                let raw = u32::from_le_bytes(header_u32);
+                let last_block = (raw & 1) != 0;
+                let block_type = match (raw >> 1) & 0b11 {
+                    0 => BT::Raw,
+                    1 => BT::RLE,
+                    2 => BT::Compressed,
+                    _ => BT::Reserved,
+                };
+                let logical_size = raw >> 3;
+                let physical_body = match block_type {
+                    BT::RLE => 1,
+                    _ => logical_size as usize,
+                };
+                blocks.push(FrameBlock {
+                    offset_in_frame: frame_header_len + cursor as u32,
+                    header_size: 3,
+                    body_size: logical_size,
+                    block_type,
+                    last_block,
+                });
+                cursor += 3 + physical_body;
+                if last_block {
+                    break;
+                }
+            }
+            let checksum_range = if cfg!(feature = "hash") {
+                let cs_start = frame_header_len + all_blocks.len() as u32;
+                Some(cs_start..cs_start + 4)
+            } else {
+                None
+            };
+            let total_size = frame_header_len
+                + all_blocks.len() as u32
+                + if checksum_range.is_some() { 4 } else { 0 };
+            self.frame_emit_info = Some(FrameEmitInfo {
+                frame_header_range: 0..frame_header_len,
+                blocks,
+                checksum_range,
+                total_size,
+            });
+        }
+    }
+
+    /// Layout of the most recently emitted frame.
+    ///
+    /// Returns `None` if [`compress`](Self::compress) has not been
+    /// called yet on this compressor. After a successful `compress()`
+    /// the returned `FrameEmitInfo` describes the frame header range,
+    /// every emitted block's offset / size / type, and the optional
+    /// trailing content-checksum range — all in frame-absolute byte
+    /// offsets matching the bytes written to the drain.
+    ///
+    /// Behind the `lsm` Cargo feature.
+    #[cfg(feature = "lsm")]
+    pub fn last_frame_emit_info(&self) -> Option<&crate::encoding::frame_emit_info::FrameEmitInfo> {
+        self.frame_emit_info.as_ref()
+    }
+
+    /// Opt in to per-block XXH64 checksum computation during
+    /// [`compress`](Self::compress). Default off; zero cost when
+    /// disabled. The captured digests are accessible via
+    /// [`last_frame_block_checksums`](Self::last_frame_block_checksums).
+    ///
+    /// One checksum is emitted per input chunk passed to the block
+    /// emitter; on the post-split optimization path (Level 16-22 with
+    /// large window) a single input chunk can produce multiple
+    /// physical FrameBlocks and the checksums vector will have fewer
+    /// entries than `FrameEmitInfo.blocks`. The chunk-level
+    /// granularity matches the forensic-ECC use case (hash the
+    /// recovered plaintext chunk, compare to the stored digest).
+    ///
+    /// Behind the `lsm` Cargo feature.
+    #[cfg(feature = "lsm")]
+    pub fn enable_per_block_checksums(&mut self) {
+        self.per_block_checksums_enabled = true;
+    }
+
+    /// Per-block XXH64 (low 32 bits) digests captured during the most
+    /// recent `compress()` call. `None` unless
+    /// [`enable_per_block_checksums`](Self::enable_per_block_checksums)
+    /// was called before `compress()`.
+    ///
+    /// Behind the `lsm` Cargo feature.
+    #[cfg(feature = "lsm")]
+    pub fn last_frame_block_checksums(&self) -> Option<&[u32]> {
+        self.block_checksums.as_deref()
     }
 
     /// Get a mutable reference to the source

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -888,7 +888,25 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         {
             use crate::blocks::block::BlockType as BT;
             use crate::encoding::frame_emit_info::{FrameBlock, FrameEmitInfo};
-            let frame_header_len = header_buf.len() as u32;
+            // All frame-offset arithmetic below is bounded by u32 on
+            // the wire (Block_Size is a 21-bit field, frames bounded
+            // by MAX_BLOCK_SIZE * #blocks). A pathologically large
+            // frame whose total emitted size exceeds u32::MAX would
+            // overflow the cast — bail out by leaving
+            // `frame_emit_info` at `None` rather than handing the
+            // caller a silently-truncated layout. Checked once for
+            // header / all_blocks / cursor up front + once per push;
+            // the overflow path is statically unreachable on every
+            // realistic frame so the predictor amortises the branch
+            // to zero cost on the hot path.
+            let frame_header_len: u32 = match u32::try_from(header_buf.len()) {
+                Ok(v) => v,
+                Err(_) => return,
+            };
+            let all_blocks_len_u32: u32 = match u32::try_from(all_blocks.len()) {
+                Ok(v) => v,
+                Err(_) => return,
+            };
             let mut blocks: Vec<FrameBlock> = Vec::new();
             let mut cursor: usize = 0;
             while cursor + 3 <= all_blocks.len() {
@@ -915,8 +933,16 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     BT::RLE => 1,
                     _ => block_size_field,
                 };
+                let cursor_u32: u32 = match u32::try_from(cursor) {
+                    Ok(v) => v,
+                    Err(_) => return,
+                };
+                let offset_in_frame = match frame_header_len.checked_add(cursor_u32) {
+                    Some(v) => v,
+                    None => return,
+                };
                 blocks.push(FrameBlock {
-                    offset_in_frame: frame_header_len + cursor as u32,
+                    offset_in_frame,
                     header_size: 3,
                     body_size: physical_body,
                     block_size_field,
@@ -929,14 +955,30 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 }
             }
             let checksum_range = if cfg!(feature = "hash") {
-                let cs_start = frame_header_len + all_blocks.len() as u32;
-                Some(cs_start..cs_start + 4)
+                let cs_start = match frame_header_len.checked_add(all_blocks_len_u32) {
+                    Some(v) => v,
+                    None => return,
+                };
+                let cs_end = match cs_start.checked_add(4) {
+                    Some(v) => v,
+                    None => return,
+                };
+                Some(cs_start..cs_end)
             } else {
                 None
             };
-            let total_size = frame_header_len
-                + all_blocks.len() as u32
-                + if checksum_range.is_some() { 4 } else { 0 };
+            let body_total = match frame_header_len.checked_add(all_blocks_len_u32) {
+                Some(v) => v,
+                None => return,
+            };
+            let total_size = if checksum_range.is_some() {
+                match body_total.checked_add(4) {
+                    Some(v) => v,
+                    None => return,
+                }
+            } else {
+                body_total
+            };
             self.frame_emit_info = Some(FrameEmitInfo {
                 frame_header_range: 0..frame_header_len,
                 blocks,

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -59,13 +59,16 @@ pub struct FrameCompressor<R: Read, W: Write, M: Matcher> {
     frame_emit_info: Option<crate::encoding::frame_emit_info::FrameEmitInfo>,
     /// When `true`, `compress()` XXH64-hashes each block's
     /// uncompressed bytes and appends the low-32-bit digest to
-    /// `block_checksums`. Default `false` (zero cost).
-    #[cfg(feature = "lsm")]
+    /// `block_checksums`. Default `false` (zero cost). Gated on
+    /// `all(lsm, hash)` because XXH64 lives behind the `hash`
+    /// feature; an `lsm`-only build has no way to compute digests.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     per_block_checksums_enabled: bool,
     /// Per-block XXH64 (low 32 bits) digests captured during
     /// `compress()` when `per_block_checksums_enabled` is set. Ordered
     /// by block-emit order. `None` until the first call after enabling.
-    #[cfg(feature = "lsm")]
+    /// Gated on `all(lsm, hash)` (see `per_block_checksums_enabled`).
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     block_checksums: Option<alloc::vec::Vec<u32>>,
 }
 
@@ -481,9 +484,9 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
             frame_emit_info: None,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             per_block_checksums_enabled: false,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             block_checksums: None,
         }
     }
@@ -514,9 +517,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
             frame_emit_info: None,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             per_block_checksums_enabled: false,
-            #[cfg(feature = "lsm")]
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             block_checksums: None,
         }
     }
@@ -574,6 +577,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         #[cfg(feature = "lsm")]
         {
             self.frame_emit_info = None;
+        }
+        #[cfg(all(feature = "lsm", feature = "hash"))]
+        {
             if self.per_block_checksums_enabled {
                 self.block_checksums = Some(alloc::vec::Vec::new());
             } else {
@@ -896,19 +902,28 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     2 => BT::Compressed,
                     _ => BT::Reserved,
                 };
-                let logical_size = raw >> 3;
-                let physical_body = match block_type {
+                let block_size_field = raw >> 3;
+                // RLE bodies are always 1 byte physical on the wire
+                // (the single repeated byte); the spec's Block_Size
+                // field carries the logical repeat count. Raw and
+                // Compressed bodies physically span block_size_field
+                // bytes. Store the physical length in body_size so the
+                // 'offset + header + body_size' arithmetic always
+                // lands on the next block boundary, and surface the
+                // raw spec field separately as block_size_field.
+                let physical_body: u32 = match block_type {
                     BT::RLE => 1,
-                    _ => logical_size as usize,
+                    _ => block_size_field,
                 };
                 blocks.push(FrameBlock {
                     offset_in_frame: frame_header_len + cursor as u32,
                     header_size: 3,
-                    body_size: logical_size,
+                    body_size: physical_body,
+                    block_size_field,
                     block_type,
                     last_block,
                 });
-                cursor += 3 + physical_body;
+                cursor += 3 + physical_body as usize;
                 if last_block {
                     break;
                 }
@@ -959,8 +974,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// granularity matches the forensic-ECC use case (hash the
     /// recovered plaintext chunk, compare to the stored digest).
     ///
-    /// Behind the `lsm` Cargo feature.
-    #[cfg(feature = "lsm")]
+    /// Behind `all(feature = "lsm", feature = "hash")` — the XXH64
+    /// primitive lives behind the `hash` feature, so this method only
+    /// compiles when both are enabled.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     pub fn enable_per_block_checksums(&mut self) {
         self.per_block_checksums_enabled = true;
     }
@@ -970,8 +987,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// [`enable_per_block_checksums`](Self::enable_per_block_checksums)
     /// was called before `compress()`.
     ///
-    /// Behind the `lsm` Cargo feature.
-    #[cfg(feature = "lsm")]
+    /// Behind `all(feature = "lsm", feature = "hash")`.
+    #[cfg(all(feature = "lsm", feature = "hash"))]
     pub fn last_frame_block_checksums(&self) -> Option<&[u32]> {
         self.block_checksums.as_deref()
     }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -380,6 +380,17 @@ fn donor_pre_split_level(level: CompressionLevel) -> Option<usize> {
 /// through. Caller is responsible for passing exactly
 /// `MAX_BLOCK_SIZE` bytes (per donor `ZSTD_splitBlock` contract —
 /// "@blockSize must be == 128 KB" in `zstd_preSplit.h`).
+/// XXH64 (low 32 bits, seed 0) over `data`. Shared helper for the
+/// per-physical-block checksum sidecar so encoder and decoder hash
+/// the exact same byte ranges with the exact same parameters.
+#[cfg(feature = "hash")]
+#[inline]
+pub(crate) fn xxh64_block_low32(data: &[u8]) -> u32 {
+    let mut h = XxHash64::with_seed(0);
+    h.write(data);
+    h.finish() as u32
+}
+
 #[cfg(feature = "bench_internals")]
 pub(crate) fn block_splitter_decision_for_bench(block: &[u8], split_level: usize) -> usize {
     assert_eq!(
@@ -777,20 +788,13 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // As we read, hash that data too
             #[cfg(feature = "hash")]
             self.hasher.write(&uncompressed_data);
-            // Per-input-chunk XXH64 (low 32 bits) for the optional
-            // per-block checksum sidecar. Chunk-level granularity
-            // matches the forensic-ECC use case (one digest per input
-            // chunk passed to the block emitter); see
-            // `enable_per_block_checksums` rustdoc for the post-split
-            // semantics. Hashed BEFORE the block-emit call below so
-            // we capture the input bytes regardless of which physical
-            // block type (Raw / RLE / Compressed) the emitter chooses.
-            #[cfg(all(feature = "lsm", feature = "hash"))]
-            if let Some(checksums) = self.block_checksums.as_mut() {
-                let mut h = XxHash64::with_seed(0);
-                h.write(&uncompressed_data);
-                checksums.push(h.finish() as u32);
-            }
+            // Per-physical-block XXH64 (low 32 bits) for the optional
+            // per-block checksum sidecar. Hashing happens INSIDE the
+            // block emitters (RLE / Raw fast-path / Compressed /
+            // post-split partitions), so the digests vector has
+            // exactly one entry per physical Block_Header written to
+            // `all_blocks` — 1:1 with `FrameEmitInfo.blocks`. See
+            // `enable_per_block_checksums` rustdoc.
             // Special handling is needed for compression of a totally empty file
             if uncompressed_data.is_empty() {
                 let header = BlockHeader {
@@ -799,6 +803,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     block_size: 0,
                 };
                 header.serialize(&mut all_blocks);
+                #[cfg(all(feature = "lsm", feature = "hash"))]
+                if let Some(checksums) = self.block_checksums.as_mut() {
+                    checksums.push(xxh64_block_low32(&[]));
+                }
                 break;
             }
 
@@ -810,6 +818,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                         block_size: uncompressed_data.len().try_into().unwrap(),
                     };
                     header.serialize(&mut all_blocks);
+                    #[cfg(all(feature = "lsm", feature = "hash"))]
+                    if let Some(checksums) = self.block_checksums.as_mut() {
+                        checksums.push(xxh64_block_low32(&uncompressed_data));
+                    }
                     all_blocks.extend_from_slice(&uncompressed_data);
                     savings +=
                         uncompressed_data.len() as i64 - (3 + uncompressed_data.len()) as i64;
@@ -821,12 +833,17 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | CompressionLevel::Level(_) => {
                     let before_len = all_blocks.len();
                     let block_len = uncompressed_data.len();
+                    #[cfg(all(feature = "lsm", feature = "hash"))]
+                    let checksum_sink = self.block_checksums.as_mut();
+                    #[cfg(not(all(feature = "lsm", feature = "hash")))]
+                    let checksum_sink: Option<&mut Vec<u32>> = None;
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
                         last_block,
                         uncompressed_data,
                         &mut all_blocks,
+                        checksum_sink,
                     );
                     savings += block_len as i64 - (all_blocks.len() - before_len) as i64;
                 }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -373,13 +373,6 @@ fn donor_pre_split_level(level: CompressionLevel) -> Option<usize> {
     }
 }
 
-/// Bench-only entry point for the donor-parity comparator test in
-/// `tests/block_splitter_donor_parity.rs`. Dispatches to the same
-/// `_from_borders` (split_level == 0) / `_by_chunks` (split_level ∈
-/// 1..=4) ports that `donor_optimal_block_size` itself routes
-/// through. Caller is responsible for passing exactly
-/// `MAX_BLOCK_SIZE` bytes (per donor `ZSTD_splitBlock` contract —
-/// "@blockSize must be == 128 KB" in `zstd_preSplit.h`).
 /// XXH64 (low 32 bits, seed 0) over `data`. Shared helper for the
 /// per-physical-block checksum sidecar so encoder and decoder hash
 /// the exact same byte ranges with the exact same parameters.
@@ -391,6 +384,13 @@ pub(crate) fn xxh64_block_low32(data: &[u8]) -> u32 {
     h.finish() as u32
 }
 
+/// Bench-only entry point for the donor-parity comparator test in
+/// `tests/block_splitter_donor_parity.rs`. Dispatches to the same
+/// `_from_borders` (split_level == 0) / `_by_chunks` (split_level ∈
+/// 1..=4) ports that `donor_optimal_block_size` itself routes
+/// through. Caller is responsible for passing exactly
+/// `MAX_BLOCK_SIZE` bytes (per donor `ZSTD_splitBlock` contract —
+/// "@blockSize must be == 128 KB" in `zstd_preSplit.h`).
 #[cfg(feature = "bench_internals")]
 pub(crate) fn block_splitter_decision_for_bench(block: &[u8], split_level: usize) -> usize {
     assert_eq!(
@@ -1025,13 +1025,15 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// disabled. The captured digests are accessible via
     /// [`last_frame_block_checksums`](Self::last_frame_block_checksums).
     ///
-    /// One checksum is emitted per input chunk passed to the block
-    /// emitter; on the post-split optimization path (Level 16-22 with
-    /// large window) a single input chunk can produce multiple
-    /// physical FrameBlocks and the checksums vector will have fewer
-    /// entries than `FrameEmitInfo.blocks`. The chunk-level
-    /// granularity matches the forensic-ECC use case (hash the
-    /// recovered plaintext chunk, compare to the stored digest).
+    /// One checksum is emitted per physical FrameBlock written to
+    /// the drain: 1:1 cardinality with
+    /// [`last_frame_emit_info`](Self::last_frame_emit_info)'s
+    /// `blocks` vector. On the post-split optimization path
+    /// (Level 16-22 with large window) the per-partition decompressed
+    /// range is hashed inside the partition loop so the digest count
+    /// still matches the emitted block count. The decoder collects
+    /// per-physical-block digests on the same granularity, so
+    /// element-wise equality holds round-trip.
     ///
     /// Behind `all(feature = "lsm", feature = "hash")` — the XXH64
     /// primitive lives behind the `hash` feature, so this method only

--- a/zstd/src/encoding/frame_emit_info.rs
+++ b/zstd/src/encoding/frame_emit_info.rs
@@ -1,0 +1,77 @@
+//! Structural metadata describing the layout of an emitted zstd frame.
+//!
+//! Surfaced via [`FrameCompressor::last_frame_emit_info`] (encode side)
+//! after every successful `compress()`. Lets storage-format consumers
+//! discover where each Block_Header / block body / optional content
+//! checksum lands in the byte buffer without re-parsing the frame
+//! themselves.
+//!
+//! Gated behind the `lsm` Cargo feature (default off) — the
+//! `FrameCompressor` field that stores this info, the methods that
+//! return it, and these public types only exist when the feature is
+//! enabled. Without `lsm` the C FFI surface stays strict drop-in for
+//! donor `libzstd` v1.5.7.
+//!
+//! [`FrameCompressor::last_frame_emit_info`]: super::FrameCompressor::last_frame_emit_info
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+pub use crate::blocks::block::BlockType;
+
+/// Layout of a single zstd block inside an emitted frame.
+///
+/// Offsets are absolute byte positions in the emitted-frame buffer:
+/// `offset_in_frame` points at the first byte of the 3-byte
+/// `Block_Header`, and the block body lives at
+/// `offset_in_frame + header_size .. offset_in_frame + header_size +
+/// body_size`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameBlock {
+    /// Byte offset of this block's `Block_Header` within the emitted
+    /// frame buffer (frame-absolute, includes the bytes consumed by
+    /// the frame header / magic / FCS that precede the first block).
+    pub offset_in_frame: u32,
+    /// Size of the `Block_Header` in bytes. Always `3` today; carried
+    /// as a field so the API stays forward-compatible with any future
+    /// spec extension that widens the header.
+    pub header_size: u8,
+    /// Length of this block's body in bytes (does NOT include
+    /// `header_size`). For Raw / Compressed blocks this is the
+    /// emitted bytes after the header; for RLE blocks this is `1`
+    /// (the repeated byte itself).
+    pub body_size: u32,
+    /// Whether the block is Raw, RLE, or Compressed per RFC 8878
+    /// §3.1.1.2.1 (`Block_Type`).
+    pub block_type: BlockType,
+    /// `true` only on the final block of the frame (matches the
+    /// `Last_Block` flag in `Block_Header`).
+    pub last_block: bool,
+}
+
+/// Complete layout of an emitted zstd frame.
+///
+/// Captures the byte positions of the frame header, every block, and
+/// the optional trailing content checksum. The ranges are `u32` byte
+/// offsets into the emitted buffer (`compressed_data` sink of
+/// [`FrameCompressor`]).
+///
+/// [`FrameCompressor`]: super::FrameCompressor
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameEmitInfo {
+    /// Byte range of the frame header (magic number + frame-header
+    /// fields). For magicless frames the magic is omitted but the
+    /// range still starts at offset 0.
+    pub frame_header_range: core::ops::Range<u32>,
+    /// One entry per emitted block, in stream order. The last entry
+    /// has `last_block = true`.
+    pub blocks: Vec<FrameBlock>,
+    /// Byte range of the trailing 4-byte content checksum (XXH64
+    /// truncated to low 32 bits). `None` if the frame was emitted
+    /// without `content_checksum`.
+    pub checksum_range: Option<core::ops::Range<u32>>,
+    /// Total emitted frame size in bytes (one past the last byte of
+    /// the frame).
+    pub total_size: u32,
+}

--- a/zstd/src/encoding/frame_emit_info.rs
+++ b/zstd/src/encoding/frame_emit_info.rs
@@ -26,7 +26,15 @@ pub use crate::blocks::block::BlockType;
 /// `offset_in_frame` points at the first byte of the 3-byte
 /// `Block_Header`, and the block body lives at
 /// `offset_in_frame + header_size .. offset_in_frame + header_size +
-/// body_size`.
+/// body_size`. The arithmetic
+/// `offset_in_frame + header_size as u32 + body_size`
+/// is the byte offset of the next block (or, on the last block, of
+/// the trailing checksum / end of frame).
+///
+/// For RLE blocks the `body_size` is `1` (the single repeated byte
+/// on the wire); the spec's `Block_Size` field carries the logical
+/// repeat count instead and is surfaced separately as
+/// [`block_size_field`](Self::block_size_field).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrameBlock {
     /// Byte offset of this block's `Block_Header` within the emitted
@@ -37,11 +45,21 @@ pub struct FrameBlock {
     /// as a field so the API stays forward-compatible with any future
     /// spec extension that widens the header.
     pub header_size: u8,
-    /// Length of this block's body in bytes (does NOT include
-    /// `header_size`). For Raw / Compressed blocks this is the
-    /// emitted bytes after the header; for RLE blocks this is `1`
-    /// (the repeated byte itself).
+    /// Physical length of this block's body in bytes on the wire (does
+    /// NOT include `header_size`). For Raw / Compressed blocks this is
+    /// the number of bytes after the header; for RLE blocks this is
+    /// always `1` (the repeated byte itself, while the spec's
+    /// `Block_Size` field encodes the logical repeat count — see
+    /// [`block_size_field`](Self::block_size_field)). The arithmetic
+    /// `offset_in_frame + header_size as u32 + body_size` always
+    /// lands on the next block boundary.
     pub body_size: u32,
+    /// Raw `Block_Size` value from the 3-byte `Block_Header`. For Raw
+    /// and Compressed blocks this equals `body_size`; for RLE blocks
+    /// it's the logical repeat count (how many bytes the single
+    /// physical body byte expands to during decode) and will differ
+    /// from `body_size` (which is `1`).
+    pub block_size_field: u32,
     /// Whether the block is Raw, RLE, or Compressed per RFC 8878
     /// §3.1.1.2.1 (`Block_Type`).
     pub block_type: BlockType,

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -226,6 +226,7 @@ mod tests {
             true,
             vec![0xAB; 1024],
             &mut output,
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );
         assert_eq!(emitted, BlockType::RLE);
@@ -268,6 +269,7 @@ mod tests {
             true,
             block.clone(),
             &mut output,
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );
         assert_eq!(emitted, BlockType::Raw);

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -35,20 +35,18 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     last_block: bool,
     uncompressed_data: Vec<u8>,
     output: &mut Vec<u8>,
-    block_checksums: Option<&mut Vec<u32>>,
+    #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = uncompressed_data.len() as u32;
     // First check to see if run length encoding can be used for the entire block
     if uncompressed_data.iter().all(|x| uncompressed_data[0].eq(x)) {
         let rle_byte = uncompressed_data[0];
-        #[cfg(feature = "hash")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
                 &uncompressed_data,
             ));
         }
-        #[cfg(not(feature = "hash"))]
-        let _ = block_checksums;
         state.matcher.commit_space(uncompressed_data);
         state.matcher.skip_matching_with_hint(Some(false));
         let header = BlockHeader {
@@ -65,14 +63,12 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         state.matcher.window_size(),
         &uncompressed_data,
     ) {
-        #[cfg(feature = "hash")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
                 &uncompressed_data,
             ));
         }
-        #[cfg(not(feature = "hash"))]
-        let _ = block_checksums;
         state.matcher.commit_space(uncompressed_data);
         state.matcher.skip_matching_with_hint(Some(true));
         let header = BlockHeader {
@@ -95,10 +91,13 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
             // into `output`; checksums (if requested) are pushed per physical
             // block from inside the partition loop so the cardinality matches
             // the decoder's per-block hash count exactly.
+            #[cfg(all(feature = "lsm", feature = "hash"))]
             compress_block_with_post_split(state, last_block, output, block_checksums);
+            #[cfg(not(all(feature = "lsm", feature = "hash")))]
+            compress_block_with_post_split(state, last_block, output);
             return BlockType::Compressed;
         }
-        #[cfg(feature = "hash")]
+        #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             // Pull the just-committed input back from the matcher so we can
             // hash the same bytes the decoder will see for this single block.
@@ -108,8 +107,8 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
                 &space[start..],
             ));
         }
-        #[cfg(not(feature = "hash"))]
-        let _ = (uncompressed_len, block_checksums);
+        #[cfg(not(all(feature = "lsm", feature = "hash")))]
+        let _ = uncompressed_len;
 
         // Keep rollback snapshots for the oversize fallback path below:
         // `compress_block` can mutate entropy/history state before we know

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -35,11 +35,20 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     last_block: bool,
     uncompressed_data: Vec<u8>,
     output: &mut Vec<u8>,
+    block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = uncompressed_data.len() as u32;
     // First check to see if run length encoding can be used for the entire block
     if uncompressed_data.iter().all(|x| uncompressed_data[0].eq(x)) {
         let rle_byte = uncompressed_data[0];
+        #[cfg(feature = "hash")]
+        if let Some(sink) = block_checksums {
+            sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
+                &uncompressed_data,
+            ));
+        }
+        #[cfg(not(feature = "hash"))]
+        let _ = block_checksums;
         state.matcher.commit_space(uncompressed_data);
         state.matcher.skip_matching_with_hint(Some(false));
         let header = BlockHeader {
@@ -56,6 +65,14 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         state.matcher.window_size(),
         &uncompressed_data,
     ) {
+        #[cfg(feature = "hash")]
+        if let Some(sink) = block_checksums {
+            sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
+                &uncompressed_data,
+            ));
+        }
+        #[cfg(not(feature = "hash"))]
+        let _ = block_checksums;
         state.matcher.commit_space(uncompressed_data);
         state.matcher.skip_matching_with_hint(Some(true));
         let header = BlockHeader {
@@ -69,16 +86,30 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     } else {
         // Compress as a standard compressed block
         let mut compressed = Vec::new();
+        let uncompressed_len = uncompressed_data.len();
         state.matcher.commit_space(uncompressed_data);
         if matches!(compression_level, CompressionLevel::Level(16..=22))
             && state.matcher.window_size() >= (1 << 17)
         {
             // This helper may emit multiple physical blocks (compressed or raw)
-            // into `output`; this function's return value remains a coarse
-            // "compressed-path selected" signal for caller accounting.
-            compress_block_with_post_split(state, last_block, output);
+            // into `output`; checksums (if requested) are pushed per physical
+            // block from inside the partition loop so the cardinality matches
+            // the decoder's per-block hash count exactly.
+            compress_block_with_post_split(state, last_block, output, block_checksums);
             return BlockType::Compressed;
         }
+        #[cfg(feature = "hash")]
+        if let Some(sink) = block_checksums {
+            // Pull the just-committed input back from the matcher so we can
+            // hash the same bytes the decoder will see for this single block.
+            let space = state.matcher.get_last_space();
+            let start = space.len() - uncompressed_len;
+            sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
+                &space[start..],
+            ));
+        }
+        #[cfg(not(feature = "hash"))]
+        let _ = (uncompressed_len, block_checksums);
 
         // Keep rollback snapshots for the oversize fallback path below:
         // `compress_block` can mutate entropy/history state before we know
@@ -196,6 +227,7 @@ mod tests {
             true,
             vec![0xAB; 1024],
             &mut output,
+            None,
         );
         assert_eq!(emitted, BlockType::RLE);
 
@@ -237,6 +269,7 @@ mod tests {
             true,
             block.clone(),
             &mut output,
+            None,
         );
         assert_eq!(emitted, BlockType::Raw);
 

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -81,11 +81,15 @@ pub(crate) mod simple;
 pub(crate) mod strategy;
 
 pub(crate) mod frame_compressor;
+#[cfg(feature = "lsm")]
+pub mod frame_emit_info;
 mod levels;
 #[cfg(feature = "bench_internals")]
 pub mod sequence_capture;
 mod streaming_encoder;
 pub use frame_compressor::FrameCompressor;
+#[cfg(feature = "lsm")]
+pub use frame_emit_info::{BlockType, FrameBlock, FrameEmitInfo};
 pub use match_generator::MatchGeneratorDriver;
 pub use streaming_encoder::StreamingEncoder;
 

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -428,6 +428,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         last_block,
                         block,
                         &mut encoded,
+                        #[cfg(all(feature = "lsm", feature = "hash"))]
                         None,
                     );
                     moved_into_matcher = true;

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -428,6 +428,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         last_block,
                         block,
                         &mut encoded,
+                        None,
                     );
                     moved_into_matcher = true;
                 }


### PR DESCRIPTION
## Summary

Adds structural visibility into emitted zstd frames + an opt-in per-block checksum stream for forensic / ECC layers in downstream storage formats. All new public surface gated behind the `lsm` Cargo feature (default off); the C FFI cdylib surface for Phase 6 is unaffected.

## Encoder

- New module `structured_zstd::encoding::frame_emit_info` with `FrameBlock` (offset_in_frame, header_size, body_size, block_type, last_block) and `FrameEmitInfo` (frame_header_range, blocks[], checksum_range, total_size). Re-exports `BlockType`.
- `FrameCompressor::last_frame_emit_info()` returns `Some(&info)` after a successful `compress()`; walks the just-emitted block stream by re-parsing Block_Header bytes so the surfaced layout matches the bytes actually written.
- `FrameCompressor::enable_per_block_checksums()` opts in to per-physical-block XXH64 (low 32 bits). Captured via `last_frame_block_checksums()`. One digest per physical FrameBlock written to the drain — cardinality 1:1 with `FrameEmitInfo.blocks[]` and element-wise equal to the decoder's per-block digests on round-trip. Post-split partitions (Level 16-22, large window) each get their own checksum from inside the partition loop.

## Decoder

- `FrameDecoder::enable_per_block_checksums()` opts in to per-block XXH64 collection. Captured via `computed_block_checksums()` on both the direct-decode path and the legacy fallback. The direct path records (start, end) ranges per block during the loop and hashes after `drop(direct)` so the digests vector stays consistent regardless of dispatch.

## Test plan

- 644/644 default tests pass
- 672/672 lsm tests pass
- `per_block_checksum_round_trip` (frame_decoder.rs) verifies cardinality + element-wise equality on a multi-block Default-level frame

Closes #173