### PR TITLE
perf(dict): greedy set-cover segment selection in fastcover trainer

### DIFF
--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -1,5 +1,10 @@
 use alloc::vec;
 use alloc::vec::Vec;
+// `std::collections::HashMap` is fine here: the whole `dictionary` module
+// is gated behind the `dict_builder` feature, which itself requires `std`
+// (training reads files / uses the system RNG), so this code never
+// compiles into a no_std build. It also matches the existing
+// `std::collections::HashSet` already used by `coverage_score` below.
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy)]

--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -95,7 +95,11 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
     // index `slot -> [(segment, count)]` lets "covering" a chosen segment's
     // d-mers decrement the score of every other segment containing them in
     // O(shared occurrences), instead of re-scoring all segments each round.
-    let mut scores = vec![0usize; n];
+    // Scores accumulate `count * frequency` products. Both factors are
+    // u32, so the product can reach ~2^64 and a running sum exceeds it —
+    // accumulate in u64 so the arithmetic is exact on 32-bit targets
+    // (i686) too, where `usize` would wrap.
+    let mut scores = vec![0u64; n];
     let mut inverted: HashMap<usize, Vec<(u32, u32)>> = HashMap::new();
     for (i, seg) in segments.iter().enumerate() {
         let mut local: HashMap<usize, u32> = HashMap::new();
@@ -103,14 +107,14 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
             *local.entry((hash_dmer(w) as usize) & mask).or_insert(0) += 1;
         }
         for (slot, cnt) in local {
-            scores[i] += cnt as usize * active[slot] as usize;
+            scores[i] += u64::from(cnt) * u64::from(active[slot]);
             inverted.entry(slot).or_default().push((i as u32, cnt));
         }
     }
 
     let mut used = vec![false; n];
     while out.len() < dict_size {
-        let mut best: Option<(usize, usize)> = None; // (score, index)
+        let mut best: Option<(u64, usize)> = None; // (score, index)
         for (i, &score) in scores.iter().enumerate() {
             if used[i] {
                 continue;
@@ -130,24 +134,37 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
         let seg = segments[idx];
         let take = seg.len().min(dict_size - out.len());
         out.extend_from_slice(&seg[..take]);
-        // Cover this segment's d-mers: zero their remaining frequency and
-        // decrement the cached score of every segment that shared them.
-        // The chosen segment's d-mers are recomputed here (this runs only
-        // once per selected segment, far cheaper than keeping a per-segment
-        // slot list resident for the whole corpus). A d-mer that recurs
-        // within this segment is already zeroed on its first occurrence, so
-        // the `freq == 0` guard makes the repeat a no-op (correct dedup).
-        for w in seg.windows(d) {
+        // Cover the d-mers of the bytes we ACTUALLY appended (`seg[..take]`,
+        // not the full segment): zero their remaining frequency and decrement
+        // the cached score of every segment that shared them. The d-mers are
+        // recomputed here (runs once per selected segment, far cheaper than
+        // keeping a per-segment slot list resident for the whole corpus). A
+        // d-mer that recurs within this segment is already zeroed on its
+        // first occurrence, so the `freq == 0` guard makes the repeat a
+        // no-op (correct dedup).
+        for w in seg[..take].windows(d) {
             let slot = (hash_dmer(w) as usize) & mask;
             let freq = active[slot];
             if freq == 0 {
                 continue;
             }
             active[slot] = 0;
+            // Each segment's initial score added `count(slot) * freq` for
+            // this exact `slot` (with `freq` = the build-time frequency,
+            // unchanged until this single zeroing), so subtracting it now is
+            // exact and can never underflow — plain subtraction (no
+            // saturating mask, no overflow: u32*u32 fits u64). The
+            // debug_assert documents the invariant; a violation is a
+            // bookkeeping bug, surfaced loudly rather than silently clamped.
+            let contribution = u64::from(freq);
             if let Some(list) = inverted.get(&slot) {
                 for &(j, cnt) in list {
-                    scores[j as usize] =
-                        scores[j as usize].saturating_sub(cnt as usize * freq as usize);
+                    let delta = u64::from(cnt) * contribution;
+                    debug_assert!(
+                        scores[j as usize] >= delta,
+                        "fastcover score underflow: bookkeeping invariant violated",
+                    );
+                    scores[j as usize] -= delta;
                 }
             }
         }

--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -1,5 +1,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy)]
 pub struct FastCoverParams {
@@ -64,18 +65,6 @@ fn build_frequency_table(sample: &[u8], d: usize, f: u32, accel: usize) -> Vec<u
     table
 }
 
-fn score_segment(segment: &[u8], d: usize, mask: usize, table: &[u32]) -> usize {
-    if segment.len() < d || d == 0 {
-        return 0;
-    }
-    let mut score = 0usize;
-    for i in 0..=(segment.len() - d) {
-        let slot = (hash_dmer(&segment[i..i + d]) as usize) & mask;
-        score += table[slot] as usize;
-    }
-    score
-}
-
 fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> Vec<u8> {
     if sample.is_empty() || dict_size == 0 {
         return Vec::new();
@@ -84,26 +73,83 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
     let params = normalize_fastcover_params(params);
     let k = params.k;
     let d = params.d;
-    let table = build_frequency_table(sample, d, params.f, params.accel);
-    let mask = table.len().saturating_sub(1);
+    let mut active = build_frequency_table(sample, d, params.f, params.accel);
+    let mask = active.len().saturating_sub(1);
 
-    let mut segments: Vec<(usize, &[u8])> = sample
-        .chunks(k)
-        .filter(|seg| seg.len() >= d)
-        .map(|seg| (score_segment(seg, d, mask, &table), seg))
-        .collect();
-    segments.sort_by_key(|segment| core::cmp::Reverse(segment.0));
-
+    let segments: Vec<&[u8]> = sample.chunks(k).filter(|seg| seg.len() >= d).collect();
+    let n = segments.len();
     let mut out = Vec::with_capacity(dict_size);
-    for (_, seg) in segments {
-        if out.len() >= dict_size {
-            break;
+    if n == 0 {
+        return out;
+    }
+
+    // Greedy set-cover selection. The plain top-frequency selection picks
+    // several high-frequency segments that cover the SAME d-mers (redundant
+    // coverage), wasting the dictionary budget. Greedy instead picks, each
+    // round, the segment whose STILL-UNCOVERED d-mers score highest, then
+    // marks those d-mers covered so later rounds value only NEW coverage —
+    // diverse coverage in fewer bytes.
+    //
+    // To keep this affordable at any corpus size (no per-size special-
+    // casing), scores are cached and updated incrementally: an inverted
+    // index `slot -> [(segment, count)]` lets "covering" a chosen segment's
+    // d-mers decrement the score of every other segment containing them in
+    // O(shared occurrences), instead of re-scoring all segments each round.
+    let mut scores = vec![0usize; n];
+    let mut inverted: HashMap<usize, Vec<(u32, u32)>> = HashMap::new();
+    for (i, seg) in segments.iter().enumerate() {
+        let mut local: HashMap<usize, u32> = HashMap::new();
+        for w in seg.windows(d) {
+            *local.entry((hash_dmer(w) as usize) & mask).or_insert(0) += 1;
         }
-        let remaining = dict_size - out.len();
-        if seg.len() <= remaining {
-            out.extend_from_slice(seg);
-        } else {
-            out.extend_from_slice(&seg[..remaining]);
+        for (slot, cnt) in local {
+            scores[i] += cnt as usize * active[slot] as usize;
+            inverted.entry(slot).or_default().push((i as u32, cnt));
+        }
+    }
+
+    let mut used = vec![false; n];
+    while out.len() < dict_size {
+        let mut best: Option<(usize, usize)> = None; // (score, index)
+        for (i, &score) in scores.iter().enumerate() {
+            if used[i] {
+                continue;
+            }
+            if best.is_none_or(|(bs, _)| score > bs) {
+                best = Some((score, i));
+            }
+        }
+        // No remaining segment covers any still-active d-mer — every
+        // distinct pattern is already represented, so adding more (now
+        // redundant) segments would only waste budget. Stop early; the
+        // dict may be < dict_size (a compact dict, like the reference's).
+        let Some((_, idx)) = best.filter(|&(s, _)| s > 0) else {
+            break;
+        };
+        used[idx] = true;
+        let seg = segments[idx];
+        let take = seg.len().min(dict_size - out.len());
+        out.extend_from_slice(&seg[..take]);
+        // Cover this segment's d-mers: zero their remaining frequency and
+        // decrement the cached score of every segment that shared them.
+        // The chosen segment's d-mers are recomputed here (this runs only
+        // once per selected segment, far cheaper than keeping a per-segment
+        // slot list resident for the whole corpus). A d-mer that recurs
+        // within this segment is already zeroed on its first occurrence, so
+        // the `freq == 0` guard makes the repeat a no-op (correct dedup).
+        for w in seg.windows(d) {
+            let slot = (hash_dmer(w) as usize) & mask;
+            let freq = active[slot];
+            if freq == 0 {
+                continue;
+            }
+            active[slot] = 0;
+            if let Some(list) = inverted.get(&slot) {
+                for &(j, cnt) in list {
+                    scores[j as usize] =
+                        scores[j as usize].saturating_sub(cnt as usize * freq as usize);
+                }
+            }
         }
     }
     out

--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -81,7 +81,16 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
     let mut active = build_frequency_table(sample, d, params.f, params.accel);
     let mask = active.len().saturating_sub(1);
 
-    let segments: Vec<&[u8]> = sample.chunks(k).filter(|seg| seg.len() >= d).collect();
+    // Segment indices are stored as `u32` in the inverted index, so cap
+    // the segment count at `u32::MAX` to keep the `i as u32` cast lossless.
+    // A corpus large enough to hit this (> u32::MAX segments, multiple TB)
+    // is far outside dictionary-training territory; the `take` is a no-op
+    // for any realistic input and only drops the unreachable tail otherwise.
+    let segments: Vec<&[u8]> = sample
+        .chunks(k)
+        .filter(|seg| seg.len() >= d)
+        .take(u32::MAX as usize)
+        .collect();
     let n = segments.len();
     let mut out = Vec::with_capacity(dict_size);
     if n == 0 {

--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -1,11 +1,6 @@
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::vec;
 use alloc::vec::Vec;
-// `std::collections::HashMap` is fine here: the whole `dictionary` module
-// is gated behind the `dict_builder` feature, which itself requires `std`
-// (training reads files / uses the system RNG), so this code never
-// compiles into a no_std build. It also matches the existing
-// `std::collections::HashSet` already used by `coverage_score` below.
-use std::collections::HashMap;
 
 #[derive(Debug, Clone, Copy)]
 pub struct FastCoverParams {
@@ -114,9 +109,9 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
     // accumulate in u64 so the arithmetic is exact on 32-bit targets
     // (i686) too, where `usize` would wrap.
     let mut scores = vec![0u64; n];
-    let mut inverted: HashMap<usize, Vec<(u32, u32)>> = HashMap::new();
+    let mut inverted: BTreeMap<usize, Vec<(u32, u32)>> = BTreeMap::new();
     for (i, seg) in segments.iter().enumerate() {
-        let mut local: HashMap<usize, u32> = HashMap::new();
+        let mut local: BTreeMap<usize, u32> = BTreeMap::new();
         for w in seg.windows(d) {
             *local.entry((hash_dmer(w) as usize) & mask).or_insert(0) += 1;
         }
@@ -190,7 +185,7 @@ fn coverage_score(dict: &[u8], eval: &[u8], d: usize, accel: usize) -> usize {
     if dict.len() < d || eval.len() < d || d == 0 {
         return 0;
     }
-    let mut seen = std::collections::HashSet::with_capacity(dict.len() / d + 1);
+    let mut seen = BTreeSet::new();
     for i in 0..=(dict.len() - d) {
         seen.insert(hash_dmer(&dict[i..i + d]));
     }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1057,12 +1057,23 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | CompressionLevel::Level(_) => {
                     let before_len = all_blocks.len();
                     let block_len = uncompressed_data.len();
+                    // A primed dictionary makes "incompressible-looking"
+                    // blocks matchable against the dict, so the raw-fast-
+                    // path inside must be bypassed (it skips matching).
+                    // Mirror prepare_frame's `use_dictionary_state`: a dict
+                    // is only PRIMED (and thus matchable) when the matcher
+                    // supports priming — a non-priming matcher ignores an
+                    // attached dictionary, so the raw-fast-path must stay
+                    // enabled for it. (This arm is already non-Uncompressed.)
+                    let dict_active = self.dictionary.is_some()
+                        && self.state.matcher.supports_dictionary_priming();
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
                         last_block,
                         uncompressed_data,
                         &mut all_blocks,
+                        dict_active,
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         self.block_checksums.as_mut(),
                     );
@@ -2497,6 +2508,98 @@ mod tests {
             .decode_all_to_vec(&hinted_output, &mut decoded)
             .unwrap();
         assert_eq!(decoded, payload);
+    }
+
+    /// A dictionary segment embedded ONCE in otherwise-incompressible
+    /// input must be matched against the dictionary. Before the fix the
+    /// raw-fast-path (which skips matching) fired on the
+    /// incompressible-looking block and the dictionary was never searched,
+    /// so `with_dict` came out the same size as `no_dict` (the embedded
+    /// match was lost). Now the block compresses against the dict.
+    #[test]
+    fn dictionary_segment_in_incompressible_input_is_matched() {
+        // Deterministic LCG bytes: high-entropy, so the only compressible
+        // content is the embedded dictionary segment.
+        fn lcg(seed: u64, n: usize) -> alloc::vec::Vec<u8> {
+            let mut s = seed;
+            (0..n)
+                .map(|_| {
+                    s = s
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    (s >> 56) as u8
+                })
+                .collect()
+        }
+        let dict_id = 0x00DC_7777;
+        let r = lcg(1, 512); // the dictionary content
+        let mut payload = lcg(2, 2000); // incompressible filler before
+        payload.extend_from_slice(&r); // the single dict-matchable segment
+        payload.extend_from_slice(&lcg(3, 1500)); // filler after
+
+        // Precondition: the payload must actually look incompressible so
+        // that the raw-fast-path WOULD fire (and skip matching) without
+        // the fix. If the heuristic ever changes and this no longer holds,
+        // the test below would pass vacuously — assert it up front.
+        assert!(
+            crate::encoding::incompressible::block_looks_incompressible(&payload),
+            "test payload must look incompressible to exercise the raw-fast-path",
+        );
+
+        let compress =
+            |level: super::CompressionLevel, dict: Option<&[u8]>| -> alloc::vec::Vec<u8> {
+                let mut out = alloc::vec::Vec::new();
+                let mut c = FrameCompressor::new(level);
+                if let Some(d) = dict {
+                    c.set_dictionary(
+                        crate::decoding::Dictionary::from_raw_content(dict_id, d.to_vec()).unwrap(),
+                    )
+                    .unwrap();
+                }
+                c.set_source(payload.as_slice());
+                c.set_drain(&mut out);
+                c.compress();
+                out
+            };
+
+        for lvl in [
+            super::CompressionLevel::Level(2),
+            super::CompressionLevel::Level(6),
+            super::CompressionLevel::Level(19),
+        ] {
+            let with_dict = compress(lvl, Some(&r));
+            let no_dict = compress(lvl, None);
+            // The 512-byte dict segment should be matched, saving most of
+            // its length (generous slack for sequence/header coding).
+            assert!(
+                with_dict.len() + 300 < no_dict.len(),
+                "{lvl:?}: dict segment not matched (with_dict={}, no_dict={})",
+                with_dict.len(),
+                no_dict.len(),
+            );
+            // The dict-compressed frame must round-trip through the decoder.
+            let mut decoder = FrameDecoder::new();
+            decoder
+                .add_dict(
+                    crate::decoding::Dictionary::from_raw_content(dict_id, r.clone()).unwrap(),
+                )
+                .unwrap();
+            let mut decoded = Vec::with_capacity(payload.len());
+            decoder.decode_all_to_vec(&with_dict, &mut decoded).unwrap();
+            assert_eq!(decoded, payload, "{lvl:?}: dict round-trip mismatch");
+
+            // A dictionary that does NOT appear in the input must not make
+            // the output larger than the no-dict (raw) encoding: the
+            // post-compress raw fallback covers incompressible-with-dict.
+            let unrelated = lcg(99, 512);
+            let with_bad_dict = compress(lvl, Some(&unrelated));
+            assert!(
+                with_bad_dict.len() <= no_dict.len() + 16,
+                "{lvl:?}: unhelpful dict expanded output (with={}, no_dict={})",
+                with_bad_dict.len(),
+                no_dict.len(),
+            );
+        }
     }
 
     #[test]

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -36,6 +36,12 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     last_block: bool,
     uncompressed_data: Vec<u8>,
     output: &mut Vec<u8>,
+    // When a dictionary is primed, an "incompressible-looking" block can
+    // still compress well by matching the dictionary content, so the
+    // raw-fast-path (which SKIPS matching) must NOT fire — otherwise the
+    // dictionary is never searched and the block is emitted raw. C always
+    // searches and only falls back to raw post-hoc; we mirror that here.
+    dict_active: bool,
     #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = uncompressed_data.len() as u32;
@@ -59,11 +65,13 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if should_emit_raw_fast_path(
-        compression_level,
-        state.matcher.window_size(),
-        &uncompressed_data,
-    ) {
+    } else if !dict_active
+        && should_emit_raw_fast_path(
+            compression_level,
+            state.matcher.window_size(),
+            &uncompressed_data,
+        )
+    {
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
@@ -120,9 +128,18 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         let saved_ml_previous = state.fse_tables.ml_previous.clone();
         let saved_of_previous = state.fse_tables.of_previous.clone();
         compress_block(state, &mut compressed);
-        // If the compressed data is larger than the maximum
-        // allowable block size, instead store uncompressed
-        if compressed.len() >= MAX_BLOCK_SIZE as usize {
+        // If the compressed data is larger than the maximum allowable
+        // block size, store uncompressed. When a dictionary is active we
+        // ALSO fall back to raw whenever compression did not actually
+        // shrink the block (`compressed >= block_size`): the raw-fast-path
+        // was bypassed to give dictionary matching a chance, so a block
+        // that turns out incompressible-even-with-the-dict must still be
+        // emitted raw instead of as a (larger) compressed block. Mirrors
+        // the reference's post-hoc raw fallback; gated on `dict_active` so
+        // the non-dictionary wire output is byte-identical to before.
+        if compressed.len() >= MAX_BLOCK_SIZE as usize
+            || (dict_active && compressed.len() >= block_size as usize)
+        {
             state.offset_hist = saved_offset_hist;
             state.last_huff_table = saved_huff_table;
             state.fse_tables.ll_previous = saved_ll_previous;
@@ -332,6 +349,7 @@ mod tests {
             true,
             vec![0xAB; 1024],
             &mut output,
+            false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );
@@ -375,6 +393,7 @@ mod tests {
             true,
             block.clone(),
             &mut output,
+            false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -428,6 +428,9 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         last_block,
                         block,
                         &mut encoded,
+                        // The streaming encoder has no dictionary state, so the
+                        // raw-fast-path stays enabled (no dict to match against).
+                        false,
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         None,
                     );


### PR DESCRIPTION
## Summary

The fastcover dictionary trainer's segment selector picked the top-frequency non-overlapping `k`-chunks and concatenated them. Several chosen chunks indexed the SAME d-mers (redundant coverage), wasting the dictionary budget on small corpora that have few distinct patterns. This made our trained dictionaries noticeably weaker than the C `zdict` trainer on small sample sets.

Replace the selection with **greedy set-cover**: each round pick the segment whose still-uncovered d-mers score highest, append it, then zero those d-mers so later rounds value only fresh patterns (diverse coverage in fewer bytes).

To keep this affordable at **any** corpus size (no per-size special-casing / no benchmark-fitting), scores are cached and updated through an inverted index `slot -> [(segment, count)]`: covering a chosen segment's d-mers decrements the score of every other segment that shared them in O(shared occurrences), instead of re-scoring all segments each round.

## Quality (FFI encoder, our trained dict vs C-trained dict, compressed bytes — lower is better)

| corpus / level | our dict (before) | our dict (after) | C dict |
|---|---|---|---|
| small-4k-log-lines L1/4/6/19 | 71/63/61/66 | **59/47/46/52** | 44/49/44/44 |
| small-10k-random (all levels) | worse than C | **beats C** (9146 vs 9218) | 9218 |
| decodecorpus-z000033 (large) | 552090… | 552122… (±0.01%) | 550232… |

Small-corpus dictionary quality improves 15-25% and now beats the C-trained dict at some levels; large corpora are unchanged within noise. The win is byte-deterministic (no timing dependence).

## Cost note

The inverted index is O(corpus) memory during training (one-time, offline). This matches the memory profile of optimal set-cover dictionary trainers. The argmax scan is O(segments x rounds); rounds = dict_size / segment_len is small.

## Testing

- 711 lib tests incl dictionary round-trips + cross-validation (FFI decode of our-dict-compressed frames)
- clippy --all-targets + fmt clean
- Byte-deterministic, verified on Mac (dict output is architecture-independent)