### PR TITLE
ci(bench): rebalance fast shards, move level_-2_fast to fast-neg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,11 +410,11 @@ jobs:
           [
             {
               "id": "fast-neg",
-              "levels": "level_-7_fast,level_-6_fast,level_-5_fast,level_-4_fast,level_-3_fast"
+              "levels": "level_-7_fast,level_-6_fast,level_-5_fast,level_-4_fast,level_-3_fast,level_-2_fast"
             },
             {
               "id": "fast-dfast",
-              "levels": "level_-2_fast,level_-1_fast,level_1_fast,level_2_fast,level_3_dfast,level_4_dfast,level_5_greedy"
+              "levels": "level_-1_fast,level_1_fast,level_2_fast,level_3_dfast,level_4_dfast,level_5_greedy"
             },
             {
               "id": "lazy-lower",


### PR DESCRIPTION
Move the lowest level out of the oversized `fast-dfast` shard (7 levels) into `fast-neg` (5 levels) so the two fast shards are balanced at 6 each. `level_-2_fast` is a negative fast level, so it belongs with the other negatives. Cuts the longest fast shard's wall-clock; no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for benchmark matrix optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->