### PR TITLE
feat(decode): kernel_* cargo features for per-tier CPU kernel selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,15 @@ jobs:
       - name: Clippy (no_std + hash)
         working-directory: zstd
         run: cargo clippy -p structured-zstd --no-default-features --features hash -- -D warnings
+      # Embedded-minimal kernel trim: scalar kernel only, all SIMD tiers and
+      # their dispatch trampolines compiled out. Guards the kernel_* feature
+      # gating so a future change can't silently break the trimmed build.
+      - name: Clippy (embedded — kernel_scalar only)
+        working-directory: zstd
+        run: cargo clippy -p structured-zstd --no-default-features --features kernel_scalar,hash -- -D warnings
+      - name: Clippy (embedded_minimal — kernel_scalar + std)
+        working-directory: zstd
+        run: cargo clippy -p structured-zstd --no-default-features --features kernel_scalar,std,hash -- -D warnings
 
   codecov:
     needs: lint

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ cargo add structured-zstd --no-default-features
 The decoder ships per-CPU-tier SIMD kernels, each behind a cargo feature
 (all on by default, picked at runtime): `kernel_scalar`, `kernel_sse2`,
 `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and `kernel_neon`,
-`kernel_sve` (aarch64). The scalar kernel is always compiled, so constrained
-targets can trim the SIMD trampolines for a smaller binary, e.g. a
-scalar-only build:
+`kernel_sve` (aarch64). The scalar kernel is always compiled (it is the
+mandatory fallback), so `kernel_scalar` is a marker that gates no code;
+disabling the SIMD tiers is what trims the binary. A scalar-only build —
+`--no-default-features` (or, equivalently, naming the marker explicitly) —
+drops every SIMD trampoline:
 
 ```bash
 cargo add structured-zstd --no-default-features --features kernel_scalar

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ time from `target_feature` on `no_std`): `kernel_scalar`, `kernel_sse2`,
 mandatory fallback), so `kernel_scalar` is a marker that gates no code;
 disabling the SIMD tiers is what trims the binary. A scalar-only build —
 `--no-default-features` (or, equivalently, naming the marker explicitly) —
-compiles out the per-tier SIMD kernel dispatch and its BMI2/AVX2/VBMI2/NEON
-trampolines. Baseline SIMD the target ABI guarantees (SSE2 on x86_64, NEON on
-aarch64, used by the small fixed-size copy primitives) is not a tier and may
-still be emitted:
+compiles out the per-tier SIMD kernel dispatch, its BMI2/AVX2/VBMI2/NEON
+trampolines, and the explicit SSE2/NEON intrinsics in the small fixed-size
+copy primitives — all gated on the matching `kernel_*` feature. These features
+control the crate's own explicit SIMD only; the compiler's autovectorizer may
+still emit vector instructions from ordinary scalar code regardless:
 
 ```bash
 cargo add structured-zstd --no-default-features --features kernel_scalar

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ For `no_std` builds disable the default features:
 cargo add structured-zstd --no-default-features
 ```
 
+The decoder ships per-CPU-tier SIMD kernels, each behind a cargo feature
+(all on by default, picked at runtime): `kernel_scalar`, `kernel_sse2`,
+`kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and `kernel_neon`,
+`kernel_sve` (aarch64). The scalar kernel is always compiled, so constrained
+targets can trim the SIMD trampolines for a smaller binary, e.g. a
+scalar-only build:
+
+```bash
+cargo add structured-zstd --no-default-features --features kernel_scalar
+```
+
 Release notes for every version live in [`zstd/CHANGELOG.md`](https://github.com/structured-world/structured-zstd/blob/main/zstd/CHANGELOG.md) (maintained by [release-plz](https://release-plz.dev/)).
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ The decoder ships per-CPU-tier SIMD kernels, each behind a cargo feature
 mandatory fallback), so `kernel_scalar` is a marker that gates no code;
 disabling the SIMD tiers is what trims the binary. A scalar-only build —
 `--no-default-features` (or, equivalently, naming the marker explicitly) —
-drops every SIMD trampoline:
+compiles out the per-tier SIMD kernel dispatch and its BMI2/AVX2/VBMI2/NEON
+trampolines. Baseline SIMD the target ABI guarantees (SSE2 on x86_64, NEON on
+aarch64, used by the small fixed-size copy primitives) is not a tier and may
+still be emitted:
 
 ```bash
 cargo add structured-zstd --no-default-features --features kernel_scalar

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ cargo add structured-zstd --no-default-features
 ```
 
 The decoder ships per-CPU-tier SIMD kernels, each behind a cargo feature
-(all on by default, picked at runtime): `kernel_scalar`, `kernel_sse2`,
+(all on by default; the tier is picked at runtime with `std`, or at compile
+time from `target_feature` on `no_std`): `kernel_scalar`, `kernel_sse2`,
 `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and `kernel_neon`,
 `kernel_sve` (aarch64). The scalar kernel is always compiled (it is the
 mandatory fallback), so `kernel_scalar` is a marker that gates no code;

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -60,7 +60,33 @@ rand = "0.10"
 zstd = { version = "0.13.3", features = ["zdict_builder", "experimental"] }
 
 [features]
-default = ["hash", "std"]
+default = [
+    "hash",
+    "std",
+    "kernel_scalar",
+    "kernel_sse2",
+    "kernel_bmi2",
+    "kernel_avx2",
+    "kernel_vbmi2",
+    "kernel_neon",
+    "kernel_sve",
+]
+# Per-CPU-tier decode kernel selection. The default build enables every
+# kernel and `detect_cpu_kernel()` picks the best at runtime (universal
+# binary). Constrained targets can trim the SIMD trampolines + their
+# dispatch arms by disabling the tiers they don't need; the scalar kernel
+# is always compiled as the fallback, so the lowest enabled tier always has
+# a backstop. Each feature only affects builds for its architecture (a
+# `kernel_avx2` flag is inert on aarch64, `kernel_neon` inert on x86), so
+# the all-on default is safe everywhere. The implication chain mirrors the
+# real ISA dependency: AVX2 implies BMI2 implies SSE2; SVE implies NEON.
+kernel_scalar = []
+kernel_sse2 = []
+kernel_bmi2 = ["kernel_sse2"]
+kernel_avx2 = ["kernel_bmi2"]
+kernel_vbmi2 = ["kernel_avx2"]
+kernel_neon = []
+kernel_sve = ["kernel_neon"]
 dict_builder = ["std", "dep:fastrand"]
 hash = ["dep:twox-hash"]
 # Opt-in cache for FSE default tables on no-atomic targets. See

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -72,9 +72,10 @@ default = [
     "kernel_sve",
 ]
 # Per-CPU-tier decode kernel selection. The default build enables every
-# kernel and `detect_cpu_kernel()` picks the best tier at runtime with `std`
-# (CPU-feature detection), or at compile time from `target_feature` on
-# `no_std` (universal binary). Constrained targets can trim the SIMD trampolines + their
+# kernel; with `std`, `detect_cpu_kernel()` picks the best tier at runtime
+# (CPU-feature detection) — a universal binary that adapts to any CPU. On
+# `no_std` the tier is fixed at compile time from `target_feature`, baking
+# the chosen ISA into the build. Constrained targets can trim the SIMD trampolines + their
 # dispatch arms by disabling the tiers they don't need; the scalar kernel
 # is always compiled as the fallback, so the lowest enabled tier always has
 # a backstop. Each feature only affects builds for its architecture (a

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -72,8 +72,9 @@ default = [
     "kernel_sve",
 ]
 # Per-CPU-tier decode kernel selection. The default build enables every
-# kernel and `detect_cpu_kernel()` picks the best at runtime (universal
-# binary). Constrained targets can trim the SIMD trampolines + their
+# kernel and `detect_cpu_kernel()` picks the best tier at runtime with `std`
+# (CPU-feature detection), or at compile time from `target_feature` on
+# `no_std` (universal binary). Constrained targets can trim the SIMD trampolines + their
 # dispatch arms by disabling the tiers they don't need; the scalar kernel
 # is always compiled as the fallback, so the lowest enabled tier always has
 # a backstop. Each feature only affects builds for its architecture (a

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -80,6 +80,11 @@ default = [
 # `kernel_avx2` flag is inert on aarch64, `kernel_neon` inert on x86), so
 # the all-on default is safe everywhere. The implication chain mirrors the
 # real ISA dependency: AVX2 implies BMI2 implies SSE2; SVE implies NEON.
+# `kernel_scalar` is a marker only: the scalar kernel is compiled
+# unconditionally (it is the mandatory fallback), so this flag gates no code.
+# It exists so the scalar tier can be named explicitly in a feature set; a
+# scalar-only build is equivalently `--no-default-features` (no SIMD tier
+# enabled) or `--no-default-features --features kernel_scalar`.
 kernel_scalar = []
 kernel_sse2 = []
 kernel_bmi2 = ["kernel_sse2"]

--- a/zstd/src/bit_io/bit_reader_reverse.rs
+++ b/zstd/src/bit_io/bit_reader_reverse.rs
@@ -247,7 +247,7 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
     /// PEXT. Vendor-specific microcode regression remains a
     /// build-time concern there — pin a known-good target with
     /// `RUSTFLAGS="-C target-cpu=..."`.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[inline(always)]
     pub(crate) fn use_pext_triple_fast(&self) -> bool {
         #[cfg(all(feature = "std", target_arch = "x86_64"))]
@@ -497,7 +497,7 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
     /// # Safety
     /// Caller MUST ensure BMI2 is available AND the running CPU
     /// benefits from `_pext_u64` (i.e. not Zen1/Zen2).
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[target_feature(enable = "bmi2")]
     #[inline]
     pub(crate) unsafe fn peek_bits_triple_bmi2(

--- a/zstd/src/bit_io/bit_reader_reverse.rs
+++ b/zstd/src/bit_io/bit_reader_reverse.rs
@@ -1,7 +1,7 @@
 use crate::cpu_kernel::{CpuKernel, ScalarKernel};
 use core::convert::TryInto;
 use core::marker::PhantomData;
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 use std::sync::OnceLock;
 
 /// Pre-computed mask table: `BIT_MASK[n]` equals the lower `n` bits set,
@@ -12,7 +12,7 @@ use std::sync::OnceLock;
 /// by the BMI2 PEXT triple-extract path on x86-64 (where the mask is
 /// constructed once per call and then fed to `_pext_u64`), and by the
 /// tests that verify mask values directly.
-#[cfg(any(test, target_arch = "x86_64"))]
+#[cfg(any(test, all(target_arch = "x86_64", feature = "kernel_bmi2")))]
 const BIT_MASK: [u64; 65] = {
     let mut table = [0u64; 65];
     let mut i: u32 = 1;
@@ -80,28 +80,28 @@ fn mask_lower_bits(value: u64, n: u8) -> u64 {
     }
 }
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[derive(Copy, Clone)]
 struct TripleExtractDispatch {
     use_pext: bool,
 }
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 static TRIPLE_EXTRACT_DISPATCH: OnceLock<TripleExtractDispatch> = OnceLock::new();
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[inline(always)]
 fn should_use_pext(vendor: [u8; 12], family: u32) -> bool {
     vendor != *b"AuthenticAMD" || family != 0x17
 }
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[inline(always)]
 fn triple_extract_dispatch() -> &'static TripleExtractDispatch {
     TRIPLE_EXTRACT_DISPATCH.get_or_init(detect_triple_extract_dispatch)
 }
 
-#[cfg(all(feature = "std", target_arch = "x86_64"))]
+#[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 fn detect_triple_extract_dispatch() -> TripleExtractDispatch {
     use core::arch::x86_64::__cpuid;
     use std::arch::is_x86_feature_detected;
@@ -137,7 +137,7 @@ fn detect_triple_extract_dispatch() -> TripleExtractDispatch {
 // `extract_triple_pext` directly via that path. Gating with
 // `#[cfg(test)]` keeps the helper available for the tests while
 // avoiding a `dead_code` warning under `-D warnings`.
-#[cfg(all(test, feature = "std", target_arch = "x86_64"))]
+#[cfg(all(test, feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[inline(always)]
 fn try_extract_triple_with_pext(all_three: u64, n1: u8, n2: u8, n3: u8) -> Option<(u64, u64, u64)> {
     if !triple_extract_dispatch().use_pext {
@@ -147,7 +147,7 @@ fn try_extract_triple_with_pext(all_three: u64, n1: u8, n2: u8, n3: u8) -> Optio
     Some(unsafe { extract_triple_pext(all_three, n1, n2, n3) })
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[target_feature(enable = "bmi2")]
 unsafe fn extract_triple_pext(all_three: u64, n1: u8, n2: u8, n3: u8) -> (u64, u64, u64) {
     use core::arch::x86_64::_pext_u64;
@@ -224,7 +224,7 @@ pub struct BitReaderReversed<'s, K: CpuKernel = ScalarKernel> {
     /// every sequence decode (thousands per block × many blocks per
     /// frame). One bool per `BitReaderReversed` lifetime, amortised
     /// across every `peek_bits_triple` in the same decode pass.
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     pub(crate) use_pext_triple: bool,
 }
 
@@ -250,7 +250,7 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
     #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[inline(always)]
     pub(crate) fn use_pext_triple_fast(&self) -> bool {
-        #[cfg(all(feature = "std", target_arch = "x86_64"))]
+        #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
         {
             self.use_pext_triple
         }
@@ -268,7 +268,7 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
             bit_container: 0,
             extra_bits: 0,
             _kernel: PhantomData,
-            #[cfg(all(feature = "std", target_arch = "x86_64"))]
+            #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
             use_pext_triple: triple_extract_dispatch().use_pext,
         }
     }
@@ -438,7 +438,7 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
         let shift_by = (64u8 - self.bits_consumed).wrapping_sub(sum);
         let all_three = self.bit_container.wrapping_shr(shift_by as u32);
 
-        #[cfg(all(feature = "std", target_arch = "x86_64"))]
+        #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
         if self.use_pext_triple {
             // SAFETY: `use_pext_triple` was set in `new()` from
             // `triple_extract_dispatch().use_pext`, which only returns
@@ -561,10 +561,10 @@ impl<'s, K: CpuKernel> BitReaderReversed<'s, K> {
 
 #[cfg(test)]
 mod test {
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     use std::arch::is_x86_feature_detected;
 
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[inline]
     fn scalar_extract_triple(all_three: u64, n1: u8, n2: u8, n3: u8) -> (u64, u64, u64) {
         let val3 = all_three & super::BIT_MASK[n3 as usize];
@@ -574,7 +574,7 @@ mod test {
         (val1, val2, val3)
     }
 
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[inline]
     fn next_test_value(state: &mut u64) -> u64 {
         let mut x = *state;
@@ -766,7 +766,7 @@ mod test {
     /// `peek_bits_bmi2` MUST produce the same value as scalar `peek_bits`
     /// on every BMI2-capable CPU. Without parity the bmi2 fast-path
     /// chain (when wired) would silently corrupt FSE state.
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[test]
     fn peek_bits_bmi2_matches_scalar() {
         if !is_x86_feature_detected!("bmi2") {
@@ -793,7 +793,7 @@ mod test {
     /// `peek_bits_triple_bmi2` MUST produce the same triple as the
     /// scalar variant for every width combination the FSE/HUF decoders
     /// can reach.
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[test]
     fn peek_bits_triple_bmi2_matches_scalar() {
         if !is_x86_feature_detected!("bmi2") {
@@ -826,7 +826,7 @@ mod test {
         }
     }
 
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[test]
     fn should_use_pext_policy_table() {
         let cases = [
@@ -840,7 +840,7 @@ mod test {
         }
     }
 
-    #[cfg(all(feature = "std", target_arch = "x86_64"))]
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
     #[test]
     fn bmi2_triple_extract_matches_scalar_reference() {
         if !is_x86_feature_detected!("bmi2") {

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -303,14 +303,18 @@ fn detect_cpu_kernel_uncached() -> CpuKernelTag {
     #[cfg(target_arch = "x86_64")]
     {
         use std::arch::is_x86_feature_detected;
+        // Gate each probe on its tier feature: `cfg!(...)` const-folds, so the
+        // `&&` short-circuits away the runtime `is_x86_feature_detected!` call
+        // (and its CPUID/cache traffic) for tiers the build disabled — the
+        // matching `select_x86_kernel` rung is `#[cfg]`-ed out anyway.
         return select_x86_kernel(
-            is_x86_feature_detected!("avx512vbmi2"),
-            is_x86_feature_detected!("avx512f"),
-            is_x86_feature_detected!("avx512vl"),
-            is_x86_feature_detected!("avx512bw"),
-            is_x86_feature_detected!("bmi2"),
-            is_x86_feature_detected!("avx2"),
-            is_x86_feature_detected!("sse2"),
+            cfg!(feature = "kernel_vbmi2") && is_x86_feature_detected!("avx512vbmi2"),
+            cfg!(feature = "kernel_vbmi2") && is_x86_feature_detected!("avx512f"),
+            cfg!(feature = "kernel_vbmi2") && is_x86_feature_detected!("avx512vl"),
+            cfg!(feature = "kernel_vbmi2") && is_x86_feature_detected!("avx512bw"),
+            cfg!(feature = "kernel_bmi2") && is_x86_feature_detected!("bmi2"),
+            cfg!(feature = "kernel_avx2") && is_x86_feature_detected!("avx2"),
+            cfg!(feature = "kernel_sse2") && is_x86_feature_detected!("sse2"),
         );
     }
     #[cfg(target_arch = "aarch64")]

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -95,11 +95,11 @@ impl CpuKernel for ScalarKernel {
 /// the Avx2 kernel. Treated as a stepping stone between Sse2 and
 /// Avx2 on hardware that has BMI2 but not AVX2 (rare in practice but
 /// matches donor's gating).
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[derive(Copy, Clone, Default)]
 pub(crate) struct Bmi2Kernel;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 impl CpuKernel for Bmi2Kernel {
     #[inline(always)]
     fn mask_lower_bits(value: u64, n: u8) -> u64 {
@@ -116,11 +116,11 @@ impl CpuKernel for Bmi2Kernel {
 /// x86 case — most CPUs released since 2013 (Haswell) have AVX2+BMI2.
 /// Uses `_bzhi_u64` for mask ops; future trait methods will use AVX2
 /// 256-bit moves for `copy_chunk` and pext for HUF burst.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
 #[derive(Copy, Clone, Default)]
 pub(crate) struct Avx2Kernel;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
 impl CpuKernel for Avx2Kernel {
     #[inline(always)]
     fn mask_lower_bits(value: u64, n: u8) -> u64 {
@@ -134,11 +134,11 @@ impl CpuKernel for Avx2Kernel {
 /// has the AVX-512 VBMI2 family available — VBMI2 unlocks a faster
 /// HUF burst inner loop (VPSHUFB-based table lookup); BMI2 mask_lower
 /// bits stays identical to Avx2 kernel.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
 #[derive(Copy, Clone, Default)]
 pub(crate) struct Vbmi2Kernel;
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
 impl CpuKernel for Vbmi2Kernel {
     #[inline(always)]
     fn mask_lower_bits(value: u64, n: u8) -> u64 {
@@ -156,12 +156,12 @@ impl CpuKernel for Vbmi2Kernel {
 /// The struct + trait impl land first so the dispatch wiring can be
 /// added incrementally without churning the CpuKernel surface; until
 /// the dispatch arm uses it the type is reachable only as a phantom.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
 #[allow(dead_code)]
 #[derive(Copy, Clone, Default)]
 pub(crate) struct NeonKernel;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
 impl CpuKernel for NeonKernel {
     #[inline(always)]
     fn mask_lower_bits(value: u64, n: u8) -> u64 {
@@ -178,12 +178,12 @@ impl CpuKernel for NeonKernel {
 /// support. Mask op identical to NEON / Scalar.
 ///
 /// `#[allow(dead_code)]`: same scaffolding rationale as `NeonKernel`.
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kernel_sve"))]
 #[allow(dead_code)]
 #[derive(Copy, Clone, Default)]
 pub(crate) struct SveKernel;
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", feature = "kernel_sve"))]
 impl CpuKernel for SveKernel {
     #[inline(always)]
     fn mask_lower_bits(value: u64, n: u8) -> u64 {
@@ -197,7 +197,7 @@ impl CpuKernel for SveKernel {
 /// same shared body. With `#[inline]` LLVM inlines the call into
 /// any caller that itself has BMI2 in scope; outside that scope the
 /// target_feature boundary is preserved.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[target_feature(enable = "bmi2")]
 #[inline]
 unsafe fn mask_lower_bits_bmi2_impl(value: u64, n: u8) -> u64 {
@@ -221,6 +221,11 @@ unsafe fn mask_lower_bits_bmi2_impl(value: u64, n: u8) -> u64 {
 /// Likewise the Avx2 tier requires both AVX2 and BMI2.
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
+// Params go unused when the matching `kernel_*` feature is disabled (the
+// rung that consumes them is `#[cfg]`-ed out); they are still passed by the
+// detect callers. Silence the conditional unused-variable warning rather
+// than thread per-feature `_`-prefixes through the signature.
+#[allow(unused_variables)]
 const fn select_x86_kernel(
     has_avx512vbmi2: bool,
     has_avx512f: bool,
@@ -230,15 +235,19 @@ const fn select_x86_kernel(
     has_avx2: bool,
     has_sse2: bool,
 ) -> CpuKernelTag {
+    #[cfg(feature = "kernel_vbmi2")]
     if has_avx512vbmi2 && has_avx512f && has_avx512vl && has_avx512bw && has_bmi2 && has_avx2 {
         return CpuKernelTag::Vbmi2;
     }
+    #[cfg(feature = "kernel_avx2")]
     if has_avx2 && has_bmi2 {
         return CpuKernelTag::Avx2;
     }
+    #[cfg(feature = "kernel_bmi2")]
     if has_bmi2 {
         return CpuKernelTag::Bmi2;
     }
+    #[cfg(feature = "kernel_sse2")]
     if has_sse2 {
         return CpuKernelTag::Sse2;
     }
@@ -256,22 +265,26 @@ const fn select_x86_kernel(
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum CpuKernelTag {
     Scalar,
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
     Sse2,
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
     Bmi2,
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
     Avx2,
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
     Vbmi2,
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
     Neon,
     // Both constructors of `Sve` need a reachable feature: runtime
     // detection via `std::arch::is_aarch64_feature_detected!` (so
     // `feature = "std"`) or compile-time `target_feature = "sve"` in
     // RUSTFLAGS. Without either, the variant is unreachable and a
     // `match` arm referencing it warns as dead.
-    #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        feature = "kernel_sve",
+        any(feature = "std", target_feature = "sve"),
+    ))]
     Sve,
 }
 
@@ -302,10 +315,13 @@ fn detect_cpu_kernel_uncached() -> CpuKernelTag {
     }
     #[cfg(target_arch = "aarch64")]
     {
+        #[cfg(any(feature = "kernel_sve", feature = "kernel_neon"))]
         use std::arch::is_aarch64_feature_detected;
+        #[cfg(feature = "kernel_sve")]
         if is_aarch64_feature_detected!("sve") {
             return CpuKernelTag::Sve;
         }
+        #[cfg(feature = "kernel_neon")]
         if is_aarch64_feature_detected!("neon") {
             return CpuKernelTag::Neon;
         }
@@ -339,11 +355,11 @@ pub(crate) fn detect_cpu_kernel() -> CpuKernelTag {
     }
     #[cfg(target_arch = "aarch64")]
     {
-        #[cfg(target_feature = "sve")]
+        #[cfg(all(feature = "kernel_sve", target_feature = "sve"))]
         {
             return CpuKernelTag::Sve;
         }
-        #[cfg(target_feature = "neon")]
+        #[cfg(all(feature = "kernel_neon", target_feature = "neon"))]
         {
             return CpuKernelTag::Neon;
         }

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -399,13 +399,15 @@ mod tests {
         );
     }
 
-    // Whole test gated on `std`: the `is_x86_feature_detected!`
+    // Gated on `std` AND `kernel_avx2`: the `is_x86_feature_detected!`
     // guard below is a no-op under `--no-default-features` (no std,
     // no runtime feature detection), so the test body would call
     // `Avx2Kernel::mask_lower_bits` unconditionally and SIGILL on any
-    // non-BMI2 CPU. Gating the test itself with `cfg(feature = "std")`
-    // ensures the runtime check is always live when the test compiles.
-    #[cfg(all(target_arch = "x86_64", feature = "std"))]
+    // non-BMI2 CPU — hence `feature = "std"`. `Avx2Kernel` itself is
+    // `#[cfg(feature = "kernel_avx2")]`, so the test must also require
+    // that feature or a `std`-only trimmed build (`kernel_avx2` off)
+    // fails to compile against the undefined type.
+    #[cfg(all(target_arch = "x86_64", feature = "std", feature = "kernel_avx2"))]
     #[test]
     fn avx2_mask_lower_bits_matches_scalar_on_bmi2_hw() {
         // Only run when BMI2 actually available — otherwise constructing

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -425,7 +425,7 @@ mod tests {
     /// previously selected as `Vbmi2`, which would SIGILL on the
     /// first AVX2-mixed VBMI2 kernel invocation. The selection must
     /// fall through to Scalar (or a non-AVX tier) in that case.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
     #[test]
     fn select_x86_kernel_vbmi2_without_avx2_does_not_pick_vbmi2() {
         let tag = select_x86_kernel(
@@ -441,7 +441,7 @@ mod tests {
     }
 
     /// Sanity: when every flag is present the selector returns Vbmi2.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
     #[test]
     fn select_x86_kernel_full_x86_v4_picks_vbmi2() {
         let tag = select_x86_kernel(true, true, true, true, true, true, true);
@@ -449,7 +449,7 @@ mod tests {
     }
 
     /// Sanity: AVX2 + BMI2 without AVX-512 → Avx2.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
     #[test]
     fn select_x86_kernel_avx2_baseline_picks_avx2() {
         let tag = select_x86_kernel(false, false, false, false, true, true, true);
@@ -457,7 +457,7 @@ mod tests {
     }
 
     /// SSE2-only (no BMI2/AVX2) → Sse2, the x86_64 floor above Scalar.
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
     #[test]
     fn select_x86_kernel_sse2_only_picks_sse2() {
         let tag = select_x86_kernel(false, false, false, false, false, false, true);

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -83,9 +83,30 @@ impl CpuKernel for ScalarKernel {
     }
 }
 
+/// x86_64 SSE2 baseline kernel. SSE2 is ABI-guaranteed on every
+/// x86_64 target, so this is the effective floor on x86_64 — the
+/// Scalar kernel is reached only off-x86_64 (or on the rare x86
+/// build without SSE2). SSE2 has no `_bzhi_u64`, so `mask_lower_bits`
+/// is identical to Scalar; the kernel's value is the 128-bit SIMD
+/// `copy_chunk` body (a 16-byte chunked copy) that diverges from the
+/// scalar 8-byte loop. Sits below Bmi2 in the kernel ladder.
+#[cfg(target_arch = "x86_64")]
+#[derive(Copy, Clone, Default)]
+pub(crate) struct Sse2Kernel;
+
+#[cfg(target_arch = "x86_64")]
+impl CpuKernel for Sse2Kernel {
+    #[inline(always)]
+    fn mask_lower_bits(value: u64, n: u8) -> u64 {
+        // SSE2 has no bit-extract instruction; the scalar shift-mask
+        // sequence is the best codegen here. Identical to ScalarKernel.
+        ScalarKernel::mask_lower_bits(value, n)
+    }
+}
+
 /// x86_64 BMI2-only kernel: `_bzhi_u64` for mask_lower_bits. Selected
 /// when the CPU has BMI2 but not the AVX2 SIMD width to upgrade to
-/// the Avx2 kernel. Treated as a stepping stone between Scalar and
+/// the Avx2 kernel. Treated as a stepping stone between Sse2 and
 /// Avx2 on hardware that has BMI2 but not AVX2 (rare in practice but
 /// matches donor's gating).
 #[cfg(target_arch = "x86_64")]
@@ -221,6 +242,7 @@ const fn select_x86_kernel(
     has_avx512bw: bool,
     has_bmi2: bool,
     has_avx2: bool,
+    has_sse2: bool,
 ) -> CpuKernelTag {
     if has_avx512vbmi2 && has_avx512f && has_avx512vl && has_avx512bw && has_bmi2 && has_avx2 {
         return CpuKernelTag::Vbmi2;
@@ -230,6 +252,9 @@ const fn select_x86_kernel(
     }
     if has_bmi2 {
         return CpuKernelTag::Bmi2;
+    }
+    if has_sse2 {
+        return CpuKernelTag::Sse2;
     }
     CpuKernelTag::Scalar
 }
@@ -245,6 +270,8 @@ const fn select_x86_kernel(
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum CpuKernelTag {
     Scalar,
+    #[cfg(target_arch = "x86_64")]
+    Sse2,
     #[cfg(target_arch = "x86_64")]
     Bmi2,
     #[cfg(target_arch = "x86_64")]
@@ -284,6 +311,7 @@ fn detect_cpu_kernel_uncached() -> CpuKernelTag {
             is_x86_feature_detected!("avx512bw"),
             is_x86_feature_detected!("bmi2"),
             is_x86_feature_detected!("avx2"),
+            is_x86_feature_detected!("sse2"),
         );
     }
     #[cfg(target_arch = "aarch64")]
@@ -320,6 +348,7 @@ pub(crate) fn detect_cpu_kernel() -> CpuKernelTag {
             cfg!(target_feature = "avx512bw"),
             cfg!(target_feature = "bmi2"),
             cfg!(target_feature = "avx2"),
+            cfg!(target_feature = "sse2"),
         );
     }
     #[cfg(target_arch = "aarch64")]
@@ -400,6 +429,7 @@ mod tests {
         let tag = select_x86_kernel(
             /* avx512vbmi2 */ true, /* avx512f */ true, /* avx512vl */ true,
             /* avx512bw */ true, /* bmi2 */ true, /* avx2 */ false,
+            /* sse2 */ true,
         );
         assert_ne!(
             tag,
@@ -412,7 +442,7 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn select_x86_kernel_full_x86_v4_picks_vbmi2() {
-        let tag = select_x86_kernel(true, true, true, true, true, true);
+        let tag = select_x86_kernel(true, true, true, true, true, true, true);
         assert_eq!(tag, CpuKernelTag::Vbmi2);
     }
 
@@ -420,8 +450,24 @@ mod tests {
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn select_x86_kernel_avx2_baseline_picks_avx2() {
-        let tag = select_x86_kernel(false, false, false, false, true, true);
+        let tag = select_x86_kernel(false, false, false, false, true, true, true);
         assert_eq!(tag, CpuKernelTag::Avx2);
+    }
+
+    /// SSE2-only (no BMI2/AVX2) → Sse2, the x86_64 floor above Scalar.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn select_x86_kernel_sse2_only_picks_sse2() {
+        let tag = select_x86_kernel(false, false, false, false, false, false, true);
+        assert_eq!(tag, CpuKernelTag::Sse2);
+    }
+
+    /// No SIMD flags at all → Scalar (off-x86_64 / pre-SSE2 x86).
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn select_x86_kernel_no_features_picks_scalar() {
+        let tag = select_x86_kernel(false, false, false, false, false, false, false);
+        assert_eq!(tag, CpuKernelTag::Scalar);
     }
 
     #[test]

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -83,26 +83,12 @@ impl CpuKernel for ScalarKernel {
     }
 }
 
-/// x86_64 SSE2 baseline kernel. SSE2 is ABI-guaranteed on every
-/// x86_64 target, so this is the effective floor on x86_64 — the
-/// Scalar kernel is reached only off-x86_64 (or on the rare x86
-/// build without SSE2). SSE2 has no `_bzhi_u64`, so `mask_lower_bits`
-/// is identical to Scalar; the kernel's value is the 128-bit SIMD
-/// `copy_chunk` body (a 16-byte chunked copy) that diverges from the
-/// scalar 8-byte loop. Sits below Bmi2 in the kernel ladder.
-#[cfg(target_arch = "x86_64")]
-#[derive(Copy, Clone, Default)]
-pub(crate) struct Sse2Kernel;
-
-#[cfg(target_arch = "x86_64")]
-impl CpuKernel for Sse2Kernel {
-    #[inline(always)]
-    fn mask_lower_bits(value: u64, n: u8) -> u64 {
-        // SSE2 has no bit-extract instruction; the scalar shift-mask
-        // sequence is the best codegen here. Identical to ScalarKernel.
-        ScalarKernel::mask_lower_bits(value, n)
-    }
-}
+// The SSE2 tier exists in `CpuKernelTag` (it carries the 128-bit copy-chunk
+// choice for the unified copy dispatch) but needs no `CpuKernel` ZST yet: the
+// only trait method, `mask_lower_bits`, has no SSE2-specific form (SSE2 has no
+// bit-extract), so the Sse2 tag routes through the scalar bodies for the
+// FSE/HUF paths. A dedicated `Sse2Kernel` lands when `copy_chunk` moves onto
+// the trait.
 
 /// x86_64 BMI2-only kernel: `_bzhi_u64` for mask_lower_bits. Selected
 /// when the CPU has BMI2 but not the AVX2 SIMD width to upgrade to

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -4,8 +4,21 @@
 use super::super::blocks::literals_section::{LiteralsSection, LiteralsSectionType};
 use super::scratch::HuffmanScratch;
 use crate::bit_io::BitReaderReversed;
-#[cfg(target_arch = "x86_64")]
-use crate::cpu_kernel::{Avx2Kernel, Bmi2Kernel, CpuKernelTag, Vbmi2Kernel};
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+use crate::cpu_kernel::Avx2Kernel;
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
+use crate::cpu_kernel::Bmi2Kernel;
+#[cfg(all(
+    target_arch = "x86_64",
+    any(
+        feature = "kernel_bmi2",
+        feature = "kernel_avx2",
+        feature = "kernel_vbmi2"
+    )
+))]
+use crate::cpu_kernel::CpuKernelTag;
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
+use crate::cpu_kernel::Vbmi2Kernel;
 use crate::cpu_kernel::{CpuKernel, ScalarKernel, detect_cpu_kernel};
 use crate::decoding::errors::DecompressLiteralsError;
 use crate::huff0::HuffmanDecoder;
@@ -141,19 +154,19 @@ fn decompress_literals(
     // into the generic caller, and the inlined-intrinsic win
     // evaporates into a function-call trampoline per mask op.
     match detect_cpu_kernel() {
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
         CpuKernelTag::Vbmi2 => unsafe {
             decompress_literals_vbmi2(section, scratch, source, target)
         },
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
         CpuKernelTag::Avx2 => unsafe { decompress_literals_avx2(section, scratch, source, target) },
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
         CpuKernelTag::Bmi2 => unsafe { decompress_literals_bmi2(section, scratch, source, target) },
         _ => decompress_literals_impl::<ScalarKernel>(section, scratch, source, target),
     }
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
 #[target_feature(enable = "bmi2,avx2")]
 unsafe fn decompress_literals_avx2(
     section: &LiteralsSection,
@@ -164,7 +177,7 @@ unsafe fn decompress_literals_avx2(
     decompress_literals_impl::<Avx2Kernel>(section, scratch, source, target)
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 #[target_feature(enable = "bmi2")]
 unsafe fn decompress_literals_bmi2(
     section: &LiteralsSection,
@@ -175,7 +188,7 @@ unsafe fn decompress_literals_bmi2(
     decompress_literals_impl::<Bmi2Kernel>(section, scratch, source, target)
 }
 
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
 #[target_feature(enable = "avx512vbmi2,avx512f,avx512vl,avx512bw,bmi2,avx2")]
 unsafe fn decompress_literals_vbmi2(
     section: &LiteralsSection,

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -77,12 +77,12 @@ pub(crate) mod scratch;
 // helpers with no remaining callers; they should be cleaned up in
 // a follow-up PR once the per-kernel monolithic shape is fully
 // settled.
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
 pub(crate) mod seq_decoder_avx2;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
 pub(crate) mod seq_decoder_bmi2;
 pub(crate) mod seq_decoder_scalar;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
 pub(crate) mod seq_decoder_vbmi2;
 pub(crate) mod sequence_execution;
 pub(crate) mod sequence_section_decoder;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -126,6 +126,23 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             )
         }
         #[cfg(target_arch = "x86_64")]
+        CpuKernelTag::Sse2 => {
+            // SSE2 has no FSE-relevant divergence (no `_bzhi_u64`); the
+            // mask_lower_bits hot op is identical to Scalar. SSE2's only
+            // distinct body is match-copy (gated per-backend via
+            // SUPPORTS_INLINE_SEQUENCE_EXEC), not the sequence FSE walk,
+            // so route to the portable scalar sequence decoder.
+            super::seq_decoder_scalar::decode_and_execute_sequences_scalar::<B>(
+                section,
+                source,
+                fse,
+                buffer,
+                offset_hist,
+                literals_buffer,
+                rle_fallback_sequences,
+            )
+        }
+        #[cfg(target_arch = "x86_64")]
         CpuKernelTag::Bmi2 => {
             // SAFETY: `detect_cpu_kernel()` only returns Bmi2 when
             // `is_x86_feature_detected!("bmi2")` confirmed BMI2 is

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -107,9 +107,13 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
     literals_buffer: &[u8],
     rle_fallback_sequences: &mut Vec<Sequence>,
 ) -> Result<(), DecompressBlockError> {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
     use crate::cpu_kernel::NeonKernel;
-    #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        feature = "kernel_sve",
+        any(feature = "std", target_feature = "sve"),
+    ))]
     use crate::cpu_kernel::SveKernel;
     use crate::cpu_kernel::{CpuKernelTag, detect_cpu_kernel};
 
@@ -125,7 +129,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 rle_fallback_sequences,
             )
         }
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
         CpuKernelTag::Sse2 => {
             // SSE2 has no FSE-relevant divergence (no `_bzhi_u64`); the
             // mask_lower_bits hot op is identical to Scalar. SSE2's only
@@ -142,7 +146,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 rle_fallback_sequences,
             )
         }
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
         CpuKernelTag::Bmi2 => {
             // SAFETY: `detect_cpu_kernel()` only returns Bmi2 when
             // `is_x86_feature_detected!("bmi2")` confirmed BMI2 is
@@ -162,7 +166,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 )
             }
         }
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
         CpuKernelTag::Avx2 => {
             // SAFETY: detect confirmed BMI2 + AVX2.
             unsafe {
@@ -177,7 +181,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 )
             }
         }
-        #[cfg(target_arch = "x86_64")]
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
         CpuKernelTag::Vbmi2 => {
             // SAFETY: detect confirmed AVX-512 VBMI2 + AVX2 + BMI2
             // (see `select_x86_kernel` precedence rules).
@@ -193,7 +197,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 )
             }
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
         CpuKernelTag::Neon => decode_and_execute_sequences_impl::<B, NeonKernel>(
             section,
             source,
@@ -203,7 +207,11 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             literals_buffer,
             rle_fallback_sequences,
         ),
-        #[cfg(all(target_arch = "aarch64", any(feature = "std", target_feature = "sve"),))]
+        #[cfg(all(
+            target_arch = "aarch64",
+            feature = "kernel_sve",
+            any(feature = "std", target_feature = "sve"),
+        ))]
         CpuKernelTag::Sve => decode_and_execute_sequences_impl::<B, SveKernel>(
             section,
             source,

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -321,7 +321,13 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 
     #[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64")))]
     {
-        #[cfg(all(target_feature = "avx512f", feature = "kernel_vbmi2"))]
+        // Gate the 64-byte copy on `avx512vbmi2`, not bare `avx512f`, to
+        // match the std tag ladder: `detect_x86_caps` sets `avx512f` (→ 64B)
+        // only for the `Vbmi2` tag, so an `avx512f`-but-not-VBMI2 target
+        // (e.g. `-C target-cpu=skylake-avx512`) is the `Avx2` tier and uses
+        // the 32B copy. Using bare `avx512f` here would diverge — no_std
+        // would emit 64B copies where std emits 32B on the same CPU.
+        #[cfg(all(target_feature = "avx512vbmi2", feature = "kernel_vbmi2"))]
         try_chunk_kernel!(64, copy_avx512);
         #[cfg(all(target_feature = "avx2", feature = "kernel_avx2"))]
         try_chunk_kernel!(32, copy_avx2);

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -8,7 +8,9 @@ use core::arch::x86_64::{
     __m128i, __m256i, __m512i, _mm_loadu_si128, _mm_storeu_si128, _mm256_loadu_si256,
     _mm256_storeu_si256, _mm512_loadu_si512, _mm512_storeu_si512,
 };
-#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+// Only the 32-bit x86 `detect_x86_caps` body queries CPU features at
+// runtime; the x86_64 body derives them from `detect_cpu_kernel()`.
+#[cfg(all(feature = "std", target_arch = "x86"))]
 use std::arch::is_x86_feature_detected;
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 use std::sync::OnceLock;
@@ -581,14 +583,62 @@ struct X86Caps {
     sse2: bool,
 }
 
+/// SIMD-copy capability flags for the chunked wildcopy dispatcher.
+///
+/// On `x86_64` these are DERIVED from the unified `detect_cpu_kernel()`
+/// tag rather than detected independently, so the whole crate has a
+/// single CPU-capability source of truth (the copy path can never
+/// disagree with the entropy/sequence path about the running CPU). The
+/// mapping follows the kernel ladder: Vbmi2 → 64/32/16-byte copies,
+/// Avx2 → 32/16, Bmi2 / Sse2 → 16, Scalar → none. One subtle
+/// consequence: an `avx512f`-but-not-VBMI2 CPU (e.g. Skylake-X) is
+/// tagged `Avx2`, so it uses the 32-byte `copy_avx2` chunk instead of
+/// the 64-byte `copy_avx512`. That is a negligible difference on match
+/// copies (which are short) and keeps the taxonomy single-axis; modern
+/// AVX-512 parts (Ice Lake+) carry VBMI2 and still reach `copy_avx512`.
+///
+/// On 32-bit `x86` the kernel tag carries no SIMD tiers (those are
+/// `x86_64`-gated), so this keeps its own runtime detection to preserve
+/// the SSE2 / AVX2 copy path there.
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 #[inline(always)]
 fn detect_x86_caps() -> X86Caps {
     static CAPS: OnceLock<X86Caps> = OnceLock::new();
-    *CAPS.get_or_init(|| X86Caps {
-        avx512f: is_x86_feature_detected!("avx512f"),
-        avx2: is_x86_feature_detected!("avx2"),
-        sse2: is_x86_feature_detected!("sse2"),
+    *CAPS.get_or_init(|| {
+        #[cfg(target_arch = "x86_64")]
+        {
+            use crate::cpu_kernel::{CpuKernelTag, detect_cpu_kernel};
+            match detect_cpu_kernel() {
+                CpuKernelTag::Vbmi2 => X86Caps {
+                    avx512f: true,
+                    avx2: true,
+                    sse2: true,
+                },
+                CpuKernelTag::Avx2 => X86Caps {
+                    avx512f: false,
+                    avx2: true,
+                    sse2: true,
+                },
+                CpuKernelTag::Bmi2 | CpuKernelTag::Sse2 => X86Caps {
+                    avx512f: false,
+                    avx2: false,
+                    sse2: true,
+                },
+                CpuKernelTag::Scalar => X86Caps {
+                    avx512f: false,
+                    avx2: false,
+                    sse2: false,
+                },
+            }
+        }
+        #[cfg(target_arch = "x86")]
+        {
+            X86Caps {
+                avx512f: is_x86_feature_detected!("avx512f"),
+                avx2: is_x86_feature_detected!("avx2"),
+                sse2: is_x86_feature_detected!("sse2"),
+            }
+        }
     })
 }
 

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -1,18 +1,27 @@
-#[cfg(target_arch = "x86")]
-use core::arch::x86::{
-    __m128i, __m256i, __m512i, _mm_loadu_si128, _mm_storeu_si128, _mm256_loadu_si256,
-    _mm256_storeu_si256, _mm512_loadu_si512, _mm512_storeu_si512,
-};
-#[cfg(target_arch = "x86_64")]
-use core::arch::x86_64::{
-    __m128i, __m256i, __m512i, _mm_loadu_si128, _mm_storeu_si128, _mm256_loadu_si256,
-    _mm256_storeu_si256, _mm512_loadu_si512, _mm512_storeu_si512,
-};
+// SIMD-intrinsic imports are split per tier and gated on the matching
+// `kernel_*` feature so a tier-trimmed build pulls in only the intrinsics
+// its enabled helpers use (a `kernel_scalar`-only trim imports none).
+#[cfg(all(target_arch = "x86", feature = "kernel_sse2"))]
+use core::arch::x86::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+#[cfg(all(target_arch = "x86", feature = "kernel_avx2"))]
+use core::arch::x86::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+#[cfg(all(target_arch = "x86", feature = "kernel_vbmi2"))]
+use core::arch::x86::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
+#[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
+use core::arch::x86_64::{__m128i, _mm_loadu_si128, _mm_storeu_si128};
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+use core::arch::x86_64::{__m256i, _mm256_loadu_si256, _mm256_storeu_si256};
+#[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
+use core::arch::x86_64::{__m512i, _mm512_loadu_si512, _mm512_storeu_si512};
 // Only the 32-bit x86 `detect_x86_caps` body queries CPU features at
 // runtime; the x86_64 body derives them from `detect_cpu_kernel()`.
-#[cfg(all(feature = "std", target_arch = "x86"))]
+#[cfg(all(feature = "std", feature = "kernel_sse2", target_arch = "x86"))]
 use std::arch::is_x86_feature_detected;
-#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "std",
+    feature = "kernel_sse2",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 use std::sync::OnceLock;
 
 #[cfg(all(
@@ -312,13 +321,24 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 
     #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
     {
+        // Bound only when at least the SSE2 tier is enabled (the lowest x86
+        // SIMD kernel; every higher tier implies it). A `kernel_scalar` trim
+        // drops the binding along with all three dispatch arms below.
+        #[cfg(feature = "kernel_sse2")]
         let caps = detect_x86_caps();
+        // Each call site is gated on its `kernel_*` feature so it disappears
+        // alongside the cfg-gated helper def in a tier-trimmed build. `caps.*`
+        // is already false when the feature is off (see `detect_x86_caps`), so
+        // this only prunes already-dead branches.
+        #[cfg(feature = "kernel_vbmi2")]
         if caps.avx512f {
             try_chunk_kernel!(64, copy_avx512);
         }
+        #[cfg(feature = "kernel_avx2")]
         if caps.avx2 {
             try_chunk_kernel!(32, copy_avx2);
         }
+        #[cfg(feature = "kernel_sse2")]
         if caps.sse2 {
             try_chunk_kernel!(16, copy_sse2);
         }
@@ -389,7 +409,10 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 /// per-tier `repeat_in_chunks_avx2` for the RingBuffer / FlatBuf
 /// (non-inline) backend paths. Keep the function until that work
 /// lands; remove if the layered-chain experiment ends up not retained.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "kernel_avx2"
+))]
 #[target_feature(enable = "avx2")]
 #[allow(dead_code)]
 pub(crate) unsafe fn copy_bytes_overshooting_avx2(
@@ -486,7 +509,11 @@ unsafe fn single_op_copy_16(src: *const u8, dst: *mut u8, len: usize) {
         vst1q_u8(dst, v);
         return;
     }
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_sse2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     unsafe {
         if detect_x86_caps().sse2 {
             copy_sse2(src, dst, 16);
@@ -515,8 +542,9 @@ unsafe fn single_op_copy_16(src: *const u8, dst: *mut u8, len: usize) {
     // dispatch above):
     //   • aarch64+neon + kernel_neon                   → arm above returns
     //   • aarch64+neon, NO kernel_neon                 → reaches here
-    //   • std + x86/x86_64 + runtime-SSE2 tag          → arm above returns
-    //   • std + x86/x86_64 + Scalar tag (no SSE2)      → reaches here
+    //   • std + x86 + kernel_sse2 + runtime-SSE2 tag   → arm above returns
+    //   • std + x86 + kernel_sse2 + Scalar tag         → reaches here
+    //   • std + x86, NO kernel_sse2                    → reaches here
     //   • no-std + x86 + target_feature sse2+kernel_sse2 → arm above returns
     //   • no-std + x86, kernel_sse2 off (or no sse2)   → reaches here
     //   • any other arch (riscv64, wasm32, …)          → reaches here
@@ -568,12 +596,21 @@ pub(crate) unsafe fn copy_bytes_overshooting_for_bench(
 #[cfg(test)]
 #[inline]
 pub(crate) fn active_chunk_size_for_tests() -> usize {
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_sse2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     {
         let caps = detect_x86_caps();
+        // Mirror the dispatcher: a tier is selectable only when BOTH its
+        // kernel_* feature is on AND the CPU exposes it, so a tier-trimmed
+        // build reports the chunk the dispatcher can actually pick.
+        #[cfg(feature = "kernel_vbmi2")]
         if caps.avx512f {
             return 64;
         }
+        #[cfg(feature = "kernel_avx2")]
         if caps.avx2 {
             return 32;
         }
@@ -641,8 +678,15 @@ unsafe fn copy_scalar(mut src: *const u8, mut dst: *mut u8, len: usize) {
     }
 }
 
-#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "std",
+    feature = "kernel_sse2",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[derive(Clone, Copy)]
+// `avx512f` / `avx2` are unread in a `kernel_sse2`-only trim (their dispatch
+// arms are cfg-gated out), so the fields are intentionally dead there.
+#[allow(dead_code)]
 struct X86Caps {
     avx512f: bool,
     avx2: bool,
@@ -666,7 +710,11 @@ struct X86Caps {
 /// On 32-bit `x86` the kernel tag carries no SIMD tiers (those are
 /// `x86_64`-gated), so this keeps its own runtime detection to preserve
 /// the SSE2 / AVX2 copy path there.
-#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(
+    feature = "std",
+    feature = "kernel_sse2",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
 #[inline(always)]
 fn detect_x86_caps() -> X86Caps {
     static CAPS: OnceLock<X86Caps> = OnceLock::new();
@@ -724,11 +772,17 @@ fn detect_x86_caps() -> X86Caps {
     })
 }
 
-// `#[allow(dead_code)]`: every call site (the chunked dispatch + the
-// `single_op_copy_16` fast path) is gated on `feature = "kernel_sse2"` in
-// no-std builds, so a `kernel_scalar`-only trim leaves this with no callers.
-// The `std` path reaches it via the runtime `detect_x86_caps` dispatch.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+// Gated on `kernel_sse2` so a `kernel_scalar`-only trim prunes the SSE2
+// helper at the source level, not just via dead-code elimination.
+// `#[allow(dead_code)]` is still required for one combo the feature gate
+// can't express: std builds reach this through runtime `detect_x86_caps`,
+// so the helper must compile even when no compile-time `target_feature =
+// "sse2"` selects it — leaving it caller-less in a no-std-without-sse2
+// build that still enables `kernel_sse2`.
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "kernel_sse2"
+))]
 #[target_feature(enable = "sse2")]
 #[allow(dead_code)]
 unsafe fn copy_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
@@ -760,7 +814,10 @@ unsafe fn copy_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
 // the loop branch, shortening AVX2 wildcopy latency. Actual speed-up
 // is workload-dependent — measured in `benches/wildcopy_candidates.rs`
 // (criterion micro) and end-to-end via `benches/compare_ffi.rs`.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "kernel_avx2"
+))]
 #[target_feature(enable = "avx2")]
 #[allow(dead_code)]
 unsafe fn copy_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
@@ -792,7 +849,10 @@ unsafe fn copy_avx2(mut src: *const u8, mut dst: *mut u8, len: usize) {
 
 // Same `#[allow(dead_code)]` rationale as `copy_avx2`: cfg-gated out in
 // no-std builds without `target_feature=+avx512f`, live elsewhere.
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    feature = "kernel_vbmi2"
+))]
 #[target_feature(enable = "avx512f")]
 #[allow(dead_code)]
 unsafe fn copy_avx512(mut src: *const u8, mut dst: *mut u8, len: usize) {
@@ -882,7 +942,11 @@ mod tests {
         assert_eq!(dst, src);
     }
 
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_sse2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     #[test]
     fn copy_sse2_copies_full_chunk_when_available() {
         if !std::arch::is_x86_feature_detected!("sse2") {
@@ -894,7 +958,11 @@ mod tests {
         assert_eq!(dst, src);
     }
 
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_avx2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     #[test]
     fn copy_avx2_copies_full_chunk_when_available() {
         if !std::arch::is_x86_feature_detected!("avx2") {
@@ -909,7 +977,11 @@ mod tests {
 
     /// Exercises one full iteration of the 64-byte unrolled body
     /// (`v0` + `v1` load/store pair) with no residual tail.
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_avx2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     #[test]
     fn copy_avx2_copies_full_unroll2_iteration() {
         use alloc::vec::Vec;
@@ -926,7 +998,11 @@ mod tests {
     /// vector 32-byte residual tail (96 = 64 + 32). Validates that
     /// the tail branch doesn't overwrite preceding bytes and copies
     /// the correct source offset.
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_avx2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     #[test]
     fn copy_avx2_copies_unroll2_loop_plus_residual_tail() {
         use alloc::vec::Vec;
@@ -941,7 +1017,11 @@ mod tests {
         assert_eq!(&dst[60..68], &[60, 61, 62, 63, 64, 65, 66, 67]);
     }
 
-    #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+    #[cfg(all(
+        feature = "std",
+        feature = "kernel_vbmi2",
+        any(target_arch = "x86", target_arch = "x86_64")
+    ))]
     #[test]
     fn copy_avx512_copies_full_chunk_when_available() {
         if !std::arch::is_x86_feature_detected!("avx512f") {

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -581,10 +581,17 @@ pub(crate) fn active_chunk_size_for_tests() -> usize {
             return 16;
         }
     }
+    // The no-std arms must mirror the dispatcher's compile-time chunk
+    // selection EXACTLY (both `target_feature` AND the matching `kernel_*`
+    // gate), otherwise a tier-trimmed build would size test scenarios for a
+    // chunk the dispatcher can never select — masking tier-gating
+    // regressions. The 64B arm keys off `avx512vbmi2` (not bare `avx512f`),
+    // matching the dispatcher's `kernel_vbmi2` 64B copy.
     #[cfg(all(
         not(feature = "std"),
         any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "avx512f"
+        target_feature = "avx512vbmi2",
+        feature = "kernel_vbmi2"
     ))]
     {
         return 64;
@@ -592,7 +599,8 @@ pub(crate) fn active_chunk_size_for_tests() -> usize {
     #[cfg(all(
         not(feature = "std"),
         any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "avx2"
+        target_feature = "avx2",
+        feature = "kernel_avx2"
     ))]
     {
         return 32;
@@ -600,12 +608,17 @@ pub(crate) fn active_chunk_size_for_tests() -> usize {
     #[cfg(all(
         not(feature = "std"),
         any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2"
+        target_feature = "sse2",
+        feature = "kernel_sse2"
     ))]
     {
         return 16;
     }
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        feature = "kernel_neon"
+    ))]
     {
         return 16;
     }
@@ -695,10 +708,17 @@ fn detect_x86_caps() -> X86Caps {
         }
         #[cfg(target_arch = "x86")]
         {
+            // Mirror the x86_64 tag ladder above: each tier is reported only
+            // when BOTH its `kernel_*` feature is enabled AND the CPU exposes
+            // it at runtime, so a tier-trimmed build (e.g.
+            // `--features kernel_scalar`) never selects a SIMD chunk on 32-bit
+            // x86. `avx512f` follows the `Vbmi2` tag exactly — it is set on
+            // `avx512vbmi2` (not bare `avx512f`), matching the rule that an
+            // AVX-512F-but-not-VBMI2 CPU stays on the 32B (AVX2) copy.
             X86Caps {
-                avx512f: is_x86_feature_detected!("avx512f"),
-                avx2: is_x86_feature_detected!("avx2"),
-                sse2: is_x86_feature_detected!("sse2"),
+                avx512f: cfg!(feature = "kernel_vbmi2") && is_x86_feature_detected!("avx512vbmi2"),
+                avx2: cfg!(feature = "kernel_avx2") && is_x86_feature_detected!("avx2"),
+                sse2: cfg!(feature = "kernel_sse2") && is_x86_feature_detected!("sse2"),
             }
         }
     })

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -288,9 +288,10 @@ pub(crate) unsafe fn copy_bytes_overshooting(
     // appropriate feature-detection mechanism (cached runtime detect under
     // std, compile-time target_feature otherwise) and falls through on miss
     // so a single dispatcher covers every arch + feature combination.
-    // Unused when every SIMD tier is feature-gated out (scalar-only trim):
-    // all invocation sites are behind `kernel_*` cfgs, so the macro itself
-    // can have no callers there.
+    // May have no callers in some builds: every invocation site is behind an
+    // arch + `kernel_*` cfg, so the macro is unused on non-x86/non-aarch64
+    // targets (no arch-specific sites compile) and on x86/aarch64 builds that
+    // trim the SIMD tiers (e.g. scalar-only). Hence `allow(unused_macros)`.
     #[allow(unused_macros)]
     macro_rules! try_chunk_kernel {
         ($chunk:expr, $kernel:ident) => {{

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -15,7 +15,11 @@ use std::arch::is_x86_feature_detected;
 #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
 use std::sync::OnceLock;
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    feature = "kernel_neon"
+))]
 use core::arch::aarch64::{uint8x16_t, vld1q_u8, vst1q_u8};
 
 /// Diagnostic-only copy-shape histogram. Compiled out unless the
@@ -472,7 +476,11 @@ pub(crate) unsafe fn copy_bytes_overshooting_avx2(
 #[inline(always)]
 unsafe fn single_op_copy_16(src: *const u8, dst: *mut u8, len: usize) {
     debug_assert!(len <= 16);
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        feature = "kernel_neon"
+    ))]
     unsafe {
         let v: uint8x16_t = vld1q_u8(src);
         vst1q_u8(dst, v);
@@ -488,7 +496,8 @@ unsafe fn single_op_copy_16(src: *const u8, dst: *mut u8, len: usize) {
     #[cfg(all(
         not(feature = "std"),
         any(target_arch = "x86", target_arch = "x86_64"),
-        target_feature = "sse2"
+        target_feature = "sse2",
+        feature = "kernel_sse2"
     ))]
     unsafe {
         copy_sse2(src, dst, 16);
@@ -500,12 +509,16 @@ unsafe fn single_op_copy_16(src: *const u8, dst: *mut u8, len: usize) {
     //
     // Reachability matrix (kept here so any future arch arm slotted
     // between the existing arms knows it must terminate with `return`
-    // or its code will be silently dead):
-    //   • aarch64+neon                                 → arm above returns
-    //   • std + x86/x86_64 + runtime-SSE2              → arm above returns
-    //   • std + x86/x86_64 + NO runtime-SSE2           → reaches here
-    //   • no-std + x86/x86_64 + target_feature=sse2    → arm above returns
-    //   • no-std + x86/x86_64 + NO target_feature=sse2 → reaches here
+    // or its code will be silently dead). The explicit-SIMD arms are
+    // gated on the matching `kernel_*` feature so a `kernel_scalar` trim
+    // falls through to the portable path (matching the chunked-copy
+    // dispatch above):
+    //   • aarch64+neon + kernel_neon                   → arm above returns
+    //   • aarch64+neon, NO kernel_neon                 → reaches here
+    //   • std + x86/x86_64 + runtime-SSE2 tag          → arm above returns
+    //   • std + x86/x86_64 + Scalar tag (no SSE2)      → reaches here
+    //   • no-std + x86 + target_feature sse2+kernel_sse2 → arm above returns
+    //   • no-std + x86, kernel_sse2 off (or no sse2)   → reaches here
     //   • any other arch (riscv64, wasm32, …)          → reaches here
     // Anything new MUST `return` from its own arm before this comment.
     #[allow(unreachable_code)]
@@ -691,8 +704,13 @@ fn detect_x86_caps() -> X86Caps {
     })
 }
 
+// `#[allow(dead_code)]`: every call site (the chunked dispatch + the
+// `single_op_copy_16` fast path) is gated on `feature = "kernel_sse2"` in
+// no-std builds, so a `kernel_scalar`-only trim leaves this with no callers.
+// The `std` path reaches it via the runtime `detect_x86_caps` dispatch.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "sse2")]
+#[allow(dead_code)]
 unsafe fn copy_sse2(mut src: *const u8, mut dst: *mut u8, len: usize) {
     let end = unsafe { src.add(len) };
     while src < end {

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -263,6 +263,10 @@ pub(crate) unsafe fn copy_bytes_overshooting(
     // appropriate feature-detection mechanism (cached runtime detect under
     // std, compile-time target_feature otherwise) and falls through on miss
     // so a single dispatcher covers every arch + feature combination.
+    // Unused when every SIMD tier is feature-gated out (scalar-only trim):
+    // all invocation sites are behind `kernel_*` cfgs, so the macro itself
+    // can have no callers there.
+    #[allow(unused_macros)]
     macro_rules! try_chunk_kernel {
         ($chunk:expr, $kernel:ident) => {{
             if copy_at_least >= $chunk {
@@ -292,15 +296,19 @@ pub(crate) unsafe fn copy_bytes_overshooting(
 
     #[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64")))]
     {
-        #[cfg(target_feature = "avx512f")]
+        #[cfg(all(target_feature = "avx512f", feature = "kernel_vbmi2"))]
         try_chunk_kernel!(64, copy_avx512);
-        #[cfg(target_feature = "avx2")]
+        #[cfg(all(target_feature = "avx2", feature = "kernel_avx2"))]
         try_chunk_kernel!(32, copy_avx2);
-        #[cfg(target_feature = "sse2")]
+        #[cfg(all(target_feature = "sse2", feature = "kernel_sse2"))]
         try_chunk_kernel!(16, copy_sse2);
     }
 
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        target_feature = "neon",
+        feature = "kernel_neon"
+    ))]
     try_chunk_kernel!(16, copy_neon);
 
     // Final fallback: scalar 8-byte chunk loop if alignment permits, else
@@ -729,7 +737,11 @@ unsafe fn copy_avx512(mut src: *const u8, mut dst: *mut u8, len: usize) {
     }
 }
 
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(all(
+    target_arch = "aarch64",
+    target_feature = "neon",
+    feature = "kernel_neon"
+))]
 #[inline(always)]
 unsafe fn copy_neon(mut src: *const u8, mut dst: *mut u8, len: usize) {
     let end = unsafe { src.add(len) };

--- a/zstd/src/decoding/simd_copy.rs
+++ b/zstd/src/decoding/simd_copy.rs
@@ -609,17 +609,26 @@ fn detect_x86_caps() -> X86Caps {
         {
             use crate::cpu_kernel::{CpuKernelTag, detect_cpu_kernel};
             match detect_cpu_kernel() {
+                #[cfg(feature = "kernel_vbmi2")]
                 CpuKernelTag::Vbmi2 => X86Caps {
                     avx512f: true,
                     avx2: true,
                     sse2: true,
                 },
+                #[cfg(feature = "kernel_avx2")]
                 CpuKernelTag::Avx2 => X86Caps {
                     avx512f: false,
                     avx2: true,
                     sse2: true,
                 },
-                CpuKernelTag::Bmi2 | CpuKernelTag::Sse2 => X86Caps {
+                #[cfg(feature = "kernel_bmi2")]
+                CpuKernelTag::Bmi2 => X86Caps {
+                    avx512f: false,
+                    avx2: false,
+                    sse2: true,
+                },
+                #[cfg(feature = "kernel_sse2")]
+                CpuKernelTag::Sse2 => X86Caps {
                     avx512f: false,
                     avx2: false,
                     sse2: true,

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -28,11 +28,12 @@
 //! so any subset is valid; a flag is inert on architectures it doesn't apply
 //! to. Constrained targets can shrink the binary by trimming tiers, e.g.
 //! `--no-default-features --features kernel_scalar` compiles out the per-tier
-//! SIMD kernel dispatch and its BMI2/AVX2/VBMI2/NEON trampolines. Baseline
-//! SIMD that the target ABI guarantees (e.g. SSE2 on x86_64, NEON on aarch64,
-//! used by the small fixed-size copy primitives) is not a tier and may still
-//! be emitted — disabling the tiers removes the dispatch, not every vector
-//! instruction.
+//! SIMD kernel dispatch, its BMI2/AVX2/VBMI2/NEON trampolines, and the
+//! explicit SSE2/NEON intrinsics in the small fixed-size copy primitives —
+//! all of which are gated on the matching `kernel_*` feature. The `kernel_*`
+//! features control the crate's own explicit SIMD; they do not constrain the
+//! compiler's autovectorizer, which may still emit vector instructions from
+//! ordinary scalar code regardless of the enabled tiers.
 //!
 //! The packaged README is included below for the docs.rs landing page; the
 //! API anchors above link straight into the per-module documentation.

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -25,8 +25,12 @@
 //! `kernel_sve` implies `kernel_neon`). The scalar kernel is always compiled,
 //! so any subset is valid; a flag is inert on architectures it doesn't apply
 //! to. Constrained targets can shrink the binary by trimming tiers, e.g.
-//! `--no-default-features --features kernel_scalar` for a scalar-only build
-//! with every SIMD trampoline compiled out.
+//! `--no-default-features --features kernel_scalar` compiles out the per-tier
+//! SIMD kernel dispatch and its BMI2/AVX2/VBMI2/NEON trampolines. Baseline
+//! SIMD that the target ABI guarantees (e.g. SSE2 on x86_64, NEON on aarch64,
+//! used by the small fixed-size copy primitives) is not a tier and may still
+//! be emitted — disabling the tiers removes the dispatch, not every vector
+//! instruction.
 //!
 //! The packaged README is included below for the docs.rs landing page; the
 //! API anchors above link straight into the per-module documentation.

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -16,9 +16,11 @@
 //!
 //! # CPU kernel features
 //!
-//! The decode hot paths ship per-CPU-tier SIMD kernels selected at runtime.
+//! The decode hot paths ship per-CPU-tier SIMD kernels. With `std` the tier
+//! is chosen at runtime (CPU-feature detection, cached on first use); on
+//! `no_std` it is chosen at compile time from `cfg(target_feature)`.
 //! Each tier is gated by a cargo feature, all enabled by default (a universal
-//! binary that detects the best kernel once on first use, cached): `kernel_scalar`,
+//! binary that picks the best available tier per the above): `kernel_scalar`,
 //! `kernel_sse2`, `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and
 //! `kernel_neon`, `kernel_sve` (aarch64). The chain mirrors the ISA
 //! dependency (`kernel_avx2` implies `kernel_bmi2` implies `kernel_sse2`;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! The decode hot paths ship per-CPU-tier SIMD kernels selected at runtime.
 //! Each tier is gated by a cargo feature, all enabled by default (a universal
-//! binary that detects the best kernel at startup): `kernel_scalar`,
+//! binary that detects the best kernel once on first use, cached): `kernel_scalar`,
 //! `kernel_sse2`, `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and
 //! `kernel_neon`, `kernel_sve` (aarch64). The chain mirrors the ISA
 //! dependency (`kernel_avx2` implies `kernel_bmi2` implies `kernel_sse2`;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -14,6 +14,20 @@
 //! No FFI, no cmake, no system zstd. `no_std` builds are supported by
 //! disabling the default `std` feature.
 //!
+//! # CPU kernel features
+//!
+//! The decode hot paths ship per-CPU-tier SIMD kernels selected at runtime.
+//! Each tier is gated by a cargo feature, all enabled by default (a universal
+//! binary that detects the best kernel at startup): `kernel_scalar`,
+//! `kernel_sse2`, `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and
+//! `kernel_neon`, `kernel_sve` (aarch64). The chain mirrors the ISA
+//! dependency (`kernel_avx2` implies `kernel_bmi2` implies `kernel_sse2`;
+//! `kernel_sve` implies `kernel_neon`). The scalar kernel is always compiled,
+//! so any subset is valid; a flag is inert on architectures it doesn't apply
+//! to. Constrained targets can shrink the binary by trimming tiers, e.g.
+//! `--no-default-features --features kernel_scalar` for a scalar-only build
+//! with every SIMD trampoline compiled out.
+//!
 //! The packaged README is included below for the docs.rs landing page; the
 //! API anchors above link straight into the per-module documentation.
 //!


### PR DESCRIPTION
## Summary

Implements #247 Part 5: per-CPU-tier cargo features so constrained targets can trim the SIMD kernels they don't need, while the default build stays a runtime-dispatched universal binary. Builds on the `CpuKernelTag::Sse2` tier from #304 (now merged into main).

Features (all on by default), with the real ISA implication chain:
- x86: `kernel_scalar`, `kernel_sse2`, `kernel_bmi2` (→sse2), `kernel_avx2` (→bmi2), `kernel_vbmi2` (→avx2)
- aarch64: `kernel_neon`, `kernel_sve` (→neon)

The scalar kernel is always compiled, so any subset is valid and the lowest enabled tier always has a fallback. A flag is inert on architectures it doesn't apply to, so the all-on default is safe everywhere.

## Cascade

Gating threads through every site that references a tier so each feature combination compiles: `CpuKernelTag` variants, per-tier kernel ZSTs + the shared BMI2 mask helper, `select_x86_kernel` precedence rungs, the runtime + compile-time `detect_cpu_kernel` arms, the literals + sequence dispatch arms and their per-tier trampolines, the `seq_decoder_{bmi2,avx2,vbmi2}` modules, the SIMD-copy capability-derivation match, and the BMI2 pext bit-reader helpers.

## Verification

Lib `cargo check` clean across: x86_64 default / `kernel_avx2`-only / `kernel_scalar`-only; aarch64 default / `kernel_scalar`-only; i686 default. A `kernel_scalar`-only build compiles out every SIMD trampoline for a smaller binary on constrained targets.

- 646/646 default lib tests pass; clippy (`--all-targets`) + fmt clean.
- CI gains two no-std lint steps that build the `kernel_scalar` embedded trim (with and without std), guarding the gating against future breakage.
- README + crate preamble document the feature axis.


Closes the Part 5 acceptance items of #247.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-CPU-tier kernel selection via Cargo features so SIMD kernels (kernel_scalar, kernel_sse2, kernel_bmi2, kernel_avx2, kernel_vbmi2, kernel_neon, kernel_sve) can be enabled/disabled; scalar remains mandatory fallback.

* **Documentation**
  * Expanded docs explaining kernel features, ISA precedence, runtime vs compile-time selection, and a scalar-only example.

* **Chores**
  * CI updated with additional build checks for kernel feature combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
