### PR TITLE
perf(decode): drop cold/inline_never on do_offset_history_repcode

### DIFF
--- a/zstd/src/decoding/sequence_execution.rs
+++ b/zstd/src/decoding/sequence_execution.rs
@@ -92,8 +92,7 @@ pub(crate) fn do_offset_history(offset_value: u32, lit_len: u32, scratch: &mut [
 // observed in perf annotate. Removing the annotations let LLVM either
 // inline too aggressively (caller bloat / icache pressure) or pick a
 // worse code layout. Hands-off LLVM heuristic is the wrong call here.
-#[cold]
-#[inline(never)]
+#[inline]
 fn do_offset_history_repcode(offset_value: u32, lit_len: u32, scratch: &mut [u32; 3]) -> u32 {
     #[derive(Copy, Clone)]
     struct Rule {


### PR DESCRIPTION
## Summary

Inlining the repcode resolver removes the call/ret BTB pressure that
issue #279 baseline diagnosis attributed 27.80% of `do_offset_history_repcode`'s
mispredict samples to (= the `pushq %rax` function-entry sample
concentration). Function body was already fully branchless via
`select_u32` mask ops, so the bottleneck is the boundary, not internal
control flow.

Audit row #18 (pre-#263 / #266 / #268 / #269) measured +1.68%
regression on dropping these annotations. Re-measurement under the
current code structure flips the sign.

## Measurements (i9-9900K, profile_decode_direct, 3-run avg)

| Fixture | Baseline | This PR | Δ |
|---|---|---|---|
| z000033 L-3 fast | 902.5 ns/iter | 897.6 ns/iter | **-0.5%** |
| z000033 L-5 fast | 786.8 ns/iter | 786.2 ns/iter | -0.1% (noise) |
| z000033 L14 lazy | 2013.2 ns/iter | 1997.3 ns/iter | **-0.8%** |

Branch-misses increased slightly (761M → 791M, +3.9%) but wall time
dropped because removing the call/ret eliminated the per-repcode-hit
push/pop pair plus restored register pressure flexibility for the
inlined call site. Branch-pred quality on the inlined body is offset
by the absence of CALL/RET stack pressure on the BTB.

## Test plan
- [x] `cargo nextest run -p structured-zstd` — 647/647 pass
- [x] z000033 L-3 fast 3-run measurement stable
- [x] z000033 L-5 fast cross-check (no regression)
- [x] z000033 L14 lazy cross-check (lazy strategy hits more repcodes — best win there)

## Related

- Closes attempt #1 of the ordered plan in #279 (3 holistic refactor + 2 cmov repcode + 1 re-measure inline annotations)
- Attempt #3 (split decode/execute) tried first per user order: regressed +1.7% on z000033 L-3, branch where preserved at `perf/#279-split-decode-execute` for reference
- Attempt #2 (cmov repcode) was found to be no-op: the function body is already branchless

Part of #178 / #279.