### PR TITLE
perf(decode): lazy ring-buffer allocation for direct-eligible frames

### DIFF
--- a/zstd/examples/alloc_audit_decode.rs
+++ b/zstd/examples/alloc_audit_decode.rs
@@ -1,0 +1,124 @@
+//! Decode-side allocation auditor with per-alloc trace. Atomic counters
+//! plus a fixed-size append-only log of (size, peak_after) pairs.
+//! Issue #279 allocator-pressure axis.
+//!
+//! Usage: alloc_audit_decode <compressed_blob> <decompressed_size>
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::env;
+use std::fs;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use structured_zstd::WILDCOPY_OVERLENGTH;
+use structured_zstd::decoding::FrameDecoder;
+
+struct AuditAllocator;
+
+static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
+static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+static ALLOC_COUNT: AtomicUsize = AtomicUsize::new(0);
+static TRACE_ENABLED: AtomicBool = AtomicBool::new(false);
+
+const TRACE_CAP: usize = 256;
+static TRACE_LEN: AtomicUsize = AtomicUsize::new(0);
+static TRACE_SIZES: [AtomicUsize; TRACE_CAP] = {
+    // Sad const-init: array of AtomicUsize with default value 0.
+    const ZERO: AtomicUsize = AtomicUsize::new(0);
+    [ZERO; TRACE_CAP]
+};
+static TRACE_PEAK_AFTER: [AtomicUsize; TRACE_CAP] = {
+    const ZERO: AtomicUsize = AtomicUsize::new(0);
+    [ZERO; TRACE_CAP]
+};
+
+unsafe impl GlobalAlloc for AuditAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            let size = layout.size();
+            let new_live = LIVE_BYTES.fetch_add(size, Ordering::Relaxed) + size;
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+            while new_live > peak {
+                match PEAK_BYTES.compare_exchange_weak(
+                    peak,
+                    new_live,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(actual) => peak = actual,
+                }
+            }
+            if TRACE_ENABLED.load(Ordering::Relaxed) {
+                let idx = TRACE_LEN.fetch_add(1, Ordering::Relaxed);
+                if idx < TRACE_CAP {
+                    TRACE_SIZES[idx].store(size, Ordering::Relaxed);
+                    TRACE_PEAK_AFTER[idx].store(new_live, Ordering::Relaxed);
+                }
+            }
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) };
+        LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
+    }
+}
+
+#[global_allocator]
+static GLOBAL: AuditAllocator = AuditAllocator;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let path = args
+        .get(1)
+        .expect("usage: alloc_audit_decode <blob> <size>");
+    let expected: usize = args.get(2).expect("size").parse().expect("size");
+    let target_len = expected.checked_add(WILDCOPY_OVERLENGTH).expect("overflow");
+
+    let compressed = fs::read(path).expect("read");
+
+    // Reset counters and enable trace AFTER input file read.
+    LIVE_BYTES.store(0, Ordering::Relaxed);
+    PEAK_BYTES.store(0, Ordering::Relaxed);
+    ALLOC_COUNT.store(0, Ordering::Relaxed);
+    TRACE_LEN.store(0, Ordering::Relaxed);
+    TRACE_ENABLED.store(true, Ordering::Relaxed);
+
+    let mut target = vec![0u8; target_len];
+    let mut decoder = FrameDecoder::new();
+    let written = decoder
+        .decode_all(compressed.as_slice(), &mut target)
+        .expect("decode");
+    assert_eq!(written, expected);
+
+    TRACE_ENABLED.store(false, Ordering::Relaxed);
+
+    let peak = PEAK_BYTES.load(Ordering::Relaxed);
+    let live = LIVE_BYTES.load(Ordering::Relaxed);
+    let count = ALLOC_COUNT.load(Ordering::Relaxed);
+    let trace_len = TRACE_LEN.load(Ordering::Relaxed).min(TRACE_CAP);
+
+    eprintln!("=== Allocation audit ===");
+    eprintln!(
+        "Peak live bytes: {} ({:.2} MB)",
+        peak,
+        peak as f64 / 1_048_576.0
+    );
+    eprintln!(
+        "Live bytes after decode: {} ({:.2} MB)",
+        live,
+        live as f64 / 1_048_576.0
+    );
+    eprintln!("Total alloc calls: {}", count);
+    eprintln!();
+    eprintln!("Per-alloc trace (first {trace_len} of {count}):");
+    eprintln!("  {:>4} {:>10} {:>14}", "idx", "size", "peak_after");
+    for i in 0..trace_len {
+        let size = TRACE_SIZES[i].load(Ordering::Relaxed);
+        let peak_after = TRACE_PEAK_AFTER[i].load(Ordering::Relaxed);
+        eprintln!("  {:>4} {:>10} {:>14}", i, size, peak_after);
+    }
+}

--- a/zstd/examples/alloc_audit_decode.rs
+++ b/zstd/examples/alloc_audit_decode.rs
@@ -21,15 +21,13 @@ static TRACE_ENABLED: AtomicBool = AtomicBool::new(false);
 
 const TRACE_CAP: usize = 256;
 static TRACE_LEN: AtomicUsize = AtomicUsize::new(0);
-static TRACE_SIZES: [AtomicUsize; TRACE_CAP] = {
-    // Sad const-init: array of AtomicUsize with default value 0.
-    const ZERO: AtomicUsize = AtomicUsize::new(0);
-    [ZERO; TRACE_CAP]
-};
-static TRACE_PEAK_AFTER: [AtomicUsize; TRACE_CAP] = {
-    const ZERO: AtomicUsize = AtomicUsize::new(0);
-    [ZERO; TRACE_CAP]
-};
+// Inline-const-expression repeat (`[const { ... }; N]`) builds the
+// array directly without requiring `AtomicUsize: Copy`. The named-const
+// form (`const ZERO: ...; [ZERO; N]`) historically required Copy, which
+// `AtomicUsize` does not implement; the inline-const variant has been
+// stable since 1.79 and is the modern idiom.
+static TRACE_SIZES: [AtomicUsize; TRACE_CAP] = [const { AtomicUsize::new(0) }; TRACE_CAP];
+static TRACE_PEAK_AFTER: [AtomicUsize; TRACE_CAP] = [const { AtomicUsize::new(0) }; TRACE_CAP];
 
 unsafe impl GlobalAlloc for AuditAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {

--- a/zstd/examples/alloc_audit_decode.rs
+++ b/zstd/examples/alloc_audit_decode.rs
@@ -65,6 +65,47 @@ unsafe impl GlobalAlloc for AuditAllocator {
         unsafe { System.dealloc(ptr, layout) };
         LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
     }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // Override the default `GlobalAlloc::realloc` shim
+        // (`alloc(new) + copy + dealloc(old)`) so peak accounting only
+        // sees the size delta, not a transient `old + new` live total.
+        // The default shim would double-count any `Vec` growth during
+        // the measured window and inflate `PEAK_BYTES`.
+        let new_ptr = unsafe { System.realloc(ptr, layout, new_size) };
+        if new_ptr.is_null() {
+            return new_ptr;
+        }
+        let old_size = layout.size();
+        if new_size > old_size {
+            let delta = new_size - old_size;
+            let new_live = LIVE_BYTES.fetch_add(delta, Ordering::Relaxed) + delta;
+            ALLOC_COUNT.fetch_add(1, Ordering::Relaxed);
+            let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+            while new_live > peak {
+                match PEAK_BYTES.compare_exchange_weak(
+                    peak,
+                    new_live,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                ) {
+                    Ok(_) => break,
+                    Err(actual) => peak = actual,
+                }
+            }
+            if TRACE_ENABLED.load(Ordering::Relaxed) {
+                let idx = TRACE_LEN.fetch_add(1, Ordering::Relaxed);
+                if idx < TRACE_CAP {
+                    TRACE_SIZES[idx].store(delta, Ordering::Relaxed);
+                    TRACE_PEAK_AFTER[idx].store(new_live, Ordering::Relaxed);
+                }
+            }
+        } else if new_size < old_size {
+            let delta = old_size - new_size;
+            LIVE_BYTES.fetch_sub(delta, Ordering::Relaxed);
+        }
+        new_ptr
+    }
 }
 
 #[global_allocator]

--- a/zstd/examples/alloc_audit_decode.rs
+++ b/zstd/examples/alloc_audit_decode.rs
@@ -54,7 +54,13 @@ unsafe impl GlobalAlloc for AuditAllocator {
                 let idx = TRACE_LEN.fetch_add(1, Ordering::Relaxed);
                 if idx < TRACE_CAP {
                     TRACE_SIZES[idx].store(size, Ordering::Relaxed);
-                    TRACE_PEAK_AFTER[idx].store(new_live, Ordering::Relaxed);
+                    // Store the current PEAK (not live-after) so the
+                    // column matches its label. Live-after can dip below
+                    // peak when deallocations precede a later alloc;
+                    // peak only ever rises, matching what the user reads
+                    // from the "peak_after" header.
+                    TRACE_PEAK_AFTER[idx]
+                        .store(PEAK_BYTES.load(Ordering::Relaxed), Ordering::Relaxed);
                 }
             }
         }
@@ -97,7 +103,10 @@ unsafe impl GlobalAlloc for AuditAllocator {
                 let idx = TRACE_LEN.fetch_add(1, Ordering::Relaxed);
                 if idx < TRACE_CAP {
                     TRACE_SIZES[idx].store(delta, Ordering::Relaxed);
-                    TRACE_PEAK_AFTER[idx].store(new_live, Ordering::Relaxed);
+                    // Store current PEAK to match column label — see
+                    // `alloc` for rationale.
+                    TRACE_PEAK_AFTER[idx]
+                        .store(PEAK_BYTES.load(Ordering::Relaxed), Ordering::Relaxed);
                 }
             }
         } else if new_size < old_size {

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -109,13 +109,14 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     pub fn reset(&mut self, window_size: usize) {
         self.window_size = window_size;
         self.buffer.clear();
-        // Lazy reserve: the backend grows on demand the first time a
-        // block writes into it. Direct-decode frames (`run_direct_decode`)
-        // write through `UserSliceBackend` and never touch this buffer,
-        // so a long-lived `FrameDecoder` reused across direct-eligible
-        // frames pays zero RingBuffer allocation for the window. The
-        // non-direct `decode_blocks` path grows via `reserve_amortized`
-        // on the first write.
+        // Lazy reserve: every `BufferBackend` grows on demand the first
+        // time a block writes into it (RingBuffer via
+        // `reserve_amortized`, FlatBuf via `Vec::reserve`). Direct-decode
+        // frames (`run_direct_decode`) write through `UserSliceBackend`
+        // and never touch this buffer, so a long-lived `FrameDecoder`
+        // reused across direct-eligible frames pays zero allocation for
+        // the window. The non-direct `decode_blocks` path triggers the
+        // backend's grow path on the first write.
         self.dict_content.clear();
         self.total_output_counter = 0;
         #[cfg(feature = "hash")]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -109,14 +109,15 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     pub fn reset(&mut self, window_size: usize) {
         self.window_size = window_size;
         self.buffer.clear();
-        // Lazy reserve: every `BufferBackend` grows on demand the first
-        // time a block writes into it (RingBuffer via
-        // `reserve_amortized`, FlatBuf via `Vec::reserve`). Direct-decode
-        // frames (`run_direct_decode`) write through `UserSliceBackend`
-        // and never touch this buffer, so a long-lived `FrameDecoder`
-        // reused across direct-eligible frames pays zero allocation for
-        // the window. The non-direct `decode_blocks` path triggers the
-        // backend's grow path on the first write.
+        // No reserve here: capacity decisions are pushed up to the frame
+        // layer. Direct-decode frames (`run_direct_decode`) write through
+        // `UserSliceBackend` and never touch this buffer, so a long-lived
+        // `FrameDecoder` reused across direct-eligible frames pays zero
+        // allocation for the window. The non-direct path is pre-reserved
+        // by `FrameDecoder::decode_all_impl` / `decode_blocks` via
+        // `DecoderScratchKind::reserve_buffer(window_size)` before any
+        // block writes — that is the only call site that knows whether
+        // the frame will actually hit this buffer.
         self.dict_content.clear();
         self.total_output_counter = 0;
         #[cfg(feature = "hash")]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -109,7 +109,13 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     pub fn reset(&mut self, window_size: usize) {
         self.window_size = window_size;
         self.buffer.clear();
-        self.buffer.reserve(self.window_size);
+        // Lazy reserve: the backend grows on demand the first time a
+        // block writes into it. Direct-decode frames (`run_direct_decode`)
+        // write through `UserSliceBackend` and never touch this buffer,
+        // so a long-lived `FrameDecoder` reused across direct-eligible
+        // frames pays zero RingBuffer allocation for the window. The
+        // non-direct `decode_blocks` path grows via `reserve_amortized`
+        // on the first write.
         self.dict_content.clear();
         self.total_output_counter = 0;
         #[cfg(feature = "hash")]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -137,9 +137,12 @@ impl DecoderScratchKind {
         // The direct-decode path (`run_direct_decode`) writes through
         // `UserSliceBackend` and never touches the ring; allocating it
         // eagerly wastes one full window of peak memory on the common
-        // direct-eligible frame. The non-direct `decode_blocks` path
-        // grows the buffer on demand via `RingBuffer::reserve_amortized`
-        // the first time a block writes into it. Issue #279 round 2.
+        // direct-eligible frame. On the non-direct path the window is
+        // pre-reserved once at frame entry (`decode_all_impl` and
+        // `decode_blocks` both call `DecoderScratchKind::reserve_buffer`
+        // before any block writes), so multi-block frames pay one
+        // amortised grow instead of repeated `reserve_amortized` steps
+        // per block. Issue #279 round 2.
         let s = DecoderScratch::<RingBuffer>::new(window_size);
         Self::Ring(s)
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -373,14 +373,17 @@ impl FrameDecoderState {
     /// (donor `ZSTD_f_zstd1_magicless`). Crate-internal — reached
     /// only via `FrameDecoder::reset`.
     ///
-    /// `DecodeBuffer::reset` no longer reserves window_size — the
-    /// ring-backed buffer is allocated lazily so direct-eligible
-    /// frames pay zero allocation here. The non-direct fallback
+    /// `DecodeBuffer::reset` no longer reserves window_size for either
+    /// backend — ring and flat both grow lazily through their own
+    /// `reserve`/`Vec` paths. For ring-backed scratch, direct-eligible
+    /// frames pay zero allocation here and the non-direct fallback
     /// reserves `window_size` once in `decode_all_impl` via
-    /// `DecoderScratchKind::reserve_buffer` after direct eligibility
-    /// is ruled out. Flat-backed scratch is re-sized eagerly inside
-    /// `DecoderScratchKind::reset` because the single-segment write
-    /// path needs the full capacity from the first block.
+    /// `DecoderScratchKind::reserve_buffer`. Flat-backed scratch is
+    /// sized to `frame_content_size` by `DecoderScratchKind::new_flat`
+    /// at first construction (and on Ring → Flat transition); a reused
+    /// flat scratch whose new frame fits within the prior FCS reuses
+    /// the existing capacity, and one whose new FCS is larger grows
+    /// the backing `Vec` on the first block write.
     pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -921,6 +921,17 @@ impl FrameDecoder {
         use FrameDecoderError as err;
         let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
 
+        // Streaming entry point: pre-reserve the backing buffer to
+        // `window_size` so multi-block frames don't pay repeated
+        // `reserve_amortized` grow steps (128 KiB → 256 KiB → ... →
+        // window) as blocks accumulate. `decode_all` does the same up
+        // front in `decode_all_impl`; this mirrors it for callers
+        // driving `decode_blocks` directly. Idempotent — the
+        // backend's `reserve` early-returns when capacity is already
+        // sufficient.
+        let window_size = state.frame_header.window_size().unwrap_or(0) as usize;
+        state.decoder_scratch.reserve_buffer(window_size);
+
         let mut block_dec = decoding::block_decoder::new();
 
         let buffer_size_before = state.decoder_scratch.buffer_len();

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -377,16 +377,17 @@ impl FrameDecoderState {
     /// only via `FrameDecoder::reset`.
     ///
     /// `DecodeBuffer::reset` no longer reserves window_size for either
-    /// backend — ring and flat both grow lazily through their own
-    /// `reserve`/`Vec` paths. For ring-backed scratch, direct-eligible
-    /// frames pay zero allocation here and the non-direct fallback
-    /// reserves `window_size` once in `decode_all_impl` via
-    /// `DecoderScratchKind::reserve_buffer`. Flat-backed scratch is
-    /// sized to `frame_content_size` by `DecoderScratchKind::new_flat`
-    /// at first construction (and on Ring → Flat transition); a reused
-    /// flat scratch whose new frame fits within the prior FCS reuses
-    /// the existing capacity, and one whose new FCS is larger grows
-    /// the backing `Vec` on the first block write.
+    /// backend — capacity decisions live one layer up. For ring-backed
+    /// scratch, direct-eligible frames pay zero allocation here and
+    /// the non-direct path is pre-reserved by `decode_all_impl` /
+    /// `decode_blocks` via `DecoderScratchKind::reserve_buffer(window_size)`
+    /// before any block writes. Flat-backed scratch is sized to
+    /// `frame_content_size` by `DecoderScratchKind::new_flat` at first
+    /// construction (and on Ring → Flat transition); a reused flat
+    /// scratch whose new frame fits within the prior FCS reuses the
+    /// existing capacity, and one whose new FCS is larger is also
+    /// pre-reserved by the same `reserve_buffer(window_size)` call at
+    /// frame entry (single-segment frames have window_size == FCS).
     pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -133,8 +133,14 @@ enum DecoderScratchKind {
 
 impl DecoderScratchKind {
     fn new_ring(window_size: usize) -> Self {
-        let mut s = DecoderScratch::<RingBuffer>::new(window_size);
-        s.buffer.reserve(window_size);
+        // Lazy ring-buffer allocation: do NOT `reserve(window_size)` here.
+        // The direct-decode path (`run_direct_decode`) writes through
+        // `UserSliceBackend` and never touches the ring; allocating it
+        // eagerly wastes one full window of peak memory on the common
+        // direct-eligible frame. The non-direct `decode_blocks` path
+        // grows the buffer on demand via `RingBuffer::reserve_amortized`
+        // the first time a block writes into it. Issue #279 round 2.
+        let s = DecoderScratch::<RingBuffer>::new(window_size);
         Self::Ring(s)
     }
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -205,8 +205,14 @@ impl DecoderScratchKind {
     /// after direct-eligibility is ruled out, so multi-segment fallback
     /// decodes don't pay repeated `reserve_amortized` grow steps
     /// (128 KiB → 256 KiB → ... → window) as blocks accumulate.
-    /// Direct-eligible frames never call this and pay zero buffer
-    /// allocation for the window.
+    ///
+    /// Direct-eligible ring-backed frames never call this and pay zero
+    /// ring allocation for the window. Flat-backed (single-segment)
+    /// frames eagerly size their `FlatBuf` to `frame_content_size` at
+    /// `new_flat` construction time, so a direct-eligible flat frame
+    /// already paid for that capacity before this helper is reachable;
+    /// the "zero buffer allocation" guarantee here applies to the
+    /// ring path only.
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
         match self {
@@ -324,9 +330,14 @@ impl FrameDecoderState {
     /// from `source`. When `magicless` is `true`, the 4-byte magic
     /// number prefix is NOT consumed (donor `ZSTD_f_zstd1_magicless`).
     /// Crate-internal — reached only via `FrameDecoder::init` /
-    /// `FrameDecoder::init_with_dict_handle`. Pre-allocates the
-    /// decode buffer to `window_size` so the first block does not
-    /// trigger incremental growth from zero capacity.
+    /// `FrameDecoder::init_with_dict_handle`. For multi-segment
+    /// (ring-backed) frames the decode buffer is allocated lazily —
+    /// direct-eligible frames pay zero buffer allocation, and the
+    /// non-direct fallback reserves `window_size` once in
+    /// `decode_all_impl` via `reserve_buffer`. Single-segment
+    /// (flat-backed) frames eagerly size the backing `FlatBuf` to
+    /// `frame_content_size` because the flat path writes the entire
+    /// output into the same buffer and cannot defer that allocation.
     pub(crate) fn new_with_format(
         source: impl Read,
         magicless: bool,
@@ -362,10 +373,14 @@ impl FrameDecoderState {
     /// (donor `ZSTD_f_zstd1_magicless`). Crate-internal — reached
     /// only via `FrameDecoder::reset`.
     ///
-    /// `DecodeBuffer::reset` reserves `window_size` internally, so
-    /// no additional frame-level reservation is needed here.
-    /// Further buffer growth during decoding is performed on demand
-    /// by the active block path.
+    /// `DecodeBuffer::reset` no longer reserves window_size — the
+    /// ring-backed buffer is allocated lazily so direct-eligible
+    /// frames pay zero allocation here. The non-direct fallback
+    /// reserves `window_size` once in `decode_all_impl` via
+    /// `DecoderScratchKind::reserve_buffer` after direct eligibility
+    /// is ruled out. Flat-backed scratch is re-sized eagerly inside
+    /// `DecoderScratchKind::reset` because the single-segment write
+    /// path needs the full capacity from the first block.
     pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -200,6 +200,21 @@ impl DecoderScratchKind {
         }
     }
 
+    /// Pre-reserve the backing buffer to `window_size` in a single
+    /// allocation. Called once on the non-direct (`decode_blocks`) path
+    /// after direct-eligibility is ruled out, so multi-segment fallback
+    /// decodes don't pay repeated `reserve_amortized` grow steps
+    /// (128 KiB → 256 KiB → ... → window) as blocks accumulate.
+    /// Direct-eligible frames never call this and pay zero buffer
+    /// allocation for the window.
+    #[inline]
+    fn reserve_buffer(&mut self, window_size: usize) {
+        match self {
+            Self::Ring(s) => s.buffer.reserve(window_size),
+            Self::Flat(s) => s.buffer.reserve(window_size),
+        }
+    }
+
     /// Last `n` bytes of the visible buffer as `(s1, s2)` (wrap-aware).
     /// Routes through whichever backend the current scratch holds.
     #[cfg(all(feature = "lsm", feature = "hash"))]
@@ -1274,10 +1289,15 @@ impl FrameDecoder {
             // frames (no FCS, active dict, output too small for
             // slack) fall through to the legacy `decode_blocks` +
             // `read` drain loop below.
-            let state_ref = self.state.as_ref().expect("init populated state");
-            let content_size = state_ref.frame_header.frame_content_size();
-            let fcs_declared = state_ref.frame_header.fcs_declared();
-            let dict_active = state_ref.using_dict.is_some();
+            let (content_size, fcs_declared, dict_active, window_size) = {
+                let state_ref = self.state.as_ref().expect("init populated state");
+                (
+                    state_ref.frame_header.frame_content_size(),
+                    state_ref.frame_header.fcs_declared(),
+                    state_ref.using_dict.is_some(),
+                    state_ref.frame_header.window_size().unwrap_or(0),
+                )
+            };
             let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
             // Per-block checksums collected inside `run_direct_decode`
             // post-loop (over recorded (start, end) ranges of `output`)
@@ -1293,6 +1313,16 @@ impl FrameDecoder {
                 output = &mut output[written..];
                 total_bytes_written += written;
                 continue;
+            }
+            // Non-direct fallback: pre-reserve the backing buffer to
+            // `window_size` in a single allocation before block decode
+            // starts, so multi-segment frames don't pay repeated
+            // `reserve_amortized` grow steps as blocks accumulate (each
+            // block only reserves MAX_BLOCK_SIZE = 128 KiB, so a window
+            // > 128 KiB otherwise grows through several intermediate
+            // sizes with `alloc_zeroed + memcpy` each time).
+            if let Some(state) = self.state.as_mut() {
+                state.decoder_scratch.reserve_buffer(window_size as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {
@@ -1389,10 +1419,15 @@ impl FrameDecoder {
             // frames (no FCS, active dict, output too small for
             // slack) fall through to the legacy `decode_blocks` +
             // `read` drain loop below.
-            let state_ref = self.state.as_ref().expect("init populated state");
-            let content_size = state_ref.frame_header.frame_content_size();
-            let fcs_declared = state_ref.frame_header.fcs_declared();
-            let dict_active = state_ref.using_dict.is_some();
+            let (content_size, fcs_declared, dict_active, window_size) = {
+                let state_ref = self.state.as_ref().expect("init populated state");
+                (
+                    state_ref.frame_header.frame_content_size(),
+                    state_ref.frame_header.fcs_declared(),
+                    state_ref.using_dict.is_some(),
+                    state_ref.frame_header.window_size().unwrap_or(0),
+                )
+            };
             let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
             let direct_eligible =
                 content_size > 0 && !dict_active && (output.len() as u64) >= needed;
@@ -1401,6 +1436,12 @@ impl FrameDecoder {
                 output = &mut output[written..];
                 total_bytes_written += written;
                 continue;
+            }
+            // Non-direct fallback: pre-reserve the backing buffer to
+            // `window_size` once so the per-block growth cycle is
+            // skipped (see same comment on the no-lsm path above).
+            if let Some(state) = self.state.as_mut() {
+                state.decoder_scratch.reserve_buffer(window_size as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {


### PR DESCRIPTION
## Summary

The `FrameDecoder` initialiser eagerly reserved `window_size` bytes
for the ring buffer in `DecoderScratchKind::new_ring`. The direct
decode path (`run_direct_decode`) writes through `UserSliceBackend`
into the caller's output slice and never touches the ring, so every
direct-eligible decode wasted one full window of peak memory.

Remove the eager reserve. The non-direct `decode_blocks` path grows
the buffer on demand the first time a block writes into it (via
`RingBuffer::reserve_amortized`), so correctness is unchanged.

## Measurement (z000033 L-3 fast, profile_decode_direct, new alloc_audit_decode tool)

| Metric | Baseline | This PR | Δ |
|---|---|---|---|
| Peak live bytes | 1,567,768 (1.50 MB) | **1,043,447 (1.00 MB)** | **−33.5%** |
| Alloc count | 16 | 15 | −1 (the 524 KB ring) |

Window size for z000033 is 524 KB; the eliminated allocation was the
`window_size + WILDCOPY_OVERLENGTH + 1` = 524,321-byte ring buffer
that ran through `alloc_zeroed`.

## Wall time (i9-9900K, profile_decode_direct)

| Fixture | Baseline | This PR | Δ |
|---|---|---|---|
| z000033 L-3 fast | 902.5 ns | 912.2 ns | +1.1% (within run-to-run noise) |
| z000033 L14 lazy | 2013 ns | 2018.5 ns | +0.3% (noise) |
| low-entropy-1m L-3 fast | 274.5 ns | **261.5 ns** | **−4.7%** ✓ |
| high-entropy-1m L-3 fast | 103.6 ns | 102.9 ns | −0.7% (noise) |

low-entropy benefit comes from skipping the kernel zero-touch of the
524 KB ring; the small z000033 wall delta is build-to-build variance
on otherwise unchanged direct-path codegen.

## Independent diagnostic tool

Adds `zstd/examples/alloc_audit_decode.rs` — a single-binary peak-bytes
auditor with per-alloc trace. Use to verify future memory wins without
the realloc-double-count artefact in the criterion `compare_ffi_memory`
harness.

## Test plan
- [x] `cargo nextest run -p structured-zstd` — 628 tests pass
- [x] `alloc_audit_decode` confirms peak −524 KB on z000033 L-3
- [x] Cross-fixture wall measurement (z000033 L-3/L14, low-entropy-1m, high-entropy-1m)
- [x] Bench-host audit matches local

## Related

- Issue #279 (DSB pressure + allocator pressure decoder gap analysis)
- Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an allocation-audit example that profiles decode-side memory behavior, tracks live/peak allocations and allocation counts, and emits a concise CLI report to aid troubleshooting.

* **Refactor**
  * Deferred buffer and ring-buffer pre-allocation; now grow backing storage on first use and reserve only when a frame requires it, reducing unnecessary allocations and improving decode memory efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->