### PR TITLE
perf(decode): inline donor match-copy on all targets via portable wildcopy

### DIFF
--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -1,7 +1,7 @@
 //! Verbatim port of donor zstd's `ZSTD_execSequence` body
-//! (lib/decompress/zstd_decompress_block.c:1008-1105) for the
-//! `UserSliceBackend` direct-write decode path. Bypasses the
-//! `DecodeBuffer::push` + `repeat` abstraction chain in favour of
+//! (lib/decompress/zstd_decompress_block.c:1008-1105) for the inline
+//! direct-write decode path (`UserSliceBackend` and `FlatBuf`). Bypasses
+//! the `DecodeBuffer::push` + `repeat` abstraction chain in favour of
 //! donor's straight-line shape:
 //!
 //! 1. Literal copy: unconditional 16-byte SIMD store + wildcopy tail
@@ -14,12 +14,17 @@
 //!    (`overlap_src_before_dst`, 8-byte loop while diff < 16,
 //!    16-byte once diff catches up).
 //!
-//! Helpers are private SSE2-baseline x86_64 ops (all supported
-//! x86_64 targets carry SSE2). Non-x86 paths fall back through the
-//! existing `BufferBackend::extend` + `DecodeBuffer::repeat` chain
-//! (`UserSliceBackend::SUPPORTS_INLINE_SEQUENCE_EXEC` returns `false`
-//! on those targets, so the dispatch site dead-eliminates this code
-//! at compile time per backend monomorphisation).
+//! Two helper implementations with an identical byte-level contract:
+//! [`x86`] uses SSE2 intrinsics (`_mm_loadu/storeu_si128`, the x86_64
+//! baseline); [`portable`] uses unaligned `u128`/`u64` moves that the
+//! backend lowers to its widest store (NEON `ldr q`/`str q` on aarch64,
+//! plain movs on i686/riscv/wasm). The backend's `exec_sequence_inline`
+//! arm picks one by `cfg(target_arch)`. Backends gate the whole path on
+//! `SUPPORTS_INLINE_SEQUENCE_EXEC` (`true` for `UserSliceBackend` /
+//! `FlatBuf` on every target, `false` for `RingBuffer`, which stays on
+//! the `extend` + `repeat` fallback for wrap-aware multi-segment frames).
+//! See the [`portable`] module doc for how the inline path is reached
+//! per target.
 
 // x86_64 only: SSE2 is the architectural baseline there (every x86_64
 // CPU has SSE2 by definition). 32-bit `x86` is excluded because the

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -193,24 +193,30 @@ pub(crate) mod x86 {
 
 /// Portable (non-x86) wildcopy helpers: identical byte-level contract
 /// to [`x86`], expressed with `read_unaligned`/`write_unaligned` so any
-/// target can use them. On aarch64 LLVM lowers the 16-byte
-/// `u128` load/store to a single NEON `ldr q`/`str q`; on other targets
-/// it picks the widest available move. Used by the aarch64 (and any
-/// `BufferBackend::exec_sequence_inline` arm to get the same donor
-/// `ZSTD_execSequence` shape the x86 path already has, instead of
-/// falling through to the slow `try_push` + `repeat` chain.
+/// target can use them. On aarch64 LLVM lowers the 16-byte `u128`
+/// load/store to a single NEON `ldr q`/`str q`; elsewhere it picks the
+/// widest available move. The `cfg(not(x86_64))` arms of
+/// `FlatBuf`/`UserSliceBackend::exec_sequence_inline` use these to get
+/// the donor `ZSTD_execSequence` shape the x86 path already has, instead
+/// of the slow `try_push` + `repeat` chain.
 ///
-/// Available on every non-x86 target: both inline-exec backends
-/// (`FlatBuf`, `UserSliceBackend`) set `SUPPORTS_INLINE_SEQUENCE_EXEC =
-/// true` everywhere and carry a `cfg(not(x86_64))` arm built on these
-/// helpers, so they are live on aarch64, i686, riscv, wasm, etc. x86_64
-/// uses the SSE2 [`x86`] module instead, so this is gated out there to
-/// avoid two definitions.
-// Compiled on every non-x86 target (where the inline-exec arms use it)
-// AND on x86_64 under `cfg(test)` so the portable helpers get exercised
-// on the main x86 CI lane too, not only the i686 job — the impl is
-// architecture-independent (`read_unaligned`/`write_unaligned`), so a
-// regression in it would otherwise hide until the i686 shard ran.
+/// How the inline path is reached per target:
+/// - aarch64: `detect_cpu_kernel` -> `Neon` -> the generic pipelined
+///   executor (`execute_one_sequence_pipelined`), which calls
+///   `exec_sequence_inline` when the backend opts in.
+/// - i686 / riscv / wasm: `detect_cpu_kernel` -> `Scalar` ->
+///   `seq_decoder_scalar`, whose execute body routes through that same
+///   `execute_one_sequence_pipelined`, so the inline path is reached in
+///   scalar-tier production dispatch too.
+///
+/// Both `FlatBuf` and `UserSliceBackend` set
+/// `SUPPORTS_INLINE_SEQUENCE_EXEC = true` on every target; `RingBuffer`
+/// keeps it `false` and stays on the wrap-aware fallback. x86_64 uses
+/// the SSE2 [`x86`] module for production, so this module is gated out
+/// there in non-test builds to avoid two definitions; it is still
+/// compiled under `cfg(test)` on x86_64 so the architecture-independent
+/// helpers are exercised on the main x86 CI lane, not only the i686
+/// shard.
 #[cfg(any(not(target_arch = "x86_64"), test))]
 pub(crate) mod portable {
     /// Donor `ZSTD_copy16`: one unaligned 16-byte move.

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -191,6 +191,129 @@ pub(crate) mod x86 {
     }
 }
 
+/// Portable (non-x86) wildcopy helpers: identical byte-level contract
+/// to [`x86`], expressed with `read_unaligned`/`write_unaligned` so any
+/// target can use them. On aarch64 LLVM lowers the 16-byte
+/// `u128` load/store to a single NEON `ldr q`/`str q`; on other targets
+/// it picks the widest available move. Used by the aarch64 (and any
+/// `BufferBackend::exec_sequence_inline` arm to get the same donor
+/// `ZSTD_execSequence` shape the x86 path already has, instead of
+/// falling through to the slow `try_push` + `repeat` chain.
+///
+/// Available on every non-x86 target: both inline-exec backends
+/// (`FlatBuf`, `UserSliceBackend`) set `SUPPORTS_INLINE_SEQUENCE_EXEC =
+/// true` everywhere and carry a `cfg(not(x86_64))` arm built on these
+/// helpers, so they are live on aarch64, i686, riscv, wasm, etc. x86_64
+/// uses the SSE2 [`x86`] module instead, so this is gated out there to
+/// avoid two definitions.
+#[cfg(not(target_arch = "x86_64"))]
+pub(crate) mod portable {
+    /// Donor `ZSTD_copy16`: one unaligned 16-byte move.
+    ///
+    /// # Safety
+    /// `dst` / `src` valid for 16 bytes; regions non-overlapping.
+    #[inline(always)]
+    pub(crate) unsafe fn copy16(dst: *mut u8, src: *const u8) {
+        unsafe {
+            let v: u128 = src.cast::<u128>().read_unaligned();
+            dst.cast::<u128>().write_unaligned(v);
+        }
+    }
+
+    /// Donor `ZSTD_wildcopy(..., ZSTD_no_overlap)`: 16-byte loop until at
+    /// least `length` bytes written. May overshoot up to 15 bytes past
+    /// `dst + length`; caller's `WILDCOPY_OVERLENGTH` slack accommodates.
+    ///
+    /// # Safety
+    /// `dst` writable for `length + 15`; `src` readable for `length + 15`;
+    /// no-overlap (`dst` and `src` regions disjoint, donor semantics).
+    #[inline(always)]
+    pub(crate) unsafe fn wildcopy_no_overlap(dst: *mut u8, src: *const u8, length: usize) {
+        debug_assert!(length > 0);
+        unsafe {
+            let mut off = 0usize;
+            loop {
+                copy16(dst.add(off), src.add(off));
+                off += 16;
+                if off >= length {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Donor `ZSTD_wildcopy(..., ZSTD_overlap_src_before_dst)` 8-byte arm:
+    /// each iter reads `src + off` (may lie in the just-written
+    /// destination), correct once the src/dst gap is ≥ 8.
+    ///
+    /// # Safety
+    /// `dst` writable for `length + 7`; `src` readable for `length + 7`;
+    /// the src/dst gap must be ≥ 8 (caller establishes via
+    /// [`overlap_copy8`]).
+    #[inline(always)]
+    pub(crate) unsafe fn wildcopy_overlap_8byte_stride(
+        dst: *mut u8,
+        src: *const u8,
+        length: usize,
+    ) {
+        debug_assert!(length > 0);
+        unsafe {
+            let mut off = 0usize;
+            loop {
+                let v: u64 = src.add(off).cast::<u64>().read_unaligned();
+                dst.add(off).cast::<u64>().write_unaligned(v);
+                off += 8;
+                if off >= length {
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Donor `ZSTD_overlapCopy8`: copies 8 bytes and, for `offset < 8`,
+    /// spreads the src/dst distance so the following wildcopy can use the
+    /// safe ≥ 8 stride. Returns the updated `(dst, src)` pair. Byte-exact
+    /// port of [`super::x86::overlap_copy8`] (same dec32/dec64 tables and
+    /// the same net-offset computation that avoids intermediate pointer
+    /// underflow).
+    ///
+    /// # Safety
+    /// `dst` writable for 8 bytes from the returned pointer's base; `src`
+    /// readable for the spread reads; `offset >= 1`.
+    #[inline(always)]
+    pub(crate) unsafe fn overlap_copy8(
+        dst: *mut u8,
+        src: *const u8,
+        offset: usize,
+    ) -> (*mut u8, *const u8) {
+        const DEC32_TABLE: [u32; 8] = [0, 1, 2, 1, 4, 4, 4, 4];
+        const DEC64_TABLE: [i32; 8] = [8, 8, 8, 7, 8, 9, 10, 11];
+        unsafe {
+            if offset < 8 {
+                let sub2 = DEC64_TABLE[offset];
+                dst.add(0).write(src.add(0).read());
+                dst.add(1).write(src.add(1).read());
+                dst.add(2).write(src.add(2).read());
+                dst.add(3).write(src.add(3).read());
+                let dec32 = DEC32_TABLE[offset] as usize;
+                let v: u32 = src.add(dec32).cast::<u32>().read_unaligned();
+                dst.add(4).cast::<u32>().write_unaligned(v);
+                let net_offset = dec32 as isize - sub2 as isize + 8;
+                debug_assert!(
+                    net_offset >= 0,
+                    "overlap_copy8 net offset is non-negative for all offset ∈ 1..=7"
+                );
+                let src_after = src.offset(net_offset);
+                (dst.add(8), src_after)
+            } else {
+                let v: u64 = src.cast::<u64>().read_unaligned();
+                dst.cast::<u64>().write_unaligned(v);
+                (dst.add(8), src.add(8))
+            }
+        }
+    }
+}
+
 #[cfg(all(test, target_arch = "x86_64"))]
 mod inline_helper_tests {
     use super::x86::{copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride};
@@ -277,5 +400,105 @@ mod inline_helper_tests {
         // pattern depends on the lookup tables; donor parity is the
         // contract).
         assert!(buf[3..11].iter().any(|&b| b != 0));
+    }
+}
+
+// Parallel coverage for the portable helpers (non-x86 targets). Mirrors
+// `inline_helper_tests` exactly: the portable module is the unsafe
+// pointer-copy backend the non-x86 `exec_sequence_inline` arms rely on,
+// so it must carry the same exact-copy / overshoot / short-offset-spread
+// assertions as the SSE2 helpers it byte-for-byte mirrors. On the host
+// CI matrix this runs under the i686-unknown-linux-gnu test job.
+#[cfg(all(test, not(target_arch = "x86_64")))]
+mod portable_helper_tests {
+    use super::portable::{
+        copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
+    };
+
+    #[test]
+    fn copy16_copies_exactly_16_bytes() {
+        let src: [u8; 16] = [
+            0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD,
+            0xAE, 0xAF,
+        ];
+        let mut dst = [0u8; 16];
+        unsafe { copy16(dst.as_mut_ptr(), src.as_ptr()) };
+        assert_eq!(dst, src);
+    }
+
+    #[test]
+    fn wildcopy_no_overlap_short_length_overshoots() {
+        // Length 1 still triggers the unconditional first 16-byte store
+        // — the wildcopy overshoots up to 15 bytes past the declared
+        // end, the donor contract.
+        let src: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        let mut dst = [0u8; 32];
+        unsafe { wildcopy_no_overlap(dst.as_mut_ptr(), src.as_ptr(), 1) };
+        assert_eq!(&dst[..16], &src[..16]);
+        assert!(dst[16..].iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn wildcopy_no_overlap_length_above_16_uses_multiple_iters() {
+        // Length 24 → first 16-byte store, then one more iter
+        // overshooting 8 bytes past the declared end.
+        let src: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        let mut dst = [0u8; 32];
+        unsafe { wildcopy_no_overlap(dst.as_mut_ptr(), src.as_ptr(), 24) };
+        assert_eq!(&dst[..32], &src[..32]);
+    }
+
+    #[test]
+    fn wildcopy_overlap_8byte_stride_rle_expansion_offset_8() {
+        // Offset = 8: src = dst - 8. Each 8-byte read picks up bytes the
+        // previous iter just wrote, expanding the seed (RLE).
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        unsafe {
+            wildcopy_overlap_8byte_stride(buf.as_mut_ptr().add(8), buf.as_ptr(), 16);
+        }
+        assert_eq!(&buf[8..16], &[1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(&buf[16..24], &[1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn overlap_copy8_offset_ge_8_does_plain_copy() {
+        // offset >= 8: straight ZSTD_copy8 (8-byte read+write).
+        let mut buf = [0u8; 32];
+        buf[..8].copy_from_slice(&[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]);
+        let (op2, ip2) = unsafe { overlap_copy8(buf.as_mut_ptr().add(8), buf.as_ptr(), 8) };
+        assert_eq!(op2, unsafe { buf.as_mut_ptr().add(16) });
+        assert_eq!(ip2, unsafe { buf.as_ptr().add(8) });
+        assert_eq!(
+            &buf[8..16],
+            &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]
+        );
+    }
+
+    #[test]
+    fn overlap_copy8_offset_lt_8_spreads_source() {
+        // offset < 8: dec32table / dec64table spread step. offset = 3.
+        let mut buf = [0u8; 32];
+        buf[..3].copy_from_slice(&[0xAA, 0xBB, 0xCC]);
+        let (op2, _ip2) = unsafe { overlap_copy8(buf.as_mut_ptr().add(3), buf.as_ptr(), 3) };
+        assert_eq!(op2, unsafe { buf.as_mut_ptr().add(11) });
+        assert!(buf[3..11].iter().any(|&b| b != 0));
+    }
+
+    /// Cross-check: the portable helpers must produce byte-identical
+    /// output to a straightforward scalar reference for the no-overlap
+    /// copy across a range of lengths. Guards against a divergence
+    /// between the u128/u64 unaligned-move lowering and plain copies.
+    #[test]
+    fn wildcopy_no_overlap_matches_scalar_reference() {
+        for len in 1usize..=48 {
+            let src: [u8; 64] = core::array::from_fn(|i| (i as u8).wrapping_mul(7).wrapping_add(1));
+            let mut dst = [0u8; 64];
+            unsafe { wildcopy_no_overlap(dst.as_mut_ptr(), src.as_ptr(), len) };
+            // Only the first `len` bytes are contractually defined; the
+            // overshoot tail is allowed to differ. Assert the defined
+            // region matches.
+            assert_eq!(&dst[..len], &src[..len], "len={len}");
+        }
     }
 }

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -206,7 +206,12 @@ pub(crate) mod x86 {
 /// helpers, so they are live on aarch64, i686, riscv, wasm, etc. x86_64
 /// uses the SSE2 [`x86`] module instead, so this is gated out there to
 /// avoid two definitions.
-#[cfg(not(target_arch = "x86_64"))]
+// Compiled on every non-x86 target (where the inline-exec arms use it)
+// AND on x86_64 under `cfg(test)` so the portable helpers get exercised
+// on the main x86 CI lane too, not only the i686 job — the impl is
+// architecture-independent (`read_unaligned`/`write_unaligned`), so a
+// regression in it would otherwise hide until the i686 shard ran.
+#[cfg(any(not(target_arch = "x86_64"), test))]
 pub(crate) mod portable {
     /// Donor `ZSTD_copy16`: one unaligned 16-byte move.
     ///
@@ -409,7 +414,10 @@ mod inline_helper_tests {
 // so it must carry the same exact-copy / overshoot / short-offset-spread
 // assertions as the SSE2 helpers it byte-for-byte mirrors. On the host
 // CI matrix this runs under the i686-unknown-linux-gnu test job.
-#[cfg(all(test, not(target_arch = "x86_64")))]
+// Runs on ALL targets (the `portable` module is compiled under
+// `cfg(test)` on x86_64 too), so the architecture-independent helpers are
+// covered on the main x86 CI lane as well as the i686 job.
+#[cfg(test)]
 mod portable_helper_tests {
     use super::portable::{
         copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -645,7 +645,6 @@ mod tests {
     /// offsets across the SSE2/AVX2 threshold boundary
     /// (offset 20 routes to SSE2 16-byte path, offset 32 to AVX2
     /// 32-byte ymm path, offset 64 to deep AVX2 path).
-    #[cfg(target_arch = "x86_64")]
     // AVX2 override is x86_64-only; this test calls it directly.
     #[cfg(target_arch = "x86_64")]
     #[test]

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -65,18 +65,17 @@ impl FlatBuf {
 
 impl BufferBackend for FlatBuf {
     /// FlatBuf opts into the donor-shape inline `exec_sequence_inline`
-    /// path on x86_64 (same gate as `UserSliceBackend`). FlatBuf is
-    /// selected for single-segment frames (frame_content_size known
-    /// up-front, single block of literals+matches). Its
-    /// `with_capacity(cap + WILDCOPY_OVERLENGTH)` reserve already
-    /// carries the 32-byte SIMD overshoot slack the inline path
-    /// requires. Issue #279 round 4 track 1c (renamed track 5a):
-    /// opting FlatBuf in unlocks the AVX2 32-byte ymm match-copy
-    /// fast path for single-segment frames (decodecorpus-z000033 et
-    /// al), which previously fell through to the layered
-    /// `repeat_lookahead_prefetched` chain via the trait-method CALL
-    /// boundary.
-    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = cfg!(target_arch = "x86_64");
+    /// path on every target: x86_64 via the SSE2
+    /// `exec_sequence_inline::x86` module, all other ISAs via the
+    /// architecture-agnostic `portable` module (the `cfg(not(x86_64))`
+    /// arm below). FlatBuf is selected for single-segment frames
+    /// (frame_content_size known up-front, single block of
+    /// literals+matches). Its `with_capacity(cap + WILDCOPY_OVERLENGTH)`
+    /// reserve already carries the SIMD overshoot slack the inline path
+    /// requires. Both arms are gated on this const, which is
+    /// unconditionally `true` because FlatBuf provides an override for
+    /// every target.
+    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = true;
 
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
@@ -160,6 +159,96 @@ impl BufferBackend for FlatBuf {
             }
 
             // Bump len. Capacity asserted above; this is safe.
+            self.buf.set_len(buf_len + total);
+        }
+        Ok(())
+    }
+
+    /// Non-x86 port of [`Self::exec_sequence_inline`] — identical donor
+    /// `ZSTD_execSequence` shape, but the wildcopy helpers come from the
+    /// portable module (16-byte `u128` / 8-byte `u64` unaligned moves,
+    /// lowered to NEON `ldr q`/`str q` on aarch64 and the widest store
+    /// available elsewhere). Without this arm the non-x86 decode path
+    /// fell through to the slow `try_push` + `repeat` trait chain; the
+    /// inline form cuts the match-copy cost that dominates match-heavy
+    /// decode.
+    #[cfg(not(target_arch = "x86_64"))]
+    #[inline(always)]
+    unsafe fn exec_sequence_inline(
+        &mut self,
+        lit_src: *const u8,
+        lit_length: usize,
+        offset: usize,
+        match_length: usize,
+    ) -> Result<(), super::errors::ExecuteSequencesError> {
+        use super::errors::ExecuteSequencesError;
+        use super::exec_sequence_inline::portable::{
+            copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
+        };
+        // Fallible capacity check mirrors the x86 arm: the 16-byte
+        // wildcopy overshoots up to 15 bytes past `tail + total`, which
+        // `with_capacity(... + WILDCOPY_OVERLENGTH)` covers for
+        // well-formed frames; malformed input surfaces as
+        // `OutputBufferOverflow` instead of a write past capacity.
+        const MAX_WILDCOPY_OVERSHOOT: usize = 15;
+        let cap = self.buf.capacity();
+        let buf_len = self.buf.len();
+        let total = match lit_length.checked_add(match_length) {
+            Some(v) => v,
+            None => {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
+                    tail: buf_len,
+                    requested: usize::MAX,
+                    capacity: cap,
+                });
+            }
+        };
+        let cap_required = buf_len
+            .checked_add(total)
+            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
+        match cap_required {
+            Some(v) if v <= cap => {}
+            _ => {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
+                    tail: buf_len,
+                    requested: total,
+                    capacity: cap,
+                });
+            }
+        }
+        debug_assert!(offset >= 1);
+        debug_assert!(match_length >= 1);
+        let live_len = buf_len - self.head;
+        debug_assert!(
+            live_len + lit_length >= offset,
+            "FlatBuf::exec_sequence_inline: offset {offset} exceeds live window",
+        );
+
+        // SAFETY: capacity check above guarantees writes (plus the
+        // ≤ 15-byte wildcopy overshoot) stay within `buf.capacity()`;
+        // `live_len + lit_length >= offset` keeps the match source
+        // in-bounds. Same invariants the x86 arm relies on.
+        unsafe {
+            let base_mut = self.buf.as_mut_ptr();
+
+            let op_lit = base_mut.add(buf_len);
+            copy16(op_lit, lit_src);
+            if lit_length > 16 {
+                wildcopy_no_overlap(op_lit.add(16), lit_src.add(16), lit_length - 16);
+            }
+
+            let op_match = base_mut.add(buf_len + lit_length);
+            let match_src = base_mut.cast_const().add(buf_len + lit_length - offset);
+
+            if offset >= 16 {
+                wildcopy_no_overlap(op_match, match_src, match_length);
+            } else {
+                let (op2, ip2) = overlap_copy8(op_match, match_src, offset);
+                if match_length > 8 {
+                    wildcopy_overlap_8byte_stride(op2, ip2, match_length - 8);
+                }
+            }
+
             self.buf.set_len(buf_len + total);
         }
         Ok(())

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -597,11 +597,13 @@ mod tests {
         assert_eq!(f.tail(), 0);
     }
 
-    /// SSE2 inline executor — verify match-copy correctness against a
+    /// Inline executor — verify match-copy correctness against a
     /// byte-by-byte reference. Exercises the non-overlap path
     /// (offset >= 16), short-offset overlapCopy8 path (offset < 16),
-    /// and the literal copy16 + wildcopy tail.
-    #[cfg(target_arch = "x86_64")]
+    /// and the literal copy16 + wildcopy tail. Runs on every target: on
+    /// x86_64 it drives the SSE2 `exec_sequence_inline` arm, elsewhere
+    /// the portable arm (both `cfg`-selected), giving the non-x86
+    /// backend method direct coverage.
     #[test]
     fn exec_sequence_inline_match_copy_correctness() {
         for offset in [4usize, 8, 12, 20, 48, 96] {
@@ -643,6 +645,8 @@ mod tests {
     /// offsets across the SSE2/AVX2 threshold boundary
     /// (offset 20 routes to SSE2 16-byte path, offset 32 to AVX2
     /// 32-byte ymm path, offset 64 to deep AVX2 path).
+    #[cfg(target_arch = "x86_64")]
+    // AVX2 override is x86_64-only; this test calls it directly.
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn exec_sequence_inline_avx2_offset_boundary_correctness() {

--- a/zstd/src/decoding/seq_decoder_scalar.rs
+++ b/zstd/src/decoding/seq_decoder_scalar.rs
@@ -48,11 +48,18 @@ macro_rules! decode_one_body {
     }};
 }
 
-/// Scalar-tier execute body. No backend-specific inline-exec path;
-/// always routes through `try_push` + `repeat_lookahead_prefetched`
-/// (the backend may or may not have an SSE2 inline path, but on the
-/// Scalar dispatch arm we don't gate on it — keep the body simple and
-/// portable).
+/// Scalar-tier execute body. Routes through the shared
+/// `execute_one_sequence_pipelined`, which uses the donor inline
+/// literal+match wildcopy on backends that opt into
+/// `SUPPORTS_INLINE_SEQUENCE_EXEC` (FlatBuf / UserSliceBackend, on every
+/// target) and falls back to `try_push` + `repeat_lookahead_prefetched`
+/// otherwise (RingBuffer, or when the per-sequence literal-slack /
+/// prefix-resident gate fails). The Scalar tier is the production
+/// dispatch target on non-x86 ISAs (i686 / riscv / wasm resolve to
+/// `CpuKernelTag::Scalar`), so routing here is what makes those targets
+/// actually reach the inline path — not just the aarch64 pipelined tier.
+/// Sharing the executor keeps the literal-slack / offset gating in one
+/// place rather than duplicating it per tier.
 macro_rules! execute_one_body {
     (
         $buffer:expr,
@@ -63,43 +70,23 @@ macro_rules! execute_one_body {
         $seq_ml:expr,
         $resolved_offset:expr
     ) => {{
-        let _result: Result<(), DecompressBlockError> = 'exec_inner: {
-            let seq_ll_v: u32 = $seq_ll;
-            let seq_ml_v: u32 = $seq_ml;
-            let resolved_offset_v: u32 = $resolved_offset;
-            let literals_buffer_len_v: usize = $literals_buffer_len;
-            let lit_cur_before = *$lit_cur;
-            let high = match lit_cur_before
-                .checked_add(seq_ll_v as usize)
-                .filter(|&h| h <= literals_buffer_len_v)
-            {
-                Some(h) => h,
-                None => {
-                    break 'exec_inner Err(ExecuteSequencesError::NotEnoughBytesForSequence {
-                        wanted: lit_cur_before.saturating_add(seq_ll_v as usize),
-                        have: literals_buffer_len_v,
-                    }
-                    .into());
-                }
-            };
-            // SAFETY: high <= literals_buffer_len_v, lit_cur_before <= high.
-            let lits = unsafe { $literals_buffer.get_unchecked(lit_cur_before..high) };
-            *$lit_cur = high;
-
-            if resolved_offset_v == 0 {
-                break 'exec_inner Err(ExecuteSequencesError::ZeroOffset.into());
-            }
-
-            if let Err(e) = $buffer.try_push(lits) {
-                break 'exec_inner Err(ExecuteSequencesError::from(e).into());
-            }
-            match $buffer.repeat_lookahead_prefetched(resolved_offset_v as usize, seq_ml_v as usize)
-            {
-                Ok(()) => Ok(()),
-                Err(e) => Err(ExecuteSequencesError::from(e).into()),
-            }
+        let resolved_offset_v: u32 = $resolved_offset;
+        // `of` is unused by the executor (it consumes the separately
+        // resolved `resolved_offset_v`); set it to the resolved value so
+        // the field carries a meaningful number rather than a sentinel.
+        let seq = Sequence {
+            ll: $seq_ll,
+            ml: $seq_ml,
+            of: resolved_offset_v,
         };
-        _result
+        super::sequence_section_decoder::execute_one_sequence_pipelined(
+            $buffer,
+            $literals_buffer,
+            $lit_cur,
+            $literals_buffer_len,
+            seq,
+            resolved_offset_v,
+        )
     }};
 }
 

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -146,17 +146,17 @@ impl<'a> UserSliceBackend<'a> {
 }
 
 impl<'a> BufferBackend for UserSliceBackend<'a> {
-    /// Donor-shape inline `ZSTD_execSequence` is available on
-    /// `x86_64`, where SSE2 is the architectural baseline and the
-    /// helpers in [`super::exec_sequence_inline::x86`] emit
-    /// `_mm_loadu_si128` / `_mm_storeu_si128` without needing a
-    /// `#[target_feature]` gate. 32-bit `x86` is excluded — its
-    /// pre-SSE2 baseline (i386 / i486 / i586) would SIGILL on the
-    /// SSE2 intrinsics. aarch64 NEON, riscv etc. fall back to the
-    /// existing `extend` + `repeat` chain — those paths already
-    /// emit the architecture's best-available SIMD via
-    /// `copy_bytes_overshooting`'s runtime detect.
-    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = cfg!(target_arch = "x86_64");
+    /// Donor-shape inline `ZSTD_execSequence` on every target: x86_64
+    /// via the SSE2 [`super::exec_sequence_inline::x86`] module
+    /// (`_mm_loadu_si128` / `_mm_storeu_si128`, SSE2 is the x86_64
+    /// baseline so no `#[target_feature]` gate), all other ISAs via the
+    /// architecture-agnostic [`super::exec_sequence_inline::portable`]
+    /// module (unaligned u128/u64 moves lowered to NEON `ldr q`/`str q`
+    /// on aarch64 and the widest available store elsewhere). Both arms
+    /// are gated on this const, unconditionally `true` because an
+    /// override exists for every target. Previously non-x86 fell back to
+    /// the slow `extend` + `repeat` chain.
+    const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = true;
 
     /// Donor `ZSTD_execSequence` body — see trait doc for
     /// preconditions / contract.
@@ -280,6 +280,96 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
                 wildcopy_no_overlap(op_match, match_src, match_length);
             } else {
                 // overlap_copy8 + wildcopy(overlap) tail.
+                let (op2, ip2) = overlap_copy8(op_match, match_src, offset);
+                if match_length > 8 {
+                    wildcopy_overlap_8byte_stride(op2, ip2, match_length - 8);
+                }
+            }
+        }
+        self.tail = new_tail;
+        Ok(())
+    }
+
+    /// Non-x86 port of [`Self::exec_sequence_inline`] — identical donor
+    /// `ZSTD_execSequence` shape through the portable wildcopy helpers
+    /// (unaligned u128/u64 moves; NEON `ldr q`/`str q` on aarch64).
+    /// Mirrors the x86 arm's capacity / offset safety checks exactly.
+    #[cfg(not(target_arch = "x86_64"))]
+    #[inline(always)]
+    unsafe fn exec_sequence_inline(
+        &mut self,
+        lit_src: *const u8,
+        lit_length: usize,
+        offset: usize,
+        match_length: usize,
+    ) -> Result<(), super::errors::ExecuteSequencesError> {
+        use super::errors::ExecuteSequencesError;
+        use super::exec_sequence_inline::portable::{
+            copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
+        };
+        const MAX_WILDCOPY_OVERSHOOT: usize = 15;
+        let cap = self.slice.len();
+        let total = match lit_length.checked_add(match_length) {
+            Some(v) => v,
+            None => {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
+                    tail: self.tail,
+                    requested: usize::MAX,
+                    capacity: cap,
+                });
+            }
+        };
+        let cap_required = self
+            .tail
+            .checked_add(total)
+            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
+        match cap_required {
+            Some(v) if v <= cap => {}
+            _ => {
+                return Err(ExecuteSequencesError::OutputBufferOverflow {
+                    tail: self.tail,
+                    requested: total,
+                    capacity: cap,
+                });
+            }
+        }
+        let new_tail = self.tail + total;
+        debug_assert!(offset >= 1);
+        debug_assert!(match_length >= 1);
+        let live_len = self.tail - self.head;
+        debug_assert!(
+            live_len
+                .checked_add(lit_length)
+                .is_some_and(|end| offset <= end),
+            "exec_sequence_inline: offset ({}) exceeds live window (len={} + lit={}, head={}, tail={})",
+            offset,
+            live_len,
+            lit_length,
+            self.head,
+            self.tail,
+        );
+
+        // SAFETY: identical invariants to the x86 arm — the capacity
+        // check bounds every write (plus the ≤ 15-byte wildcopy
+        // overshoot) inside `self.slice`; `offset <= tail + lit_length`
+        // keeps the match source in-bounds; `lit_src` carries the parent
+        // literals buffer's provenance (dispatch-site `inline_path_safe`
+        // gate guarantees the unconditional 16-byte literal read stays
+        // valid).
+        unsafe {
+            let base = self.slice.as_mut_ptr();
+            let op_lit = base.add(self.tail);
+            copy16(op_lit, lit_src);
+            if lit_length > 16 {
+                wildcopy_no_overlap(op_lit.add(16), lit_src.add(16), lit_length - 16);
+            }
+
+            let op_match = base.add(self.tail + lit_length);
+            let match_src = base.cast_const().add(self.tail + lit_length - offset);
+
+            if offset >= 16 {
+                wildcopy_no_overlap(op_match, match_src, match_length);
+            } else {
                 let (op2, ip2) = overlap_copy8(op_match, match_src, offset);
                 if match_length > 8 {
                     wildcopy_overlap_8byte_stride(op2, ip2, match_length - 8);

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -956,7 +956,6 @@ mod tests {
     extern crate alloc;
     use super::*;
     use alloc::vec;
-    #[cfg(target_arch = "x86_64")]
     use alloc::vec::Vec;
 
     #[test]
@@ -1238,7 +1237,7 @@ mod tests {
         // 40-byte literals (forces wildcopy tail) — needs 40-byte
         // source buffer with extra read slack for the final
         // 16-byte load.
-        let lits: alloc::vec::Vec<u8> = (0..40u8 + 16).map(|i| 0x80 + i).collect();
+        let lits: Vec<u8> = (0..40u8 + 16).map(|i| 0x80 + i).collect();
         unsafe {
             b.exec_sequence_inline(lits.as_ptr(), 40, 16, 8).unwrap();
         }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -1188,7 +1188,6 @@ mod tests {
     /// callee. Tests cover: short-literal + short-match, long
     /// literal (wildcopy tail), short-offset match (overlapCopy8 +
     /// 8-byte stride), long-offset match (wildcopy_no_overlap).
-    #[cfg(target_arch = "x86_64")]
     #[test]
     fn exec_sequence_inline_short_literal_plus_long_offset_match() {
         // Layout: pre-fill `tail = 8` with a "history" region so
@@ -1224,7 +1223,6 @@ mod tests {
         assert_eq!(&buf[40..48], &[24u8, 25, 26, 27, 28, 29, 30, 31]);
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[test]
     fn exec_sequence_inline_long_literal_uses_wildcopy_tail() {
         // litLength > 16 path: unconditional copy16 + wildcopy tail
@@ -1240,7 +1238,7 @@ mod tests {
         // 40-byte literals (forces wildcopy tail) — needs 40-byte
         // source buffer with extra read slack for the final
         // 16-byte load.
-        let lits: Vec<u8> = (0..40 + 16).map(|i| 0x80 + i as u8).collect();
+        let lits: alloc::vec::Vec<u8> = (0..40u8 + 16).map(|i| 0x80 + i).collect();
         unsafe {
             b.exec_sequence_inline(lits.as_ptr(), 40, 16, 8).unwrap();
         }
@@ -1251,7 +1249,6 @@ mod tests {
         assert_eq!(&buf[72..80], &lits[24..32]);
     }
 
-    #[cfg(target_arch = "x86_64")]
     #[test]
     fn exec_sequence_inline_short_offset_match_uses_overlap_copy() {
         // offset < 16 takes the overlapCopy8 + 8-byte stride path


### PR DESCRIPTION
## Summary

Generalises the donor `ZSTD_execSequence` inline match-copy from an
x86-only optimisation to a universal one. The straight-line
literal+match wildcopy (`ZSTD_copy16` + wildcopy, `ZSTD_overlapCopy8`
for short offsets) previously lived only behind `cfg(target_arch =
"x86_64")` in `exec_sequence_inline::x86` (SSE2 intrinsics). On
aarch64 / i686 / riscv / wasm the decode path fell through to the slow
`try_push` + `repeat` chain (byte-by-byte overlapping copy, per-call
`libc memcpy` for short matches).

## What changed

- New `exec_sequence_inline::portable` module: the same four helpers
  (`copy16` / `wildcopy_no_overlap` / `overlap_copy8` /
  `wildcopy_overlap_8byte_stride`) via unaligned `u128`/`u64` moves the
  backend lowers to its widest store (NEON `ldr q`/`str q` on aarch64,
  plain movs on i686/riscv/wasm). Gated `cfg(not(target_arch = "x86_64"))`.
- Both inline-exec backends (`FlatBuf`, `UserSliceBackend`) grow a
  `cfg(not(x86_64))` arm built on the portable helpers and set
  `SUPPORTS_INLINE_SEQUENCE_EXEC = true` unconditionally.
- `RingBuffer` keeps the trait default (`false`, no override):
  multi-segment frames stay on the wrap-aware chain. The const may be
  `true` only for a backend that actually overrides
  `exec_sequence_inline`, else the dispatch reaches the `unreachable!()`
  trait default. The scalar / NEON dispatch gates the inline call on the
  const and otherwise falls back to the legacy chain, so `RingBuffer` is
  never routed to the inline path.
- x86_64 keeps the SSE2 `x86` module and the AVX2 override unchanged.

Both sequence-execution tiers reach the inline path via the shared
`execute_one_sequence_pipelined`: the pipelined/NEON tier
(`decode_and_execute_sequences_impl`) and the hand-written Scalar-tier
monolith (`seq_decoder_scalar`, `CpuKernelTag::Scalar`), whose
`execute_one_body!` was rerouted from `try_push` +
`repeat_lookahead_prefetched` to that same executor. The executor gates
the inline call on the backend const, so opt-out backends (`RingBuffer`)
still take the legacy `try_push` + `repeat` fallback. This is what lets
non-x86 and baseline-x86_64-without-BMI2 production dispatch (which resolve
to `CpuKernelTag::Scalar`) reach the inline path, not only aarch64 — so
those Scalar dispatch configurations ARE affected by this change.

## Impact

M1 `decode_loop` match-heavy decode vs C (FFI), level 2 dfast
single-segment, interleaved ratio: ~1.44x -> ~1.2x (gap to C roughly
halved). Literal-heavy corpus unchanged at 0.94x (already ahead of C).

## Testing

- 634 lib tests pass, including `decode_all_multi_segment_frame_decodes_correctly`
  and `decode_all_propagates_checksum_into_persistent_scratch` (the
  multi-segment paths that guard the RingBuffer fallback).
- `clippy` clean on `aarch64-apple-darwin`, `i686-unknown-linux-gnu`,
  `x86_64-unknown-linux-gnu`.
- x86 runtime perf unaffected (SSE2 path byte-identical); not yet
  re-benched on the x86 host.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline sequence execution (previously x86_64-only) enabled on all architectures with a portable implementation for non-x86_64 targets.

* **Behavioral Changes**
  * Inline executor now performs explicit capacity/overflow checks and reports output-buffer overflow when space is insufficient.

* **Tests**
  * Expanded and consolidated tests to run on all targets; added portable helper tests and cross-checks against reference behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
