### PR TITLE
perf(decode): unify SIMD-copy capability detection under the CpuKernel tag

### DIFF
--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -83,9 +83,30 @@ impl CpuKernel for ScalarKernel {
     }
 }
 
+/// x86_64 SSE2 baseline kernel. SSE2 is ABI-guaranteed on every
+/// x86_64 target, so this is the effective floor on x86_64 — the
+/// Scalar kernel is reached only off-x86_64 (or on the rare x86
+/// build without SSE2). SSE2 has no `_bzhi_u64`, so `mask_lower_bits`
+/// is identical to Scalar; the kernel's value is the 128-bit SIMD
+/// `copy_chunk` body (a 16-byte chunked copy) that diverges from the
+/// scalar 8-byte loop. Sits below Bmi2 in the kernel ladder.
+#[cfg(target_arch = "x86_64")]
+#[derive(Copy, Clone, Default)]
+pub(crate) struct Sse2Kernel;
+
+#[cfg(target_arch = "x86_64")]
+impl CpuKernel for Sse2Kernel {
+    #[inline(always)]
+    fn mask_lower_bits(value: u64, n: u8) -> u64 {
+        // SSE2 has no bit-extract instruction; the scalar shift-mask
+        // sequence is the best codegen here. Identical to ScalarKernel.
+        ScalarKernel::mask_lower_bits(value, n)
+    }
+}
+
 /// x86_64 BMI2-only kernel: `_bzhi_u64` for mask_lower_bits. Selected
 /// when the CPU has BMI2 but not the AVX2 SIMD width to upgrade to
-/// the Avx2 kernel. Treated as a stepping stone between Scalar and
+/// the Avx2 kernel. Treated as a stepping stone between Sse2 and
 /// Avx2 on hardware that has BMI2 but not AVX2 (rare in practice but
 /// matches donor's gating).
 #[cfg(target_arch = "x86_64")]
@@ -221,6 +242,7 @@ const fn select_x86_kernel(
     has_avx512bw: bool,
     has_bmi2: bool,
     has_avx2: bool,
+    has_sse2: bool,
 ) -> CpuKernelTag {
     if has_avx512vbmi2 && has_avx512f && has_avx512vl && has_avx512bw && has_bmi2 && has_avx2 {
         return CpuKernelTag::Vbmi2;
@@ -230,6 +252,9 @@ const fn select_x86_kernel(
     }
     if has_bmi2 {
         return CpuKernelTag::Bmi2;
+    }
+    if has_sse2 {
+        return CpuKernelTag::Sse2;
     }
     CpuKernelTag::Scalar
 }
@@ -245,6 +270,8 @@ const fn select_x86_kernel(
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum CpuKernelTag {
     Scalar,
+    #[cfg(target_arch = "x86_64")]
+    Sse2,
     #[cfg(target_arch = "x86_64")]
     Bmi2,
     #[cfg(target_arch = "x86_64")]
@@ -284,6 +311,7 @@ fn detect_cpu_kernel_uncached() -> CpuKernelTag {
             is_x86_feature_detected!("avx512bw"),
             is_x86_feature_detected!("bmi2"),
             is_x86_feature_detected!("avx2"),
+            is_x86_feature_detected!("sse2"),
         );
     }
     #[cfg(target_arch = "aarch64")]
@@ -320,6 +348,7 @@ pub(crate) fn detect_cpu_kernel() -> CpuKernelTag {
             cfg!(target_feature = "avx512bw"),
             cfg!(target_feature = "bmi2"),
             cfg!(target_feature = "avx2"),
+            cfg!(target_feature = "sse2"),
         );
     }
     #[cfg(target_arch = "aarch64")]
@@ -400,6 +429,7 @@ mod tests {
         let tag = select_x86_kernel(
             /* avx512vbmi2 */ true, /* avx512f */ true, /* avx512vl */ true,
             /* avx512bw */ true, /* bmi2 */ true, /* avx2 */ false,
+            /* sse2 */ true,
         );
         assert_ne!(
             tag,
@@ -412,7 +442,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn select_x86_kernel_full_x86_v4_picks_vbmi2() {
-        let tag = select_x86_kernel(true, true, true, true, true, true);
+        let tag = select_x86_kernel(true, true, true, true, true, true, true);
         assert_eq!(tag, CpuKernelTag::Vbmi2);
     }
 
@@ -420,8 +450,24 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn select_x86_kernel_avx2_baseline_picks_avx2() {
-        let tag = select_x86_kernel(false, false, false, false, true, true);
+        let tag = select_x86_kernel(false, false, false, false, true, true, true);
         assert_eq!(tag, CpuKernelTag::Avx2);
+    }
+
+    /// SSE2-only (no BMI2/AVX2) → Sse2, the x86_64 floor above Scalar.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn select_x86_kernel_sse2_only_picks_sse2() {
+        let tag = select_x86_kernel(false, false, false, false, false, false, true);
+        assert_eq!(tag, CpuKernelTag::Sse2);
+    }
+
+    /// No SIMD flags at all → Scalar (off-x86_64 / pre-SSE2 x86).
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn select_x86_kernel_no_features_picks_scalar() {
+        let tag = select_x86_kernel(false, false, false, false, false, false, false);
+        assert_eq!(tag, CpuKernelTag::Scalar);
     }
 
     #[test]

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -83,26 +83,12 @@ impl CpuKernel for ScalarKernel {
     }
 }
 
-/// x86_64 SSE2 baseline kernel. SSE2 is ABI-guaranteed on every
-/// x86_64 target, so this is the effective floor on x86_64 — the
-/// Scalar kernel is reached only off-x86_64 (or on the rare x86
-/// build without SSE2). SSE2 has no `_bzhi_u64`, so `mask_lower_bits`
-/// is identical to Scalar; the kernel's value is the 128-bit SIMD
-/// `copy_chunk` body (a 16-byte chunked copy) that diverges from the
-/// scalar 8-byte loop. Sits below Bmi2 in the kernel ladder.
-#[cfg(target_arch = "x86_64")]
-#[derive(Copy, Clone, Default)]
-pub(crate) struct Sse2Kernel;
-
-#[cfg(target_arch = "x86_64")]
-impl CpuKernel for Sse2Kernel {
-    #[inline(always)]
-    fn mask_lower_bits(value: u64, n: u8) -> u64 {
-        // SSE2 has no bit-extract instruction; the scalar shift-mask
-        // sequence is the best codegen here. Identical to ScalarKernel.
-        ScalarKernel::mask_lower_bits(value, n)
-    }
-}
+// The SSE2 tier exists in `CpuKernelTag` (it carries the 128-bit copy-chunk
+// choice for the unified copy dispatch) but needs no `CpuKernel` ZST yet: the
+// only trait method, `mask_lower_bits`, has no SSE2-specific form (SSE2 has no
+// bit-extract), so the Sse2 tag routes through the scalar bodies for the
+// FSE/HUF paths. A dedicated `Sse2Kernel` lands when `copy_chunk` moves onto
+// the trait.
 
 /// x86_64 BMI2-only kernel: `_bzhi_u64` for mask_lower_bits. Selected
 /// when the CPU has BMI2 but not the AVX2 SIMD width to upgrade to

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -126,6 +126,23 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             )
         }
         #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Sse2 => {
+            // SSE2 has no FSE-relevant divergence (no `_bzhi_u64`); the
+            // mask_lower_bits hot op is identical to Scalar. SSE2's only
+            // distinct body is match-copy (gated per-backend via
+            // SUPPORTS_INLINE_SEQUENCE_EXEC), not the sequence FSE walk,
+            // so route to the portable scalar sequence decoder.
+            super::seq_decoder_scalar::decode_and_execute_sequences_scalar::<B>(
+                section,
+                source,
+                fse,
+                buffer,
+                offset_hist,
+                literals_buffer,
+                rle_fallback_sequences,
+            )
+        }
+        #[cfg(target_arch = "x86_64")]
         CpuKernelTag::Bmi2 => {
             // SAFETY: `detect_cpu_kernel()` only returns Bmi2 when
             // `is_x86_feature_detected!("bmi2")` confirmed BMI2 is

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -8,7 +8,9 @@ use core::arch::x86_64::{
     __m128i, __m256i, __m512i, _mm_loadu_si128, _mm_storeu_si128, _mm256_loadu_si256,
     _mm256_storeu_si256, _mm512_loadu_si512, _mm512_storeu_si512,
 };
-#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+// Only the 32-bit x86 `detect_x86_caps` body queries CPU features at
+// runtime; the x86_64 body derives them from `detect_cpu_kernel()`.
+#[cfg(all(feature = "std", target_arch = "x86"))]
 use std::arch::is_x86_feature_detected;
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 use std::sync::OnceLock;
@@ -581,14 +583,62 @@ struct X86Caps {
     sse2: bool,
 }
 
+/// SIMD-copy capability flags for the chunked wildcopy dispatcher.
+///
+/// On `x86_64` these are DERIVED from the unified `detect_cpu_kernel()`
+/// tag rather than detected independently, so the whole crate has a
+/// single CPU-capability source of truth (the copy path can never
+/// disagree with the entropy/sequence path about the running CPU). The
+/// mapping follows the kernel ladder: Vbmi2 → 64/32/16-byte copies,
+/// Avx2 → 32/16, Bmi2 / Sse2 → 16, Scalar → none. One subtle
+/// consequence: an `avx512f`-but-not-VBMI2 CPU (e.g. Skylake-X) is
+/// tagged `Avx2`, so it uses the 32-byte `copy_avx2` chunk instead of
+/// the 64-byte `copy_avx512`. That is a negligible difference on match
+/// copies (which are short) and keeps the taxonomy single-axis; modern
+/// AVX-512 parts (Ice Lake+) carry VBMI2 and still reach `copy_avx512`.
+///
+/// On 32-bit `x86` the kernel tag carries no SIMD tiers (those are
+/// `x86_64`-gated), so this keeps its own runtime detection to preserve
+/// the SSE2 / AVX2 copy path there.
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 fn detect_x86_caps() -> X86Caps {
     static CAPS: OnceLock<X86Caps> = OnceLock::new();
-    *CAPS.get_or_init(|| X86Caps {
-        avx512f: is_x86_feature_detected!("avx512f"),
-        avx2: is_x86_feature_detected!("avx2"),
-        sse2: is_x86_feature_detected!("sse2"),
+    *CAPS.get_or_init(|| {
+        #[cfg(target_arch = "x86_64")]
+        {
+            use crate::cpu_kernel::{CpuKernelTag, detect_cpu_kernel};
+            match detect_cpu_kernel() {
+                CpuKernelTag::Vbmi2 => X86Caps {
+                    avx512f: true,
+                    avx2: true,
+                    sse2: true,
+                },
+                CpuKernelTag::Avx2 => X86Caps {
+                    avx512f: false,
+                    avx2: true,
+                    sse2: true,
+                },
+                CpuKernelTag::Bmi2 | CpuKernelTag::Sse2 => X86Caps {
+                    avx512f: false,
+                    avx2: false,
+                    sse2: true,
+                },
+                CpuKernelTag::Scalar => X86Caps {
+                    avx512f: false,
+                    avx2: false,
+                    sse2: false,
+                },
+            }
+        }
+        #[cfg(target_arch = "x86")]
+        {
+            X86Caps {
+                avx512f: is_x86_feature_detected!("avx512f"),
+                avx2: is_x86_feature_detected!("avx2"),
+                sse2: is_x86_feature_detected!("sse2"),
+            }
+        }
     })
 }
 


### PR DESCRIPTION
## Summary

Completes the copy half of #247's single-top-level-dispatch goal. The chunked wildcopy dispatcher had its own `OnceLock`-cached AVX-512/AVX2/SSE2 detection, independent of the `CpuKernel` tag that drives the entropy + sequence hot paths — two CPU-capability sources of truth that could disagree.

Two commits:

1. **Add the `Sse2` kernel tier.** SSE2 is ABI-guaranteed on every x86_64 target, so it is the effective kernel floor there (Scalar is only reached off-x86_64 or on pre-SSE2 x86). Ladder is now `Scalar < Sse2 < Bmi2 < Avx2 < Vbmi2` (x86_64) / `Scalar < Neon < Sve` (aarch64). The tier is a `CpuKernelTag` variant only — it has no `CpuKernel` ZST yet because the single trait method (`mask_lower_bits`) has no SSE2-specific form, so the Sse2 tag routes through the scalar FSE/HUF bodies. Its purpose is to carry the 128-bit copy-chunk choice in the copy dispatch below.

2. **Derive SIMD-copy caps from the unified tag.** On x86_64 `detect_x86_caps()` now maps `detect_cpu_kernel()` → copy widths (Vbmi2→64/32/16, Avx2→32/16, Bmi2/Sse2→16, Scalar→none), so a single CPUID query feeds both the entropy/sequence dispatch and the copy dispatch. 32-bit x86 keeps its own runtime detection (the kernel tag carries no SIMD tiers there, so routing through it would drop the SSE2/AVX2 copy path on i686).

### Edge: avx512f without VBMI2 (Skylake-X)

Such a part is tagged `Avx2`, so it uses the 32-byte `copy_avx2` chunk rather than 64-byte `copy_avx512`. Negligible on the short match copies that dominate; modern AVX-512 parts (Ice Lake+) carry VBMI2 and still reach `copy_avx512`.

## Verification

- x86_64 build, **`cargo check --target i686-unknown-linux-gnu`** clean (i686 copy path intact).
- 646/646 lib tests, clippy (`--all-targets --features bench_internals`) + fmt clean.
- **i9 perf-neutral** (decodecorpus-z000033 L-3 fast decompress, baseline `main` vs branch): rust_stream pure_rust −0.22%, c_stream pure_rust +1.80% (p=0.11, not significant). c_ffi control arms moved +0.5% / −4.1%, i.e. the machine noise floor is ±4% — the pure_rust deltas sit inside it. Copy selection on AVX2 hardware is byte-identical to before by construction.

Part of #247.
