### PR TITLE
perf(encode): skip decoder-table build when loading a dict for encoding

### DIFF
--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -85,6 +85,30 @@ impl Dictionary {
     /// and returns a fully constructed [`Dictionary`] whose `id` can be
     /// checked against the frame's `dict_id`.
     pub fn decode_dict(raw: &[u8]) -> Result<Dictionary, DictionaryDecodeError> {
+        Self::decode_dict_inner(raw, true)
+    }
+
+    /// Parse a dictionary for ENCODER use: builds the entropy
+    /// probabilities/weights needed by `to_encoder_table` but skips the
+    /// FSE *decoding* tables and their `enrich_*` post-passes, which the
+    /// encoder never reads. Produces a [`Dictionary`] whose
+    /// `symbol_probabilities` / `accuracy_log` (and HUF weights) match
+    /// `decode_dict` exactly, so the encoder entropy tables — and thus
+    /// the emitted frame — are byte-identical; only the wasted decode
+    /// table build is dropped. Offset history + content are parsed the
+    /// same way.
+    pub fn decode_dict_for_encoding(raw: &[u8]) -> Result<Dictionary, DictionaryDecodeError> {
+        Self::decode_dict_inner(raw, false)
+    }
+
+    /// Shared dictionary parser. `build_decode_tables` selects whether the
+    /// FSE tables get their full decoding table + `enrich_*` passes (decoder
+    /// path) or only the probability parse (encoder path — see
+    /// [`Self::decode_dict_for_encoding`]).
+    fn decode_dict_inner(
+        raw: &[u8],
+        build_decode_tables: bool,
+    ) -> Result<Dictionary, DictionaryDecodeError> {
         const MIN_MAGIC_AND_ID_LEN: usize = 8;
         const OFFSET_HISTORY_LEN: usize = 12;
 
@@ -120,31 +144,55 @@ impl Dictionary {
         let huf_size = new_dict.huf.table.build_decoder(raw_tables)?;
         let raw_tables = &raw_tables[huf_size as usize..];
 
-        let of_size = new_dict.fse.offsets.build_decoder(
-            raw_tables,
-            crate::decoding::sequence_section_decoder::OF_MAX_LOG,
-        )?;
-        new_dict.fse.offsets.enrich_for_offsets();
+        let of_size = if build_decode_tables {
+            let n = new_dict.fse.offsets.build_decoder(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::OF_MAX_LOG,
+            )?;
+            new_dict.fse.offsets.enrich_for_offsets();
+            n
+        } else {
+            new_dict.fse.offsets.read_table_probabilities(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::OF_MAX_LOG,
+            )?
+        };
         let raw_tables = &raw_tables[of_size..];
 
-        let ml_size = new_dict.fse.match_lengths.build_decoder(
-            raw_tables,
-            crate::decoding::sequence_section_decoder::ML_MAX_LOG,
-        )?;
-        new_dict
-            .fse
-            .match_lengths
-            .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::ML_META);
+        let ml_size = if build_decode_tables {
+            let n = new_dict.fse.match_lengths.build_decoder(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::ML_MAX_LOG,
+            )?;
+            new_dict
+                .fse
+                .match_lengths
+                .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::ML_META);
+            n
+        } else {
+            new_dict.fse.match_lengths.read_table_probabilities(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::ML_MAX_LOG,
+            )?
+        };
         let raw_tables = &raw_tables[ml_size..];
 
-        let ll_size = new_dict.fse.literal_lengths.build_decoder(
-            raw_tables,
-            crate::decoding::sequence_section_decoder::LL_MAX_LOG,
-        )?;
-        new_dict
-            .fse
-            .literal_lengths
-            .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::LL_META);
+        let ll_size = if build_decode_tables {
+            let n = new_dict.fse.literal_lengths.build_decoder(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::LL_MAX_LOG,
+            )?;
+            new_dict
+                .fse
+                .literal_lengths
+                .enrich_with_packed_seq_meta(&crate::decoding::sequence_section_decoder::LL_META);
+            n
+        } else {
+            new_dict.fse.literal_lengths.read_table_probabilities(
+                raw_tables,
+                crate::decoding::sequence_section_decoder::LL_MAX_LOG,
+            )?
+        };
         let raw_tables = &raw_tables[ll_size..];
 
         if raw_tables.len() < OFFSET_HISTORY_LEN {

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -98,7 +98,16 @@ impl Dictionary {
     /// tables — and thus the emitted frame — are byte-identical; only the
     /// wasted decode-table builds are dropped. Offset history + content
     /// are parsed the same way.
-    pub fn decode_dict_for_encoding(raw: &[u8]) -> Result<Dictionary, DictionaryDecodeError> {
+    /// Crate-internal: the returned [`Dictionary`] deliberately has no
+    /// decode lookup tables (`packed_decode` / FSE `decode`), so it is
+    /// NOT safe to feed into a [`FrameDecoder`](crate::decoding::FrameDecoder)
+    /// — Huffman decode would index an empty `packed_decode`. The encoder
+    /// (`FrameCompressor::set_dictionary_from_bytes`) is the only caller and
+    /// only reads the entropy ENCODER tables, so keeping this `pub(crate)`
+    /// avoids exposing a decode footgun on the public `Dictionary` type.
+    pub(crate) fn decode_dict_for_encoding(
+        raw: &[u8],
+    ) -> Result<Dictionary, DictionaryDecodeError> {
         Self::decode_dict_inner(raw, false)
     }
 

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -101,10 +101,11 @@ impl Dictionary {
     /// Crate-internal: the returned [`Dictionary`] deliberately has no
     /// decode lookup tables (`packed_decode` / FSE `decode`), so it is
     /// NOT safe to feed into a [`FrameDecoder`](crate::decoding::FrameDecoder)
-    /// — Huffman decode would index an empty `packed_decode`. The encoder
-    /// (`FrameCompressor::set_dictionary_from_bytes`) is the only caller and
-    /// only reads the entropy ENCODER tables, so keeping this `pub(crate)`
-    /// avoids exposing a decode footgun on the public `Dictionary` type.
+    /// — Huffman decode would index an empty `packed_decode`. The only caller
+    /// is `EncoderDictionary::from_bytes`, which wraps the result in the
+    /// encoder-only `EncoderDictionary` type (no decode path), so this
+    /// incomplete dictionary can never escape to the decode side. Keeping
+    /// this `pub(crate)` keeps it off the public `Dictionary` API entirely.
     pub(crate) fn decode_dict_for_encoding(
         raw: &[u8],
     ) -> Result<Dictionary, DictionaryDecodeError> {

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -90,20 +90,22 @@ impl Dictionary {
 
     /// Parse a dictionary for ENCODER use: builds the entropy
     /// probabilities/weights needed by `to_encoder_table` but skips the
-    /// FSE *decoding* tables and their `enrich_*` post-passes, which the
-    /// encoder never reads. Produces a [`Dictionary`] whose
-    /// `symbol_probabilities` / `accuracy_log` (and HUF weights) match
-    /// `decode_dict` exactly, so the encoder entropy tables — and thus
-    /// the emitted frame — are byte-identical; only the wasted decode
-    /// table build is dropped. Offset history + content are parsed the
-    /// same way.
+    /// decode-only work the encoder never reads — the FSE *decoding*
+    /// tables + their `enrich_*` post-passes, and the HUF decode lookup
+    /// table (`packed_decode`). Produces a [`Dictionary`] whose FSE
+    /// `symbol_probabilities` / `accuracy_log` and HUF `bits` /
+    /// `max_num_bits` match `decode_dict` exactly, so the encoder entropy
+    /// tables — and thus the emitted frame — are byte-identical; only the
+    /// wasted decode-table builds are dropped. Offset history + content
+    /// are parsed the same way.
     pub fn decode_dict_for_encoding(raw: &[u8]) -> Result<Dictionary, DictionaryDecodeError> {
         Self::decode_dict_inner(raw, false)
     }
 
     /// Shared dictionary parser. `build_decode_tables` selects whether the
-    /// FSE tables get their full decoding table + `enrich_*` passes (decoder
-    /// path) or only the probability parse (encoder path — see
+    /// FSE/HUF tables get their full decoding tables (FSE decode table +
+    /// `enrich_*`, HUF `packed_decode`; decoder path) or only the
+    /// probability/weight parse (encoder path — see
     /// [`Self::decode_dict_for_encoding`]).
     fn decode_dict_inner(
         raw: &[u8],
@@ -141,7 +143,11 @@ impl Dictionary {
 
         let raw_tables = &raw[8..];
 
-        let huf_size = new_dict.huf.table.build_decoder(raw_tables)?;
+        let huf_size = if build_decode_tables {
+            new_dict.huf.table.build_decoder(raw_tables)?
+        } else {
+            new_dict.huf.table.build_weights_only(raw_tables)?
+        };
         let raw_tables = &raw_tables[huf_size as usize..];
 
         let of_size = if build_decode_tables {

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -17,25 +17,6 @@ use crate::fse::fse_encoder::{FSETable, default_ll_table, default_ml_table, defa
 
 use crate::io::{Read, Write};
 
-/// An interface for compressing arbitrary data with the ZStandard compression algorithm.
-///
-/// `FrameCompressor` will generally be used by:
-/// 1. Initializing a compressor by providing a buffer of data using `FrameCompressor::new()`
-/// 2. Starting compression and writing that compression into a vec using `FrameCompressor::begin`
-///
-/// # Examples
-/// ```
-/// use structured_zstd::encoding::{FrameCompressor, CompressionLevel};
-/// let mock_data: &[_] = &[0x1, 0x2, 0x3, 0x4];
-/// let mut output = std::vec::Vec::new();
-/// // Initialize a compressor.
-/// let mut compressor = FrameCompressor::new(CompressionLevel::Uncompressed);
-/// compressor.set_source(mock_data);
-/// compressor.set_drain(&mut output);
-///
-/// // `compress` writes the compressed output into the provided buffer.
-/// compressor.compress();
-/// ```
 /// A dictionary prepared for the ENCODER side, analogous to zstd's `CDict`
 /// (vs the decoder's [`Dictionary`](crate::decoding::Dictionary) / `DDict`).
 ///
@@ -78,6 +59,25 @@ impl EncoderDictionary {
     }
 }
 
+/// An interface for compressing arbitrary data with the ZStandard compression algorithm.
+///
+/// `FrameCompressor` will generally be used by:
+/// 1. Initializing a compressor by providing a buffer of data using `FrameCompressor::new()`
+/// 2. Starting compression and writing that compression into a vec using `FrameCompressor::begin`
+///
+/// # Examples
+/// ```
+/// use structured_zstd::encoding::{FrameCompressor, CompressionLevel};
+/// let mock_data: &[_] = &[0x1, 0x2, 0x3, 0x4];
+/// let mut output = std::vec::Vec::new();
+/// // Initialize a compressor.
+/// let mut compressor = FrameCompressor::new(CompressionLevel::Uncompressed);
+/// compressor.set_source(mock_data);
+/// compressor.set_drain(&mut output);
+///
+/// // `compress` writes the compressed output into the provided buffer.
+/// compressor.compress();
+/// ```
 pub struct FrameCompressor<R: Read, W: Write, M: Matcher> {
     uncompressed_data: Option<R>,
     compressed_data: Option<W>,

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2074,6 +2074,53 @@ mod tests {
     }
 
     #[test]
+    fn set_dictionary_from_bytes_matches_full_decode_byte_for_byte() {
+        // The encoder-only dict parse (`decode_dict_for_encoding`, used by
+        // `set_dictionary_from_bytes`) skips the FSE/HUF decoder-table build and
+        // the enrich passes. The encoder entropy tables are derived purely from
+        // the symbol probabilities / Huffman weights, so the compressed output
+        // MUST be byte-identical to the full-decode path. This pins the
+        // load-bearing equivalence so a future FSE/HUF parsing refactor that
+        // still round-trips but silently diverges on the probabilities/weights
+        // fails loudly here instead of producing a different (but valid) frame.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n\
+              tenant=demo table=orders op=put key=2 value=aaaaabbbbbcccccdddddeeeee\n";
+
+        // Path A: encoder-only parse straight from the raw blob.
+        let mut from_bytes_out = Vec::new();
+        {
+            let mut compressor = FrameCompressor::new(super::CompressionLevel::Fastest);
+            compressor
+                .set_dictionary_from_bytes(dict_raw)
+                .expect("dictionary bytes should parse");
+            compressor.set_source(payload.as_slice());
+            compressor.set_drain(&mut from_bytes_out);
+            compressor.compress();
+        }
+
+        // Path B: full decode (builds the decoder tables too), then attach for
+        // encoding via the `Dictionary` setter.
+        let full_decode = crate::decoding::Dictionary::decode_dict(dict_raw)
+            .expect("dictionary bytes should fully decode");
+        let mut full_decode_out = Vec::new();
+        {
+            let mut compressor = FrameCompressor::new(super::CompressionLevel::Fastest);
+            compressor
+                .set_dictionary(full_decode)
+                .expect("full-decode dictionary should attach");
+            compressor.set_source(payload.as_slice());
+            compressor.set_drain(&mut full_decode_out);
+            compressor.compress();
+        }
+
+        assert_eq!(
+            from_bytes_out, full_decode_out,
+            "encoder-only dict parse must produce byte-identical output to the full decode"
+        );
+    }
+
+    #[test]
     fn set_dictionary_rejects_zero_dictionary_id() {
         let invalid = crate::decoding::Dictionary {
             id: 0,

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1172,6 +1172,22 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         self.attach_dictionary(EncoderDictionary::from_bytes(raw_dictionary)?)
     }
 
+    /// Attach an already-parsed [`EncoderDictionary`] without reparsing a raw
+    /// blob.
+    ///
+    /// Accepts an `EncoderDictionary` produced once via
+    /// [`EncoderDictionary::from_bytes`] / [`EncoderDictionary::from_dictionary`]
+    /// or handed back by [`Self::clear_dictionary`] / the `set_dictionary*`
+    /// return value, so callers can reattach or reuse a prepared dictionary
+    /// across compressions without re-running the dictionary parse each time.
+    /// Returns the previously-attached dictionary, if any.
+    pub fn set_encoder_dictionary(
+        &mut self,
+        dictionary: EncoderDictionary,
+    ) -> Result<Option<EncoderDictionary>, crate::decoding::errors::DictionaryDecodeError> {
+        self.attach_dictionary(dictionary)
+    }
+
     /// Remove the attached dictionary, returning it as an [`EncoderDictionary`].
     pub fn clear_dictionary(&mut self) -> Option<EncoderDictionary> {
         self.dictionary_entropy_cache = None;
@@ -1990,6 +2006,63 @@ mod tests {
         assert!(
             compressor.state.fse_tables.of_previous.is_some(),
             "dictionary entropy should seed previous of table before first block"
+        );
+    }
+
+    #[test]
+    fn set_encoder_dictionary_reattaches_prepared_dict_without_reparse() {
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n\
+              tenant=demo table=orders op=put key=2 value=aaaaabbbbbcccccdddddeeeee\n";
+
+        // Prepare the EncoderDictionary once, then attach it via the prepared-
+        // dictionary API (no raw-blob reparse at attach time).
+        let prepared =
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");
+        let dict_id = prepared.id();
+
+        let mut with_dict = Vec::new();
+        let mut compressor = FrameCompressor::new(super::CompressionLevel::Fastest);
+        let previous = compressor
+            .set_encoder_dictionary(prepared)
+            .expect("prepared dictionary should attach");
+        assert!(previous.is_none());
+        compressor.set_source(payload.as_slice());
+        compressor.set_drain(&mut with_dict);
+        compressor.compress();
+        // clear_dictionary hands the prepared dictionary back (last use of
+        // `compressor`, so its `&mut with_dict` drain borrow ends here).
+        let returned = compressor
+            .clear_dictionary()
+            .expect("dictionary was attached");
+        assert_eq!(returned.id(), dict_id);
+
+        // The reattached dictionary drives the frame: its id is advertised and
+        // the stream round-trips through a decoder primed with the same dict.
+        let (frame_header, _) = crate::decoding::frame::read_frame_header(with_dict.as_slice())
+            .expect("encoded stream should have a frame header");
+        assert_eq!(frame_header.dictionary_id(), Some(dict_id));
+        let decoder_dict = crate::decoding::Dictionary::decode_dict(dict_raw).unwrap();
+        let mut decoder = FrameDecoder::new();
+        decoder.add_dict(decoder_dict).unwrap();
+        let mut decoded = Vec::with_capacity(payload.len());
+        decoder.decode_all_to_vec(&with_dict, &mut decoded).unwrap();
+        assert_eq!(decoded.as_slice(), payload.as_slice());
+
+        // The dictionary handed back by clear_dictionary reattaches to another
+        // compressor without touching the raw bytes again, producing an
+        // identical frame.
+        let mut with_dict2 = Vec::new();
+        let mut compressor2 = FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor2
+            .set_encoder_dictionary(returned)
+            .expect("returned dictionary should reattach");
+        compressor2.set_source(payload.as_slice());
+        compressor2.set_drain(&mut with_dict2);
+        compressor2.compress();
+        assert_eq!(
+            with_dict2, with_dict,
+            "reattached prepared dict must produce an identical frame"
         );
     }
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -36,11 +36,53 @@ use crate::io::{Read, Write};
 /// // `compress` writes the compressed output into the provided buffer.
 /// compressor.compress();
 /// ```
+/// A dictionary prepared for the ENCODER side, analogous to zstd's `CDict`
+/// (vs the decoder's [`Dictionary`](crate::decoding::Dictionary) / `DDict`).
+///
+/// It carries the entropy tables, content, and repeat-offset history the
+/// compressor needs, but is a distinct type with **no decode path**: there is
+/// no way to turn it into a [`DictionaryHandle`](crate::decoding::DictionaryHandle)
+/// or feed it to a [`FrameDecoder`](crate::decoding::FrameDecoder). That keeps
+/// the compress-only state (which may have been parsed without building the
+/// decode lookup tables, see
+/// [`set_dictionary_from_bytes`](FrameCompressor::set_dictionary_from_bytes))
+/// from ever reaching the decode side — the encoder/decoder dictionary split
+/// mirrors C zstd's `CDict` / `DDict`.
+pub struct EncoderDictionary {
+    pub(crate) inner: crate::decoding::Dictionary,
+}
+
+impl EncoderDictionary {
+    /// Wrap an already-parsed [`Dictionary`](crate::decoding::Dictionary) for
+    /// encoder use. A fully-decoded dictionary is valid here; only the encoder
+    /// entropy tables, content, and offset history are read.
+    pub fn from_dictionary(dictionary: crate::decoding::Dictionary) -> Self {
+        Self { inner: dictionary }
+    }
+
+    /// Parse a serialized dictionary blob for encoder use, skipping the decode
+    /// lookup-table build the encoder never reads (see
+    /// `Dictionary::decode_dict_for_encoding`). The encoder entropy tables — and
+    /// thus the emitted frame — are identical to a full parse.
+    pub fn from_bytes(
+        raw_dictionary: &[u8],
+    ) -> Result<Self, crate::decoding::errors::DictionaryDecodeError> {
+        Ok(Self {
+            inner: crate::decoding::Dictionary::decode_dict_for_encoding(raw_dictionary)?,
+        })
+    }
+
+    /// The dictionary id (`> 0`).
+    pub fn id(&self) -> u32 {
+        self.inner.id
+    }
+}
+
 pub struct FrameCompressor<R: Read, W: Write, M: Matcher> {
     uncompressed_data: Option<R>,
     compressed_data: Option<W>,
     compression_level: CompressionLevel,
-    dictionary: Option<crate::decoding::Dictionary>,
+    dictionary: Option<EncoderDictionary>,
     dictionary_entropy_cache: Option<CachedDictionaryEntropy>,
     source_size_hint: Option<u64>,
     state: CompressState<M>,
@@ -630,10 +672,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         if use_dictionary_state && let Some(dict) = self.dictionary.as_ref() {
             // This state drives sequence encoding, while matcher priming below updates
             // the match generator's internal repeat-offset history for match finding.
-            self.state.offset_hist = dict.offset_hist;
+            self.state.offset_hist = dict.inner.offset_hist;
             self.state
                 .matcher
-                .prime_with_dictionary(dict.dict_content.as_slice(), dict.offset_hist);
+                .prime_with_dictionary(dict.inner.dict_content.as_slice(), dict.inner.offset_hist);
         }
         if let Some(cache) = cached_entropy {
             self.state.last_huff_table.clone_from(&cache.huff);
@@ -865,7 +907,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             single_segment,
             content_checksum: cfg!(feature = "hash"),
             dictionary_id: if use_dictionary_state {
-                self.dictionary.as_ref().map(|dict| dict.id as u64)
+                self.dictionary.as_ref().map(|dict| dict.inner.id as u64)
             } else {
                 None
             },
@@ -1114,8 +1156,36 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     pub fn set_dictionary(
         &mut self,
         dictionary: crate::decoding::Dictionary,
-    ) -> Result<Option<crate::decoding::Dictionary>, crate::decoding::errors::DictionaryDecodeError>
-    {
+    ) -> Result<Option<EncoderDictionary>, crate::decoding::errors::DictionaryDecodeError> {
+        self.attach_dictionary(EncoderDictionary::from_dictionary(dictionary))
+    }
+
+    /// Parse and attach a serialized dictionary blob.
+    ///
+    /// Parses with the encoder-only path (skips the FSE/HUF decode lookup-table
+    /// build the encoder never reads); the entropy ENCODER tables — and thus
+    /// the emitted frame — are identical to a full parse.
+    pub fn set_dictionary_from_bytes(
+        &mut self,
+        raw_dictionary: &[u8],
+    ) -> Result<Option<EncoderDictionary>, crate::decoding::errors::DictionaryDecodeError> {
+        self.attach_dictionary(EncoderDictionary::from_bytes(raw_dictionary)?)
+    }
+
+    /// Remove the attached dictionary, returning it as an [`EncoderDictionary`].
+    pub fn clear_dictionary(&mut self) -> Option<EncoderDictionary> {
+        self.dictionary_entropy_cache = None;
+        self.dictionary.take()
+    }
+
+    /// Validate `enc`, build the encoder entropy cache from it, store it, and
+    /// return the previously-attached dictionary. Shared by `set_dictionary`
+    /// and `set_dictionary_from_bytes`.
+    fn attach_dictionary(
+        &mut self,
+        enc: EncoderDictionary,
+    ) -> Result<Option<EncoderDictionary>, crate::decoding::errors::DictionaryDecodeError> {
+        let dictionary = &enc.inner;
         if dictionary.id == 0 {
             return Err(crate::decoding::errors::DictionaryDecodeError::ZeroDictionaryId);
         }
@@ -1144,27 +1214,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 .to_encoder_table()
                 .map(|table| PreviousFseTable::Custom(Box::new(table))),
         });
-        Ok(self.dictionary.replace(dictionary))
-    }
-
-    /// Parse and attach a serialized dictionary blob.
-    pub fn set_dictionary_from_bytes(
-        &mut self,
-        raw_dictionary: &[u8],
-    ) -> Result<Option<crate::decoding::Dictionary>, crate::decoding::errors::DictionaryDecodeError>
-    {
-        // Encoder-only parse: skips the FSE decoding-table build + enrich
-        // passes the encoder never reads (see `decode_dict_for_encoding`).
-        // The probabilities/weights feeding `to_encoder_table` are identical
-        // to `decode_dict`, so the emitted frame is byte-for-byte unchanged.
-        let dictionary = crate::decoding::Dictionary::decode_dict_for_encoding(raw_dictionary)?;
-        self.set_dictionary(dictionary)
-    }
-
-    /// Remove the attached dictionary.
-    pub fn clear_dictionary(&mut self) -> Option<crate::decoding::Dictionary> {
-        self.dictionary_entropy_cache = None;
-        self.dictionary.take()
+        Ok(self.dictionary.replace(enc))
     }
 }
 
@@ -1801,7 +1851,7 @@ mod tests {
                 .set_dictionary(dict_for_encoder)
                 .expect("valid dictionary should attach")
                 .expect("set_dictionary_from_bytes inserted previous dictionary")
-                .id,
+                .id(),
             dict_for_decoder.id
         );
         compressor.set_source(data.as_slice());

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -53,7 +53,13 @@ impl EncoderDictionary {
         })
     }
 
-    /// The dictionary id (`> 0`).
+    /// The dictionary id.
+    ///
+    /// A dictionary attached for encoding always has a non-zero id (the
+    /// `set_dictionary*` / `set_encoder_dictionary` attach path rejects a
+    /// zero id). This getter, however, reflects the wrapped dictionary as-is:
+    /// an `EncoderDictionary` built via [`Self::from_dictionary`] from a raw
+    /// `Dictionary` with `id == 0` reports `0` here until it is attached.
     pub fn id(&self) -> u32 {
         self.inner.id
     }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1153,7 +1153,11 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         raw_dictionary: &[u8],
     ) -> Result<Option<crate::decoding::Dictionary>, crate::decoding::errors::DictionaryDecodeError>
     {
-        let dictionary = crate::decoding::Dictionary::decode_dict(raw_dictionary)?;
+        // Encoder-only parse: skips the FSE decoding-table build + enrich
+        // passes the encoder never reads (see `decode_dict_for_encoding`).
+        // The probabilities/weights feeding `to_encoder_table` are identical
+        // to `decode_dict`, so the emitted frame is byte-for-byte unchanged.
+        let dictionary = crate::decoding::Dictionary::decode_dict_for_encoding(raw_dictionary)?;
         self.set_dictionary(dictionary)
     }
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1201,8 +1201,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     }
 
     /// Validate `enc`, build the encoder entropy cache from it, store it, and
-    /// return the previously-attached dictionary. Shared by `set_dictionary`
-    /// and `set_dictionary_from_bytes`.
+    /// return the previously-attached dictionary. Shared by every public
+    /// attach entry point: `set_dictionary`, `set_dictionary_from_bytes`, and
+    /// `set_encoder_dictionary`.
     fn attach_dictionary(
         &mut self,
         enc: EncoderDictionary,

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -87,7 +87,7 @@ mod levels;
 #[cfg(feature = "bench_internals")]
 pub mod sequence_capture;
 mod streaming_encoder;
-pub use frame_compressor::FrameCompressor;
+pub use frame_compressor::{EncoderDictionary, FrameCompressor};
 #[cfg(feature = "lsm")]
 pub use frame_emit_info::{BlockType, FrameBlock, FrameEmitInfo};
 pub use match_generator::MatchGeneratorDriver;

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -338,7 +338,11 @@ impl<E: FseEntry> FSETableImpl<E> {
     /// otherwise pass whenever the old `decode.len()` still equalled
     /// `1 << accuracy_log`). After this call the table is intentionally
     /// non-decodable until `build_decoding_table` runs.
-    pub fn read_table_probabilities(
+    // `pub(crate)`: this leaves the table in an intentionally non-decodable
+    // partial-init state, so it must not be reachable from the public API
+    // (the module is re-exported with `pub use`). Only the crate-internal
+    // encoder-dictionary parse calls it.
+    pub(crate) fn read_table_probabilities(
         &mut self,
         source: &[u8],
         max_log: u8,

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -321,6 +321,26 @@ impl<E: FseEntry> FSETableImpl<E> {
         Ok(bytes_read)
     }
 
+    /// Parse the table description into `symbol_probabilities` +
+    /// `accuracy_log` WITHOUT building the decoding table.
+    ///
+    /// Returns the same byte count as [`Self::build_decoder`] (the table
+    /// description length), so a caller stepping a cursor over a packed
+    /// stream of tables advances identically. Used by the encoder
+    /// dictionary load: [`Self::to_encoder_table`] reads only the
+    /// probabilities + accuracy log, so building the decode table (and
+    /// the `enrich_*` post-passes, which touch only decode entries) is
+    /// pure waste there.
+    pub fn read_table_probabilities(
+        &mut self,
+        source: &[u8],
+        max_log: u8,
+    ) -> Result<usize, FSETableError> {
+        let max_log = max_log.min(ENTRY_MAX_ACCURACY_LOG);
+        self.accuracy_log = 0;
+        self.read_probabilities(source, max_log)
+    }
+
     /// Given the provided accuracy log, build a decoding table from that log.
     pub fn build_from_probabilities(
         &mut self,

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -331,6 +331,13 @@ impl<E: FseEntry> FSETableImpl<E> {
     /// probabilities + accuracy log, so building the decode table (and
     /// the `enrich_*` post-passes, which touch only decode entries) is
     /// pure waste there.
+    ///
+    /// The existing `decode` table is cleared so a reused `FSETableImpl`
+    /// can't silently keep decoding against a stale table that no longer
+    /// matches the just-parsed probabilities (`init_state` would
+    /// otherwise pass whenever the old `decode.len()` still equalled
+    /// `1 << accuracy_log`). After this call the table is intentionally
+    /// non-decodable until `build_decoding_table` runs.
     pub fn read_table_probabilities(
         &mut self,
         source: &[u8],
@@ -338,6 +345,7 @@ impl<E: FseEntry> FSETableImpl<E> {
     ) -> Result<usize, FSETableError> {
         let max_log = max_log.min(ENTRY_MAX_ACCURACY_LOG);
         self.accuracy_log = 0;
+        self.decode.clear();
         self.read_probabilities(source, max_log)
     }
 

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -410,6 +410,20 @@ impl HuffmanTable {
         Ok(bytes_used)
     }
 
+    /// Parse the weight header into `bits` + `max_num_bits` WITHOUT building
+    /// the decode lookup table. Returns the same byte count as
+    /// [`Self::build_decoder`] (the weight-header length), so a caller
+    /// stepping a cursor over packed tables advances identically. Used by
+    /// the encoder dictionary load: [`Self::to_encoder_table`] reads only
+    /// `bits` + `max_num_bits`, so filling `packed_decode` is pure waste.
+    pub fn build_weights_only(&mut self, source: &[u8]) -> Result<u32, HuffmanTableError> {
+        self.packed_decode.clear();
+
+        let bytes_used = self.read_weights(source)?;
+        self.compute_huffman_bits()?;
+        Ok(bytes_used)
+    }
+
     /// Read weights from the provided source.
     ///
     /// The huffman table is represented in the input data as a list of weights.
@@ -570,7 +584,13 @@ impl HuffmanTable {
     /// into a table, and use that table to decode the actual compressed data.
     ///
     /// This function populates the rest of the table from the series of weights.
-    fn build_table_from_weights(&mut self) -> Result<(), HuffmanTableError> {
+    /// Compute per-symbol code lengths (`bits`) + `max_num_bits` from the
+    /// parsed `weights`, returning `max_bits`. This is the slice of the
+    /// table build the ENCODER side needs: [`Self::to_encoder_table`] reads
+    /// only `bits` + `max_num_bits`. The decode lookup-table fill
+    /// (`bit_ranks` / `packed_decode` / `rank_indexes`) is decoder-only and
+    /// lives in [`Self::build_table_from_weights`].
+    fn compute_huffman_bits(&mut self) -> Result<u8, HuffmanTableError> {
         use HuffmanTableError as err;
 
         self.bits.clear();
@@ -614,6 +634,12 @@ impl HuffmanTable {
         if max_bits > MAX_MAX_NUM_BITS {
             return Err(err::MaxBitsTooHigh { got: max_bits });
         }
+
+        Ok(max_bits)
+    }
+
+    fn build_table_from_weights(&mut self) -> Result<(), HuffmanTableError> {
+        let max_bits = self.compute_huffman_bits()?;
 
         self.bit_ranks.clear();
         self.bit_ranks.resize((max_bits + 1) as usize, 0);

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -416,7 +416,11 @@ impl HuffmanTable {
     /// stepping a cursor over packed tables advances identically. Used by
     /// the encoder dictionary load: [`Self::to_encoder_table`] reads only
     /// `bits` + `max_num_bits`, so filling `packed_decode` is pure waste.
-    pub fn build_weights_only(&mut self, source: &[u8]) -> Result<u32, HuffmanTableError> {
+    ///
+    /// Crate-internal: the table it produces is intentionally non-decodable
+    /// (empty `packed_decode`); only `decode_dict_for_encoding` calls it, and
+    /// its result is wrapped in an `EncoderDictionary` that has no decode path.
+    pub(crate) fn build_weights_only(&mut self, source: &[u8]) -> Result<u32, HuffmanTableError> {
         self.packed_decode.clear();
 
         let bytes_used = self.read_weights(source)?;

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -584,10 +584,6 @@ impl HuffmanTable {
         Ok(bytes_read as u32)
     }
 
-    /// Once the weights have been read from the data, you can decode the weights
-    /// into a table, and use that table to decode the actual compressed data.
-    ///
-    /// This function populates the rest of the table from the series of weights.
     /// Compute per-symbol code lengths (`bits`) + `max_num_bits` from the
     /// parsed `weights`, returning `max_bits`. This is the slice of the
     /// table build the ENCODER side needs: [`Self::to_encoder_table`] reads


### PR DESCRIPTION
## Summary

Encoder-side dictionary loading, reworked to mirror upstream zstd's **CDict / DDict split**.

**1. Skip decode-only work on encoder dict load.** Loading a dictionary for compression built the FSE/HUF *decode* lookup tables + `enrich_*` passes, then immediately converted them to encoder tables via `to_encoder_table` (which reads only the symbol probabilities / code lengths). On a tiny dict-compressed payload that wasted work is a measurable per-call cost (i9 perf: FSE `build_decoding_table` 8.5% + `enrich_*` 2.9% + HUF `build_decoder` 4.1%, all discarded). `Dictionary::decode_dict_for_encoding` parses via `read_table_probabilities` (FSE) + `build_weights_only` (HUF, split out of `build_table_from_weights`), skipping the decode-table builds. Byte-identical output (same probabilities/weights feed `to_encoder_table`; decoder path unchanged).

**2. Encoder-only dictionary type (footgun fix).** The skip leaves a `Dictionary` with no decode tables, which previously could escape to callers via `set_dictionary` / `clear_dictionary` return values and panic if fed to a `FrameDecoder`. New `encoding::EncoderDictionary` (≈ CDict): a distinct type wrapping the parsed dictionary with **no decode path** (no `into_handle`/decode), so the compress-only state can never reach the decode side — closed by the type system, matching C's CDict/DDict. `FrameCompressor::{set_dictionary, set_dictionary_from_bytes, clear_dictionary}` now take/return `EncoderDictionary` (both setters funnel through a shared `attach_dictionary`). `build_weights_only` + `decode_dict_for_encoding` are `pub(crate)`. `set_encoder_dictionary(EncoderDictionary)` accepts a prepared dictionary back, so one built via `EncoderDictionary::from_bytes` (or handed back by `clear_dictionary`) can be reattached/reused across compressions without reparsing the raw blob.

## Impact (i9, quiet host, c_ffi arm flat as control)

compress-dict/level_2_dfast/small-4k-log-lines, `pure_rust_with_dict`: **−15.79%** (43.6 → 36.72 µs, p=0.00), with the `c_ffi_with_dict` control flat (−0.98%) confirming the win is real. Decompress unaffected (−0.58%). Residual gap to C on this fixture is the per-call entropy-table build + allocations (a prepared-dict cache, now natural on `EncoderDictionary`, is the follow-up).

## Testing

- 703 lib tests green (`cargo nextest run`), incl. dictionary + dict_builder round-trips (encode-with-dict → decode-with-dict byte match).
- clippy `--all-targets --features dict_builder` + fmt clean; trimmed kernel-feature combos checked in CI.

## API note

`set_dictionary` / `clear_dictionary` / `set_dictionary_from_bytes` now return `Option<EncoderDictionary>` instead of `Option<Dictionary>` (semver-minor on 0.x). Intentional: an encoder dict is no longer decode-capable, so it is a distinct type. `set_encoder_dictionary(EncoderDictionary)` is the inverse — it reattaches a prepared/returned encoder dict without reparsing.

Closes #313.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a specialized dictionary type for compression operations with improved management of dictionary-specific data and metadata.

* **Refactor**
  * Optimized dictionary parsing to separate encoding and decoding workflows, eliminating unnecessary processing during compression setup.
  * Enhanced decoder table construction to support building only weight information when full decoding tables are not required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->