### PR TITLE
perf(encode): align levels 13-15 to reference search budget

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8481,12 +8481,12 @@ fn lazy_band_target_len_matches_donor_default_table() {
     for level in 5..=15i32 {
         // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
         // call with any (level, srcSize, dictSize) combination.
-        let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
+        let reference = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
         let params = resolve_level_params(CompressionLevel::Level(level), None);
         assert_eq!(
-            params.hc.target_len as u32, donor.targetLength,
+            params.hc.target_len as u32, reference.targetLength,
             "L{level}: hc.target_len ({}) must match reference cParams.targetLength ({})",
-            params.hc.target_len, donor.targetLength
+            params.hc.target_len, reference.targetLength
         );
     }
 }
@@ -8506,29 +8506,29 @@ fn upper_lazy_band_params_match_donor_default_table() {
     for level in 13..=15i32 {
         // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
         // call with any (level, srcSize, dictSize) combination.
-        let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
+        let reference = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
         let params = resolve_level_params(CompressionLevel::Level(level), None);
         assert_eq!(
             params.hc.search_depth as u32,
-            1u32 << donor.searchLog,
+            1u32 << reference.searchLog,
             "L{level}: hc.search_depth ({}) must equal 1<<cParams.searchLog ({})",
             params.hc.search_depth,
-            1u32 << donor.searchLog
+            1u32 << reference.searchLog
         );
         assert_eq!(
-            params.window_log as u32, donor.windowLog,
+            params.window_log as u32, reference.windowLog,
             "L{level}: window_log ({}) must equal cParams.windowLog ({})",
-            params.window_log, donor.windowLog
+            params.window_log, reference.windowLog
         );
         assert_eq!(
-            params.hc.hash_log as u32, donor.hashLog,
+            params.hc.hash_log as u32, reference.hashLog,
             "L{level}: hc.hash_log ({}) must equal cParams.hashLog ({})",
-            params.hc.hash_log, donor.hashLog
+            params.hc.hash_log, reference.hashLog
         );
         assert_eq!(
-            params.hc.chain_log as u32, donor.chainLog,
+            params.hc.chain_log as u32, reference.chainLog,
             "L{level}: hc.chain_log ({}) must equal cParams.chainLog ({})",
-            params.hc.chain_log, donor.chainLog
+            params.hc.chain_log, reference.chainLog
         );
     }
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8510,7 +8510,7 @@ fn upper_lazy_band_params_match_donor_default_table() {
         let params = resolve_level_params(CompressionLevel::Level(level), None);
         assert_eq!(
             params.hc.search_depth as u32,
-            1 << donor.searchLog,
+            1u32 << donor.searchLog,
             "L{level}: hc.search_depth ({}) must equal 1<<cParams.searchLog ({})",
             params.hc.search_depth,
             1u32 << donor.searchLog

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -306,16 +306,17 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 16 }, row: ROW_CONFIG },
     /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 32, target_len: 16 }, row: ROW_CONFIG },
     /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
-    // L13-15: the reference uses btlazy2 (a binary-tree finder) here, where a
-    // small searchLog is compensated by the tree. We run these on the
-    // hash-chain Lazy parser, so the per-level budget must grow monotonically
-    // or the parse (hence output) is identical across levels — previously
-    // search_depth=32 / target_len=32 were flat for L12-15, collapsing four
-    // levels onto one output. Grow search_depth + target_len with the level
-    // so the ladder stays strictly monotonic on hash-chain inputs.
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 64,  target_len: 48  }, row: ROW_CONFIG },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 128, target_len: 64  }, row: ROW_CONFIG },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 256, target_len: 128 }, row: ROW_CONFIG },
+    // L13-15: reference uses btlazy2 (binary-tree finder) with searchLog 4/5/6
+    // (search_depth 16/32/64) and targetLength 32. We run the hash-chain Lazy
+    // parser here, so we mirror the reference search budget rather than inflate
+    // it: matching the table keeps speed near the reference and makes per-level
+    // perf divergences comparable. The binary-tree finder that would let a
+    // smaller searchLog find longer matches (and re-establish a strict ratio
+    // ladder above L12) is tracked separately; until it lands these levels sit
+    // close to L12 on hash-chain inputs by design.
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }, row: ROW_CONFIG },
     /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
@@ -8461,29 +8462,23 @@ fn fast_levels_driver_wiring_threads_cparams_into_inner_matcher() {
     }
 }
 
-/// Pins lazy-band `hc.target_len` to the reference `cParams.targetLength`
-/// from `clevels.h` table[0] (default — `srcSize > 256 KB`) for the
-/// levels we run on the SAME strategy as the reference: 5-12 (greedy +
-/// lazy/lazy2). The reference's lazy outer loop treats `targetLength` as
+/// Pins `hc.target_len` to the reference `cParams.targetLength` from
+/// `clevels.h` table[0] (default — `srcSize > 256 KB`) across levels
+/// 5-15. The reference's lazy outer loop treats `targetLength` as
 /// `sufficient_len` — the "nice match" threshold that breaks the chain
 /// walk as soon as a candidate reaches that length.
 ///
-/// Levels 13-15 are EXCLUDED: the reference runs btlazy2 (a binary-tree
-/// finder) there, where a small searchLog is offset by the tree, so its
-/// `targetLength` (32) is tuned for that finder. We run 13-15 on the
-/// hash-chain Lazy parser instead, where holding `search_depth` /
-/// `target_len` flat at the L12 values made L12-15 produce byte-identical
-/// output (the level ladder collapsed). So 13-15 deliberately use a
-/// larger, monotonically-growing budget than the reference table; pinning
-/// them to the reference `targetLength` is wrong for our finder.
+/// Levels 13-15 run btlazy2 in the reference and the hash-chain Lazy
+/// parser here, but the reference `targetLength` (32) is the same nice-match
+/// threshold for both finders, so we mirror it directly.
 ///
 /// Test queries the reference via `ZSTD_getCParams(level, 0, 0)` so any
-/// future table tweak upstream is reflected automatically for 5-12.
+/// future table tweak upstream is reflected automatically.
 #[test]
 fn lazy_band_target_len_matches_donor_default_table() {
     use zstd::zstd_safe::zstd_sys;
 
-    for level in 5..=12i32 {
+    for level in 5..=15i32 {
         // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
         // call with any (level, srcSize, dictSize) combination.
         let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
@@ -8496,35 +8491,27 @@ fn lazy_band_target_len_matches_donor_default_table() {
     }
 }
 
-/// The hash-chain Lazy levels 13-15 must form a STRICTLY MONOTONIC ladder
-/// (each searches at least as hard as the one below, and at least one of
-/// search_depth / target_len strictly increases), otherwise adjacent
-/// levels produce identical output — the bug this guards against. The
-/// reference uses btlazy2 here; we use Lazy, so the budget grows by level.
+/// Levels 13-15 mirror the reference btlazy2 search budget: `search_depth`
+/// equals `1 << cParams.searchLog` (16 / 32 / 64). We run them on the
+/// hash-chain Lazy parser rather than a binary-tree finder, so they do not
+/// re-establish a strict ratio ladder above L12 on window-fitting inputs;
+/// keeping the table aligned holds speed near the reference and is the
+/// regression guard against re-inflating the budget.
 #[test]
-fn lazy_upper_band_ladder_is_monotonic() {
-    let p12 = resolve_level_params(CompressionLevel::Level(12), None);
-    let p13 = resolve_level_params(CompressionLevel::Level(13), None);
-    let p14 = resolve_level_params(CompressionLevel::Level(14), None);
-    let p15 = resolve_level_params(CompressionLevel::Level(15), None);
-    for (lo, hi, lo_n, hi_n) in [(p12, p13, 12, 13), (p13, p14, 13, 14), (p14, p15, 14, 15)] {
-        assert!(
-            hi.hc.search_depth >= lo.hc.search_depth && hi.hc.target_len >= lo.hc.target_len,
-            "L{hi_n} budget must not shrink below L{lo_n}: \
-             search_depth {} vs {}, target_len {} vs {}",
-            hi.hc.search_depth,
-            lo.hc.search_depth,
-            hi.hc.target_len,
-            lo.hc.target_len
-        );
-        assert!(
-            hi.hc.search_depth > lo.hc.search_depth || hi.hc.target_len > lo.hc.target_len,
-            "L{hi_n} must search strictly harder than L{lo_n} (else identical output): \
-             search_depth {} vs {}, target_len {} vs {}",
-            hi.hc.search_depth,
-            lo.hc.search_depth,
-            hi.hc.target_len,
-            lo.hc.target_len
+fn upper_lazy_band_search_depth_matches_donor_search_log() {
+    use zstd::zstd_safe::zstd_sys;
+
+    for level in 13..=15i32 {
+        // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
+        // call with any (level, srcSize, dictSize) combination.
+        let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
+        let params = resolve_level_params(CompressionLevel::Level(level), None);
+        assert_eq!(
+            params.hc.search_depth as u32,
+            1 << donor.searchLog,
+            "L{level}: hc.search_depth ({}) must equal 1<<cParams.searchLog ({})",
+            params.hc.search_depth,
+            1u32 << donor.searchLog
         );
     }
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -306,9 +306,16 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 16 }, row: ROW_CONFIG },
     /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 32, target_len: 16 }, row: ROW_CONFIG },
     /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    // L13-15: the reference uses btlazy2 (a binary-tree finder) here, where a
+    // small searchLog is compensated by the tree. We run these on the
+    // hash-chain Lazy parser, so the per-level budget must grow monotonically
+    // or the parse (hence output) is identical across levels — previously
+    // search_depth=32 / target_len=32 were flat for L12-15, collapsing four
+    // levels onto one output. Grow search_depth + target_len with the level
+    // so the ladder stays strictly monotonic on hash-chain inputs.
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 64,  target_len: 48  }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 128, target_len: 64  }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 256, target_len: 128 }, row: ROW_CONFIG },
     /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTOPT_HC_CONFIG, row: ROW_CONFIG },
     /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA_HC_CONFIG, row: ROW_CONFIG },
@@ -8454,30 +8461,70 @@ fn fast_levels_driver_wiring_threads_cparams_into_inner_matcher() {
     }
 }
 
-/// Pins lazy-band `hc.target_len` to donor `cParams.targetLength` from
-/// `clevels.h` table[0] (default — `srcSize > 256 KB`). Donor's lazy
-/// outer loop treats `targetLength` as `sufficient_len` — the
-/// "nice match" threshold that breaks the chain walk as soon as a
-/// candidate reaches that length. Inflating it above donor forces the
-/// chain walk to complete `search_depth` iterations on inputs that
-/// would have committed early under donor — the dominant cost in
-/// the L5..=L15 speed regression vs FFI tracked at the parent issue.
+/// Pins lazy-band `hc.target_len` to the reference `cParams.targetLength`
+/// from `clevels.h` table[0] (default — `srcSize > 256 KB`) for the
+/// levels we run on the SAME strategy as the reference: 5-12 (greedy +
+/// lazy/lazy2). The reference's lazy outer loop treats `targetLength` as
+/// `sufficient_len` — the "nice match" threshold that breaks the chain
+/// walk as soon as a candidate reaches that length.
 ///
-/// Test queries donor via `ZSTD_getCParams(level, 0, 0)` so any future
-/// donor-table tweak in upstream zstd is reflected automatically.
+/// Levels 13-15 are EXCLUDED: the reference runs btlazy2 (a binary-tree
+/// finder) there, where a small searchLog is offset by the tree, so its
+/// `targetLength` (32) is tuned for that finder. We run 13-15 on the
+/// hash-chain Lazy parser instead, where holding `search_depth` /
+/// `target_len` flat at the L12 values made L12-15 produce byte-identical
+/// output (the level ladder collapsed). So 13-15 deliberately use a
+/// larger, monotonically-growing budget than the reference table; pinning
+/// them to the reference `targetLength` is wrong for our finder.
+///
+/// Test queries the reference via `ZSTD_getCParams(level, 0, 0)` so any
+/// future table tweak upstream is reflected automatically for 5-12.
 #[test]
 fn lazy_band_target_len_matches_donor_default_table() {
     use zstd::zstd_safe::zstd_sys;
 
-    for level in 5..=15i32 {
+    for level in 5..=12i32 {
         // SAFETY: `ZSTD_getCParams` reads from a static table; safe to
         // call with any (level, srcSize, dictSize) combination.
         let donor = unsafe { zstd_sys::ZSTD_getCParams(level, 0, 0) };
         let params = resolve_level_params(CompressionLevel::Level(level), None);
         assert_eq!(
             params.hc.target_len as u32, donor.targetLength,
-            "L{level}: hc.target_len ({}) must match donor cParams.targetLength ({})",
+            "L{level}: hc.target_len ({}) must match reference cParams.targetLength ({})",
             params.hc.target_len, donor.targetLength
+        );
+    }
+}
+
+/// The hash-chain Lazy levels 13-15 must form a STRICTLY MONOTONIC ladder
+/// (each searches at least as hard as the one below, and at least one of
+/// search_depth / target_len strictly increases), otherwise adjacent
+/// levels produce identical output — the bug this guards against. The
+/// reference uses btlazy2 here; we use Lazy, so the budget grows by level.
+#[test]
+fn lazy_upper_band_ladder_is_monotonic() {
+    let p12 = resolve_level_params(CompressionLevel::Level(12), None);
+    let p13 = resolve_level_params(CompressionLevel::Level(13), None);
+    let p14 = resolve_level_params(CompressionLevel::Level(14), None);
+    let p15 = resolve_level_params(CompressionLevel::Level(15), None);
+    for (lo, hi, lo_n, hi_n) in [(p12, p13, 12, 13), (p13, p14, 13, 14), (p14, p15, 14, 15)] {
+        assert!(
+            hi.hc.search_depth >= lo.hc.search_depth && hi.hc.target_len >= lo.hc.target_len,
+            "L{hi_n} budget must not shrink below L{lo_n}: \
+             search_depth {} vs {}, target_len {} vs {}",
+            hi.hc.search_depth,
+            lo.hc.search_depth,
+            hi.hc.target_len,
+            lo.hc.target_len
+        );
+        assert!(
+            hi.hc.search_depth > lo.hc.search_depth || hi.hc.target_len > lo.hc.target_len,
+            "L{hi_n} must search strictly harder than L{lo_n} (else identical output): \
+             search_depth {} vs {}, target_len {} vs {}",
+            hi.hc.search_depth,
+            lo.hc.search_depth,
+            hi.hc.target_len,
+            lo.hc.target_len
         );
     }
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8491,14 +8491,16 @@ fn lazy_band_target_len_matches_donor_default_table() {
     }
 }
 
-/// Levels 13-15 mirror the reference btlazy2 search budget: `search_depth`
-/// equals `1 << cParams.searchLog` (16 / 32 / 64). We run them on the
+/// Levels 13-15 mirror the reference btlazy2 window/hash/chain/search
+/// budget from `clevels.h` table[0]: `search_depth == 1 << cParams.searchLog`
+/// (16 / 32 / 64) plus `window_log` / `hash_log` / `chain_log` equal to the
+/// reference `windowLog` / `hashLog` / `chainLog`. We run them on the
 /// hash-chain Lazy parser rather than a binary-tree finder, so they do not
 /// re-establish a strict ratio ladder above L12 on window-fitting inputs;
-/// keeping the table aligned holds speed near the reference and is the
-/// regression guard against re-inflating the budget.
+/// asserting the full row (not just `search_depth`) keeps the whole budget
+/// aligned and guards every field against silent drift.
 #[test]
-fn upper_lazy_band_search_depth_matches_donor_search_log() {
+fn upper_lazy_band_params_match_donor_default_table() {
     use zstd::zstd_safe::zstd_sys;
 
     for level in 13..=15i32 {
@@ -8512,6 +8514,21 @@ fn upper_lazy_band_search_depth_matches_donor_search_log() {
             "L{level}: hc.search_depth ({}) must equal 1<<cParams.searchLog ({})",
             params.hc.search_depth,
             1u32 << donor.searchLog
+        );
+        assert_eq!(
+            params.window_log as u32, donor.windowLog,
+            "L{level}: window_log ({}) must equal cParams.windowLog ({})",
+            params.window_log, donor.windowLog
+        );
+        assert_eq!(
+            params.hc.hash_log as u32, donor.hashLog,
+            "L{level}: hc.hash_log ({}) must equal cParams.hashLog ({})",
+            params.hc.hash_log, donor.hashLog
+        );
+        assert_eq!(
+            params.hc.chain_log as u32, donor.chainLog,
+            "L{level}: hc.chain_log ({}) must equal cParams.chainLog ({})",
+            params.hc.chain_log, donor.chainLog
         );
     }
 }


### PR DESCRIPTION
## Summary

On `main`, levels 13-15 ran the hash-chain Lazy parser with a flat `search_depth=32 / target_len=32` — byte-identical to each other and to level 12 on inputs that fit the window. The level ladder above 12 had collapsed.

The reference runs btlazy2 (a binary-tree finder) at 13-15 with searchLog 4/5/6 and targetLength 32. This aligns our table to those values: `search_depth = 1<<searchLog` (16/32/64), `target_len = 32`, plus the reference window/hash/chain logs. The three levels now produce distinct output and run close to the reference speed.

A hash-chain finder cannot turn a small searchLog into longer matches the way a binary tree can, so these levels do not re-establish a strict ratio ladder above L12 (L13 dips slightly because its budget, 16, is below L12's 32). That is by design until a real binary-tree finder lands (tracked separately). Aligning the table keeps per-level perf divergences directly comparable to the reference.

## Verification (i9, decodecorpus-z000033)

Speed (pure_rust / c_ffi), levels now distinct and back near the previous build instead of the 3-4x regression an inflated budget caused:

| Level | rust | c_ffi | rust/ffi |
|-------|------|-------|----------|
| L12 (control) | 70.2 ms | 17.5 ms | 4.0x |
| L13 | 63.7 ms | 26.8 ms | 2.4x |
| L14 | 69.3 ms | 28.3 ms | 2.4x |
| L15 | 79.2 ms | 28.8 ms | 2.75x |

Ratio — distinct per level, smaller than the reference at every level:

| Level | rust_bytes | ffi_bytes |
|-------|-----------|-----------|
| L12 | 477966 | 509326 |
| L13 | 478757 | 508905 |
| L14 | 477966 | 508492 |
| L15 | 477368 | 508287 |

The residual ~2.4x speed gap at 13-15 is structural to the hash-chain finder; closing it to parity requires the binary-tree finder.

## Tests

- Extended `lazy_band_target_len_matches_donor_default_table` to levels 5-15 (all match the reference targetLength).
- Replaced the monotonic-ladder test with `upper_lazy_band_params_match_donor_default_table`, asserting the full L13-15 row (`search_depth = 1<<cParams.searchLog` plus `window_log` / `hash_log` / `chain_log`) against `ZSTD_getCParams`.
- 647/647 lib tests pass, clippy + fmt clean.

Part of #247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined compression tuning for levels 13-15, optimizing performance metrics to match reference compression standards.

* **Tests**
  * Added regression test validating compression search parameters for levels 13-15 remain consistent with reference implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
