### PR TITLE
feat(bench): show commit subject in dashboard snapshot selectors + table

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1721,6 +1721,14 @@
         return row.generated_at || row.commit_sha || "local-run";
       }
 
+      // Single-line, length-capped commit subject for display. Guards the
+      // layout against stray newlines (first line only) and very long
+      // subjects (72-char clip) wherever a commit message is shown.
+      function clipSubject(msg) {
+        const firstLine = String(msg).split("\n", 1)[0].trim();
+        return firstLine.length > 72 ? `${firstLine.slice(0, 71)}…` : firstLine;
+      }
+
       // Decorate a snapshot stamp with its commit subject for display in the
       // selectors. The option `value` stays the raw stamp (filters match on
       // it); only the visible text gains the message. Long subjects are
@@ -1728,8 +1736,7 @@
       function snapshotOptionText(stamp) {
         const msg = state.snapshotMessages && state.snapshotMessages.get(stamp);
         if (!msg) return stamp;
-        const trimmed = msg.length > 72 ? `${msg.slice(0, 71)}…` : msg;
-        return `${stamp} · ${trimmed}`;
+        return `${stamp} · ${clipSubject(msg)}`;
       }
 
       function repopulateSnapshotOptions() {
@@ -1922,7 +1929,7 @@
         }
         const latestSha = (latest.commit_sha || "local-run").slice(0, 12);
         el("stat-commit").textContent = latest.commit_message
-          ? `${latestSha} · ${latest.commit_message}`
+          ? `${latestSha} · ${clipSubject(latest.commit_message)}`
           : latestSha;
         el("stat-snapshot").textContent = latest.generated_at || "n/a";
 

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -561,13 +561,15 @@
         select.replaceChildren(fragment);
       }
 
+      // Snapshot range selectors (From / To). Values are `generated_at`
+      // stamps; the visible text is decorated with the commit subject.
       function renderPointOptions(select, values) {
         const fragment = document.createDocumentFragment();
         for (const value of values) {
           const option = document.createElement("option");
           const text = String(value);
           option.value = text;
-          option.textContent = text;
+          option.textContent = snapshotOptionText(text);
           fragment.appendChild(option);
         }
         select.replaceChildren(fragment);
@@ -1719,6 +1721,17 @@
         return row.generated_at || row.commit_sha || "local-run";
       }
 
+      // Decorate a snapshot stamp with its commit subject for display in the
+      // selectors. The option `value` stays the raw stamp (filters match on
+      // it); only the visible text gains the message. Long subjects are
+      // clipped so the dropdown stays scannable.
+      function snapshotOptionText(stamp) {
+        const msg = state.snapshotMessages && state.snapshotMessages.get(stamp);
+        if (!msg) return stamp;
+        const trimmed = msg.length > 72 ? `${msg.slice(0, 71)}…` : msg;
+        return `${stamp} · ${trimmed}`;
+      }
+
       function repopulateSnapshotOptions() {
         const target = selectors.target.value;
         const scenario = selectors.scenario.value;
@@ -1753,7 +1766,7 @@
         for (const label of labels) {
           const opt = document.createElement("option");
           opt.value = String(label);
-          opt.textContent = String(label);
+          opt.textContent = snapshotOptionText(String(label));
           fragment.appendChild(opt);
         }
         profileSelectors.snapshot.replaceChildren(fragment);
@@ -1840,6 +1853,14 @@
           const code = document.createElement("code");
           code.textContent = commit;
           commitCell.appendChild(code);
+          // github-action-benchmark stores the full commit object; show the
+          // subject (first line) next to the hash so the row is searchable
+          // by what changed, not just the SHA.
+          const commitMessage = latest?.commit?.message;
+          if (commitMessage) {
+            const subject = commitMessage.split("\n", 1)[0];
+            commitCell.appendChild(document.createTextNode(` ${subject}`));
+          }
           row.appendChild(commitCell);
 
           const benchCell = document.createElement("td");
@@ -1874,6 +1895,18 @@
         state.records = payload.records || [];
         if (!state.records.length) throw new Error("benchmark-relative.json has no records");
 
+        // Map each snapshot (its `generated_at` key) to the commit subject,
+        // so the snapshot selectors + history table show WHAT changed, not
+        // just when — picking a run by timestamp alone is hard. Every record
+        // from one run carries the same message; first non-empty wins.
+        state.snapshotMessages = new Map();
+        for (const r of state.records) {
+          const key = snapshotLabel(r);
+          if (r.commit_message && !state.snapshotMessages.has(key)) {
+            state.snapshotMessages.set(key, r.commit_message);
+          }
+        }
+
         const targets = uniq(state.records.map((r) => r.target));
         const latest = latestRecord(state.records);
         if (!latest) throw new Error("Unable to determine latest benchmark snapshot");
@@ -1887,7 +1920,10 @@
           chip.textContent = target;
           targetsContainer.appendChild(chip);
         }
-        el("stat-commit").textContent = (latest.commit_sha || "local-run").slice(0, 12);
+        const latestSha = (latest.commit_sha || "local-run").slice(0, 12);
+        el("stat-commit").textContent = latest.commit_message
+          ? `${latestSha} · ${latest.commit_message}`
+          : latestSha;
         el("stat-snapshot").textContent = latest.generated_at || "n/a";
 
         renderOptions(selectors.target, targets);

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -156,7 +156,11 @@ if not commit_message:
         ).stdout.strip()
     except Exception:
         commit_message = None
-commit_message = commit_message or None
+# Normalize to a single trimmed line. An env override may carry trailing
+# newlines / surrounding whitespace from CI step output, and a stray
+# newline flowing into the JSON would break the dashboard option layout.
+commit_message = commit_message.strip() if commit_message else ""
+commit_message = commit_message.splitlines()[0].strip() if commit_message else None
 generated_at = os.environ.get("STRUCTURED_ZSTD_BENCH_GENERATED_AT") or datetime.now(timezone.utc).isoformat()
 timing_point_count = 0
 

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -139,6 +139,24 @@ bench_target_label = os.environ.get("BENCH_TARGET_LABEL", "host")
 bench_target_triple = os.environ.get("BENCH_TARGET_TRIPLE", "")
 bench_target_id = os.environ.get("BENCH_TARGET_ID", bench_target_label)
 commit_sha = os.environ.get("GITHUB_SHA")
+# Commit subject for the dashboard snapshot selector — picking a run by
+# date alone is hard, so each record carries the one-line message too.
+# Prefer an explicit env override; otherwise read the subject from git
+# (CI checks out the repo, so this resolves in the benchmark job).
+commit_message = os.environ.get("STRUCTURED_ZSTD_BENCH_COMMIT_MESSAGE")
+if not commit_message:
+    import subprocess
+
+    try:
+        commit_message = subprocess.run(
+            ["git", "log", "-1", "--format=%s", commit_sha or "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except Exception:
+        commit_message = None
+commit_message = commit_message or None
 generated_at = os.environ.get("STRUCTURED_ZSTD_BENCH_GENERATED_AT") or datetime.now(timezone.utc).isoformat()
 timing_point_count = 0
 
@@ -631,6 +649,7 @@ for key in all_keys:
                 "target_label": bench_target_label,
                 "target_triple": bench_target_triple or None,
                 "commit_sha": commit_sha,
+                "commit_message": commit_message,
                 "generated_at": generated_at,
             },
         }
@@ -650,6 +669,7 @@ for row in delta_rows:
         "source": params["source"],
         "key": row["key"],
         "commit_sha": row["meta"]["commit_sha"],
+        "commit_message": row["meta"].get("commit_message"),
         "generated_at": row["meta"]["generated_at"],
     }
 
@@ -728,6 +748,7 @@ for row in memory_rows:
             "source": source,
             "key": canonical_key(stage, row["scenario"], row["level"], source),
             "commit_sha": commit_sha,
+            "commit_message": commit_message,
             "generated_at": generated_at,
             # Both sides feed the SAME pair of atomic counters in
             # `compare_ffi_memory`: Rust-side via the
@@ -774,6 +795,7 @@ for row in dictionary_rows:
             "source": None,
             "key": canonical_key("compress-dict", row["scenario"], row["level"], None),
             "commit_sha": commit_sha,
+            "commit_message": commit_message,
             "generated_at": generated_at,
             "metric": "compression_ratio",
             "rust_value": rust_ratio,
@@ -797,6 +819,7 @@ relative_payload = {
         "delta_high": DELTA_HIGH,
     },
     "commit_sha": commit_sha,
+    "commit_message": commit_message,
     "generated_at": generated_at,
     "records": relative_rows,
 }


### PR DESCRIPTION
## Summary

Picking a benchmark run by timestamp alone is hard. This carries the commit subject through the benchmark pipeline and surfaces it in the dashboard so each snapshot is identifiable by *what changed*.

- `run-benchmarks.sh`: capture the commit subject (env override `STRUCTURED_ZSTD_BENCH_COMMIT_MESSAGE`, else `git log -1 --format=%s`) and write `commit_message` into every emitted record. `merge-benchmarks.py` passes it through unchanged (`dict(row)` copy — no change needed).
- dashboard `index.html`: build a `generated_at -> commit_message` map and decorate the **From/To** range selectors, the profile **Snapshot** pin, and the **Latest Commit** stat box as `stamp · subject`. Option *values* stay the raw stamp, so filter matching / URLs are unaffected; long subjects are clipped.
- **raw-timings table**: append the subject (first line of the github-action-benchmark `commit.message`, already present in `data.js`) next to the hash.

Older relative snapshots that predate this change lack `commit_message` and fall back gracefully to the bare timestamp; the raw-timings table shows subjects immediately for all rows (the data is already in `data.js`).

## Testing

- Embedded benchmark Python (`run-benchmarks.sh`) `py_compile`-clean; `git log -1 --format=%s` fallback verified to return the subject.
- Dashboard inline script `node --check`-clean.
- Option values unchanged (raw `generated_at`), so existing filter / time-window logic is untouched.

Closes #311.