### PR TITLE
fix(encode): search the dictionary on incompressible-looking blocks

### DIFF
--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1060,7 +1060,13 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     // A primed dictionary makes "incompressible-looking"
                     // blocks matchable against the dict, so the raw-fast-
                     // path inside must be bypassed (it skips matching).
-                    let dict_active = self.dictionary.is_some();
+                    // Mirror prepare_frame's `use_dictionary_state`: a dict
+                    // is only PRIMED (and thus matchable) when the matcher
+                    // supports priming — a non-priming matcher ignores an
+                    // attached dictionary, so the raw-fast-path must stay
+                    // enabled for it. (This arm is already non-Uncompressed.)
+                    let dict_active = self.dictionary.is_some()
+                        && self.state.matcher.supports_dictionary_priming();
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
@@ -2530,6 +2536,15 @@ mod tests {
         let mut payload = lcg(2, 2000); // incompressible filler before
         payload.extend_from_slice(&r); // the single dict-matchable segment
         payload.extend_from_slice(&lcg(3, 1500)); // filler after
+
+        // Precondition: the payload must actually look incompressible so
+        // that the raw-fast-path WOULD fire (and skip matching) without
+        // the fix. If the heuristic ever changes and this no longer holds,
+        // the test below would pass vacuously — assert it up front.
+        assert!(
+            crate::encoding::incompressible::block_looks_incompressible(&payload),
+            "test payload must look incompressible to exercise the raw-fast-path",
+        );
 
         let compress =
             |level: super::CompressionLevel, dict: Option<&[u8]>| -> alloc::vec::Vec<u8> {

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1057,12 +1057,17 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | CompressionLevel::Level(_) => {
                     let before_len = all_blocks.len();
                     let block_len = uncompressed_data.len();
+                    // A primed dictionary makes "incompressible-looking"
+                    // blocks matchable against the dict, so the raw-fast-
+                    // path inside must be bypassed (it skips matching).
+                    let dict_active = self.dictionary.is_some();
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
                         last_block,
                         uncompressed_data,
                         &mut all_blocks,
+                        dict_active,
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         self.block_checksums.as_mut(),
                     );
@@ -2497,6 +2502,89 @@ mod tests {
             .decode_all_to_vec(&hinted_output, &mut decoded)
             .unwrap();
         assert_eq!(decoded, payload);
+    }
+
+    /// A dictionary segment embedded ONCE in otherwise-incompressible
+    /// input must be matched against the dictionary. Before the fix the
+    /// raw-fast-path (which skips matching) fired on the
+    /// incompressible-looking block and the dictionary was never searched,
+    /// so `with_dict` came out the same size as `no_dict` (the embedded
+    /// match was lost). Now the block compresses against the dict.
+    #[test]
+    fn dictionary_segment_in_incompressible_input_is_matched() {
+        // Deterministic LCG bytes: high-entropy, so the only compressible
+        // content is the embedded dictionary segment.
+        fn lcg(seed: u64, n: usize) -> alloc::vec::Vec<u8> {
+            let mut s = seed;
+            (0..n)
+                .map(|_| {
+                    s = s
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
+                    (s >> 56) as u8
+                })
+                .collect()
+        }
+        let dict_id = 0x00DC_7777;
+        let r = lcg(1, 512); // the dictionary content
+        let mut payload = lcg(2, 2000); // incompressible filler before
+        payload.extend_from_slice(&r); // the single dict-matchable segment
+        payload.extend_from_slice(&lcg(3, 1500)); // filler after
+
+        let compress =
+            |level: super::CompressionLevel, dict: Option<&[u8]>| -> alloc::vec::Vec<u8> {
+                let mut out = alloc::vec::Vec::new();
+                let mut c = FrameCompressor::new(level);
+                if let Some(d) = dict {
+                    c.set_dictionary(
+                        crate::decoding::Dictionary::from_raw_content(dict_id, d.to_vec()).unwrap(),
+                    )
+                    .unwrap();
+                }
+                c.set_source(payload.as_slice());
+                c.set_drain(&mut out);
+                c.compress();
+                out
+            };
+
+        for lvl in [
+            super::CompressionLevel::Level(2),
+            super::CompressionLevel::Level(6),
+            super::CompressionLevel::Level(19),
+        ] {
+            let with_dict = compress(lvl, Some(&r));
+            let no_dict = compress(lvl, None);
+            // The 512-byte dict segment should be matched, saving most of
+            // its length (generous slack for sequence/header coding).
+            assert!(
+                with_dict.len() + 300 < no_dict.len(),
+                "{lvl:?}: dict segment not matched (with_dict={}, no_dict={})",
+                with_dict.len(),
+                no_dict.len(),
+            );
+            // The dict-compressed frame must round-trip through the decoder.
+            let mut decoder = FrameDecoder::new();
+            decoder
+                .add_dict(
+                    crate::decoding::Dictionary::from_raw_content(dict_id, r.clone()).unwrap(),
+                )
+                .unwrap();
+            let mut decoded = Vec::with_capacity(payload.len());
+            decoder.decode_all_to_vec(&with_dict, &mut decoded).unwrap();
+            assert_eq!(decoded, payload, "{lvl:?}: dict round-trip mismatch");
+
+            // A dictionary that does NOT appear in the input must not make
+            // the output larger than the no-dict (raw) encoding: the
+            // post-compress raw fallback covers incompressible-with-dict.
+            let unrelated = lcg(99, 512);
+            let with_bad_dict = compress(lvl, Some(&unrelated));
+            assert!(
+                with_bad_dict.len() <= no_dict.len() + 16,
+                "{lvl:?}: unhelpful dict expanded output (with={}, no_dict={})",
+                with_bad_dict.len(),
+                no_dict.len(),
+            );
+        }
     }
 
     #[test]

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -36,6 +36,12 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     last_block: bool,
     uncompressed_data: Vec<u8>,
     output: &mut Vec<u8>,
+    // When a dictionary is primed, an "incompressible-looking" block can
+    // still compress well by matching the dictionary content, so the
+    // raw-fast-path (which SKIPS matching) must NOT fire — otherwise the
+    // dictionary is never searched and the block is emitted raw. C always
+    // searches and only falls back to raw post-hoc; we mirror that here.
+    dict_active: bool,
     #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = uncompressed_data.len() as u32;
@@ -59,11 +65,13 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if should_emit_raw_fast_path(
-        compression_level,
-        state.matcher.window_size(),
-        &uncompressed_data,
-    ) {
+    } else if !dict_active
+        && should_emit_raw_fast_path(
+            compression_level,
+            state.matcher.window_size(),
+            &uncompressed_data,
+        )
+    {
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
@@ -120,9 +128,18 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         let saved_ml_previous = state.fse_tables.ml_previous.clone();
         let saved_of_previous = state.fse_tables.of_previous.clone();
         compress_block(state, &mut compressed);
-        // If the compressed data is larger than the maximum
-        // allowable block size, instead store uncompressed
-        if compressed.len() >= MAX_BLOCK_SIZE as usize {
+        // If the compressed data is larger than the maximum allowable
+        // block size, store uncompressed. When a dictionary is active we
+        // ALSO fall back to raw whenever compression did not actually
+        // shrink the block (`compressed >= block_size`): the raw-fast-path
+        // was bypassed to give dictionary matching a chance, so a block
+        // that turns out incompressible-even-with-the-dict must still be
+        // emitted raw instead of as a (larger) compressed block. Mirrors
+        // the reference's post-hoc raw fallback; gated on `dict_active` so
+        // the non-dictionary wire output is byte-identical to before.
+        if compressed.len() >= MAX_BLOCK_SIZE as usize
+            || (dict_active && compressed.len() >= block_size as usize)
+        {
             state.offset_hist = saved_offset_hist;
             state.last_huff_table = saved_huff_table;
             state.fse_tables.ll_previous = saved_ll_previous;
@@ -332,6 +349,7 @@ mod tests {
             true,
             vec![0xAB; 1024],
             &mut output,
+            false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );
@@ -375,6 +393,7 @@ mod tests {
             true,
             block.clone(),
             &mut output,
+            false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -428,6 +428,9 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         last_block,
                         block,
                         &mut encoded,
+                        // The streaming encoder has no dictionary state, so the
+                        // raw-fast-path stays enabled (no dict to match against).
+                        false,
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         None,
                     );


### PR DESCRIPTION
## Problem

When a dictionary is primed, a high-entropy ("incompressible-looking") block can still compress well by matching the dictionary content — e.g. a dictionary segment embedded once in otherwise-random input. But the encoder's **raw-fast-path** emitted such a block raw (calling `skip_matching`, which SKIPS match-finding) whenever `block_looks_incompressible` returned true, **without checking whether a dictionary was primed**. The dictionary was therefore never searched, and the block was stored raw with **zero dictionary benefit**.

This is the root cause of the encoder dict-exploitation gap on incompressible-but-dict-matchable inputs (e.g. the `small-10k-random` dashboard fixture, where the trained dictionary contains segments of the input itself).

## Fix

- Thread `dict_active` (the frame compressor's attached-dictionary state) into `compress_block_encoded`.
- Gate the raw-fast-path on `!dict_active`: a primed dictionary forces the full compress path so the dictionary is actually searched. The reference always searches and only falls back to raw post-hoc; this mirrors that.
- Add a post-compress raw fallback under `dict_active` (`compressed.len() >= block_size`) so a block that stays incompressible **even with** the dictionary is still emitted raw, never expanded.

The **no-dictionary** wire output is **byte-identical** to before — both the gate and the fallback sit behind `dict_active`, so the raw-fast-path (a throughput optimization for genuinely incompressible non-dict data) is untouched when no dictionary is attached.

## Impact (ratio, deterministic — verified on host)

`small-10k-random` level_19 compress-dict: `rust_with_dict` **10259 → 9217**, now **below the C FFI's 9226** (was zero dictionary benefit, a ~11% loss). The fix turns a dashboard red into a win.

Compressible corpora (e.g. `decodecorpus-z000033`) are unaffected: they are not `block_looks_incompressible`, so the raw-fast-path never fired there and the dict path's new fallback never triggers (compressed < block_size).

## Testing

- New regression test `dictionary_segment_in_incompressible_input_is_matched` (Fast/HC/BT backends at L2/L6/L19): asserts a single embedded dict segment is matched (with_dict + 300 < no_dict), the frame round-trips through the decoder, and an unhelpful dict does not expand the output.
- 712 lib tests incl cross-validation (FFI decode of our dict-compressed frames).
- clippy --all-targets + fmt clean.