### PR TITLE
perf(encode): close level-5 greedy speed gap (row match-span cap)

### DIFF
--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -216,6 +216,26 @@ const ROW_CONFIG: RowConfig = RowConfig {
     target_len: ROW_TARGET_LEN,
 };
 
+// Level-5 greedy is the ONLY strategy routed to the Row backend
+// (`StrategyTag::backend`: greedy -> Row; lazy / btopt / btultra* ->
+// HashChain), so it is the only level whose `row:` field is read. The donor
+// `clevels.h` default row (srcSize > 256 KB) for level 5 is searchLog=3,
+// targetLength=2, from which the row matcher derives:
+//   rowLog       = clamp(searchLog, 4, 6) = 4
+//   search_depth = 1 << min(searchLog, rowLog) = 8   (= nbAttempts)
+//   target_len   = targetLength = 2                  (nice-match early-out)
+// The shared `ROW_CONFIG` (row_log=5, search_depth=16, target_len=48) ran a
+// level-12-grade search here: 16 slots per row, never early-exiting until a
+// 48-byte match. That exhaustive walk was the dominant cost in greedy L5's
+// encode-speed regression vs FFI. `hash_bits` stays at the `ROW_HASH_BITS`
+// cap (the row table size is a separate budget).
+const ROW_L5: RowConfig = RowConfig {
+    hash_bits: ROW_HASH_BITS,
+    row_log: 4,
+    search_depth: 8,
+    target_len: 2,
+};
+
 /// Resolved tuning parameters for a compression level. The
 /// [`StrategyTag`] is the single source of truth for the backend
 /// family and the compile-time strategy consts; the runtime
@@ -285,7 +305,7 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // search_depth iterations instead of breaking on the first
     // long-enough match — the dominant cost in the L5..=L15 speed
     // regression vs FFI (see lazy_band_target_len_matches_donor_default_table).
-    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 2 }, row: ROW_CONFIG },
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 2 }, row: ROW_L5 },
     /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }, row: ROW_CONFIG },
     /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }, row: ROW_CONFIG },
     /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
@@ -5747,7 +5767,9 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
     let full_rows = driver.row_matcher().row_heads.len();
-    assert_eq!(full_rows, 1 << (ROW_HASH_BITS - ROW_LOG));
+    // Level 5 uses the donor row_log (clamp(searchLog=3, 4, 6) = 4), not the
+    // shared ROW_LOG, so the row count is 1 << (hash_bits - ROW_L5.row_log).
+    assert_eq!(full_rows, 1 << (ROW_HASH_BITS - ROW_L5.row_log));
 
     driver.set_source_size_hint(1024);
     driver.reset(CompressionLevel::Level(5));
@@ -5761,7 +5783,7 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     assert_eq!(driver.window_size(), 1 << MIN_HINTED_WINDOW_LOG);
     assert_eq!(
         hinted_rows,
-        1 << ((MIN_HINTED_WINDOW_LOG as usize) - ROW_LOG)
+        1 << ((MIN_HINTED_WINDOW_LOG as usize) - ROW_L5.row_log)
     );
     assert!(
         hinted_rows < full_rows,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -482,7 +482,7 @@ impl RowMatchGenerator {
 
             let best = self.best_match(abs_pos, lit_len);
             if let Some(candidate) = self.pick_lazy_match(abs_pos, lit_len, best) {
-                self.insert_positions(abs_pos, candidate.start + candidate.match_len);
+                self.insert_match_span(abs_pos, candidate.start + candidate.match_len);
                 let current = self.window.back().unwrap().as_slice();
                 let start = candidate.start - current_abs_start;
                 let literals = &current[literals_start..start];
@@ -703,7 +703,7 @@ impl RowMatchGenerator {
             // `candidate.start` lower bound regresses `rust_bytes` by
             // ~+447 over `abs_pos` (537897 -> 538344), so the
             // narrower range is intentional.
-            self.insert_positions(abs_pos, candidate.start + candidate.match_len);
+            self.insert_match_span(abs_pos, candidate.start + candidate.match_len);
             let current = self.window.back().unwrap().as_slice();
             let literals = &current[literals_start..start];
             handle_sequence(Sequence::Triple {
@@ -930,6 +930,28 @@ impl RowMatchGenerator {
     fn insert_positions(&mut self, start: usize, end: usize) {
         for pos in start..end {
             self.insert_position(pos);
+        }
+    }
+
+    /// Index a just-emitted match span, mirroring the donor
+    /// `ZSTD_row_update_internal` skip-threshold (`zstd_lazy.c:922-940`):
+    /// when the span exceeds `SKIP_THRESHOLD` positions, only the first
+    /// `MAX_START` and last `MAX_END` are indexed and the interior is
+    /// skipped. Indexing every interior byte of a long match is
+    /// O(matchlen) and dominates encode time on periodic inputs (e.g.
+    /// repeated log lines), where a single greedy/lazy match can span an
+    /// entire block: that O(matchlen) fill, not the search, is what left
+    /// the row backend ~11x slower than FFI on those streams. The donor
+    /// caps the fill at 96 + 32 positions regardless of match length.
+    fn insert_match_span(&mut self, start: usize, end: usize) {
+        const SKIP_THRESHOLD: usize = 384;
+        const MAX_START: usize = 96;
+        const MAX_END: usize = 32;
+        if end.saturating_sub(start) > SKIP_THRESHOLD {
+            self.insert_positions(start, start + MAX_START);
+            self.insert_positions(end - MAX_END, end);
+        } else {
+            self.insert_positions(start, end);
         }
     }
 

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -653,24 +653,20 @@ impl RowMatchGenerator {
             //     ties / near-ties the rep wins by being cheaper to
             //     encode (single-digit-bit offset code vs 9-13 bits for
             //     a regular offset).
-            let regular_match = self.row_candidate(abs_pos, lit_len);
-            let chosen = match (rep_match, regular_match) {
-                (Some(rep), Some(reg)) => {
-                    // Prefer the longer; tie-break to rep for cheaper
-                    // encoding. `best_len_offset_candidate` ties on
-                    // shorter offset which is the wrong direction for
-                    // rep-vs-regular (regular offsets are always bigger
-                    // than the corresponding rep, so it would always
-                    // pick rep on ties — that's the right choice here
-                    // but we want strict length preference too).
-                    if reg.match_len > rep.match_len {
-                        Some(reg)
-                    } else {
-                        Some(rep)
-                    }
-                }
-                (Some(rep), None) => Some(rep),
-                (None, reg) => reg,
+            // Donor greedy (depth 0): a repcode hit commits immediately and
+            // SKIPS the regular row search (`zstd_lazy.c:2039`,
+            // `if (depth==0) goto _storeSequence`). The regular
+            // `row_candidate` (SIMD row scan + match extension) is the
+            // dominant per-position cost; running it on every rep hit made
+            // rep-dense inputs (repetitive logs) up to ~11x slower than the
+            // donor, which short-circuits. So only run the regular search
+            // when there is no rep to take. `row_candidate` is `&self` (a
+            // pure search, no table mutation), so skipping it drops no hash
+            // insert — the post-emit `insert_positions(abs_pos, ..)` still
+            // indexes the committed span.
+            let chosen = match rep_match {
+                Some(rep) => Some(rep),
+                None => self.row_candidate(abs_pos, lit_len),
             };
 
             let Some(candidate) = chosen else {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -902,7 +902,15 @@ impl RowMatchGenerator {
             if match_len >= ROW_MIN_MATCH_LEN {
                 let candidate = self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len);
                 best = best_len_offset_candidate(best, Some(candidate));
-                if best.is_some_and(|best| best.match_len >= self.target_len) {
+                // Donor `ZSTD_RowFindBestMatch` walks every probed slot and
+                // keeps the longest; its only early break is "best possible"
+                // (the match already reaches the block end, so no later slot
+                // can beat it). cParams.targetLength is the LAZY outer loop's
+                // nice-match threshold, NOT a row-search cutoff — gating the
+                // row walk on it (target_len=2 at level 5) returned the first
+                // most-recent slot instead of the longest, inflating sequence
+                // count and losing ratio. Keep only the best-possible break.
+                if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
                     return best;
                 }
             }


### PR DESCRIPTION
## Summary

Close the level-5 greedy encode-speed gap vs FFI, dominated by the
`large-log-stream` scenario. Four donor-aligned changes to the Row backend
(greedy is the only strategy routed to it):

1. **Donor row params for level 5.** Level 5 used the shared `ROW_CONFIG`
   (`row_log=5`, `search_depth=16`, `target_len=48`). The reference level-5
   row is `searchLog=3` / `targetLength=2`, giving `row_log=4`,
   `nbAttempts=8`.

2. **Short-circuit the regular search on a greedy repcode hit**
   (`zstd_lazy.c:2039`, `if (depth==0) goto _storeSequence`): commit the rep
   and skip the per-position regular search.

3. **Cap match-span indexing (the dominant cost).** Indexing every interior
   position of an emitted match is O(matchlen); on periodic input a single
   match spans a whole block. The reference caps this at 96 + 32 positions
   (`ZSTD_row_update_internal`, `zstd_lazy.c:922`). `insert_match_span`
   mirrors it, turning the fill into O(1) per long match.

4. **Walk all row slots, drop the targetLength search cutoff.**
   `row_candidate` returned on the first match reaching `target_len`; with
   `targetLength=2` that took the most-recent (short) match instead of the
   longest. The reference `ZSTD_RowFindBestMatch` walks every probed slot
   and keeps the longest (`targetLength` is the lazy nice-match threshold,
   not a row-search cutoff).

## Benchmark (i9-9900K, compress, level 5 greedy, vs main, c_ffi control flat)

| fixture | before | after | vs C reference |
|---------|--------|-------|----------------|
| large-log-stream | 759 ms | **41.2 ms** (-94.6%) | 19.8x -> **1.09x** |
| decodecorpus-z000033 | 42.6 ms | 38.3 ms (-10%) | 4.6x -> 4.3x |

Sequence alignment vs the reference on z000033 improves from 43% to 64%
match (our sequence count drops 54569 -> 51794, reference 51577).

`large-log-stream` output is 7.4% smaller than the C reference;
`decodecorpus-z000033` is ~5.7% larger, a residual row-greedy
match-quality gap (offset/repcode selection on the differing sequences),
tracked separately.

## Testing

Tests pass (roundtrip + cross-validation + per-level param dispatch),
clippy and fmt clean.
