### PR TITLE
perf(decode): skip post-decode XXH64 when content_checksum_flag is 0

### DIFF
--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -54,6 +54,11 @@ fn main() {
         written,
         level
     );
+    eprintln!(
+        "FHD byte4=0x{:02x}, content_checksum_flag (bit 2) = {}",
+        compressed[4],
+        (compressed[4] >> 2) & 1
+    );
 
     let mut target = vec![0u8; n + WILDCOPY_OVERLENGTH];
     // Pre-touch pages so first iter doesn't pay anon-fault cost.

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -1,0 +1,82 @@
+//! Standalone decode-loop binary for clean perf-record profiles.
+//! Generates a 1MB deterministic corpus, FFI-encodes once at the given
+//! level, then loops `decode_all` for N iters. No criterion overhead,
+//! no per-iter encode — pure decoder hot path.
+//!
+//! Build: cargo build --profile flamegraph -p structured-zstd \
+//!          --example decode_loop_z000033 --features dict_builder
+//! Run:   perf record -F 999 -g --call-graph dwarf,16384 -- \
+//!          target/flamegraph/examples/decode_loop_z000033 3 50000
+
+use std::env;
+
+use structured_zstd::WILDCOPY_OVERLENGTH;
+use structured_zstd::decoding::FrameDecoder;
+use zstd::zstd_safe::zstd_sys;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(50_000);
+
+    // Deterministic 1MB synthetic — LCG, repeatable across hosts.
+    let n = 1_048_576usize;
+    let mut src = Vec::with_capacity(n);
+    let mut state: u64 = 0x517cc1b727220a95;
+    while src.len() < n {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        src.push((state >> 56) as u8);
+    }
+
+    // FFI encode once at requested level.
+    let dst_cap = unsafe { zstd_sys::ZSTD_compressBound(src.len()) };
+    let mut compressed: Vec<u8> = vec![0u8; dst_cap];
+    let written = unsafe {
+        zstd_sys::ZSTD_compress(
+            compressed.as_mut_ptr() as *mut core::ffi::c_void,
+            dst_cap,
+            src.as_ptr() as *const core::ffi::c_void,
+            src.len(),
+            level,
+        )
+    };
+    assert_eq!(
+        unsafe { zstd_sys::ZSTD_isError(written) },
+        0,
+        "encode failed"
+    );
+    compressed.truncate(written);
+    eprintln!(
+        "encoded {} bytes → {} bytes at level {}",
+        src.len(),
+        written,
+        level
+    );
+
+    let mut target = vec![0u8; n + WILDCOPY_OVERLENGTH];
+    // Pre-touch pages so first iter doesn't pay anon-fault cost.
+    for chunk in target.chunks_mut(4096) {
+        chunk[0] = 0;
+    }
+    let mut decoder = FrameDecoder::new();
+
+    eprintln!("starting {} decode iters", iters);
+    let start = std::time::Instant::now();
+    let mut total = 0usize;
+    for _ in 0..iters {
+        let wrote = decoder
+            .decode_all(std::hint::black_box(&compressed), &mut target)
+            .expect("decode_all");
+        total = total.wrapping_add(wrote);
+    }
+    let elapsed = start.elapsed();
+    eprintln!(
+        "decoded {} iters, {} total bytes, {:?} wall, {:.0} ns/iter",
+        iters,
+        total,
+        elapsed,
+        elapsed.as_nanos() as f64 / iters as f64
+    );
+}

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -871,10 +871,17 @@ impl FrameDecoder {
     }
 
     /// Returns the checksum that was calculated while decoding.
-    /// Only a sensible value after all decoded bytes have been collected/read from the FrameDecoder
+    /// Only a sensible value after all decoded bytes have been collected/read from the FrameDecoder.
+    /// Returns `None` when the frame header has `content_checksum_flag = 0`:
+    /// no hash is computed for such frames (the post-decode XXH64 pass was a
+    /// 63 % decode-wall hotspot on flag-off frames; skipping it when the
+    /// frame format declares no trailing digest avoids that wasted work).
     #[cfg(feature = "hash")]
     pub fn get_calculated_checksum(&self) -> Option<u32> {
         let state = self.state.as_ref()?;
+        if !state.frame_header.descriptor.content_checksum_flag() {
+            return None;
+        }
         let cksum_64bit = state.decoder_scratch.hash_finish();
         //truncate to lower 32bit because reasons...
         Some(cksum_64bit as u32)
@@ -1795,14 +1802,20 @@ impl FrameDecoder {
             }
         }
         #[cfg(feature = "hash")]
-        {
+        if state.frame_header.descriptor.content_checksum_flag() {
             // Direct path bypasses the per-write hash accounting
             // (DecodeBuffer hashes during drain; the direct path
             // never drains because the user slice IS the buffer).
             // Walk the decoded output once and propagate the
-            // resulting hasher state into the persistent scratch's
-            // buffer so `get_calculated_checksum()` returns the
-            // right value path-independently.
+            // resulting hasher state so the frame-tail XXH64 check
+            // (in the block loop above) can verify the digest.
+            //
+            // Gated on `content_checksum_flag`: frames without a
+            // trailing checksum byte have nothing to verify, and the
+            // 1 MiB+ second-pass scan dominated decode wall time
+            // (63 % of total on z000033 L-3 in the standalone perf
+            // loop). `get_calculated_checksum()` now returns `None`
+            // for flag-off frames, matching this skip.
             use core::hash::Hasher;
             let mut hasher = twox_hash::XxHash64::with_seed(0);
             hasher.write(&output[..written]);


### PR DESCRIPTION
## Summary

The direct-decode path used to scan the entire output buffer through XXH64 after every frame, regardless of whether the frame header advertised a trailing checksum. A standalone `perf record` on a 1 MiB LCG synthetic at level −3 (default `ZSTD_compress` simple API → no checksum) showed that second pass eating **63 % of decode wall time** — pure waste because the frame had no digest to verify.

Gating it on `content_checksum_flag()` drops the LCG-fixture decode_loop bench from **104.9 → 38.4 µs/iter (−63.4 %)** on i9-9900K @ 3.6 GHz.

## Bench (i9, 50 000 iters, 1 MiB LCG fixture, level −3 fast)

Clean rebuild on both branches (`cargo clean --profile flamegraph` before each), same DWARF-symbolicated `flamegraph` profile, same binary path. FHD byte4 dumped on each run to verify the input frame's `content_checksum_flag` bit.

| Branch | ns/iter | Δ | FHD byte4 | checksum_flag |
|---|---|---|---|---|
| main | 104 907 | baseline | 0x80 | **0** |
| this PR | 38 354 | **−63.4 %** | 0x80 | **0** |

The fixture is genuinely flag-off (default `ZSTD_compress` simple API), so the gate now skips the post-decode hash entirely.

## Scope

- **Direct-decode path** (`decode_all_into` / `FrameDecoder::decode_all`): post-decode `hasher.write(&output[..written])` now runs only when `content_checksum_flag` is set in the frame header.
- **`get_calculated_checksum()`**: now returns `None` for flag-off frames (the field is no longer populated; there is no trailing digest to expose). Doc updated.
- **Drain-path hashing** (`DecodeBuffer::drain*` in `decode_buffer.rs`): unchanged. Only the streaming-Read interface hits that path; out of scope for this fix. Follow-up could thread the flag through `DecodeBuffer` to gate it too.

## Why this is a behaviour change, not a pure perf win

Previously `get_calculated_checksum()` always returned the XXH64 of the decoded output, regardless of whether the frame contained a trailing digest. That guarantee is dropped: callers that want the hash for diagnostic purposes on a flag-off frame must compute it themselves over the decoded bytes. The trade-off is 63 % of decode wall time vs a path-independent diagnostic accessor with no in-tree consumer.

## Compare_ffi bench (z000033 flag-on)

The `compare_ffi` matrix encodes via FFI with `ZSTD_c_checksumFlag = 1` when `feature = "hash"` is enabled (default), so its fixtures all carry a trailing digest and this PR is a no-op on that bench. Verified empirically:

| Bench | Δ vs pr285_clean baseline |
|---|---|
| `decompress/level_-3_fast/decodecorpus-z000033/rust_stream/matrix/pure_rust` | −0.10 % (noise) |
| `decompress/level_-3_fast/decodecorpus-z000033/c_stream/matrix/pure_rust` | +0.64 % (noise) |

The win is for library callers whose frames do not declare a content checksum — common for embedded, streaming-with-external-integrity, and any caller using the simple `ZSTD_compress` API (which defaults to checksum-off).

## Testing

- 647/647 nextest pass (full suite, `--features hash`).
- Roundtrip tests (66 cases) cover both encoder/decoder paths — flag is set on the encoder side via `ZSTD_compress2` defaults under `feature = "hash"`, so the inline verify path stays exercised.
- New diagnostic example `decode_loop_z000033.rs` ships in the PR for future clean perf profiling without criterion's setup-encode noise.

Part of #279