### PR TITLE
perf(encode): hoist hash-table slice + hash_log in Fast kernel

### DIFF
--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -202,48 +202,21 @@ impl FastHashTable {
     #[inline(always)]
     pub(crate) unsafe fn hash_ptr<const MLS: u32>(&self, ptr: *const u8) -> u32 {
         debug_assert_eq!(MLS, self.mls, "monomorphised MLS must match table mls");
-        match MLS {
-            4 => {
-                // SAFETY: caller guarantees ≥4 readable bytes at ptr.
-                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u32>()) }.to_le();
-                u.wrapping_mul(PRIME_4_BYTES) >> (32 - self.hash_log)
-            }
-            5 => {
-                // SAFETY: caller guarantees ≥8 readable bytes per the
-                // method-level doc — every MLS≥5 path performs a
-                // wide u64 load and shifts off the unused top bits;
-                // a 5-byte promise would leave 3 bytes of the load
-                // past the caller's range.
-                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
-                ((u << (64 - 40)).wrapping_mul(PRIME_5_BYTES) >> (64 - self.hash_log)) as u32
-            }
-            6 => {
-                // SAFETY: caller guarantees ≥8 readable bytes (u64
-                // load — only the bottom 48 bits feed the hash, but
-                // the LOAD is still 8 bytes wide).
-                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
-                ((u << (64 - 48)).wrapping_mul(PRIME_6_BYTES) >> (64 - self.hash_log)) as u32
-            }
-            7 => {
-                // SAFETY: caller guarantees ≥8 readable bytes (u64
-                // load — bottom 56 bits feed the hash; LOAD is 8).
-                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
-                ((u << (64 - 56)).wrapping_mul(PRIME_7_BYTES) >> (64 - self.hash_log)) as u32
-            }
-            8 => {
-                // SAFETY: caller guarantees ≥8 readable bytes — the
-                // donor reads the full u64 unchanged for mls=8.
-                let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
-                (u.wrapping_mul(PRIME_8_BYTES) >> (64 - self.hash_log)) as u32
-            }
-            _ => {
-                // Compile-time unreachable for monomorphised callers;
-                // emitting an `unreachable_unchecked()` here would be
-                // UB in debug builds if anyone instantiates a bad MLS.
-                debug_assert!(false, "unsupported MLS {MLS}");
-                0
-            }
-        }
+        // SAFETY: forwarded — caller upholds `hash_ptr`'s readable-bytes
+        // contract; `self.hash_log` is the table's own log.
+        unsafe { hash_ptr_raw::<MLS>(ptr, self.hash_log) }
+    }
+
+    /// Hoist the table's backing slice + `hash_log` into locals for a hot
+    /// loop. Binding `&mut [u32]` to a local caches the `(ptr, len)` once, so
+    /// per-position `get_unchecked` / `get_unchecked_mut` don't reload the
+    /// `Vec` header on every access — the optimiser otherwise conservatively
+    /// re-reads it through `&mut FastHashTable` after each interior write
+    /// (the "chases the Vec" reload). Pair with [`hash_ptr_raw`] so the loop
+    /// never touches `self` and stays reload-free.
+    #[inline(always)]
+    pub(crate) fn hot_state(&mut self) -> (&mut [u32], u32) {
+        (self.table.as_mut_slice(), self.hash_log)
     }
 
     /// Direct table access — `table[hash]`. Bounds-check at index time
@@ -276,6 +249,50 @@ impl FastHashTable {
         // SAFETY: see method-level doc.
         unsafe {
             *self.table.get_unchecked_mut(hash as usize) = pos;
+        }
+    }
+}
+
+/// Free-function form of [`FastHashTable::hash_ptr`] taking `hash_log`
+/// explicitly so a hot loop can hoist it into a register once (via
+/// [`FastHashTable::hot_state`]) instead of re-reading `self.hash_log` per
+/// hash. Bit-for-bit identical to the method.
+///
+/// # Safety
+/// Same readable-bytes contract as [`FastHashTable::hash_ptr`]: `MLS == 4`
+/// needs ≥4 readable bytes at `ptr`, `MLS >= 5` needs ≥8. `hash_log` must be
+/// in `1..=30` (the constructor's accepted band) so the shift is well-defined.
+#[inline(always)]
+pub(crate) unsafe fn hash_ptr_raw<const MLS: u32>(ptr: *const u8, hash_log: u32) -> u32 {
+    match MLS {
+        4 => {
+            // SAFETY: caller guarantees ≥4 readable bytes at ptr.
+            let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u32>()) }.to_le();
+            u.wrapping_mul(PRIME_4_BYTES) >> (32 - hash_log)
+        }
+        5 => {
+            // SAFETY: caller guarantees ≥8 readable bytes (wide u64 load).
+            let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+            ((u << (64 - 40)).wrapping_mul(PRIME_5_BYTES) >> (64 - hash_log)) as u32
+        }
+        6 => {
+            // SAFETY: caller guarantees ≥8 readable bytes (u64 load).
+            let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+            ((u << (64 - 48)).wrapping_mul(PRIME_6_BYTES) >> (64 - hash_log)) as u32
+        }
+        7 => {
+            // SAFETY: caller guarantees ≥8 readable bytes (u64 load).
+            let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+            ((u << (64 - 56)).wrapping_mul(PRIME_7_BYTES) >> (64 - hash_log)) as u32
+        }
+        8 => {
+            // SAFETY: caller guarantees ≥8 readable bytes (full u64).
+            let u = unsafe { core::ptr::read_unaligned(ptr.cast::<u64>()) }.to_le();
+            (u.wrapping_mul(PRIME_8_BYTES) >> (64 - hash_log)) as u32
+        }
+        _ => {
+            debug_assert!(false, "unsupported MLS {MLS}");
+            0
         }
     }
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -9,7 +9,7 @@
 //! per-call via the `USE_CMOV` const generic.
 
 use super::count::count_forward;
-use super::hash_table::FastHashTable;
+use super::hash_table::{FastHashTable, hash_ptr_raw};
 use crate::encoding::Sequence;
 
 /// Per-iteration diagnostic tracing of the Fast kernel inner loop.
@@ -513,6 +513,12 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         step_size,
         MLS,
     );
+    // Hoist the hash table's backing slice + hash_log into locals so the hot
+    // loop's `get`/`put`/hash compute don't re-read the `Vec` header / the
+    // `hash_log` field through `&mut FastHashTable` on every access (see
+    // `FastHashTable::hot_state`). The table is fixed-size for the frame, so
+    // the slice ptr stays valid for the whole loop.
+    let (table, hlog) = hash_table.hot_state();
     'restart: while ip0 < ilimit {
         // _start: setup. ip0 already positioned; derive ip1/ip2/ip3
         // from current step. If even ip3 is past ilimit, the loop
@@ -537,9 +543,9 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
         // SAFETY: ip0, ip1 < ilimit = iend - 8, so ≥ 8 readable
         // bytes at each `base + ip*`. MLS ≤ 8 matches hash_ptr's
         // contract.
-        let mut hash0 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
-        let mut hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip1)) };
-        let mut match_idx = unsafe { hash_table.get(hash0) };
+        let mut hash0 = unsafe { hash_ptr_raw::<MLS>(base.add(ip0), hlog) };
+        let mut hash1 = unsafe { hash_ptr_raw::<MLS>(base.add(ip1), hlog) };
+        let mut match_idx = unsafe { *table.get_unchecked(hash0 as usize) };
         ktrace!(
             "OUTER ip0={} ip1={} ip2={} ip3={} step={} hash0={} hash1={} match_idx={} rep1={} rep2={}",
             ip0,
@@ -605,7 +611,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             // SAFETY: hash0 from hash_ptr ⇒ in-bounds; ip0 ≤ u32::MAX
             // by the entry-point cap.
             ktrace!("PUT hash0={} pos={} (iter-start)", hash0, ip0);
-            unsafe { hash_table.put(hash0, ip0 as u32) };
+            unsafe { *table.get_unchecked_mut(hash0 as usize) = ip0 as u32 };
 
             // Repcode-at-ip2 check. Bitwise `&` (not short-circuit `&&`)
             // so both operands evaluate unconditionally — the
@@ -652,7 +658,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // match site), so its position won't conflict with
                 // the match's forward extension. Donor lines 286-287.
                 ktrace!("PUT hash1={} pos={} (rep-emit post)", hash1, ip1);
-                unsafe { hash_table.put(hash1, ip1 as u32) };
+                unsafe { *table.get_unchecked_mut(hash1 as usize) = ip1 as u32 };
                 ktrace!(
                     "MATCH rep new_ip={} match0={} m_len={} offset={}",
                     new_ip,
@@ -678,7 +684,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // Safe writeback for hash1 (ip1 = ip0 + 1, before
                 // search resumption). Donor line 296.
                 ktrace!("PUT hash1={} pos={} (explicit1 post)", hash1, ip1);
-                unsafe { hash_table.put(hash1, ip1 as u32) };
+                unsafe { *table.get_unchecked_mut(hash1 as usize) = ip1 as u32 };
                 ktrace!(
                     "MATCH explicit1 ip0={} match_idx={} offset={}",
                     ip0,
@@ -697,16 +703,16 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             // the CURRENT ip2 (before the cursor shift below), which
             // becomes the new ip1 — so post-shift `hash1` matches
             // the new `ip1`, NOT the new `ip2`.
-            match_idx = unsafe { hash_table.get(hash1) };
+            match_idx = unsafe { *table.get_unchecked(hash1 as usize) };
             hash0 = hash1;
-            hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip2)) };
+            hash1 = unsafe { hash_ptr_raw::<MLS>(base.add(ip2), hlog) };
             ip0 = ip1;
             ip1 = ip2;
             ip2 = ip3;
 
             // Writeback for new ip0. Donor lines 314-315.
             ktrace!("PUT hash0={} pos={} (post-shift1)", hash0, ip0);
-            unsafe { hash_table.put(hash0, ip0 as u32) };
+            unsafe { *table.get_unchecked_mut(hash0 as usize) = ip0 as u32 };
 
             // Second explicit-match probe at the shifted ip0
             // (donor line 317).
@@ -719,7 +725,7 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // past the match start when we resume scanning.
                 if step <= 4 {
                     ktrace!("PUT hash1={} pos={} (explicit2 post, step<=4)", hash1, ip1);
-                    unsafe { hash_table.put(hash1, ip1 as u32) };
+                    unsafe { *table.get_unchecked_mut(hash1 as usize) = ip1 as u32 };
                 }
                 ktrace!(
                     "MATCH explicit2 ip0={} match_idx={} offset={}",
@@ -738,9 +744,9 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
             // shift is the one that advances ip2/ip3 by `step`
             // rather than by 1; this is where the step-skip kicks
             // in. Donor lines 329-339.
-            match_idx = unsafe { hash_table.get(hash1) };
+            match_idx = unsafe { *table.get_unchecked(hash1 as usize) };
             hash0 = hash1;
-            hash1 = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip2)) };
+            hash1 = unsafe { hash_ptr_raw::<MLS>(base.add(ip2), hlog) };
             ip0 = ip1;
             ip1 = ip2;
             // Same overflow defence as the loop-head setup: a wild
@@ -912,12 +918,12 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 // guarantees `current0 + 2 + HASH_READ_SIZE` fits in
                 // `usize`, so the `+ 2` cannot wrap.
                 let current0_plus_2 = current0 + 2;
-                let h_fwd = unsafe { hash_table.hash_ptr::<MLS>(base.add(current0_plus_2)) };
-                unsafe { hash_table.put(h_fwd, current0_plus_2 as u32) };
+                let h_fwd = unsafe { hash_ptr_raw::<MLS>(base.add(current0_plus_2), hlog) };
+                unsafe { *table.get_unchecked_mut(h_fwd as usize) = current0_plus_2 as u32 };
             }
             if ip0 >= 2 {
-                let h_back = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0 - 2)) };
-                unsafe { hash_table.put(h_back, (ip0 - 2) as u32) };
+                let h_back = unsafe { hash_ptr_raw::<MLS>(base.add(ip0 - 2), hlog) };
+                unsafe { *table.get_unchecked_mut(h_back as usize) = (ip0 - 2) as u32 };
             }
 
             // Repcode-2 inner loop. Donor swaps rep1 / rep2 on each
@@ -944,8 +950,8 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
                 core::mem::swap(&mut rep_offset1, &mut rep_offset2);
 
                 // Hash refill at ip0 (donor line 415).
-                let h_at = unsafe { hash_table.hash_ptr::<MLS>(base.add(ip0)) };
-                unsafe { hash_table.put(h_at, ip0 as u32) };
+                let h_at = unsafe { hash_ptr_raw::<MLS>(base.add(ip0), hlog) };
+                unsafe { *table.get_unchecked_mut(h_at as usize) = ip0 as u32 };
 
                 // Emit lit_len=0 rep1 sequence.
                 // SAFETY: this immediate-rep2 branch runs with `anchor ==


### PR DESCRIPTION
## Summary

Removes the "chases the Vec" per-access reload from the no-dict Fast
encoder kernel's hot loop.

The loop did `hash_table.get` / `.put` / `.hash_ptr` per cursor through
`&mut FastHashTable`. After each interior write the optimiser
conservatively re-reads the `Vec` header (`ptr`, `len`) and the `hash_log`
field on the next access. This hoists the backing slice and `hash_log` into
loop locals once (`FastHashTable::hot_state`) and computes hashes through a
new free `hash_ptr_raw` that takes `hash_log` explicitly, so the 19
per-position accesses no longer reload.

The table is fixed-size for the frame, so the hoisted slice `(ptr, len)` is
loop-invariant. Only the no-dict kernel is converted here.

## Results (i9, `compress/level_-1_fast/decodecorpus-z000033`)

- `pure_rust`: **-0.28%** (p = 0.00) vs the base branch.
- `c_ffi` control: flat (+0.01%, p = 0.95) — machine stable, the delta is
  real.

Small but real and safe; the kind of hot-path instruction-count reduction
that accumulates. Byte-identical output.

## Testing

- 712 unit/integration tests pass (incl. roundtrip + cross-validation).
- clippy (`hash,std,dict_builder,bench_internals --benches` and no-std
  sets) and `fmt` clean.

## Note

Stacked on #328 (Fast dict size-gate); base will retarget to `main` once
that merges.
