### PR TITLE
bench(dict): report Rust dict-compressed size + emit compress-dict ratio

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -91,7 +91,8 @@ MEM_RE = re.compile(
     r'^REPORT_MEM scenario=(\S+) label="((?:[^"\\]|\\.)+)" level=(\S+) stage=(\S+) rust_peak_alloc_bytes=(\d+) ffi_peak_alloc_bytes=(\d+)$'
 )
 DICT_RE = re.compile(
-    r'^REPORT_DICT scenario=(\S+) label="((?:[^"\\]|\\.)+)" level=(\S+) dict_bytes=(\d+) train_ms=([0-9.]+) ffi_no_dict_bytes=(\d+) ffi_with_dict_bytes=(\d+) ffi_no_dict_ratio=([0-9.]+) ffi_with_dict_ratio=([0-9.]+)$'
+    r'^REPORT_DICT scenario=(\S+) label="((?:[^"\\]|\\.)+)" level=(\S+) dict_bytes=(\d+) train_ms=([0-9.]+) ffi_no_dict_bytes=(\d+) ffi_with_dict_bytes=(\d+) ffi_no_dict_ratio=([0-9.]+) ffi_with_dict_ratio=([0-9.]+)'
+    r'(?: rust_with_dict_bytes=(\d+) rust_with_dict_ratio=([0-9.]+))?$'
 )
 DICT_TRAIN_RE = re.compile(
     r'^REPORT_DICT_TRAIN scenario=(\S+) label="((?:[^"\\]|\\.)+)" training_bytes=(\d+) dict_bytes_requested=(\d+) rust_train_ms=([0-9.]+) ffi_train_ms=([0-9.]+) rust_dict_bytes=(\d+) ffi_dict_bytes=(\d+) rust_fastcover_score=(\d+)$'
@@ -334,8 +335,20 @@ with open(raw_path) as f:
                 ffi_with_dict_bytes,
                 ffi_no_dict_ratio,
                 ffi_with_dict_ratio,
+                rust_with_dict_bytes,
+                rust_with_dict_ratio,
             ) = dict_match.groups()
             label = unescape_report_label(label)
+            # rust_with_dict_* are optional trailing fields (older bench logs
+            # omit them). A reported 0 means the Rust dict path was
+            # unavailable for this (scenario, level) — treat as "no rust dict
+            # ratio" so no misleading compress-dict ratio series is emitted.
+            rust_with_dict_bytes_val = (
+                int(rust_with_dict_bytes) if rust_with_dict_bytes is not None else 0
+            )
+            rust_with_dict_ratio_val = (
+                float(rust_with_dict_ratio) if rust_with_dict_ratio is not None else 0.0
+            )
             dictionary_rows.append({
                 "scenario": scenario,
                 "label": label,
@@ -346,6 +359,8 @@ with open(raw_path) as f:
                 "ffi_with_dict_bytes": int(ffi_with_dict_bytes),
                 "ffi_no_dict_ratio": float(ffi_no_dict_ratio),
                 "ffi_with_dict_ratio": float(ffi_with_dict_ratio),
+                "rust_with_dict_bytes": rust_with_dict_bytes_val,
+                "rust_with_dict_ratio": rust_with_dict_ratio_val,
             })
             continue
 
@@ -731,6 +746,42 @@ for row in memory_rows:
             "delta_percent": delta_percent,
             "status_band": "n/a",
             "interpretation": "delta>1 means Rust allocates more peak memory than FFI",
+        }
+    )
+
+# compress-dict compression-ratio rows. The dict path emits REPORT_DICT
+# (not REPORT), so its ratio data lives in `dictionary_rows`, separate from
+# the non-dict `ratios`/`delta_rows`. Surface a `compression_ratio` relative
+# row for the `compress-dict` stage so the dashboard's existing ratio series
+# renders it (previously compress-dict had a timing series but no ratio
+# graph). rust_value/ffi_value are the dict-compressed-size ratios
+# (compressed / input); delta = rust/ffi, >1 meaning Rust's dict output is
+# larger than FFI's (a ratio regression, same direction as the non-dict
+# compression_ratio metric). Skip rows where the Rust dict size is 0 (the
+# bench could not run the Rust dict path for that scenario/level).
+for row in dictionary_rows:
+    rust_ratio = row.get("rust_with_dict_ratio", 0.0)
+    ffi_ratio = row["ffi_with_dict_ratio"]
+    if rust_ratio <= 0.0 or ffi_ratio <= 0.0:
+        continue
+    delta_ratio = rust_ratio / ffi_ratio
+    relative_rows.append(
+        {
+            "target": bench_target_id,
+            "stage": "compress-dict",
+            "scenario": row["scenario"],
+            "level": row["level"],
+            "source": None,
+            "key": canonical_key("compress-dict", row["scenario"], row["level"], None),
+            "commit_sha": commit_sha,
+            "generated_at": generated_at,
+            "metric": "compression_ratio",
+            "rust_value": rust_ratio,
+            "ffi_value": ffi_ratio,
+            "delta_ratio": delta_ratio,
+            "delta_percent": (delta_ratio - 1.0) * 100.0,
+            "status_band": classify_ratio_delta(delta_ratio),
+            "interpretation": "delta>1 means Rust dict-compressed output is larger than FFI",
         }
     )
 

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -578,6 +578,27 @@ fn bench_dictionary(c: &mut Criterion) {
                 zstd::bulk::Compressor::with_dictionary(level.ffi_level, &ffi_dictionary).unwrap();
             let no_dict_bytes = no_dict.compress(&scenario.bytes).unwrap();
             let with_dict_bytes = with_dict.compress(&scenario.bytes).unwrap();
+
+            // Rust dict-compressed output size, for the compress-dict
+            // compression-ratio report (rust vs FFI). Only computable when the
+            // dictionary parsed into a Rust handle; mirrors the gate the
+            // `pure_rust_with_dict` timing arm uses below. Reused as the
+            // timing-loop preallocation hint so we compress once, not twice.
+            let rust_with_dict_len: Option<usize> = if rust_dict_handle.is_some() {
+                let mut warmup_compressor = FrameCompressor::new(level.rust_level);
+                warmup_compressor
+                    .set_dictionary_from_bytes(&ffi_dictionary)
+                    .expect("dictionary should attach");
+                warmup_compressor.set_source_size_hint(scenario.bytes.len() as u64);
+                warmup_compressor.set_source(scenario.bytes.as_slice());
+                let mut warmup_output = Vec::new();
+                warmup_compressor.set_drain(&mut warmup_output);
+                warmup_compressor.compress();
+                Some(warmup_output.len())
+            } else {
+                None
+            };
+
             if emit_reports {
                 emit_dictionary_report(
                     scenario,
@@ -586,6 +607,9 @@ fn bench_dictionary(c: &mut Criterion) {
                     ffi_train_ms,
                     &no_dict_bytes,
                     &with_dict_bytes,
+                    // When the Rust dict path is unavailable, report 0 (the
+                    // CI parser treats a 0 rust size as "no rust dict ratio").
+                    rust_with_dict_len.unwrap_or(0),
                 );
             }
 
@@ -641,29 +665,15 @@ fn bench_dictionary(c: &mut Criterion) {
             // routes through the same Dictionary::decode_dict and
             // would fail identically. An `.expect()` panic inside
             // b.iter would abort the whole bench suite.
-            if rust_dict_handle.is_some() {
-                // One-time pre-compress (outside b.iter) to learn the
-                // Rust encoder's actual output size at this (scenario,
-                // level, dict). Using `with_dict_bytes.len()` here —
-                // the FFI-side compressed size — would under-allocate
-                // when Rust emits a slightly larger frame, forcing
-                // `Vec` reallocations inside the timing loop and
-                // skewing the measurement vs FFI (which always
-                // allocates exact output size internally). Doing one
-                // setup compress matches `Compressor::compress`'s
-                // up-front allocation shape on both sides.
-                let preallocated_capacity = {
-                    let mut warmup_compressor = FrameCompressor::new(level.rust_level);
-                    warmup_compressor
-                        .set_dictionary_from_bytes(&ffi_dictionary)
-                        .expect("dictionary should attach");
-                    warmup_compressor.set_source_size_hint(scenario.bytes.len() as u64);
-                    warmup_compressor.set_source(scenario.bytes.as_slice());
-                    let mut warmup_output = Vec::new();
-                    warmup_compressor.set_drain(&mut warmup_output);
-                    warmup_compressor.compress();
-                    warmup_output.len()
-                };
+            if let Some(preallocated_capacity) = rust_with_dict_len {
+                // `rust_with_dict_len` above already did the one-time
+                // pre-compress that learns the Rust encoder's actual output
+                // size at this (scenario, level, dict) — reuse it as the
+                // timing-loop preallocation hint. Using `with_dict_bytes.len()`
+                // (the FFI-side size) would under-allocate when Rust emits a
+                // slightly larger frame, forcing `Vec` reallocations inside the
+                // timing loop and skewing the measurement vs FFI (which always
+                // allocates exact output size internally).
                 group.bench_function("pure_rust_with_dict", |b| {
                     b.iter(|| {
                         let mut compressor = FrameCompressor::new(level.rust_level);
@@ -962,19 +972,25 @@ fn emit_dictionary_report(
     train_ms: f64,
     no_dict_bytes: &[u8],
     with_dict_bytes: &[u8],
+    rust_with_dict_len: usize,
 ) {
     let input_len = scenario.len() as f64;
     let escaped_label = escape_report_label(&scenario.label);
-    let (no_dict_ratio, with_dict_ratio) = if input_len > 0.0 {
+    let (no_dict_ratio, with_dict_ratio, rust_with_dict_ratio) = if input_len > 0.0 {
         (
             no_dict_bytes.len() as f64 / input_len,
             with_dict_bytes.len() as f64 / input_len,
+            rust_with_dict_len as f64 / input_len,
         )
     } else {
-        (0.0, 0.0)
+        (0.0, 0.0, 0.0)
     };
+    // `rust_with_dict_bytes` / `rust_with_dict_ratio` are appended after the
+    // FFI fields so existing parsers that only read the leading columns keep
+    // working; the CI report parser's REPORT_DICT regex captures the two new
+    // trailing fields to emit a compress-dict compression-ratio series.
     println!(
-        "REPORT_DICT scenario={} label=\"{}\" level={} dict_bytes={} train_ms={:.3} ffi_no_dict_bytes={} ffi_with_dict_bytes={} ffi_no_dict_ratio={:.6} ffi_with_dict_ratio={:.6}",
+        "REPORT_DICT scenario={} label=\"{}\" level={} dict_bytes={} train_ms={:.3} ffi_no_dict_bytes={} ffi_with_dict_bytes={} ffi_no_dict_ratio={:.6} ffi_with_dict_ratio={:.6} rust_with_dict_bytes={} rust_with_dict_ratio={:.6}",
         scenario.id,
         escaped_label,
         level.name,
@@ -983,7 +999,9 @@ fn emit_dictionary_report(
         no_dict_bytes.len(),
         with_dict_bytes.len(),
         no_dict_ratio,
-        with_dict_ratio
+        with_dict_ratio,
+        rust_with_dict_len,
+        rust_with_dict_ratio
     );
 }
 


### PR DESCRIPTION
## Summary

The dictionary compress benchmark measured the Rust dict-compressed output size (as the timing-loop preallocation warmup) but discarded it. `REPORT_DICT` carried only the FFI dict sizes/ratios, so the CI report produced no rust-vs-FFI ratio for the `compress-dict` stage — and the dashboard had a compress-dict throughput series but no ratio graph.

## Changes

- **`compare_ffi.rs`**: compute the Rust dict-compressed size once (reused as the existing timing preallocation hint, so no extra compress), and append `rust_with_dict_bytes` / `rust_with_dict_ratio` to the `REPORT_DICT` line. Existing fields are unchanged and stay leading, so any parser reading only the original columns keeps working.
- **`run-benchmarks.sh`**: extend the `REPORT_DICT` regex to capture the two new trailing fields (optional group, so historical logs still parse), thread them through `dictionary_rows`, and emit a `compression_ratio` relative row for `stage=compress-dict` (`rust_value`/`ffi_value` = dict-compressed-size ratios, `delta = rust/ffi`). Rows where the Rust dict size is 0 (dict path unavailable for that scenario/level) are skipped.

## Effect

The compress-dict ratio now round-trips into `benchmark-relative.json` so the dashboard's compression-ratio series can render it. The new data immediately surfaces that Rust dictionary compression is materially worse than FFI on the small-random corpus (rust 1.00x vs ffi 0.90x), consistent with the compress-dict throughput alert — useful signal that was previously invisible.

## Testing

- Ran the dict bench locally with `STRUCTURED_ZSTD_EMIT_REPORT=1`: the new `REPORT_DICT` fields are present and correct.
- Verified the CI parser regex matches both the new format and historical (pre-field) lines, and that the new emit loop produces 87 compress-dict `compression_ratio` rows from a captured log with correct deltas.
- `cargo nextest run` 700/700, clippy `--all-targets --features dict_builder` clean, fmt clean.

## Follow-up (not in this PR)

The dashboard does not yet expose dict ratio in the profile/aggregate charts — its `profileLogicalMetric` collapses across stages and only maps `stage == "compress"`. Surfacing dict ratio there needs either a separate dict logical-metric or a "with dict" toggle that swaps the stage feeding the existing series; that UI work is tracked separately.

Part of #247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dictionary compression benchmarking to capture and track compression metrics including file sizes and compression ratios. Benchmark reports now surface relative compression performance data for dictionary compression stages, providing improved visibility into compression performance and enabling better comparative analysis across different implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->