### PR TITLE
perf(encode): lower row-matcher min match to 5 (donor parity)

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -55,7 +55,7 @@ use std::arch::is_x86_feature_detected;
 
 pub(crate) const DFAST_MIN_MATCH_LEN: usize = 5;
 pub(crate) const DFAST_SHORT_HASH_LOOKAHEAD: usize = 4;
-pub(crate) const ROW_MIN_MATCH_LEN: usize = 6;
+pub(crate) const ROW_MIN_MATCH_LEN: usize = 5;
 pub(crate) const DFAST_TARGET_LEN: usize = 48;
 // Donor `clevels.h:31` at level 3 large-input bucket sets
 // `hashLog = 17` (the long-hash table) and `chainLog = 16` (the
@@ -5689,6 +5689,11 @@ fn row_pick_lazy_returns_best_when_lookahead_is_out_of_bounds() {
     let mut matcher = RowMatchGenerator::new(1 << 22);
     matcher.configure(ROW_CONFIG);
     matcher.add_data(b"abcabc".to_vec(), |_| {});
+    // Build the row tables before probing: the lookahead path reaches
+    // `row_candidate` -> `row_heads[..]` once the accept floor is small
+    // enough to pass the length gate, so the tables must be allocated
+    // (production always calls this before any candidate probe).
+    matcher.ensure_tables();
 
     let best = MatchCandidate {
         start: 0,
@@ -6481,7 +6486,9 @@ fn row_pick_lazy_depth2_returns_none_when_next2_significantly_better() {
         .best_match(abs_pos, 0)
         .expect("expected baseline repcode match");
     assert_eq!(best.offset, 9);
-    assert_eq!(best.match_len, ROW_MIN_MATCH_LEN);
+    // Baseline match length is fixed by the fixture data (the offset-9
+    // rep run is 6 bytes long), independent of the accept threshold.
+    assert_eq!(best.match_len, 6);
 
     if let Some(next) = matcher.best_match(abs_pos + 1, 1) {
         assert!(next.match_len <= best.match_len);
@@ -6518,7 +6525,9 @@ fn row_pick_lazy_depth2_keeps_best_when_next2_is_only_one_byte_better() {
         .best_match(abs_pos, 0)
         .expect("expected baseline repcode match");
     assert_eq!(best.offset, 9);
-    assert_eq!(best.match_len, ROW_MIN_MATCH_LEN);
+    // Baseline match length is fixed by the fixture data (the offset-9
+    // rep run is 6 bytes long), independent of the accept threshold.
+    assert_eq!(best.match_len, 6);
 
     let next2 = matcher
         .best_match(abs_pos + 2, 2)
@@ -6668,7 +6677,11 @@ fn btultra2_main_hash_uses_donor_hash4_formula() {
 fn row_candidate_returns_none_when_abs_pos_near_end_of_history() {
     let mut matcher = RowMatchGenerator::new(1 << 22);
     matcher.configure(ROW_CONFIG);
-    matcher.history = b"abcde".to_vec();
+    // One byte short of the accept floor: from abs_pos 0 there are fewer
+    // than `ROW_MIN_MATCH_LEN` bytes left, so the length gate in
+    // `row_candidate` must short-circuit to `None` before touching the
+    // (here unbuilt) row tables.
+    matcher.history = alloc::vec![b'a'; ROW_MIN_MATCH_LEN - 1];
     matcher.history_start = 0;
     matcher.history_abs_start = 0;
 

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -282,7 +282,7 @@ impl RowMatchGenerator {
         }
     }
 
-    /// Donor-parity greedy parse for `lazy_depth == 0` (level 4).
+    /// Donor-parity greedy parse for `lazy_depth == 0` (level 5).
     ///
     /// Mirrors `ZSTD_compressBlock_lazy_generic` (`zstd_lazy.c:1560`) with
     /// `depth == 0`, `dictMode == ZSTD_noDict`. The structural features
@@ -309,10 +309,13 @@ impl RowMatchGenerator {
     ///    iteration, and the longer match wins (ties go to rep for
     ///    cheaper encoding via [`best_len_offset_candidate`]). Donor
     ///    can afford pure commit-on-first-rep because it recovers any
-    ///    ratio loss via `minMatch = 5` and superblock-level entropy
-    ///    sharing; we don't replicate those yet, so the hybrid form
-    ///    avoids a measured ~3pp ratio cliff on decodecorpus while
-    ///    still skipping the donor `lazy_depth == 1` lookahead probe
+    ///    ratio loss via superblock-level entropy sharing, which we
+    ///    don't replicate yet, so the hybrid form avoids a measured
+    ///    ratio cliff on decodecorpus. (The row accept floor itself now
+    ///    matches donor's `minMatch = 5` via `ROW_MIN_MATCH_LEN`; the
+    ///    remaining un-replicated piece is the cross-block entropy
+    ///    sharing, not the match-length threshold.) The hybrid form
+    ///    still skips the donor `lazy_depth == 1` lookahead probe
     ///    that [`start_matching`] above runs unconditionally — the
     ///    speed shape stays donor-like.
     ///
@@ -358,18 +361,18 @@ impl RowMatchGenerator {
 
         // Donor mls for repcode probes is 4 (`MEM_read32` compare on
         // `ip+1` against `ip+1-offset_1`, length extended by
-        // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 6`
+        // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 5`
         // gates the *regular* search via the row-table layout; rep
         // probes are independent of the row table and benefit from
-        // the lower donor threshold (a 4-5 byte rep is cheap to
+        // the lower donor threshold (a 4-byte rep is cheap to
         // encode and frequently outperforms emitting the bytes as
         // literals).
         const REP_MIN_MATCH_LEN: usize = 4;
         // Outer-loop lookahead floor: at least `REP_MIN_MATCH_LEN + 1`
-        // bytes left so the `abs_pos + 1` repcode probe can succeed
-        // even in the block tail. Gating the loop on the stricter
-        // `ROW_MIN_MATCH_LEN` (6) would miss the last 5-byte rep-only
-        // case and let those bytes fall through as literals.
+        // bytes left so the `abs_pos + 1` repcode probe can succeed even
+        // in the block tail (the rep probe needs `REP_MIN_MATCH_LEN`
+        // bytes one position ahead). This keeps the tail 4-byte rep-only
+        // case from falling through as literals.
         const GREEDY_MIN_LOOKAHEAD: usize = REP_MIN_MATCH_LEN + 1;
 
         let mut pos = 0usize;


### PR DESCRIPTION
## Summary

The row match-finder's regular-search accept floor was `ROW_MIN_MATCH_LEN = 6`, one byte stricter than upstream. `clevels.h` pins `minMatch = 5` for **every** row-matcher level (5-15: greedy / lazy / lazy2 / btlazy2), so we rejected 5-byte matches the reference accepts and emitted those bytes as literals — a measurable ratio loss on string-heavy data.

The sequence comparator localised it (ratio gate justified: `rust_bytes > ffi_bytes`): on `decodecorpus-z000033` level 5 the reference emits **51577** sequences vs our **36639** (~40% more matches). The gap is parse under-matching, not entropy coding. `ROW_HASH_KEY_LEN` is already 4, so short candidates are found — only the acceptance gate was too high.

Fix: `ROW_MIN_MATCH_LEN` 6 → 5 (now matches the reference for the whole row range).

## Impact — z000033 (input 1022035 B), i9-9900K

**Ratio** (deterministic compressed bytes):

| Level | before | after | C ffi | result |
|---|---|---|---|---|
| 5 (greedy) | 537897 | **512638** | 513921 | was +4.67% worse → now **beats C** by 1283 |
| 6 | — | 493663 | 510884 | win |
| 8 | — | 481116 | 510499 | win |
| 15 | — | 477368 | 508287 | win |

Full level sweep: every row level (5-15) beats C, **zero regression**. Other fixtures win or tie. Remaining z000033 losses at L1/L2 (Fast/Dfast) and L18/L19 (btultra) are separate strategies, unaffected.

**Speed** (L5 compress, baseline = main same SSH session, c_ffi arm as machine control):

| arm | main | this PR | change |
|---|---|---|---|
| pure_rust | 42.423 ms | **40.365 ms** | **−4.85%** (p=0.00) |
| c_ffi (control) | 8.783 ms | 8.791 ms | +0.09% (flat) |

The ratio fix came **with** a speed win: more accepted 5-byte matches means fewer literal bytes to entropy-encode.

## Testing

- 647 lib tests green (`cargo nextest run`). Four row unit tests hard-coded the old threshold; updated to assert the data-determined match length, size the near-end fixture to `ROW_MIN_MATCH_LEN - 1`, and build the row tables before the lookahead probe.
- clippy `--all-targets` + fmt clean.
- Ratio measured locally (architecture-independent); speed measured on the i9 bench host with the c_ffi control flat, confirming the −4.85% is real.

Closes #184.