### PR TITLE
test(decode): decode_loop binary — add --mode ffi and --corpus path

### DIFF
--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -78,13 +78,21 @@ fn main() {
     let mut total = 0usize;
     match mode {
         "ffi" => {
-            // Reuse one DCtx to mirror the c_ffi compare_ffi arm.
-            let dctx = unsafe { zstd_sys::ZSTD_createDCtx() };
-            assert!(!dctx.is_null(), "ZSTD_createDCtx failed");
+            // Reuse one DCtx to mirror the c_ffi compare_ffi arm. RAII
+            // guard ensures `ZSTD_freeDCtx` runs even if the per-iter
+            // `assert_eq!` below panics on a corrupted fixture.
+            struct DCtxGuard(*mut zstd_sys::ZSTD_DCtx_s);
+            impl Drop for DCtxGuard {
+                fn drop(&mut self) {
+                    unsafe { zstd_sys::ZSTD_freeDCtx(self.0) };
+                }
+            }
+            let dctx = DCtxGuard(unsafe { zstd_sys::ZSTD_createDCtx() });
+            assert!(!dctx.0.is_null(), "ZSTD_createDCtx failed");
             for _ in 0..iters {
                 let wrote = unsafe {
                     zstd_sys::ZSTD_decompressDCtx(
-                        dctx,
+                        dctx.0,
                         target.as_mut_ptr() as *mut _,
                         target.len(),
                         std::hint::black_box(compressed.as_ptr() as *const _),
@@ -98,7 +106,6 @@ fn main() {
                 );
                 total = total.wrapping_add(wrote);
             }
-            unsafe { zstd_sys::ZSTD_freeDCtx(dctx) };
         }
         _ => {
             let mut decoder = FrameDecoder::new();

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -18,17 +18,25 @@ fn main() {
     let args: Vec<String> = env::args().collect();
     let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
     let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(50_000);
+    let mode: &str = args.get(3).map(|s| s.as_str()).unwrap_or("rust");
+    let corpus_path: Option<&str> = args.get(4).map(|s| s.as_str());
 
-    // Deterministic 1MB synthetic — LCG, repeatable across hosts.
-    let n = 1_048_576usize;
-    let mut src = Vec::with_capacity(n);
-    let mut state: u64 = 0x517cc1b727220a95;
-    while src.len() < n {
-        state = state
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407);
-        src.push((state >> 56) as u8);
-    }
+    // Source: either a file from disk, or a deterministic 1MB LCG synthetic.
+    let src: Vec<u8> = if let Some(path) = corpus_path {
+        std::fs::read(path).expect("read corpus file")
+    } else {
+        let n = 1_048_576usize;
+        let mut src = Vec::with_capacity(n);
+        let mut state: u64 = 0x517cc1b727220a95;
+        while src.len() < n {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            src.push((state >> 56) as u8);
+        }
+        src
+    };
+    let n = src.len();
 
     // FFI encode once at requested level.
     let dst_cap = unsafe { zstd_sys::ZSTD_compressBound(src.len()) };
@@ -65,23 +73,50 @@ fn main() {
     for chunk in target.chunks_mut(4096) {
         chunk[0] = 0;
     }
-    let mut decoder = FrameDecoder::new();
-
-    eprintln!("starting {} decode iters", iters);
+    eprintln!("starting {} decode iters in mode {}", iters, mode);
     let start = std::time::Instant::now();
     let mut total = 0usize;
-    for _ in 0..iters {
-        let wrote = decoder
-            .decode_all(std::hint::black_box(&compressed), &mut target)
-            .expect("decode_all");
-        total = total.wrapping_add(wrote);
+    match mode {
+        "ffi" => {
+            // Reuse one DCtx to mirror the c_ffi compare_ffi arm.
+            let dctx = unsafe { zstd_sys::ZSTD_createDCtx() };
+            assert!(!dctx.is_null(), "ZSTD_createDCtx failed");
+            for _ in 0..iters {
+                let wrote = unsafe {
+                    zstd_sys::ZSTD_decompressDCtx(
+                        dctx,
+                        target.as_mut_ptr() as *mut _,
+                        target.len(),
+                        std::hint::black_box(compressed.as_ptr() as *const _),
+                        compressed.len(),
+                    )
+                };
+                assert_eq!(
+                    unsafe { zstd_sys::ZSTD_isError(wrote) },
+                    0,
+                    "ZSTD_decompressDCtx"
+                );
+                total = total.wrapping_add(wrote);
+            }
+            unsafe { zstd_sys::ZSTD_freeDCtx(dctx) };
+        }
+        _ => {
+            let mut decoder = FrameDecoder::new();
+            for _ in 0..iters {
+                let wrote = decoder
+                    .decode_all(std::hint::black_box(&compressed), &mut target)
+                    .expect("decode_all");
+                total = total.wrapping_add(wrote);
+            }
+        }
     }
     let elapsed = start.elapsed();
     eprintln!(
-        "decoded {} iters, {} total bytes, {:?} wall, {:.0} ns/iter",
+        "decoded {} iters, {} total bytes, {:?} wall, {:.0} ns/iter ({})",
         iters,
         total,
         elapsed,
-        elapsed.as_nanos() as f64 / iters as f64
+        elapsed.as_nanos() as f64 / iters as f64,
+        mode
     );
 }


### PR DESCRIPTION
## Summary

Extends `examples/decode_loop_z000033.rs` (introduced in #287's diagnostic work) with two argv-driven options so it can directly compare rust-vs-ffi decode on the same fixture:

* **`mode = "ffi" | "rust"`** (argv 3, default `rust`). The `ffi` arm reuses one `ZSTD_DCtx` across iterations and routes through `ZSTD_decompressDCtx`, mirroring the `c_ffi` arm of the `compare_ffi` decompression matrix.
* **`corpus = <path>`** (argv 4, optional). When provided the fixture is read from disk instead of the deterministic LCG synthetic. Useful for profiling against real `decodecorpus_files/zNNNNNN` corpus rather than incompressible random bytes.

## Why

`compare_ffi`'s criterion wrapper runs setup-encode for every (scenario, level, source) combo registered in the bench harness, even when the iter closure for a non-matching arm never fires. With heavy levels in the matrix that setup work dominates `cargo flamegraph` profiles — ~30% of perf samples land in the C zstd encoder, not in the rust decoder we want to inspect.

Running this binary directly through `perf record` skips criterion entirely: one-shot encode, then N iterations of the chosen decoder. The flamegraph is decoder-only.

## Example

```bash
# Both arms on the same real corpus, same level, same iter count
target/flamegraph/examples/decode_loop_z000033 -5 20000 rust \\
    zstd/decodecorpus_files/z000033
target/flamegraph/examples/decode_loop_z000033 -5 20000 ffi \\
    zstd/decodecorpus_files/z000033

# Flamegraph the rust arm with full DWARF symbolication
perf record -F 999 -g --call-graph dwarf,16384 -o perf.data -- \\
    target/flamegraph/examples/decode_loop_z000033 -5 20000 rust \\
    zstd/decodecorpus_files/z000033
perf report -i perf.data --stdio --no-children --percent-limit 1.0
```

## Used for

This is the tool that surfaced the post-decode XXH64 second-pass hot path that PR #287 fixed (63% of decode wall on flag-off frames). The `--corpus` flag was added during the L-5 regression investigation so the rust-vs-ffi gap could be measured against the same real corpus the dashboard tracks.

## Scope

* Pure tooling change — no production code touched, no behaviour change.
* Example only compiles under `--features dict_builder` (same as the rest of the bench infra). Existing build flag works.

Part of #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Decoder example accepts a mode selector and optional corpus path for flexible input and test configurations.
  * Added an alternate decoding path selectable via mode for comparative/performance runs.
  * Improved run logging to include the chosen mode and per-iteration latency in the final timing output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/structured-world/structured-zstd/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->