### PR TITLE
perf(decode): drop #[cold] on do_offset_history_repcode for hot workloads

### DIFF
--- a/zstd/src/decoding/sequence_execution.rs
+++ b/zstd/src/decoding/sequence_execution.rs
@@ -84,17 +84,23 @@ pub(crate) fn do_offset_history(offset_value: u32, lit_len: u32, scratch: &mut [
     do_offset_history_repcode(offset_value, lit_len, scratch)
 }
 
-// `#[cold]` keeps the body out of caller hot layout and biases icache
-// against pulling it unless hit. Earlier the helper was also
-// `#[inline(never)]`; round-1 findings on issue #279 (branch-mispredict
-// diagnostic) attributed 15.42% of decoder mispredicts to this function,
-// with 27.80% landing on the `pushq %rax` fn entry — call/ret BTB
-// pressure from the never-inlined boundary. Dropping `#[inline(never)]`
-// while keeping `#[cold]` lets LLVM inline at hot call sites where the
-// boundary cost outweighs body duplication; cold paths (low-entropy
-// blocks where the previous "drop both" variant regressed +15.9% on
-// L14) keep the out-of-line shape via the cold attribute.
-#[cold]
+// Previously `#[cold]+#[inline(never)]`; round-1 findings on issue
+// #279 attributed 15.42% of decoder mispredicts to this function with
+// 27.80% on the `pushq %rax` fn entry — call/ret BTB pressure from
+// the never-inlined boundary. `#[inline(never)]` was dropped first,
+// keeping `#[cold]` to preserve out-of-line layout for low-entropy
+// blocks (the prior «drop both» variant regressed +15.9% on L14).
+//
+// For high-repcode workloads (z000033 L-5, decode_all flamegraph
+// surfaces this helper at 1.93% self-time despite the `#[cold]`
+// label), the cold-bias attribute itself blocks LLVM from inlining
+// even at the hot call sites where the call/ret + BTB cost still
+// dominates the body work. Drop `#[cold]` and let the inline
+// cost-model see the full picture — body is small enough (RULES
+// lookup + 6 branchless cmov), so duplication into hot callers is
+// affordable, and cold callers don't pay anything they weren't
+// paying before (their cost was already dominated by the surrounding
+// rare-path work, not this helper).
 fn do_offset_history_repcode(offset_value: u32, lit_len: u32, scratch: &mut [u32; 3]) -> u32 {
     #[derive(Copy, Clone)]
     struct Rule {


### PR DESCRIPTION
## Summary

P4 of decoder gap-closure scope. Drops the `#[cold]` attribute from `do_offset_history_repcode`.

## Background

Issue #279 round-1 mispredict diagnosis attributed 15.42% of decoder mispredicts to this helper, with 27.80% on the `pushq %rax` function entry — call/ret BTB pressure from the never-inlined boundary. `#[inline(never)]` was dropped earlier; `#[cold]` was kept to preserve out-of-line layout for low-entropy blocks where the prior «drop both» variant regressed +15.9% on L14.

## Why drop `#[cold]` now

The z000033 L-5 decode flamegraph surfaces this helper at **1.93% self-time** despite the `#[cold]` label. The cold-bias attribute blocks LLVM from inlining even at hot call sites where call/ret + BTB cost dominates the body work. The body is small (RULES lookup + 6 branchless cmov via `select_u32`); inlining duplicates a tight scalar sequence into the per-sequence loop without bloating the icache footprint significantly.

Cold callers don't pay anything they weren't paying before — their total cost was already dominated by surrounding rare-path work, not this helper. (The +15.9% L14 regression in the prior round came from dropping BOTH `#[cold]` AND `#[inline(never)]` together; this PR only drops `#[cold]`.)

## Bench (i9, decode_all_slice on z000033)

| Version | time | vs r14-baseline | cumulative vs r12 |
|---|---|---|---|
| r14-baseline (PR #293 tip) | 4.2587 ms | — | −1.45% |
| r16 drop #[cold] | 4.1987 ms | **−1.41%** (p=0.00) | **−2.84%** |

p<0.05, CI [−1.44% −1.39%], extremely tight. Criterion explicitly reports «Performance has improved» (outside the 2% noise threshold).

## Risk

The «drop both» round-1 incident regressed +15.9% on L14 (low-entropy workload). This PR only drops `#[cold]`, leaving LLVM's normal inline cost model to decide. The L14 regression is a known concern; if it reappears we re-add `#[cold]` and target the call/ret cost via a different route (manual inline at hot call sites only).

Branch is named `r16` matching the gap-closure scope memory note (P4). The naming gap (r15) reserves slots for the in-flight P3 per-kernel ISA divergence work.

## Stack

Base: perf/#279-r14-fse-shift-formula (PR #293)

Related to #279.