### PR TITLE
perf(decoding): mirror donor ddictIsCold signal for pipelined dispatch

### DIFF
--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -153,6 +153,7 @@ impl<B: BufferBackend> DecoderScratch<B> {
                 match_lengths: AlignedFSETable::new(MAX_MATCH_LENGTH_CODE),
                 ml_rle: None,
                 offsets_long_share: 0,
+                ddict_is_cold: false,
             },
             buffer: DecodeBuffer::new(window_size),
             offset_hist: [1, 4, 8],
@@ -235,6 +236,13 @@ impl<B: BufferBackend> DecoderScratch<B> {
         self.buffer
             .dict_content
             .extend_from_slice(&dict.dict_content);
+        // Donor parity: `ZSTD_decompressBegin_usingDDict` sets
+        // `dctx->ddictIsCold = 1` so the first block of the frame
+        // engages the prefetch decoder regardless of long-offset
+        // share. We do the same here; the first
+        // `decode_and_execute_sequences` call consumes the flag and
+        // resets it to `false`.
+        self.fse.ddict_is_cold = true;
     }
 }
 
@@ -273,6 +281,16 @@ pub struct FSEScratch {
     /// The sequence-section pipeline gate reads this directly instead
     /// of re-walking `offsets.decode` per block.
     pub offsets_long_share: u32,
+    /// Mirrors donor `ZSTD_DCtx::ddictIsCold`. Set to `true` when a
+    /// dictionary is freshly attached (its FSE / HUF tables are not
+    /// yet in cache); the first sequence-section decode of the
+    /// resulting frame engages the pipelined prefetch decoder
+    /// unconditionally, then clears the flag so subsequent blocks
+    /// fall back to the `offsets_long_share` heuristic. Without
+    /// a dictionary the flag stays `false` (cache state of the
+    /// predefined / repeat tables is not considered "cold" in the
+    /// donor model).
+    pub ddict_is_cold: bool,
 }
 
 impl FSEScratch {
@@ -285,6 +303,7 @@ impl FSEScratch {
             match_lengths: AlignedFSETable::new(MAX_MATCH_LENGTH_CODE),
             ml_rle: None,
             offsets_long_share: 0,
+            ddict_is_cold: false,
         }
     }
 
@@ -340,5 +359,34 @@ impl Deref for AlignedFSETable {
 impl DerefMut for AlignedFSETable {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::decoding::dictionary::Dictionary;
+
+    #[test]
+    fn init_from_dict_marks_fse_ddict_is_cold() {
+        // Donor parity: `ZSTD_decompressBegin_usingDDict` sets
+        // `dctx->ddictIsCold = 1`. Mirror: `init_from_dict` must
+        // leave `fse.ddict_is_cold = true` so the first
+        // sequence-section decode of the frame engages the prefetch
+        // pipeline regardless of `offsets_long_share`.
+        extern crate std;
+        let dict_raw =
+            std::fs::read("./dict_tests/dictionary").expect("dictionary fixture should load");
+        let dict = Dictionary::decode_dict(&dict_raw).expect("dictionary should parse");
+        let mut scratch: DecoderScratch = DecoderScratch::new(1024);
+        assert!(
+            !scratch.fse.ddict_is_cold,
+            "fresh DecoderScratch must not advertise a cold dict"
+        );
+        scratch.init_from_dict(&dict);
+        assert!(
+            scratch.fse.ddict_is_cold,
+            "init_from_dict must set ddict_is_cold = true"
+        );
     }
 }

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -224,6 +224,14 @@ impl<B: BufferBackend> DecoderScratch<B> {
         // (or vice versa: skip the pipeline when the new frame
         // actually has long offsets).
         self.fse.offsets_long_share = 0;
+        // Pair the one-shot cold-dict flag with `reset`: a scratch
+        // reused from a dictionary-attached frame whose blocks never
+        // entered sequence decoding (raw-/RLE-only blocks, zero-seq
+        // compressed blocks) would otherwise carry the flag into the
+        // next frame and mis-apply the cold-dict gate there. Cleared
+        // alongside `offsets_long_share` so the no-dict path keeps
+        // the documented "no behaviour change" property.
+        self.fse.ddict_is_cold = false;
 
         self.huf.table.reset();
     }

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -293,11 +293,14 @@ pub struct FSEScratch {
     /// dictionary is freshly attached (its FSE / HUF tables are not
     /// yet in cache); the first sequence-section decode of the
     /// resulting frame engages the pipelined prefetch decoder
-    /// unconditionally, then clears the flag so subsequent blocks
-    /// fall back to the `offsets_long_share` heuristic. Without
-    /// a dictionary the flag stays `false` (cache state of the
-    /// predefined / repeat tables is not considered "cold" in the
-    /// donor model).
+    /// regardless of long-offset share, then clears the flag so
+    /// subsequent blocks fall back to the `offsets_long_share`
+    /// heuristic. The sequence-count guard `num_sequences >= ADVANCE
+    /// * 2` still applies: blocks too small to fill the lookahead
+    /// pipeline take the short-block fallback in both the cold-dict
+    /// and warm cases. Without a dictionary the flag stays `false`
+    /// (cache state of the predefined / repeat tables is not
+    /// considered "cold" in the donor model).
     pub ddict_is_cold: bool,
 }
 

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -401,14 +401,19 @@ fn decode_and_execute_sequences_impl<
     const MIN_LONG_OFFSET_SHARE: u32 = 7;
     #[cfg(not(target_pointer_width = "64"))]
     const MIN_LONG_OFFSET_SHARE: u32 = 20;
-    let use_long_pipeline =
-        num_sequences >= ADVANCE * 2 && fse.offsets_long_share >= MIN_LONG_OFFSET_SHARE;
-    // Donor also engages the prefetch decoder when the dictionary is
-    // cold or when the format-level `isLongOffset` flag is set. We
-    // don't track dictionary-coldness on this decode path and the
-    // 32-bit `isLongOffset` shortcut is irrelevant on the
-    // u32-indexed decoder, so the FSE-share signal carries the
-    // whole decision.
+    // Donor `ZSTD_decompressBlock_internal`: `usePrefetchDecoder` is
+    // initialised from `dctx->ddictIsCold` so the first block of a
+    // freshly-attached-dict frame engages the prefetch decoder
+    // unconditionally, then `ddictIsCold = 0` after the dispatch so
+    // subsequent blocks fall back to the `longOffsetShare` heuristic.
+    // We mirror the consume-once semantics here.
+    let ddict_is_cold = fse.ddict_is_cold;
+    fse.ddict_is_cold = false;
+    let use_long_pipeline = num_sequences >= ADVANCE * 2
+        && (ddict_is_cold || fse.offsets_long_share >= MIN_LONG_OFFSET_SHARE);
+    // The format-level `isLongOffset` shortcut from donor is
+    // irrelevant on our u32-indexed decoder, so on top of the
+    // long-offset share the cold-dict signal is the only other gate.
 
     if use_long_pipeline {
         // The pipelined branch must roll `offset_hist` back to

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -269,6 +269,18 @@ fn decode_and_execute_sequences_impl<
     // any external caller that inspects scratch.sequences after decode.
     rle_fallback_sequences.clear();
 
+    // Consume the one-shot `ddict_is_cold` flag at function entry,
+    // BEFORE any early returns (RLE-mode fallback below, padding-bit
+    // validation). Donor `ZSTD_decompressBlock_internal` clears
+    // `dctx->ddictIsCold = 0` unconditionally after the
+    // sequence-section dispatch decision; if the early-return paths
+    // left the flag set, a later block's gate would mis-apply the
+    // cold-dict signal that no longer holds (FSE/HUF tables are now
+    // warm regardless of whether the previous block decoded
+    // sequences or fell back to RLE).
+    let ddict_is_cold = fse.ddict_is_cold;
+    fse.ddict_is_cold = false;
+
     let bytes_read = maybe_update_fse_tables(section, source, fse)?;
     vprintln!("Updating tables used {} bytes", bytes_read);
 
@@ -406,9 +418,8 @@ fn decode_and_execute_sequences_impl<
     // freshly-attached-dict frame engages the prefetch decoder
     // unconditionally, then `ddictIsCold = 0` after the dispatch so
     // subsequent blocks fall back to the `longOffsetShare` heuristic.
-    // We mirror the consume-once semantics here.
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
+    // The consume-once read/clear happens at function entry above so
+    // RLE-mode early returns don't leak the flag to a later block.
     let use_long_pipeline = num_sequences >= ADVANCE * 2
         && (ddict_is_cold || fse.offsets_long_share >= MIN_LONG_OFFSET_SHARE);
     // The format-level `isLongOffset` shortcut from donor is

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -416,10 +416,16 @@ fn decode_and_execute_sequences_impl<
     // Donor `ZSTD_decompressBlock_internal`: `usePrefetchDecoder` is
     // initialised from `dctx->ddictIsCold` so the first block of a
     // freshly-attached-dict frame engages the prefetch decoder
-    // unconditionally, then `ddictIsCold = 0` after the dispatch so
-    // subsequent blocks fall back to the `longOffsetShare` heuristic.
-    // The consume-once read/clear happens at function entry above so
-    // RLE-mode early returns don't leak the flag to a later block.
+    // regardless of long-offset share, then `ddictIsCold = 0` after
+    // the dispatch so subsequent blocks fall back to the
+    // `longOffsetShare` heuristic. The consume-once read/clear
+    // happens at function entry above so RLE-mode early returns
+    // don't leak the flag to a later block. Note the sequence-count
+    // guard `num_sequences >= ADVANCE * 2` ALWAYS applies — blocks
+    // too small for the 8-deep lookahead pipeline still go through
+    // the short-block fallback in both cold-dict and warm cases;
+    // the cold flag only bypasses the long-offset-share threshold,
+    // not the sequence-count threshold.
     let use_long_pipeline = num_sequences >= ADVANCE * 2
         && (ddict_is_cold || fse.offsets_long_share >= MIN_LONG_OFFSET_SHARE);
     // The format-level `isLongOffset` shortcut from donor is


### PR DESCRIPTION
## Summary

Adds the missing donor-parity \`ddictIsCold\` signal to the seq-decoder dispatch gate. The first block of a freshly-attached-dict frame now engages the prefetch pipeline regardless of long-offset share, matching donor \`ZSTD_decompressBlock_internal\`.

- \`FSEScratch.ddict_is_cold: bool\` field, default false
- \`DecoderScratch::init_from_dict\` sets it true (donor \`ZSTD_decompressBegin_usingDDict\` parity)
- \`decode_and_execute_sequences_impl\` reads + clears + ORs into \`use_long_pipeline\` gate
- No-dict path unchanged (flag stays false, gate value identical to pre-PR)

## Bench results (i9-9900K, \`decode_dict_handle\` bench, vs origin/main baseline)

| Bench | time | change vs main | significance |
|---|---|---|---|
| \`decode/dict_handle/prepared_handle/512\` | 2.75 µs | \`-2.96%\` | p=0.60 (within noise) |
| \`decode/dict_handle/raw_dict_each_call/512\` | 19.62 µs | \`-2.26%\` | **p<0.05 (significant)** |

Both scenarios show improvement on the dict-attach-then-decode pattern. \`raw_dict_each_call\` reparses the dict every iter so the cold-block prefetch engages on every iter and the gain is statistically significant. \`prepared_handle\` reuses the parsed handle so cold-cache lifetime is dominated by L1 residency — improvement is in the noise band.

## Test plan

- Unit test: \`init_from_dict_marks_fse_ddict_is_cold\` (scratch.rs) verifies the flag is set by \`init_from_dict\` and unset on a fresh scratch.
- 645/645 default tests pass
- 671/671 lsm tests pass

Closes #273