### PR TITLE
test(bench): add encode_loop_z000033 example for clean encoder profiles

### DIFF
--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -76,7 +76,14 @@ fn main() {
         // which takes `impl Read` and re-buffers via `read_to_end` into
         // a fresh `Vec` every iteration.
         out.clear();
-        let mut frame_enc = FrameCompressor::new(CompressionLevel::Level(level));
+        // `from_level` is the canonical constructor: it maps 0 and 3 to
+        // `Default`, 1/7/11 to their named variants, and everything else to
+        // `Level(n)`. Constructing `Level(level)` directly would bypass that
+        // — most visibly for `level == 0`, which the documented C-zstd
+        // semantics treat as the default (3) but a raw `Level(0)` resolves
+        // to a literal 0. Use the canonical path so the example profiles the
+        // same encoder configuration a real caller's numeric level selects.
+        let mut frame_enc = FrameCompressor::new(CompressionLevel::from_level(level));
         frame_enc.set_source_size_hint(src.len() as u64);
         frame_enc.set_source(src.as_slice());
         frame_enc.set_drain(&mut out);

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -29,7 +29,7 @@ use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(-1);
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
     let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2000);
     let corpus_path: Option<&str> = args.get(3).map(|s| s.as_str());
 
@@ -67,6 +67,17 @@ fn main() {
         .expect("corpus too large: output-capacity bound overflows usize");
     let mut out: Vec<u8> = Vec::with_capacity(cap);
 
+    // `from_level` is the canonical constructor: it maps 0 and 3 to
+    // `Default`, 1/7/11 to their named variants, and everything else to
+    // `Level(n)`. Constructing `Level(level)` directly would bypass that
+    // — most visibly for `level == 0`, which the documented C-zstd
+    // semantics treat as the default (3) but a raw `Level(0)` resolves
+    // to a literal 0. Use the canonical path so the example profiles the
+    // same encoder configuration a real caller's numeric level selects.
+    // Resolved once here, outside the loop, so the per-iteration profile
+    // measures only the encoder, not the constant level-to-config mapping.
+    let compressor_level = CompressionLevel::from_level(level);
+
     let mut sink: usize = 0;
     for _ in 0..iters {
         // Reuse the buffer: `clear()` resets len to 0 but keeps the
@@ -76,14 +87,7 @@ fn main() {
         // which takes `impl Read` and re-buffers via `read_to_end` into
         // a fresh `Vec` every iteration.
         out.clear();
-        // `from_level` is the canonical constructor: it maps 0 and 3 to
-        // `Default`, 1/7/11 to their named variants, and everything else to
-        // `Level(n)`. Constructing `Level(level)` directly would bypass that
-        // — most visibly for `level == 0`, which the documented C-zstd
-        // semantics treat as the default (3) but a raw `Level(0)` resolves
-        // to a literal 0. Use the canonical path so the example profiles the
-        // same encoder configuration a real caller's numeric level selects.
-        let mut frame_enc = FrameCompressor::new(CompressionLevel::from_level(level));
+        let mut frame_enc = FrameCompressor::new(compressor_level);
         frame_enc.set_source_size_hint(src.len() as u64);
         frame_enc.set_source(src.as_slice());
         frame_enc.set_drain(&mut out);

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -10,9 +10,13 @@
 //! iteration, so steady-state iters do zero output-buffer allocation —
 //! the flamegraph stays on the encoder hot path instead of per-iter
 //! `Vec` growth + first-touch page faults. A fresh `FrameCompressor` per
-//! iter mirrors a real per-frame encode (there is no compressor-reset
-//! API; the matcher-table init is inherent encode cost, unlike the
-//! pure-noise output realloc).
+//! iter mirrors a real per-frame encode: each frame in production is
+//! compressed by its own `FrameCompressor`, and the matcher-table
+//! allocation that `new()` performs is part of that real per-frame cost.
+//! `FrameCompressor::compress()` does reset the matcher + offset history
+//! per call, so a single instance could be reused; this binary keeps the
+//! fresh-per-iter shape on purpose so the profile includes the matcher
+//! allocation, unlike the pure-noise output realloc which we elide.
 //!
 //! Build: `cargo build --profile flamegraph -p structured-zstd
 //!          --example encode_loop_z000033 --features dict_builder`

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -14,10 +14,10 @@
 //! API; the matcher-table init is inherent encode cost, unlike the
 //! pure-noise output realloc).
 //!
-//! Build: cargo build --profile flamegraph -p structured-zstd \
-//!          --example encode_loop_z000033 --features dict_builder
-//! Run:   cargo flamegraph --example encode_loop_z000033 --features dict_builder \
-//!          --profile flamegraph -- <level> <iters> <corpus_path>
+//! Build: `cargo build --profile flamegraph -p structured-zstd
+//!          --example encode_loop_z000033 --features dict_builder`
+//! Run:   `cargo flamegraph --example encode_loop_z000033 --features dict_builder
+//!          --profile flamegraph -- <level> <iters> <corpus_path>`
 
 use std::env;
 

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -1,9 +1,18 @@
 //! Standalone encode-loop binary for clean perf-record profiles of the
-//! ENCODER hot path. Reads a raw corpus, then loops `compress_to_vec` at
-//! the given level for N iters. No criterion, no FFI side — the perf
-//! samples land purely in our encoder (the `compare_ffi` compress bench
-//! runs the donor in the same process, so its flamegraph mixes
-//! `ZSTD_*` donor symbols with ours; this binary does not).
+//! ENCODER hot path. Reads a raw corpus, then loops a `FrameCompressor`
+//! over a contiguous `&[u8]` source at the given level for N iters. No
+//! criterion, no FFI side — the perf samples land purely in our encoder
+//! (the `compare_ffi` compress bench runs the donor in the same process,
+//! so its flamegraph mixes `ZSTD_*` donor symbols with ours; this binary
+//! does not).
+//!
+//! The output buffer is allocated ONCE and `clear()`-reused every
+//! iteration, so steady-state iters do zero output-buffer allocation —
+//! the flamegraph stays on the encoder hot path instead of per-iter
+//! `Vec` growth + first-touch page faults. A fresh `FrameCompressor` per
+//! iter mirrors a real per-frame encode (there is no compressor-reset
+//! API; the matcher-table init is inherent encode cost, unlike the
+//! pure-noise output realloc).
 //!
 //! Build: cargo build --profile flamegraph -p structured-zstd \
 //!          --example encode_loop_z000033 --features dict_builder
@@ -12,7 +21,7 @@
 
 use std::env;
 
-use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
+use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -36,15 +45,29 @@ fn main() {
         src
     };
 
+    // Output buffer reused across iterations. Generous capacity
+    // (src + 1/8 + 4 KiB) exceeds any frame's compressed size — even the
+    // incompressible worst case (raw blocks + frame/block headers stays
+    // well under src * 1.125) — so no iteration ever reallocates. We
+    // can't call the crate-internal `compress_bound` from an example, so
+    // this closed-form bound stands in for it.
+    let cap = src.len() + (src.len() >> 3) + 4096;
+    let mut out: Vec<u8> = Vec::with_capacity(cap);
+
     let mut sink: usize = 0;
     for _ in 0..iters {
-        // `compress_slice_to_vec` (NOT `compress_to_vec`): the input is
-        // already a contiguous `&[u8]`. `compress_to_vec` takes `impl
-        // Read` and re-buffers via `read_to_end` into a fresh `Vec`
-        // every iteration — that per-iter input allocation + copy would
-        // pollute the encoder flamegraph with `memmove` / alloc traffic
-        // that isn't part of the encode hot path.
-        let out = compress_slice_to_vec(src.as_slice(), CompressionLevel::Level(level));
+        // Reuse the buffer: `clear()` resets len to 0 but keeps the
+        // capacity, so the drain writes into already-faulted-in pages.
+        // Drive the low-level `FrameCompressor` directly (the input is
+        // already a contiguous `&[u8]`) instead of `compress_to_vec`,
+        // which takes `impl Read` and re-buffers via `read_to_end` into
+        // a fresh `Vec` every iteration.
+        out.clear();
+        let mut frame_enc = FrameCompressor::new(CompressionLevel::Level(level));
+        frame_enc.set_source_size_hint(src.len() as u64);
+        frame_enc.set_source(src.as_slice());
+        frame_enc.set_drain(&mut out);
+        frame_enc.compress();
         // Defeat dead-code elimination of the compress call.
         sink = sink.wrapping_add(out.len());
         core::hint::black_box(&out);

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -12,7 +12,7 @@
 
 use std::env;
 
-use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -38,7 +38,13 @@ fn main() {
 
     let mut sink: usize = 0;
     for _ in 0..iters {
-        let out = compress_to_vec(src.as_slice(), CompressionLevel::Level(level));
+        // `compress_slice_to_vec` (NOT `compress_to_vec`): the input is
+        // already a contiguous `&[u8]`. `compress_to_vec` takes `impl
+        // Read` and re-buffers via `read_to_end` into a fresh `Vec`
+        // every iteration — that per-iter input allocation + copy would
+        // pollute the encoder flamegraph with `memmove` / alloc traffic
+        // that isn't part of the encode hot path.
+        let out = compress_slice_to_vec(src.as_slice(), CompressionLevel::Level(level));
         // Defeat dead-code elimination of the compress call.
         sink = sink.wrapping_add(out.len());
         core::hint::black_box(&out);

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -1,0 +1,54 @@
+//! Standalone encode-loop binary for clean perf-record profiles of the
+//! ENCODER hot path. Reads a raw corpus, then loops `compress_to_vec` at
+//! the given level for N iters. No criterion, no FFI side — the perf
+//! samples land purely in our encoder (the `compare_ffi` compress bench
+//! runs the donor in the same process, so its flamegraph mixes
+//! `ZSTD_*` donor symbols with ours; this binary does not).
+//!
+//! Build: cargo build --profile flamegraph -p structured-zstd \
+//!          --example encode_loop_z000033 --features dict_builder
+//! Run:   cargo flamegraph --example encode_loop_z000033 --features dict_builder \
+//!          --profile flamegraph -- <level> <iters> <corpus_path>
+
+use std::env;
+
+use structured_zstd::encoding::{CompressionLevel, compress_to_vec};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(-1);
+    let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2000);
+    let corpus_path: Option<&str> = args.get(3).map(|s| s.as_str());
+
+    let src: Vec<u8> = if let Some(path) = corpus_path {
+        std::fs::read(path).expect("read corpus file")
+    } else {
+        // Deterministic 1 MiB LCG synthetic fallback.
+        let n = 1_048_576usize;
+        let mut src = Vec::with_capacity(n);
+        let mut state: u64 = 0x517cc1b727220a95;
+        while src.len() < n {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            src.push((state >> 56) as u8);
+        }
+        src
+    };
+
+    let mut sink: usize = 0;
+    for _ in 0..iters {
+        let out = compress_to_vec(src.as_slice(), CompressionLevel::Level(level));
+        // Defeat dead-code elimination of the compress call.
+        sink = sink.wrapping_add(out.len());
+        core::hint::black_box(&out);
+    }
+
+    eprintln!(
+        "encoded {} bytes × {} iters at level {}; last-out-sum={}",
+        src.len(),
+        iters,
+        level,
+        sink
+    );
+}

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -55,7 +55,14 @@ fn main() {
     // well under src * 1.125) — so no iteration ever reallocates. We
     // can't call the crate-internal `compress_bound` from an example, so
     // this closed-form bound stands in for it.
-    let cap = src.len() + (src.len() >> 3) + 4096;
+    // `saturating_add` so a multi-GB corpus can't wrap `usize` into an
+    // undersized capacity (debug panic / release OOB on the drain). The
+    // bound is approximate anyway; saturating to `usize::MAX` would just
+    // make `with_capacity` fail loudly instead of silently undersizing.
+    let cap = src
+        .len()
+        .saturating_add(src.len() >> 3)
+        .saturating_add(4096);
     let mut out: Vec<u8> = Vec::with_capacity(cap);
 
     let mut sink: usize = 0;

--- a/zstd/examples/encode_loop_z000033.rs
+++ b/zstd/examples/encode_loop_z000033.rs
@@ -55,14 +55,16 @@ fn main() {
     // well under src * 1.125) — so no iteration ever reallocates. We
     // can't call the crate-internal `compress_bound` from an example, so
     // this closed-form bound stands in for it.
-    // `saturating_add` so a multi-GB corpus can't wrap `usize` into an
-    // undersized capacity (debug panic / release OOB on the drain). The
-    // bound is approximate anyway; saturating to `usize::MAX` would just
-    // make `with_capacity` fail loudly instead of silently undersizing.
+    // `checked_add` (not `saturating_add`): a corpus large enough to
+    // overflow the `usize` bound is operator error for a profiling
+    // example, so fail loudly with a clear message rather than saturate
+    // to `usize::MAX` and OOM in `with_capacity`, or wrap to a too-small
+    // capacity that silently defeats the no-realloc goal.
     let cap = src
         .len()
-        .saturating_add(src.len() >> 3)
-        .saturating_add(4096);
+        .checked_add(src.len() >> 3)
+        .and_then(|v| v.checked_add(4096))
+        .expect("corpus too large: output-capacity bound overflows usize");
     let mut out: Vec<u8> = Vec::with_capacity(cap);
 
     let mut sink: usize = 0;


### PR DESCRIPTION
## Summary

Adds `encode_loop_z000033` example — the encode-side analog of `decode_loop_z000033`. Reads a raw corpus, loops `compress_to_vec` at a given level N times, no criterion and no FFI.

## Why

The `compare_ffi` compress benchmark runs the donor (`ZSTD_compress`) in the same process, so `cargo flamegraph` on it mixes donor `ZSTD_DUBT_findBestMatch` / `ZSTD_recordFingerprint` symbols with ours — unusable for isolating the pure-Rust encoder hot path. This binary produces clean encoder perf-record samples.

`black_box` + len-sum sink defeats dead-code elimination of the compress call.

## Usage

```
cargo flamegraph --example encode_loop_z000033 --features dict_builder \
  --profile flamegraph -- <level> <iters> zstd/decodecorpus_files/z000033
```

Used to map the Fast L-1 encode hot path (start_matching 25%, sequence-emit 30%, HUF encode4x 8%) for #111 Phase 7 work.

Related to #111.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new encoder performance benchmark example demonstrating efficient encoding patterns with buffer reuse and compression configuration for performance testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->