### PR TITLE
perf(encode): dedup window<->history live-region storage

### DIFF
--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -712,7 +712,8 @@ mod hc_tests {
         t.chain_log = 8;
         t.hash3_log = 0;
         t.ensure_tables();
-        t.window.push_back(buf.to_vec());
+        // `history` is set directly above; record one live chunk.
+        t.chunk_lens.push_back(buf.len());
         t
     }
 
@@ -841,7 +842,7 @@ mod hc_tests {
         t.chain_log = 8;
         t.hash3_log = 0;
         t.ensure_tables();
-        t.window.push_back(t.history.clone());
+        t.chunk_lens.push_back(t.history.len());
         t.insert_positions(0, 24);
 
         let hc = HcMatcher::new(2, 16, 64);
@@ -945,7 +946,7 @@ mod hc_tests {
         t.chain_log = 8;
         t.hash3_log = 0;
         t.ensure_tables();
-        t.window.push_back(t.history.clone());
+        t.chunk_lens.push_back(t.history.len());
 
         // The probe is at abs_pos 27 (start of the fourth
         // "abcdefgh" chunk). Hand-wire the chain so the walker

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1295,8 +1295,14 @@ impl Matcher for MatchGeneratorDriver {
                 // so `evicted = pre + space_len - post`.
                 let pre = m.window_size;
                 let space_len = space.len();
-                m.add_data(space, |mut data| {
-                    data.resize(data.capacity(), 0);
+                m.add_data(space, |data| {
+                    // Same per-block recycle as the HashChain arm: push
+                    // the spent input buffer back as-is rather than
+                    // zero-filling to capacity. `add_data` mirrors the
+                    // bytes into `history` and calls this every block, so
+                    // capacity-wide zeroing would be hot-path waste;
+                    // `get_next_space` zeroes at most `slice_size` bytes
+                    // when it later reuses the buffer.
                     vec_pool.push(data);
                 });
                 evicted_bytes += pre.saturating_add(space_len).saturating_sub(m.window_size);
@@ -1317,8 +1323,16 @@ impl Matcher for MatchGeneratorDriver {
                 // `evicted = pre + space_len - post`.
                 let pre = m.table.window_size;
                 let space_len = space.len();
-                m.table.add_data(space, |mut data| {
-                    data.resize(data.capacity(), 0);
+                m.table.add_data(space, |data| {
+                    // Recycle the spent input buffer to the pool as-is.
+                    // `add_data` runs this callback for every committed
+                    // block (the bytes are mirrored into `history`), so
+                    // growing the buffer to its full capacity here would
+                    // zero the whole allocation on the hot path.
+                    // `get_next_space` resizes a popped buffer to
+                    // `slice_size` on demand, touching at most
+                    // `slice_size` bytes — never the larger capacity the
+                    // pool retains.
                     vec_pool.push(data);
                 });
                 evicted_bytes += pre

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1309,11 +1309,21 @@ impl Matcher for MatchGeneratorDriver {
                 });
             }
             MatcherStorage::HashChain(m) => {
+                // MatchTable::add_data now recycles the *incoming* buffer
+                // through `reuse_space` (its bytes are copied into the
+                // contiguous `history` mirror), so the callback no longer
+                // reports evicted chunks. Derive the eviction delta from
+                // `window_size` before/after, exactly like the Simple arm:
+                // `evicted = pre + space_len - post`.
+                let pre = m.table.window_size;
+                let space_len = space.len();
                 m.table.add_data(space, |mut data| {
-                    evicted_bytes += data.len();
                     data.resize(data.capacity(), 0);
                     vec_pool.push(data);
                 });
+                evicted_bytes += pre
+                    .saturating_add(space_len)
+                    .saturating_sub(m.table.window_size);
             }
         }
         // Gate the second backend trim pass on actual budget
@@ -7296,6 +7306,39 @@ fn prime_with_dictionary_budget_shrinks_after_hc_eviction() {
         driver.hc_matcher().table.max_window_size,
         base_window,
         "retired dictionary budget must not remain reusable for live history"
+    );
+}
+
+#[test]
+fn hc_commit_without_eviction_retires_no_dictionary_budget() {
+    // Regression: after the window<->history dedup, MatchTable::add_data
+    // invokes its reuse_space callback for the *input* buffer (recycle),
+    // not for evicted chunks. The HC arm of commit_space must therefore
+    // derive eviction bytes from the window_size delta — counting the
+    // callback argument as evicted would charge the whole committed block
+    // as "evicted" and prematurely retire dictionary budget even when the
+    // window is nowhere near full.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    driver.reset(CompressionLevel::Better);
+    // A large live window so a small committed block evicts nothing.
+    driver.hc_matcher_mut().table.max_window_size = 1 << 20;
+    driver.reported_window_size = 1 << 20;
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    let budget_after_prime = driver.dictionary_retained_budget;
+    assert!(
+        budget_after_prime > 0,
+        "priming must retain a non-zero dictionary budget"
+    );
+
+    let mut space = driver.get_next_space();
+    space.clear();
+    space.extend_from_slice(b"AAAAAAAA");
+    driver.commit_space(space);
+    driver.skip_matching_with_hint(None);
+
+    assert_eq!(
+        driver.dictionary_retained_budget, budget_after_prime,
+        "a commit that evicts nothing must retire no dictionary budget"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -820,15 +820,14 @@ impl MatchGeneratorDriver {
                     }
                 }
                 super::strategy::BackendTag::HashChain => {
-                    let mut retired = Vec::new();
-                    self.hc_matcher_mut().table.trim_to_window(|data| {
-                        evicted_bytes += data.len();
-                        retired.push(data);
-                    });
-                    for mut data in retired {
-                        data.resize(data.capacity(), 0);
-                        self.vec_pool.push(data);
-                    }
+                    // HC keeps bytes only in the contiguous `history` mirror
+                    // (no per-block Vecs to recycle since the window<->history
+                    // dedup), so derive the eviction count from the
+                    // `window_size` delta, mirroring the Dfast arm above.
+                    let table = &mut self.hc_matcher_mut().table;
+                    let pre = table.window_size;
+                    table.trim_to_window();
+                    evicted_bytes += pre - table.window_size;
                 }
             }
             if evicted_bytes == 0 {
@@ -3002,7 +3001,7 @@ impl HcMatchGenerator {
             && bt.ldm_sequences.is_empty()
             && self.table.window_size == current_len
             && self.table.history_abs_start == 0
-            && self.table.window.len() == 1
+            && self.table.chunk_lens.len() == 1
             && current_len > HC_PREDEF_THRESHOLD
     }
 
@@ -3165,10 +3164,17 @@ impl HcMatchGenerator {
     fn start_matching_lazy(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
         self.table.ensure_tables();
 
-        let current_len = self.table.window.back().unwrap().len();
+        let current_len = *self.table.chunk_lens.back().unwrap();
         if current_len == 0 {
             return;
         }
+        // The current block is the tail of `history`. Hoist it as a raw
+        // slice (like `start_matching_optimal`): the routine mutates the
+        // hash/chain tables + `offset_hist` but never reallocates
+        // `history`, so the slice stays valid and we avoid re-borrowing
+        // `self.table` (which would conflict with the `offset_hist` write).
+        let current_ptr = self.table.get_last_space().as_ptr();
+        let current: &[u8] = unsafe { core::slice::from_raw_parts(current_ptr, current_len) };
 
         let current_abs_start = self.table.history_abs_start + self.table.window_size - current_len;
         let current_abs_end = current_abs_start + current_len;
@@ -3185,7 +3191,6 @@ impl HcMatchGenerator {
             if let Some(candidate) = self.hc.pick_lazy_match(&self.table, abs_pos, lit_len, best) {
                 self.table
                     .insert_positions(abs_pos, candidate.start + candidate.match_len);
-                let current = self.table.window.back().unwrap().as_slice();
                 let start = candidate.start - current_abs_start;
                 let literals = &current[literals_start..start];
                 handle_sequence(Sequence::Triple {
@@ -3214,7 +3219,6 @@ impl HcMatchGenerator {
         }
 
         if literals_start < current_len {
-            let current = self.table.window.back().unwrap().as_slice();
             handle_sequence(Sequence::Literals {
                 literals: &current[literals_start..],
             });
@@ -3226,14 +3230,14 @@ impl HcMatchGenerator {
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
         self.table.ensure_tables();
-        let current_len = self.table.window.back().unwrap().len();
+        let current_len = *self.table.chunk_lens.back().unwrap();
         if current_len == 0 {
             return;
         }
-        let current_ptr = self.table.window.back().unwrap().as_ptr();
+        let current_ptr = self.table.get_last_space().as_ptr();
         // `start_matching_optimal()` mutates tables/state but never mutates or
-        // reorders `self.table.window`, so this block slice remains valid for the
-        // duration of the routine and avoids cloning the full block.
+        // reallocates `self.table.history`, so this tail slice remains valid for
+        // the duration of the routine and avoids cloning the full block.
         let current = unsafe { core::slice::from_raw_parts(current_ptr, current_len) };
 
         let current_abs_start = self.table.history_abs_start + self.table.window_size - current_len;
@@ -5008,7 +5012,7 @@ fn btultra2_seed_pass_disabled_when_prefix_history_exists() {
         26,
     );
     hc.table.history_abs_start = 17;
-    hc.table.window.push_back(b"abcdefghijklmnop".to_vec());
+    hc.table.push_test_chunk(b"abcdefghijklmnop".to_vec());
     assert!(
         !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 9),
         "btultra2 warmup must be first-block only (no prefix history)"
@@ -5055,9 +5059,9 @@ fn btultra2_seed_pass_disabled_when_not_at_frame_start() {
     // Simulate non-first block state: current block has no prefix in deque,
     // but total produced window already includes prior output.
     hc.table.window_size = HC_PREDEF_THRESHOLD + 64;
-    hc.table
-        .window
-        .push_back(alloc::vec![b'A'; HC_PREDEF_THRESHOLD + 32]);
+    // window_size set manually above to simulate prior output; record the
+    // current block as one live chunk (seed-pass check reads lengths, not bytes).
+    hc.table.chunk_lens.push_back(HC_PREDEF_THRESHOLD + 32);
     assert!(
         !hc.should_run_btultra2_seed_pass::<super::strategy::BtUltra2>(HC_PREDEF_THRESHOLD + 32),
         "btultra2 warmup must not run after frame start"
@@ -5073,9 +5077,7 @@ fn btultra2_seed_pass_disabled_when_ldm_sequences_exist() {
         26,
     );
     hc.table.window_size = HC_PREDEF_THRESHOLD + 64;
-    hc.table
-        .window
-        .push_back(alloc::vec![b'A'; HC_PREDEF_THRESHOLD + 64]);
+    hc.table.chunk_lens.push_back(HC_PREDEF_THRESHOLD + 64);
     hc.backend.bt_mut().ldm_sequences.push(HcRawSeq {
         lit_length: 8,
         offset: 16,

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -645,9 +645,9 @@ impl MatchTable {
     /// `Vec::fill(HC_EMPTY)`) if they're already sized; otherwise
     /// they're left empty so the next `ensure_tables()` call resizes
     /// them. The window is now just `chunk_lens` (the bytes live in
-    /// `history`, cleared above), so there are no per-block buffers to
-    /// drain; `_reuse_space` is retained only for caller signature
-    /// compatibility and is intentionally unused.
+    /// `history`, which this method clears below), so there are no
+    /// per-block buffers to drain; `_reuse_space` is retained only for
+    /// caller signature compatibility and is intentionally unused.
     pub(crate) fn reset(&mut self, _reuse_space: impl FnMut(Vec<u8>)) {
         self.window_size = 0;
         self.chunk_lens.clear();

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -199,7 +199,12 @@ pub(crate) const HC3_HASH_LOG: usize = 17;
 /// lives in the matcher modules.
 pub(crate) struct MatchTable {
     pub(crate) max_window_size: usize,
-    pub(crate) window: VecDeque<Vec<u8>>,
+    /// Per-chunk lengths of the live window, in add order. The bytes
+    /// themselves live only in `history` (the contiguous mirror); this
+    /// deque tracks chunk boundaries for eviction and locates the
+    /// current block (the back chunk) as a tail slice of `history`,
+    /// so the live region is never duplicated.
+    pub(crate) chunk_lens: VecDeque<usize>,
     pub(crate) window_size: usize,
     pub(crate) history: Vec<u8>,
     pub(crate) history_start: usize,
@@ -238,7 +243,7 @@ impl MatchTable {
     pub(crate) fn new(max_window_size: usize) -> Self {
         Self {
             max_window_size,
-            window: VecDeque::new(),
+            chunk_lens: VecDeque::new(),
             window_size: 0,
             history: Vec::new(),
             history_start: 0,
@@ -475,28 +480,31 @@ impl MatchTable {
         assert!(data.len() <= self.max_window_size);
         check_stream_abs_headroom(self.history_abs_start, self.window_size, data.len());
         while self.window_size + data.len() > self.max_window_size {
-            let removed = self.window.pop_front().unwrap();
-            self.window_size -= removed.len();
-            self.history_start += removed.len();
-            self.history_abs_start += removed.len();
-            reuse_space(removed);
+            let removed_len = self.chunk_lens.pop_front().unwrap();
+            self.window_size -= removed_len;
+            self.history_start += removed_len;
+            self.history_abs_start += removed_len;
         }
         self.compact_history();
+        let added = data.len();
         self.history.extend_from_slice(&data);
         self.next_to_update3 = self.next_to_update3.max(self.history_abs_start);
-        self.window_size += data.len();
-        self.window.push_back(data);
+        self.window_size += added;
+        self.chunk_lens.push_back(added);
+        // The input buffer's bytes now live in `history`; hand the buffer
+        // straight back to the caller's pool instead of holding a second
+        // copy in the window (the source of the per-compress duplicate).
+        reuse_space(data);
     }
 
     /// Drop window slices that have rolled past `max_window_size`.
     /// Used after `max_window_size` shrinks (dictionary release path).
-    pub(crate) fn trim_to_window(&mut self, mut reuse_space: impl FnMut(Vec<u8>)) {
+    pub(crate) fn trim_to_window(&mut self) {
         while self.window_size > self.max_window_size {
-            let removed = self.window.pop_front().unwrap();
-            self.window_size -= removed.len();
-            self.history_start += removed.len();
-            self.history_abs_start += removed.len();
-            reuse_space(removed);
+            let removed_len = self.chunk_lens.pop_front().unwrap();
+            self.window_size -= removed_len;
+            self.history_start += removed_len;
+            self.history_abs_start += removed_len;
         }
     }
 
@@ -531,7 +539,19 @@ impl MatchTable {
     /// the most recent buffer in the rolling window — panics if no
     /// data has been committed yet.
     pub(crate) fn get_last_space(&self) -> &[u8] {
-        self.window.back().unwrap().as_slice()
+        let last = *self.chunk_lens.back().unwrap();
+        &self.history[self.history.len() - last..]
+    }
+
+    /// Test-only: append a chunk to the live window without eviction /
+    /// compaction, mirroring the storage side of [`add_data`]. Replaces
+    /// the old `window.push_back(vec)` setup now that chunk bytes live
+    /// only in `history`.
+    #[cfg(test)]
+    pub(crate) fn push_test_chunk(&mut self, data: Vec<u8>) {
+        self.history.extend_from_slice(&data);
+        self.window_size += data.len();
+        self.chunk_lens.push_back(data.len());
     }
 
     /// Convert an absolute position into the (relative_pos + 1) form
@@ -626,8 +646,9 @@ impl MatchTable {
     /// they're left empty so the next `ensure_tables()` call resizes
     /// them. Window buffers are drained through `reuse_space` so the
     /// driver can recycle them across frames.
-    pub(crate) fn reset(&mut self, mut reuse_space: impl FnMut(Vec<u8>)) {
+    pub(crate) fn reset(&mut self, _reuse_space: impl FnMut(Vec<u8>)) {
         self.window_size = 0;
+        self.chunk_lens.clear();
         self.history.clear();
         self.history_start = 0;
         self.history_abs_start = 0;
@@ -647,10 +668,6 @@ impl MatchTable {
         self.hash_table.fill(HC_EMPTY);
         self.hash3_table.fill(HC_EMPTY);
         self.chain_table.fill(HC_EMPTY);
-        for mut data in self.window.drain(..) {
-            data.resize(data.capacity(), 0);
-            reuse_space(data);
-        }
     }
 
     /// Donor parity: `ZSTD_compressBlock_btopt_generic` starts its main
@@ -1326,7 +1343,7 @@ impl MatchTable {
     /// `incompressible_hint`). BT and HC modes branch via `uses_bt`.
     pub(crate) fn skip_matching(&mut self, incompressible_hint: Option<bool>) {
         self.ensure_tables();
-        let current_len = self.window.back().unwrap().len();
+        let current_len = *self.chunk_lens.back().unwrap();
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
         let current_abs_end = current_abs_start + current_len;
         self.backfill_boundary_positions(current_abs_start, current_abs_end);
@@ -1515,7 +1532,10 @@ impl MatchTable {
         plan: &[HcOptimalSequence],
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
-        let current = self.window.back().unwrap().as_slice();
+        // Direct field borrow of `history` (not `get_last_space()`, which
+        // borrows all of `self`) so the per-sequence `&mut self.offset_hist`
+        // write below stays a disjoint-field borrow.
+        let current = &self.history[self.history.len() - current_len..];
         if plan.is_empty() {
             handle_sequence(Sequence::Literals { literals: current });
             return;
@@ -1572,7 +1592,8 @@ mod storage_tests {
 
     fn new_table(window: usize) -> MatchTable {
         let mut t = MatchTable::new(window);
-        t.window_size = window;
+        // window_size is driven by `push_test_chunk` (= sum of live chunk
+        // lengths), so it is not preset here.
         t.hash_log = 8;
         t.chain_log = 8;
         t.hash3_log = 0;
@@ -1599,7 +1620,7 @@ mod storage_tests {
     #[test]
     fn skip_matching_bt_incompressible_routes_through_sparse_block() {
         let mut t = new_table(32);
-        t.window.push_back(vec![0u8; 32]);
+        t.push_test_chunk(vec![0u8; 32]);
         t.ensure_tables();
         t.uses_bt = true;
         t.is_btultra2 = false;
@@ -1616,7 +1637,7 @@ mod storage_tests {
     #[test]
     fn skip_matching_bt_dense_routes_through_bt_update_tree() {
         let mut t = new_table(32);
-        t.window.push_back(vec![1u8; 32]);
+        t.push_test_chunk(vec![1u8; 32]);
         t.ensure_tables();
         t.uses_bt = true;
         t.is_btultra2 = false;
@@ -1689,7 +1710,8 @@ mod storage_tests {
         t.history_start = 0;
         t.history_abs_start = 0;
         t.window_size = t.history.len();
-        t.window.push_back(t.history.clone());
+        // `history` is set directly above; just record it as one live chunk.
+        t.chunk_lens.push_back(t.history.len());
         t.hash_log = 8;
         t.chain_log = 8;
         // btultra2-style: HC3 side table allocated.
@@ -1719,7 +1741,7 @@ mod storage_tests {
     fn insert_positions_with_step_zero_step_is_noop() {
         let mut t = new_table(32);
         t.history = vec![0u8; 32];
-        t.window.push_back(vec![0u8; 32]);
+        t.push_test_chunk(vec![0u8; 32]);
         t.ensure_tables();
         let next_to_update3_before = t.next_to_update3;
         // step=0 must early-return without touching anything.
@@ -1735,7 +1757,7 @@ mod storage_tests {
         // guard breaks out of the loop after one insert.
         let mut t = new_table(32);
         t.history = vec![1u8; 32];
-        t.window.push_back(vec![1u8; 32]);
+        t.push_test_chunk(vec![1u8; 32]);
         t.ensure_tables();
         t.insert_positions_with_step(0, 16, usize::MAX);
         // Exactly one position should have been inserted before the
@@ -1787,7 +1809,7 @@ mod storage_tests {
     #[test]
     fn emit_optimal_plan_empty_plan_emits_full_literals() {
         let mut t = new_table(8);
-        t.window.push_back(b"abcdefgh".to_vec());
+        t.push_test_chunk(b"abcdefgh".to_vec());
         let mut emitted: Vec<u8> = Vec::new();
         t.emit_optimal_plan(8, &[], &mut |seq| {
             if let Sequence::Literals { literals } = seq {
@@ -1800,7 +1822,7 @@ mod storage_tests {
     #[test]
     fn emit_optimal_plan_skips_oversized_plan_item_and_emits_trailing_literals() {
         let mut t = new_table(8);
-        t.window.push_back(b"abcdefgh".to_vec());
+        t.push_test_chunk(b"abcdefgh".to_vec());
         // Plan item asks for `start + match_len > current_len` → skip.
         // The function must still emit the trailing literals at the end.
         let plan = [HcOptimalSequence {

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -468,14 +468,14 @@ impl MatchTable {
         };
     }
 
-    /// Append a freshly committed buffer to the rolling window. Evicts
-    /// the oldest slices until the new total fits inside
-    /// `max_window_size`, hands them back through `reuse_space` for
-    /// pool reuse, then extends the contiguous `history` mirror.
-    ///
-    /// History duplicates window data for O(1) contiguous access during
-    /// match finding (`common_prefix_len`, `extend_backwards`). Peak:
-    /// ~2x window size for data buffers + 6 MB tables.
+    /// Append a freshly committed buffer to the rolling window. Drops
+    /// chunk-length entries for the oldest slices until the new total
+    /// fits inside `max_window_size`, extends the contiguous `history`
+    /// mirror with the new bytes, then hands the *input* buffer back
+    /// through `reuse_space` for pool reuse — `history` now owns the
+    /// bytes, so the input buffer carries no live data. (Callers must
+    /// therefore treat the callback as recycle-only, not as an eviction
+    /// report; eviction bytes come from the `window_size` delta.)
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
         check_stream_abs_headroom(self.history_abs_start, self.window_size, data.len());
@@ -644,8 +644,10 @@ impl MatchTable {
     /// hash3 tables themselves are zeroed in place (via
     /// `Vec::fill(HC_EMPTY)`) if they're already sized; otherwise
     /// they're left empty so the next `ensure_tables()` call resizes
-    /// them. Window buffers are drained through `reuse_space` so the
-    /// driver can recycle them across frames.
+    /// them. The window is now just `chunk_lens` (the bytes live in
+    /// `history`, cleared above), so there are no per-block buffers to
+    /// drain; `_reuse_space` is retained only for caller signature
+    /// compatibility and is intentionally unused.
     pub(crate) fn reset(&mut self, _reuse_space: impl FnMut(Vec<u8>)) {
         self.window_size = 0;
         self.chunk_lens.clear();


### PR DESCRIPTION
Part of #316 (piece 3, partial).

## What

`MatchTable` stored every input chunk twice: `history.extend_from_slice(&data)` (the contiguous mirror the match finders index) and `window.push_back(data)` (a `VecDeque<Vec<u8>>` of the original chunks). `get_last_space()` read the back chunk for the current-block source, but the non-back window chunks were used only for `.len()` at eviction — their bytes already lived in `history`. So the live region (~`window_size`) was held twice during matching.

Replace `window: VecDeque<Vec<u8>>` with `chunk_lens: VecDeque<usize>`:
- `add_data` extends `history` once, records the chunk length, and recycles the input buffer to the caller pool immediately (history owns the bytes).
- `get_last_space()` / current-block reads return the tail slice of `history`.
- eviction / `trim_to_window` pop chunk lengths; the dictionary-budget loop derives the eviction count from the `window_size` delta (mirroring the Dfast arm).

Absolute-position state (`history_abs_start` / `history_start` / `position_base`) is untouched, so match finding is byte-identical.

## Measured (i9, high-entropy-1m compress level_-6_fast, same-session rust/ffi ratio)

- main 7.22x -> branch **6.83x** = -5.4% on the rust/ffi ratio (less page-fault churn / matching-phase memory).
- **Peak allocation unchanged** (4.28 MB): the peak is set during the entropy stage (literal-staging + compressed-scratch + output), not during matching where the window duplicate lived, and the freed input buffer is pool-retained rather than freed. The peak-alloc / i686-memory outliers need the incompressible raw-fast-path (the remaining #316 pieces 1/2), not this dedup. This lands the matching-phase saving + the cleaner single-source-of-truth storage.

## Tests

705 lib tests incl roundtrip + cross-validation green; clippy `--all-targets` + fmt clean.