### PR TITLE
perf(decode): drop inline_never on repcode resolver, keep cold attr

### DIFF
--- a/zstd/src/decoding/sequence_execution.rs
+++ b/zstd/src/decoding/sequence_execution.rs
@@ -84,16 +84,17 @@ pub(crate) fn do_offset_history(offset_value: u32, lit_len: u32, scratch: &mut [
     do_offset_history_repcode(offset_value, lit_len, scratch)
 }
 
-// Kept `#[cold]` + `#[inline(never)]` despite the helper firing at
-// ~2% of decode time on the i9 primary bench. An earlier experiment
-// dropping both annotations (audit row #18) regressed +1.68% — the
-// out-of-line placement plus branch-prediction bias for the common
-// non-repcode fallthrough are worth more than the saved push/pop
-// observed in perf annotate. Removing the annotations let LLVM either
-// inline too aggressively (caller bloat / icache pressure) or pick a
-// worse code layout. Hands-off LLVM heuristic is the wrong call here.
+// `#[cold]` keeps the body out of caller hot layout and biases icache
+// against pulling it unless hit. Earlier the helper was also
+// `#[inline(never)]`; round-1 findings on issue #279 (branch-mispredict
+// diagnostic) attributed 15.42% of decoder mispredicts to this function,
+// with 27.80% landing on the `pushq %rax` fn entry — call/ret BTB
+// pressure from the never-inlined boundary. Dropping `#[inline(never)]`
+// while keeping `#[cold]` lets LLVM inline at hot call sites where the
+// boundary cost outweighs body duplication; cold paths (low-entropy
+// blocks where the previous "drop both" variant regressed +15.9% on
+// L14) keep the out-of-line shape via the cold attribute.
 #[cold]
-#[inline(never)]
 fn do_offset_history_repcode(offset_value: u32, lit_len: u32, scratch: &mut [u32; 3]) -> u32 {
     #[derive(Copy, Clone)]
     struct Rule {


### PR DESCRIPTION
## Summary

Replace `#[cold] + #[inline(never)]` with `#[cold]` alone on
`do_offset_history_repcode`. LLVM's `#[cold]` heuristic chooses the
inline decision per call site: hot loops (z000033-style sequence
density) inline the body to eliminate the call/ret BTB pressure that
issue #279 diagnosed as 15.42% of decoder branch mispredicts (27.80%
on the `pushq %rax` fn entry); cold paths (low-entropy 1M with one
mega-match) keep the out-of-line shape, avoiding the +15.9% L14
regression that PR #280 hit when dropping both annotations.

## Measurements (i9-9900K, profile_decode_direct, 5000 iter / 5-run median where noted)

| Fixture | Level | Baseline | This PR | Δ |
|---|---|---|---|---|
| z000033 | L-3 fast | 927.3K ns | 900.5K ns | **-2.9%** ✓ |
| z000033 | L-14 lazy | 2063.3K ns | 2013.2K ns | **-2.4%** ✓ |
| low-entropy-1m | L-3 fast | 274.5K ns | 262.0K ns | **-4.5%** ✓ |
| low-entropy-1m | L-14 lazy | 250.3K mean | 253.1K mean | +1.1% (within noise — 5-run median identical at 249.1K) |
| high-entropy-1m | L-3 fast | 103.6K ns | 101.7K ns | **-1.8%** ✓ |
| high-entropy-1m | L-14 lazy | 104.9K ns | 103.4K ns | **-1.4%** ✓ |

Compared to PR #280 (dropped BOTH annotations, closed for +15.9% L14
regression on low-entropy-1m): retaining `#[cold]` recovered the
low-entropy regression to noise floor while preserving the z000033
and high-entropy wins.

## Test plan
- [x] `cargo nextest run -p structured-zstd` — 628 tests pass
- [x] Cross-corpus measured (z000033, low-entropy-1m, high-entropy-1m × L-3 fast + L-14 lazy)
- [x] 5-run repeat on regression-prone low-entropy-1m L14 confirms within-noise

## Related

- Issue #279 round 1 follow-up (escalation path from closed PR #280)
- Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal sequence decoding performance with compiler-level adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->