### PR TITLE
fix(fuzz): bound decode target output to avoid decompression-bomb OOM

### DIFF
--- a/zstd/fuzz/fuzz_targets/decode.rs
+++ b/zstd/fuzz/fuzz_targets/decode.rs
@@ -2,17 +2,16 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 
-use std::io::Read;
+use std::io::{self, Read};
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(decoder) = structured_zstd::decoding::StreamingDecoder::new(data) {
-        let mut output = Vec::new();
         // Cap decoded output: an adversarial frame can legitimately
         // decompress to far more than its input (RLE / repeated matches),
-        // so an unbounded `read_to_end` would OOM the fuzzer materializing
-        // a multi-GB decompression bomb. The decoder streams correctly;
-        // bounding total output is the caller's policy. 256 MiB exercises
-        // every decode path without the OOM risk.
-        let _ = decoder.take(256 << 20).read_to_end(&mut output);
+        // so an unbounded read would OOM the fuzzer materializing a
+        // multi-GB decompression bomb. Stream the bounded output through
+        // `io::sink()` so the decoder still walks every decode path
+        // (up to 256 MiB) without ever buffering it in memory.
+        let _ = io::copy(&mut decoder.take(256 << 20), &mut io::sink());
     }
 });

--- a/zstd/fuzz/fuzz_targets/decode.rs
+++ b/zstd/fuzz/fuzz_targets/decode.rs
@@ -5,8 +5,14 @@ extern crate libfuzzer_sys;
 use std::io::Read;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(mut decoder) = structured_zstd::decoding::StreamingDecoder::new(data) {
+    if let Ok(decoder) = structured_zstd::decoding::StreamingDecoder::new(data) {
         let mut output = Vec::new();
-        _ = decoder.read_to_end(&mut output);
+        // Cap decoded output: an adversarial frame can legitimately
+        // decompress to far more than its input (RLE / repeated matches),
+        // so an unbounded `read_to_end` would OOM the fuzzer materializing
+        // a multi-GB decompression bomb. The decoder streams correctly;
+        // bounding total output is the caller's policy. 256 MiB exercises
+        // every decode path without the OOM risk.
+        let _ = decoder.take(256 << 20).read_to_end(&mut output);
     }
 });


### PR DESCRIPTION
## Problem

The `decode` fuzz target read arbitrary input into an unbounded `Vec` via `read_to_end`:

```rust
let mut decoder = StreamingDecoder::new(data)?;
let mut output = Vec::new();
_ = decoder.read_to_end(&mut output);
```

An adversarial frame legitimately decompresses to far more than its input (RLE blocks, repeated matches), so the unbounded read materialized a multi-GB decompression bomb and OOM-killed the fuzzer:

```
==> ERROR: libFuzzer: out-of-memory (malloc(2200682496))
```

This surfaced as a red `Fuzz smoke` job (non-deterministic — empty seed corpus, random input), unrelated to whatever PR happens to be running.

## Root cause is NOT the decoder

The decoder is correct here:
- The window is already capped at 100 MiB (`MAXIMUM_ALLOWED_WINDOW_SIZE`) in `FrameDecoderState::new_with_format`, so a frame declaring a huge window (e.g. window_log 31 → 2 GiB) is **rejected**, not allocated.
- Decode output is streamed block-by-block (≤ 128 KiB per block); there is no single oversized allocation in the decoder.

The 2.2 GiB allocation is the **harness's** `read_to_end` Vec growing to the full decompressed size. Bounding total decoded output is a caller policy, not a decoder invariant.

## Fix

Cap the harness output at 256 MiB with `Read::take` — enough to exercise every decode path, but it can't be driven into a multi-GB bomb:

```rust
let _ = decoder.take(256 << 20).read_to_end(&mut output);
```

Other fuzz targets are unaffected: `encode` and `interop` decode only their own freshly-compressed (input-bounded) output, never an arbitrary adversarial frame.

## Testing

- `cargo check` on the fuzz crate passes (target builds).
- Library code is unchanged; lib tests / clippy / fmt are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decompression safety in testing by capping decoded output at 256 MiB and switching to streaming copy to avoid excessive memory use; added comments explaining the decompression-bomb / OOM risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->