### PR TITLE
perf(encode): block-split greedy/lazy blocks for better literal ratio

### DIFF
--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -93,8 +93,21 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         let mut compressed = Vec::new();
         let uncompressed_len = uncompressed_data.len();
         state.matcher.commit_space(uncompressed_data);
-        if matches!(compression_level, CompressionLevel::Level(16..=22))
-            && state.matcher.window_size() >= (1 << 17)
+        // Block splitting fits entropy tables to local statistics, the
+        // dominant literal-section win on mixed corpora (z000033 level 5:
+        // a single 128 KiB block spans varied literal distributions and
+        // carries one ill-fitting HUF table). Previously gated to btopt+
+        // (`Level(16..=22)`), which left greedy/lazy emitting un-split
+        // blocks. Extend to every search-based strategy (greedy and up);
+        // the Fast/Dfast speed tiers stay un-split because the splitter's
+        // per-partition entropy probes cost more than the ratio they buy
+        // when match-finding is already cheap.
+        if state.matcher.window_size() >= (1 << 17)
+            && !matches!(
+                state.strategy_tag,
+                crate::encoding::strategy::StrategyTag::Fast
+                    | crate::encoding::strategy::StrategyTag::Dfast
+            )
         {
             // This helper may emit multiple physical blocks (compressed or raw)
             // into `output`; checksums (if requested) are pushed per physical

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -165,6 +165,13 @@ pub(crate) struct RowConfig {
     pub(crate) row_log: usize,
     pub(crate) search_depth: usize,
     pub(crate) target_len: usize,
+    /// Donor `cParams.minMatch` for the row matcher: the regular-search
+    /// acceptance floor (a row candidate must extend to >= `mls` bytes).
+    /// The C-like advanced API surfaces this as the row min-match knob.
+    /// `ROW_MIN_MATCH_LEN` (5) is the default; the row hash key width stays
+    /// 4 bytes (an internal detail), so this only tunes the acceptance
+    /// floor, not the candidate hash distribution.
+    pub(crate) mls: usize,
 }
 
 const HC_CONFIG: HcConfig = HcConfig {
@@ -214,6 +221,7 @@ const ROW_CONFIG: RowConfig = RowConfig {
     row_log: ROW_LOG,
     search_depth: ROW_SEARCH_DEPTH,
     target_len: ROW_TARGET_LEN,
+    mls: ROW_MIN_MATCH_LEN,
 };
 
 // Level-5 greedy is the ONLY strategy routed to the Row backend
@@ -234,6 +242,7 @@ const ROW_L5: RowConfig = RowConfig {
     row_log: 4,
     search_depth: 8,
     target_len: 2,
+    mls: ROW_MIN_MATCH_LEN,
 };
 
 /// Resolved tuning parameters for a compression level. The
@@ -4643,6 +4652,56 @@ fn parse_search_matrix_decoupled_roundtrips() {
         &data,
     );
     assert_eq!(got, data, "lazy-on-rowhash diverged");
+}
+
+/// The row `mls` knob (C-like `minMatch`) is respected: every accepted
+/// match (regular row + repcode, on the lazy parse) is at least `mls`
+/// bytes, and the stream still round-trips for the whole 4..=7 range. The
+/// default (5) reproduces the historical `ROW_MIN_MATCH_LEN` behaviour.
+#[test]
+fn row_mls_knob_gates_matches_and_roundtrips() {
+    let data: Vec<u8> = (0..4000u32)
+        .flat_map(|i| {
+            let mut v = b"abcdefgh".to_vec();
+            v.extend_from_slice(&i.to_le_bytes());
+            v
+        })
+        .collect();
+
+    for mls in [4usize, 5, 6, 7] {
+        let mut matcher = RowMatchGenerator::new(1 << 22);
+        let mut cfg = ROW_CONFIG;
+        cfg.mls = mls;
+        matcher.configure(cfg);
+        matcher.add_data(data.clone(), |_| {});
+
+        let mut out: Vec<u8> = Vec::with_capacity(data.len());
+        let mut shortest_match = usize::MAX;
+        matcher.start_matching(|seq| match seq {
+            Sequence::Literals { literals } => out.extend_from_slice(literals),
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => {
+                out.extend_from_slice(literals);
+                shortest_match = shortest_match.min(match_len);
+                let start = out.len() - offset;
+                for i in 0..match_len {
+                    let byte = out[start + i];
+                    out.push(byte);
+                }
+            }
+        });
+
+        assert_eq!(out, data, "mls={mls} round-trip diverged");
+        if shortest_match != usize::MAX {
+            assert!(
+                shortest_match >= mls,
+                "mls={mls}: emitted a {shortest_match}-byte match below the floor",
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -244,6 +244,12 @@ const ROW_L5: RowConfig = RowConfig {
 #[derive(Copy, Clone)]
 struct LevelParams {
     strategy_tag: super::strategy::StrategyTag,
+    /// Decoupled search-method axis. Independent of `strategy_tag`'s
+    /// parse half: a level can pair any parse (greedy / lazy depth via
+    /// `lazy_depth`) with any search backend here. Defaults to the
+    /// historical pairing (`strategy_tag.search()`) but is overridable
+    /// per level so the parse×search matrix can be swept and tuned.
+    search: super::strategy::SearchMethod,
     window_log: u8,
     /// Donor `cParams.hashLog` — only consumed by the Fast strategy
     /// backend (`FastKernelMatcher`). Other backends ignore.
@@ -264,11 +270,23 @@ struct LevelParams {
 }
 
 impl LevelParams {
-    /// Backend family for the driver dispatcher. Always derived from
-    /// `strategy_tag` so there is no second authoritative mapping
-    /// for the `(level → backend)` decision.
+    /// Backend family (storage variant) for the driver dispatcher.
+    /// Derived from the decoupled `search` axis so a level can route to
+    /// a different search backend than its `strategy_tag` historically
+    /// implied.
     fn backend(&self) -> super::strategy::BackendTag {
-        self.strategy_tag.backend()
+        self.search.backend()
+    }
+
+    /// Parse mode for the greedy/lazy band, read off `lazy_depth`. The
+    /// opt tags carry `ParseMode::Optimal` regardless of `lazy_depth`.
+    fn parse(&self) -> super::strategy::ParseMode {
+        match self.strategy_tag {
+            super::strategy::StrategyTag::BtOpt
+            | super::strategy::StrategyTag::BtUltra
+            | super::strategy::StrategyTag::BtUltra2 => super::strategy::ParseMode::Optimal,
+            _ => super::strategy::ParseMode::from_lazy_depth(self.lazy_depth),
+        }
     }
 }
 
@@ -294,10 +312,10 @@ fn row_hash_bits_for_window(max_window_size: usize) -> usize {
 const LEVEL_TABLE: [LevelParams; 22] = [
     // Lvl  Strategy       wlog  fast_hlog  fast_mls  fast_step  lazy  HC config                                   row config
     // ---  -------------- ----  ---------  --------  ---------  ----  ------------------------------------------  ----------
-    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, window_log: 20, fast_hash_log: 16, fast_mls: 6, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
-    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 1 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, search: super::strategy::SearchMethod::Fast, window_log: 19, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 2 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Fast, search: super::strategy::SearchMethod::Fast, window_log: 20, fast_hash_log: 16, fast_mls: 6, fast_step_size: 2, lazy_depth: 0, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 3 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, search: super::strategy::SearchMethod::DoubleFast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
+    /* 4 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Dfast, search: super::strategy::SearchMethod::DoubleFast, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HC_CONFIG, row: ROW_CONFIG },
     // target_len column for L5..=L15 matches donor cParams.targetLength
     // from clevels.h table[0] (default — srcSize > 256 KB). Donor uses
     // it as the lazy outer loop's `sufficient_len` (nice-match) threshold.
@@ -305,14 +323,14 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // search_depth iterations instead of breaking on the first
     // long-enough match — the dominant cost in the L5..=L15 speed
     // regression vs FFI (see lazy_band_target_len_matches_donor_default_table).
-    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 2 }, row: ROW_L5 },
-    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }, row: ROW_CONFIG },
-    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }, row: ROW_CONFIG },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
-    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
-    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 16 }, row: ROW_CONFIG },
-    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 32, target_len: 16 }, row: ROW_CONFIG },
-    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, search: super::strategy::SearchMethod::RowHash, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 0, hc: HcConfig { hash_log: 18, chain_log: 17, search_depth: 4,  target_len: 2 }, row: ROW_L5 },
+    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }, row: ROW_CONFIG },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 1, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }, row: ROW_CONFIG },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 20, chain_log: 19, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
+    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: BETTER_WINDOW_LOG, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 24, target_len: 16 }, row: ROW_CONFIG },
+    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 28, target_len: 16 }, row: ROW_CONFIG },
+    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 24, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 21, chain_log: 20, search_depth: 32, target_len: 16 }, row: ROW_CONFIG },
+    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
     // L13-15: reference uses btlazy2 (binary-tree finder) with searchLog 4/5/6
     // (search_depth 16/32/64) and targetLength 32. We run the hash-chain Lazy
     // parser here, so we mirror the reference search budget rather than inflate
@@ -321,16 +339,16 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // smaller searchLog find longer matches (and re-establish a strict ratio
     // ladder above L12) is tracked separately; until it lands these levels sit
     // close to L12 on hash-chain inputs by design.
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }, row: ROW_CONFIG },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }, row: ROW_CONFIG },
-    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 48 }, row: ROW_CONFIG },
-    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 23, search_depth: 32, target_len: 64 }, row: ROW_CONFIG },
-    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 23, search_depth: 64, target_len: 64 }, row: ROW_CONFIG },
-    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 24, search_depth: 128, target_len: 256 }, row: ROW_CONFIG },
-    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 25, search_depth: 128, target_len: 256 }, row: ROW_CONFIG },
-    /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
-    /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, window_log: 27, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }, row: ROW_CONFIG },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }, row: ROW_CONFIG },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }, row: ROW_CONFIG },
+    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 48 }, row: ROW_CONFIG },
+    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 23, search_depth: 32, target_len: 64 }, row: ROW_CONFIG },
+    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 23, search_depth: 64, target_len: 64 }, row: ROW_CONFIG },
+    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 22, chain_log: 24, search_depth: 128, target_len: 256 }, row: ROW_CONFIG },
+    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 25, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: HcConfig { hash_log: 23, chain_log: 25, search_depth: 128, target_len: 256 }, row: ROW_CONFIG },
+    /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 26, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG, row: ROW_CONFIG },
+    /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 27, fast_hash_log: 14, fast_mls: 7, fast_step_size: 2, lazy_depth: 2, hc: BTULTRA2_HC_CONFIG_L22, row: ROW_CONFIG },
 ];
 
 /// Smallest window_log the encoder will use regardless of source size.
@@ -411,6 +429,7 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
     }
     LevelParams {
         strategy_tag: super::strategy::StrategyTag::BtUltra2,
+        search: super::strategy::SearchMethod::BinaryTree,
         window_log,
         fast_hash_log: 14,
         fast_mls: 7,
@@ -430,6 +449,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
     let params = match level {
         CompressionLevel::Uncompressed => LevelParams {
             strategy_tag: super::strategy::StrategyTag::Fast,
+            search: super::strategy::SearchMethod::Fast,
             // Uncompressed frames emit raw blocks and never reference
             // history; advertising a larger window only inflates
             // decoder-side buffer reservation. Stay at 17 (128 KiB).
@@ -491,6 +511,7 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                 // ladder on both ratio and throughput.
                 LevelParams {
                     strategy_tag: super::strategy::StrategyTag::Fast,
+                    search: super::strategy::SearchMethod::Fast,
                     window_log: 19,
                     fast_hash_log: 13,
                     fast_mls: 7,
@@ -586,6 +607,23 @@ pub struct MatchGeneratorDriver {
     // this tag to enter the corresponding `Strategy`
     // monomorphisation (`compress_block::<S>`).
     strategy_tag: super::strategy::StrategyTag,
+    // Decoupled search-method axis resolved at `reset()` from
+    // `LevelParams.search`. The per-block dispatcher routes on this
+    // (not on `strategy_tag`) so a level's parse and search backend can
+    // be chosen independently. The `BinaryTree` arm still consults
+    // `strategy_tag` to pick the opt `Strategy` ZST.
+    search: super::strategy::SearchMethod,
+    // Decoupled parse-mode axis resolved at `reset()` from
+    // `LevelParams::parse()`. Independent of `search`: greedy / lazy /
+    // lazy2 can run on any non-opt search backend. The backends still
+    // read their own `lazy_depth` (kept in sync at `reset()`); this is
+    // the authoritative parse selector for the dispatcher.
+    parse: super::strategy::ParseMode,
+    /// Test-only per-level recipe override applied in `reset()` before
+    /// backend selection. Lets the parse×search matrix be exercised
+    /// without editing `LEVEL_TABLE`; never compiled into production.
+    #[cfg(test)]
+    config_override: Option<(super::strategy::SearchMethod, super::strategy::ParseMode)>,
     slice_size: usize,
     base_slice_size: usize,
     // Frame header window size must stay at the configured live-window budget.
@@ -673,6 +711,10 @@ impl MatchGeneratorDriver {
                 2, // donor default step_size (targetLength=0 → step=2)
             )),
             strategy_tag: super::strategy::StrategyTag::Fast,
+            search: super::strategy::SearchMethod::Fast,
+            parse: super::strategy::ParseMode::Greedy,
+            #[cfg(test)]
+            config_override: None,
             slice_size,
             base_slice_size: slice_size,
             // Report the ROUNDED-UP window size that the matcher
@@ -993,7 +1035,18 @@ impl Matcher for MatchGeneratorDriver {
         // hint is consumed here, but priming happens just after reset).
         self.reset_source_size = hint;
         let hinted = hint.is_some();
-        let params = Self::level_params(level, hint);
+        #[cfg_attr(not(test), allow(unused_mut))]
+        let mut params = Self::level_params(level, hint);
+        // Test-only: apply a parse×search override so the matrix can be
+        // exercised without editing `LEVEL_TABLE`. Mutating `params` here
+        // (before `next_backend`) flows the override through storage
+        // selection, `configure`, and the `self.search`/`self.parse`
+        // writes uniformly. Opt strategies keep their `Optimal` parse.
+        #[cfg(test)]
+        if let Some((search, parse)) = self.config_override {
+            params.search = search;
+            params.lazy_depth = parse.lazy_depth();
+        }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
         self.dictionary_retained_budget = 0;
@@ -1094,6 +1147,8 @@ impl Matcher for MatchGeneratorDriver {
         // so there is no separate runtime tag that could drift against
         // `LEVEL_TABLE`.
         self.strategy_tag = params.strategy_tag;
+        self.search = params.search;
+        self.parse = params.parse();
         self.slice_size = self.base_slice_size.min(max_window_size);
         self.reported_window_size = max_window_size;
         let strategy_tag = self.strategy_tag;
@@ -1482,24 +1537,54 @@ impl Matcher for MatchGeneratorDriver {
                 .start_matching_borrowed(block_start, block_end, &mut handle_sequence);
             return;
         }
-        // 7-arm match over the compile-time strategy tag fires once
-        // per block and hands off to a monomorphised
-        // `compress_block::<S>` that the optimiser specialises per
-        // strategy. Strategy-shaped predicates (`S::USE_BT`,
-        // `S::USE_HASH3`, `S::OPTIMAL_PASS_COUNT`) compile to constants
-        // inside each monomorphisation, so the dead arms drop out at
-        // codegen time — there is no remaining runtime parse-mode
-        // dispatch on the per-block hot path.
-        match self.strategy_tag {
-            StrategyTag::Fast => self.compress_block::<strategy::Fast>(&mut handle_sequence),
-            StrategyTag::Dfast => self.compress_block::<strategy::Dfast>(&mut handle_sequence),
-            StrategyTag::Greedy => self.compress_block::<strategy::Greedy>(&mut handle_sequence),
-            StrategyTag::Lazy => self.compress_block::<strategy::Lazy>(&mut handle_sequence),
-            StrategyTag::BtOpt => self.compress_block::<strategy::BtOpt>(&mut handle_sequence),
-            StrategyTag::BtUltra => self.compress_block::<strategy::BtUltra>(&mut handle_sequence),
-            StrategyTag::BtUltra2 => {
-                self.compress_block::<strategy::BtUltra2>(&mut handle_sequence)
+        // Decoupled parse×search dispatch (fires once per block). The
+        // search axis (`self.search`) picks the candidate-finding backend;
+        // the parse axis (greedy vs lazy depth) is carried by the
+        // backend's runtime `lazy_depth`, set per level at `reset()`.
+        // The two are independent, so any parse can run on any search
+        // backend. The `BinaryTree` arm still selects the opt `Strategy`
+        // ZST off `strategy_tag` so `compress_block::<S>` keeps its
+        // const-folded optimal-parser monomorphisation.
+        use super::strategy::SearchMethod;
+        match self.search {
+            SearchMethod::Fast => {
+                self.simple_mut().start_matching(&mut handle_sequence);
+                self.recycle_simple_space();
             }
+            SearchMethod::DoubleFast => {
+                self.dfast_matcher_mut()
+                    .start_matching(&mut handle_sequence);
+            }
+            SearchMethod::RowHash => {
+                // Greedy parse (depth 0) = donor-greedy entry (default
+                // `ip + 1` start, greedy repcode commit); lazy / lazy2 use
+                // the `pick_lazy_match` lookahead entry (reads `lazy_depth`).
+                let greedy = self.parse == super::strategy::ParseMode::Greedy;
+                let row = self.row_matcher_mut();
+                if greedy {
+                    row.start_matching_greedy(&mut handle_sequence);
+                } else {
+                    row.start_matching(&mut handle_sequence);
+                }
+            }
+            SearchMethod::HashChain => {
+                // Greedy/lazy/lazy2 all flow through the lazy parser; it
+                // reads `hc.lazy_depth` (0 = greedy commit).
+                self.hc_matcher_mut()
+                    .start_matching_lazy(&mut handle_sequence);
+            }
+            SearchMethod::BinaryTree => match self.strategy_tag {
+                StrategyTag::BtOpt => self.compress_block::<strategy::BtOpt>(&mut handle_sequence),
+                StrategyTag::BtUltra => {
+                    self.compress_block::<strategy::BtUltra>(&mut handle_sequence)
+                }
+                StrategyTag::BtUltra2 => {
+                    self.compress_block::<strategy::BtUltra2>(&mut handle_sequence)
+                }
+                _ => unreachable!(
+                    "SearchMethod::BinaryTree requires an opt strategy tag (BtOpt/BtUltra/BtUltra2)"
+                ),
+            },
         }
     }
 
@@ -3320,7 +3405,10 @@ impl HcMatchGenerator {
         }
     }
 
-    fn start_matching_lazy(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+    pub(crate) fn start_matching_lazy(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
         self.table.ensure_tables();
 
         let current_len = *self.table.chunk_lens.back().unwrap();
@@ -4495,6 +4583,105 @@ fn driver_level4_greedy_round_trip_cross_slice() {
 /// Helper: round-trip `data` through the L4 greedy parse and assert
 /// the reconstructed bytes match. Returns `(triple_count, max_offset)`
 /// so callers can probe parse shape (matches emitted, max-offset).
+#[cfg(test)]
+impl MatchGeneratorDriver {
+    /// Test-only: stage a parse×search recipe override applied on the
+    /// next `reset()`. Routes a level through a non-default (parse,
+    /// search) pair so the decoupling can be exercised end-to-end.
+    pub(crate) fn set_config_override(
+        &mut self,
+        search: super::strategy::SearchMethod,
+        parse: super::strategy::ParseMode,
+    ) {
+        self.config_override = Some((search, parse));
+    }
+}
+
+/// Drive a full compress parse for `data` at `level` (optionally with a
+/// parse×search override) and reconstruct the bytes from the emitted
+/// sequences. The returned buffer must equal `data` for a correct parse.
+#[cfg(test)]
+fn drive_roundtrip_with_override(
+    level: CompressionLevel,
+    over: Option<(super::strategy::SearchMethod, super::strategy::ParseMode)>,
+    data: &[u8],
+) -> Vec<u8> {
+    let mut driver = MatchGeneratorDriver::new(1 << 17, 8);
+    if let Some((s, p)) = over {
+        driver.set_config_override(s, p);
+    }
+    driver.reset(level);
+
+    let mut out: Vec<u8> = Vec::with_capacity(data.len());
+    let mut offset_in_data = 0usize;
+    while offset_in_data < data.len() {
+        let mut space = driver.get_next_space();
+        let take = (data.len() - offset_in_data).min(space.len());
+        space[..take].copy_from_slice(&data[offset_in_data..offset_in_data + take]);
+        space.truncate(take);
+        driver.commit_space(space);
+        offset_in_data += take;
+
+        driver.start_matching(|seq| match seq {
+            Sequence::Literals { literals } => out.extend_from_slice(literals),
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => {
+                out.extend_from_slice(literals);
+                let start = out.len() - offset;
+                for i in 0..match_len {
+                    let byte = out[start + i];
+                    out.push(byte);
+                }
+            }
+        });
+    }
+    out
+}
+
+/// Phase 1 capability proof: parse and search are decoupled, so a level
+/// can run any parse mode on any non-opt search backend. Greedy-on-
+/// HashChain and Lazy2-on-RowHash are pairings the legacy `strategy_tag`
+/// could not express; both must reconstruct the input exactly.
+#[test]
+fn parse_search_matrix_decoupled_roundtrips() {
+    use super::strategy::{ParseMode, SearchMethod};
+    // Mixed repetitive + literal payload that exercises matches and reps.
+    let mut data = Vec::new();
+    for i in 0..4000u32 {
+        data.extend_from_slice(b"the quick brown fox ");
+        data.extend_from_slice(&i.to_le_bytes());
+    }
+
+    // Greedy parse on the HashChain search backend (legacy: Greedy was
+    // welded to RowHash).
+    let got = drive_roundtrip_with_override(
+        CompressionLevel::Level(5),
+        Some((SearchMethod::HashChain, ParseMode::Greedy)),
+        &data,
+    );
+    assert_eq!(got, data, "greedy-on-hashchain diverged");
+
+    // Lazy2 parse on the RowHash search backend (legacy: Lazy was welded
+    // to HashChain).
+    let got = drive_roundtrip_with_override(
+        CompressionLevel::Level(8),
+        Some((SearchMethod::RowHash, ParseMode::Lazy2)),
+        &data,
+    );
+    assert_eq!(got, data, "lazy2-on-rowhash diverged");
+
+    // Lazy on RowHash too (depth 1).
+    let got = drive_roundtrip_with_override(
+        CompressionLevel::Level(6),
+        Some((SearchMethod::RowHash, ParseMode::Lazy)),
+        &data,
+    );
+    assert_eq!(got, data, "lazy-on-rowhash diverged");
+}
+
 #[cfg(test)]
 fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (usize, usize) {
     let mut driver = MatchGeneratorDriver::new(slice_size, max_slices);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1559,6 +1559,8 @@ impl Matcher for MatchGeneratorDriver {
                 // Greedy parse (depth 0) = donor-greedy entry (default
                 // `ip + 1` start, greedy repcode commit); lazy / lazy2 use
                 // the `pick_lazy_match` lookahead entry (reads `lazy_depth`).
+                // Both bare entries dispatch on `row_log` internally into the
+                // const-`ROW_LOG` hot loop (donor per-rowLog variant table).
                 let greedy = self.parse == super::strategy::ParseMode::Greedy;
                 let row = self.row_matcher_mut();
                 if greedy {
@@ -1622,65 +1624,26 @@ impl Matcher for MatchGeneratorDriver {
 }
 
 impl MatchGeneratorDriver {
-    /// Monomorphised per-block encoder entry point. Each call from
-    /// [`Matcher::start_matching`] picks one concrete `S: Strategy` via
-    /// the [`super::strategy::StrategyTag`] resolved at `reset()`, so
-    /// the optimiser compiles a separate copy of this body per
-    /// strategy with `S::USE_BT` / `S::USE_HASH3` / `S::ACCURATE_PRICE`
-    /// inlined as compile-time constants. The backend dispatch below
-    /// is a `match S::BACKEND` over an associated `const`, so the
-    /// compiler keeps exactly one arm per monomorphisation.
+    /// Monomorphised optimal-parser entry point. Only the `BinaryTree`
+    /// search arm of [`Matcher::start_matching`] routes here, selecting
+    /// the concrete opt `S: Strategy` (BtOpt / BtUltra / BtUltra2) off
+    /// `strategy_tag`, so the optimiser keeps the cost-model predicates
+    /// (`S::USE_BT` / `S::USE_HASH3` / `S::ACCURATE_PRICE` /
+    /// `S::TWO_PASS_SEED`) const-folded per strategy. The non-opt search
+    /// backends (Fast / DoubleFast / RowHash / HashChain) are dispatched
+    /// directly off the search axis and never reach this method, so all
+    /// strategies arriving here are HashChain-backed.
     fn compress_block<S: super::strategy::Strategy>(
         &mut self,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
-        use super::strategy::BackendTag;
-        match S::BACKEND {
-            BackendTag::Simple => {
-                // FastKernelMatcher's `start_matching` is a SINGLE
-                // call per block — the donor-shape kernel walks the
-                // entire block internally and emits every
-                // `Sequence::Triple` through the handler. Replaces
-                // the legacy MatchGenerator's
-                // `while matcher.next_sequence(...) {}` loop where
-                // each iteration produced at most one sequence and
-                // re-paid the dispatch cost. The terminal
-                // `Sequence::Literals` (from `tail_literals_len`)
-                // also flows through this same handler invocation.
-                self.simple_mut().start_matching(&mut *handle_sequence);
-                self.recycle_simple_space();
-            }
-            BackendTag::Dfast => self.dfast_matcher_mut().start_matching(handle_sequence),
-            BackendTag::Row => {
-                // The Row backend is currently selected only by
-                // `StrategyTag::Greedy` (level 4) — see
-                // `StrategyTag::backend` in `strategy.rs`. Donor
-                // `ZSTD_compressBlock_lazy_generic` with `depth == 0`
-                // is a structurally different parse (default
-                // `start = ip + 1`, greedy repcode commit,
-                // immediate-rep loop after store) versus the lazy /
-                // lazy2 parse the plain `start_matching` runs, so L4
-                // dispatches directly to `start_matching_greedy`.
-                //
-                // The `debug_assert!` documents the invariant: any
-                // future routing of L5+ through the Row backend must
-                // first decide whether `start_matching_greedy` (depth
-                // == 0) or `start_matching` (depth >= 1, with
-                // `pick_lazy_match`) is the right entry point and
-                // adjust this dispatch accordingly. Today only
-                // `lazy_depth == 0` ever lands here.
-                let matcher = self.row_matcher_mut();
-                debug_assert_eq!(
-                    matcher.lazy_depth, 0,
-                    "Row backend currently expects lazy_depth == 0 (donor-greedy); \
-                     wire a depth-aware dispatch before routing lazy levels here",
-                );
-                matcher.start_matching_greedy(handle_sequence);
-            }
-            BackendTag::HashChain => self
-                .hc_matcher_mut()
-                .start_matching_strategy::<S>(handle_sequence),
-        }
+        debug_assert_eq!(S::BACKEND, super::strategy::BackendTag::HashChain);
+        debug_assert!(
+            S::USE_BT,
+            "compress_block only handles the optimal (BT) path"
+        );
+        self.hc_matcher_mut()
+            .start_matching_strategy::<S>(handle_sequence);
     }
 }
 

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -99,35 +99,112 @@ impl RowTagKernel {
         #[allow(unreachable_code)]
         RowTagKernel::Scalar
     }
+}
 
-    /// Bitmask of row slots whose tag byte equals `tag` (bit `j` set iff
-    /// `tags[j] == tag`). `tags.len()` is the row width (16 / 32 / 64, all
-    /// multiples of 16) so the result fits in a `u64`.
+/// Compile-time row tag-match kernel. Each ZST monomorphises the per-row
+/// tag compare so the search hot loop drops the runtime `RowTagKernel`
+/// enum branch (one predictable branch + all-tiers' inlined SIMD bodies
+/// per position become a single tier's body, no branch). The bare
+/// dispatchers select the impl once per block from the runtime-detected
+/// `tag_kernel`, so an impl is only instantiated/used on a CPU that
+/// supports its ISA — the same contract `RowTagKernel::detect` upholds for
+/// the enum's `unsafe` SIMD calls.
+pub(crate) trait RowTags: Copy {
+    /// `true` for SIMD tiers: precompute a full match bitmask once, then
+    /// test one bit per probed slot. `false` for scalar: on-the-fly
+    /// per-slot byte compare (cheaper when `search_depth < row_entries`).
+    const USE_MASK: bool;
+    /// Bitmask of slots whose tag byte equals `tag` (bit `j` ⇔ `tags[j]
+    /// == tag`). Only called when `USE_MASK`. `tags.len()` is the row
+    /// width (16 / 32 / 64).
+    fn mask(tags: &[u8], tag: u8) -> u64;
+}
+
+#[derive(Copy, Clone)]
+struct ScalarTags;
+impl RowTags for ScalarTags {
+    const USE_MASK: bool = false;
+    // `USE_MASK == false` const-folds the mask branch away, so this is never
+    // invoked on the hot path; it delegates to the scalar reference for
+    // completeness (and to keep the reference fn live outside `cfg(test)`).
     #[inline]
-    fn match_mask(self, tags: &[u8], tag: u8) -> u64 {
-        // Row width is `1 << row_log` with `row_log` clamped to 4..=6, so the
-        // slice is always 16 / 32 / 64 bytes — the widths the SIMD kernels and
-        // the u64 mask assume. Guard it so a future row-width change can't
-        // silently truncate the mask (>64 slots) or drop SIMD tail bytes.
-        debug_assert!(
-            matches!(tags.len(), 16 | 32 | 64),
-            "row tag kernel expects widths 16/32/64, got {}",
-            tags.len()
-        );
-        match self {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            // SAFETY: this variant is only produced by `detect()` after
-            // confirming AVX2 (runtime) or `target_feature = "avx2"`.
-            RowTagKernel::Avx2 => unsafe { row_tag_match_mask_avx2(tags, tag) },
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            // SAFETY: SSE2 confirmed by `detect()` (always true on x86_64).
-            RowTagKernel::Sse2 => unsafe { row_tag_match_mask_sse2(tags, tag) },
-            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-            // SAFETY: NEON confirmed by `detect()` (baseline on aarch64).
-            RowTagKernel::Neon => unsafe { row_tag_match_mask_neon(tags, tag) },
-            RowTagKernel::Scalar => row_tag_match_mask_scalar(tags, tag),
-        }
+    fn mask(tags: &[u8], tag: u8) -> u64 {
+        row_tag_match_mask_scalar(tags, tag)
     }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[derive(Copy, Clone)]
+struct Sse2Tags;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl RowTags for Sse2Tags {
+    const USE_MASK: bool = true;
+    #[inline]
+    fn mask(tags: &[u8], tag: u8) -> u64 {
+        // SAFETY: only dispatched-to when `tag_kernel == Sse2` (SSE2 is
+        // baseline on x86_64 and confirmed by `detect()` on x86).
+        unsafe { row_tag_match_mask_sse2(tags, tag) }
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[derive(Copy, Clone)]
+struct Avx2Tags;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+impl RowTags for Avx2Tags {
+    const USE_MASK: bool = true;
+    #[inline]
+    fn mask(tags: &[u8], tag: u8) -> u64 {
+        // SAFETY: only dispatched-to when `tag_kernel == Avx2`, set by
+        // `detect()` after confirming AVX2.
+        unsafe { row_tag_match_mask_avx2(tags, tag) }
+    }
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[derive(Copy, Clone)]
+struct NeonTags;
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+impl RowTags for NeonTags {
+    const USE_MASK: bool = true;
+    #[inline]
+    fn mask(tags: &[u8], tag: u8) -> u64 {
+        // SAFETY: only dispatched-to when `tag_kernel == Neon` (baseline
+        // on little-endian aarch64, confirmed by `detect()`).
+        unsafe { row_tag_match_mask_neon(tags, tag) }
+    }
+}
+
+/// Resolve the runtime `tag_kernel` to a `RowTags` ZST once, then call a
+/// `*_k::<K>` method that binds the `row_log` const. The kernel branch
+/// runs once per block (cold), so the per-position hot loop is fully
+/// monomorphised over the selected tier — no runtime kernel enum inside.
+macro_rules! dispatch_tag_kernel {
+    ($self:ident . $k_method:ident ( $($arg:expr),* )) => {
+        match $self.tag_kernel {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            RowTagKernel::Avx2 => $self.$k_method::<Avx2Tags>($($arg),*),
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            RowTagKernel::Sse2 => $self.$k_method::<Sse2Tags>($($arg),*),
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+            RowTagKernel::Neon => $self.$k_method::<NeonTags>($($arg),*),
+            RowTagKernel::Scalar => $self.$k_method::<ScalarTags>($($arg),*),
+        }
+    };
+}
+
+/// Bind the runtime `row_log` (clamped 4..=6) to the const `ROW_LOG` of a
+/// `*_rl::<K, ROW_LOG>` hot loop. Mirrors the donor's per-rowLog variant
+/// table; the branch is cold (once per block / call).
+macro_rules! dispatch_row_log {
+    ($self:ident . $rl_method:ident :: <$k:ty> ( $($arg:expr),* )) => {
+        match $self.row_log {
+            4 => $self.$rl_method::<$k, 4>($($arg),*),
+            5 => $self.$rl_method::<$k, 5>($($arg),*),
+            6 => $self.$rl_method::<$k, 6>($($arg),*),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    };
 }
 
 /// Scalar reference: one byte compare per slot. SIMD kernels below compute
@@ -464,7 +541,7 @@ impl RowMatchGenerator {
     /// row-hash machinery, which is wasteful. The `dead_code` allow is
     /// scoped to this method and its private helpers so any new
     /// caller will pick them up unmodified.
-    pub(crate) fn start_matching_rl<const ROW_LOG: usize>(
+    pub(crate) fn start_matching_rl<K: RowTags, const ROW_LOG: usize>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
@@ -487,8 +564,8 @@ impl RowMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            let best = self.best_match_rl::<ROW_LOG>(abs_pos, lit_len);
-            if let Some(candidate) = self.pick_lazy_match_rl::<ROW_LOG>(abs_pos, lit_len, best) {
+            let best = self.best_match_rl::<K, ROW_LOG>(abs_pos, lit_len);
+            if let Some(candidate) = self.pick_lazy_match_rl::<K, ROW_LOG>(abs_pos, lit_len, best) {
                 self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
                 let current = self.window.back().unwrap().as_slice();
                 let start = candidate.start - current_abs_start;
@@ -585,7 +662,7 @@ impl RowMatchGenerator {
     ///
     /// `pick_lazy_match` is intentionally not called here — depth == 0
     /// means "no lookahead", emit the first viable hit.
-    pub(crate) fn start_matching_greedy_rl<const ROW_LOG: usize>(
+    pub(crate) fn start_matching_greedy_rl<K: RowTags, const ROW_LOG: usize>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
@@ -674,7 +751,7 @@ impl RowMatchGenerator {
             // indexes the committed span.
             let chosen = match rep_match {
                 Some(rep) => Some(rep),
-                None => self.row_candidate_rl::<ROW_LOG>(abs_pos, lit_len),
+                None => self.row_candidate_rl::<K, ROW_LOG>(abs_pos, lit_len),
             };
 
             let Some(candidate) = chosen else {
@@ -813,17 +890,17 @@ impl RowMatchGenerator {
     /// Used only by the dead-code [`Self::start_matching`] (lazy-style
     /// row parse). Kept paired with that method so reviving the lazy
     /// path doesn't have to re-derive the rep+row best-of-two pick.
-    pub(crate) fn best_match_rl<const ROW_LOG: usize>(
+    pub(crate) fn best_match_rl<K: RowTags, const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         let rep = self.repcode_candidate(abs_pos, lit_len);
-        let row = self.row_candidate_rl::<ROW_LOG>(abs_pos, lit_len);
+        let row = self.row_candidate_rl::<K, ROW_LOG>(abs_pos, lit_len);
         best_len_offset_candidate(rep, row)
     }
 
-    pub(crate) fn pick_lazy_match_rl<const ROW_LOG: usize>(
+    pub(crate) fn pick_lazy_match_rl<K: RowTags, const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
         lit_len: usize,
@@ -839,7 +916,7 @@ impl RowMatchGenerator {
                 lazy_depth: self.lazy_depth,
                 history_abs_end: self.history_abs_end(),
             },
-            |next_pos, next_lit_len| self.best_match_rl::<ROW_LOG>(next_pos, next_lit_len),
+            |next_pos, next_lit_len| self.best_match_rl::<K, ROW_LOG>(next_pos, next_lit_len),
         )
     }
 
@@ -859,32 +936,31 @@ impl RowMatchGenerator {
         )
     }
 
-    // Bounded `row_log` dispatchers. Each reads the runtime `row_log`
-    // (clamped to 4..=6 in `configure`) once and routes into the
-    // const-`ROW_LOG` monomorphisation, mirroring the donor's per-rowLog
-    // matchfinder variant table. The per-block / per-call dispatch cost is
-    // amortised over the whole block's hot loop. Callers (the driver and
-    // tests) use these bare names; the hot loops call the `_rl` siblings
-    // directly with the const already bound.
+    // Two-level bounded dispatch: resolve the tag kernel (`K: RowTags`)
+    // then the `row_log` const, both cold (once per block / call), into the
+    // fully monomorphised `_rl::<K, ROW_LOG>` hot loop. The per-position
+    // loop carries no runtime kernel enum and no `row_log` reload. Callers
+    // (driver + tests) use these bare names; the hot loops call the `_rl`
+    // siblings directly with the type and const already bound. `skip` does
+    // no tag compare, so it dispatches on `row_log` only.
     pub(crate) fn start_matching(&mut self, handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
-        match self.row_log {
-            4 => self.start_matching_rl::<4>(handle_sequence),
-            5 => self.start_matching_rl::<5>(handle_sequence),
-            6 => self.start_matching_rl::<6>(handle_sequence),
-            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
-        }
+        dispatch_tag_kernel!(self.start_matching_k(handle_sequence))
+    }
+    fn start_matching_k<K: RowTags>(&mut self, handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+        dispatch_row_log!(self.start_matching_rl::<K>(handle_sequence))
     }
 
     pub(crate) fn start_matching_greedy(
         &mut self,
         handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
-        match self.row_log {
-            4 => self.start_matching_greedy_rl::<4>(handle_sequence),
-            5 => self.start_matching_greedy_rl::<5>(handle_sequence),
-            6 => self.start_matching_greedy_rl::<6>(handle_sequence),
-            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
-        }
+        dispatch_tag_kernel!(self.start_matching_greedy_k(handle_sequence))
+    }
+    fn start_matching_greedy_k<K: RowTags>(
+        &mut self,
+        handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dispatch_row_log!(self.start_matching_greedy_rl::<K>(handle_sequence))
     }
 
     pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
@@ -898,12 +974,10 @@ impl RowMatchGenerator {
 
     #[allow(dead_code)]
     pub(crate) fn best_match(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
-        match self.row_log {
-            4 => self.best_match_rl::<4>(abs_pos, lit_len),
-            5 => self.best_match_rl::<5>(abs_pos, lit_len),
-            6 => self.best_match_rl::<6>(abs_pos, lit_len),
-            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
-        }
+        dispatch_tag_kernel!(self.best_match_k(abs_pos, lit_len))
+    }
+    fn best_match_k<K: RowTags>(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
+        dispatch_row_log!(self.best_match_rl::<K>(abs_pos, lit_len))
     }
 
     #[allow(dead_code)]
@@ -913,25 +987,30 @@ impl RowMatchGenerator {
         lit_len: usize,
         best: Option<MatchCandidate>,
     ) -> Option<MatchCandidate> {
-        match self.row_log {
-            4 => self.pick_lazy_match_rl::<4>(abs_pos, lit_len, best),
-            5 => self.pick_lazy_match_rl::<5>(abs_pos, lit_len, best),
-            6 => self.pick_lazy_match_rl::<6>(abs_pos, lit_len, best),
-            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
-        }
+        dispatch_tag_kernel!(self.pick_lazy_match_k(abs_pos, lit_len, best))
+    }
+    fn pick_lazy_match_k<K: RowTags>(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+        best: Option<MatchCandidate>,
+    ) -> Option<MatchCandidate> {
+        dispatch_row_log!(self.pick_lazy_match_rl::<K>(abs_pos, lit_len, best))
     }
 
     #[allow(dead_code)]
     pub(crate) fn row_candidate(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
-        match self.row_log {
-            4 => self.row_candidate_rl::<4>(abs_pos, lit_len),
-            5 => self.row_candidate_rl::<5>(abs_pos, lit_len),
-            6 => self.row_candidate_rl::<6>(abs_pos, lit_len),
-            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
-        }
+        dispatch_tag_kernel!(self.row_candidate_k(abs_pos, lit_len))
+    }
+    fn row_candidate_k<K: RowTags>(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dispatch_row_log!(self.row_candidate_rl::<K>(abs_pos, lit_len))
     }
 
-    pub(crate) fn row_candidate_rl<const ROW_LOG: usize>(
+    pub(crate) fn row_candidate_rl<K: RowTags, const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
         lit_len: usize,
@@ -950,17 +1029,14 @@ impl RowMatchGenerator {
         let head = self.row_heads[row] as usize;
         let max_walk = self.search_depth.min(row_entries);
 
-        // The SIMD kernels compare all `row_entries` tags in one vector op, so
-        // building a full match bitmask up front is free and lets the walk test
-        // a single bit per slot. The scalar kernel has no such win: scanning all
-        // `row_entries` would do more byte-compares than the `max_walk` slots
-        // actually walked when `search_depth < row_entries`, so it keeps the
-        // on-the-fly `row_tags[idx] == tag` check instead. `row_entries <= 64`
-        // (row_log clamps to 4..=6) so the mask fits a `u64`.
-        let use_mask = self.tag_kernel != RowTagKernel::Scalar;
-        let tag_match = if use_mask {
-            self.tag_kernel
-                .match_mask(&self.row_tags[row_base..row_base + row_entries], tag)
+        // `K::USE_MASK` is a compile-time const per tag kernel, so this whole
+        // branch const-folds: SIMD tiers precompute the full bitmask once and
+        // test one bit per probed slot; the scalar tier drops the mask and
+        // does an on-the-fly byte compare (cheaper when
+        // `search_depth < row_entries`). No runtime kernel enum on the hot
+        // path. `row_entries <= 64` (ROW_LOG 4..=6) so the mask fits a `u64`.
+        let tag_match = if K::USE_MASK {
+            K::mask(&self.row_tags[row_base..row_base + row_entries], tag)
         } else {
             0
         };
@@ -969,7 +1045,7 @@ impl RowMatchGenerator {
         for i in 0..max_walk {
             let slot = (head + i) & row_mask;
             let idx = row_base + slot;
-            let matched = if use_mask {
+            let matched = if K::USE_MASK {
                 (tag_match >> slot) & 1 != 0
             } else {
                 self.row_tags[idx] == tag

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -371,14 +371,18 @@ impl RowMatchGenerator {
         }
     }
 
-    pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
+    pub(crate) fn skip_matching_with_hint_rl<const ROW_LOG: usize>(
+        &mut self,
+        incompressible_hint: Option<bool>,
+    ) {
+        debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
         let current_len = self.window.back().unwrap().len();
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
         let current_abs_end = current_abs_start + current_len;
         let backfill_start = self.backfill_start(current_abs_start);
         if backfill_start < current_abs_start {
-            self.insert_positions(backfill_start, current_abs_start);
+            self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
         }
         match incompressible_hint {
             Some(true) => {
@@ -386,7 +390,7 @@ impl RowMatchGenerator {
                 // unlikely to compress, so we seed only every
                 // `INCOMPRESSIBLE_SKIP_STEP` position plus a small tail to
                 // keep cross-block continuity at the boundary.
-                self.insert_positions_with_step(
+                self.insert_positions_with_step::<ROW_LOG>(
                     current_abs_start,
                     current_abs_end,
                     INCOMPRESSIBLE_SKIP_STEP,
@@ -397,7 +401,7 @@ impl RowMatchGenerator {
                     .max(current_abs_start);
                 for pos in tail_start..current_abs_end {
                     if !(pos - current_abs_start).is_multiple_of(INCOMPRESSIBLE_SKIP_STEP) {
-                        self.insert_position(pos);
+                        self.insert_position::<ROW_LOG>(pos);
                     }
                 }
             }
@@ -412,7 +416,7 @@ impl RowMatchGenerator {
                 // future fast-paths (e.g. an RLE / raw-block emitter
                 // that still wants cross-block matches into the skipped
                 // bytes) can reuse it without rewording the contract.
-                self.insert_positions(current_abs_start, current_abs_end);
+                self.insert_positions::<ROW_LOG>(current_abs_start, current_abs_end);
             }
             None => {
                 // Donor parity: a plain `skip_matching` (no hint) leaves
@@ -460,8 +464,11 @@ impl RowMatchGenerator {
     /// row-hash machinery, which is wasteful. The `dead_code` allow is
     /// scoped to this method and its private helpers so any new
     /// caller will pick them up unmodified.
-    #[allow(dead_code)]
-    pub(crate) fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+    pub(crate) fn start_matching_rl<const ROW_LOG: usize>(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
 
         let current_len = self.window.back().unwrap().len();
@@ -471,7 +478,7 @@ impl RowMatchGenerator {
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
         let backfill_start = self.backfill_start(current_abs_start);
         if backfill_start < current_abs_start {
-            self.insert_positions(backfill_start, current_abs_start);
+            self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
         }
 
         let mut pos = 0usize;
@@ -480,9 +487,9 @@ impl RowMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            let best = self.best_match(abs_pos, lit_len);
-            if let Some(candidate) = self.pick_lazy_match(abs_pos, lit_len, best) {
-                self.insert_match_span(abs_pos, candidate.start + candidate.match_len);
+            let best = self.best_match_rl::<ROW_LOG>(abs_pos, lit_len);
+            if let Some(candidate) = self.pick_lazy_match_rl::<ROW_LOG>(abs_pos, lit_len, best) {
+                self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
                 let current = self.window.back().unwrap().as_slice();
                 let start = candidate.start - current_abs_start;
                 let literals = &current[literals_start..start];
@@ -499,13 +506,13 @@ impl RowMatchGenerator {
                 pos = start + candidate.match_len;
                 literals_start = pos;
             } else {
-                self.insert_position(abs_pos);
+                self.insert_position::<ROW_LOG>(abs_pos);
                 pos += 1;
             }
         }
 
         while pos + ROW_HASH_KEY_LEN <= current_len {
-            self.insert_position(current_abs_start + pos);
+            self.insert_position::<ROW_LOG>(current_abs_start + pos);
             pos += 1;
         }
 
@@ -578,10 +585,11 @@ impl RowMatchGenerator {
     ///
     /// `pick_lazy_match` is intentionally not called here — depth == 0
     /// means "no lookahead", emit the first viable hit.
-    pub(crate) fn start_matching_greedy(
+    pub(crate) fn start_matching_greedy_rl<const ROW_LOG: usize>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
+        debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
 
         let current_len = self.window.back().unwrap().len();
@@ -591,7 +599,7 @@ impl RowMatchGenerator {
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
         let backfill_start = self.backfill_start(current_abs_start);
         if backfill_start < current_abs_start {
-            self.insert_positions(backfill_start, current_abs_start);
+            self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
         }
 
         // Donor mls for repcode probes is 4 (`MEM_read32` compare on
@@ -666,7 +674,7 @@ impl RowMatchGenerator {
             // indexes the committed span.
             let chosen = match rep_match {
                 Some(rep) => Some(rep),
-                None => self.row_candidate(abs_pos, lit_len),
+                None => self.row_candidate_rl::<ROW_LOG>(abs_pos, lit_len),
             };
 
             let Some(candidate) = chosen else {
@@ -683,7 +691,7 @@ impl RowMatchGenerator {
                 // drain.
                 const SKIP_STRENGTH: u32 = 10;
                 let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
-                self.insert_position(abs_pos);
+                self.insert_position::<ROW_LOG>(abs_pos);
                 pos += step;
                 continue;
             };
@@ -703,7 +711,7 @@ impl RowMatchGenerator {
             // `candidate.start` lower bound regresses `rust_bytes` by
             // ~+447 over `abs_pos` (537897 -> 538344), so the
             // narrower range is intentional.
-            self.insert_match_span(abs_pos, candidate.start + candidate.match_len);
+            self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
             let current = self.window.back().unwrap().as_slice();
             let literals = &current[literals_start..start];
             handle_sequence(Sequence::Triple {
@@ -736,7 +744,7 @@ impl RowMatchGenerator {
         }
 
         while pos + ROW_HASH_KEY_LEN <= current_len {
-            self.insert_position(current_abs_start + pos);
+            self.insert_position::<ROW_LOG>(current_abs_start + pos);
             pos += 1;
         }
 
@@ -805,15 +813,17 @@ impl RowMatchGenerator {
     /// Used only by the dead-code [`Self::start_matching`] (lazy-style
     /// row parse). Kept paired with that method so reviving the lazy
     /// path doesn't have to re-derive the rep+row best-of-two pick.
-    #[allow(dead_code)]
-    pub(crate) fn best_match(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
+    pub(crate) fn best_match_rl<const ROW_LOG: usize>(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
         let rep = self.repcode_candidate(abs_pos, lit_len);
-        let row = self.row_candidate(abs_pos, lit_len);
+        let row = self.row_candidate_rl::<ROW_LOG>(abs_pos, lit_len);
         best_len_offset_candidate(rep, row)
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn pick_lazy_match(
+    pub(crate) fn pick_lazy_match_rl<const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
         lit_len: usize,
@@ -829,7 +839,7 @@ impl RowMatchGenerator {
                 lazy_depth: self.lazy_depth,
                 history_abs_end: self.history_abs_end(),
             },
-            |next_pos, next_lit_len| self.best_match(next_pos, next_lit_len),
+            |next_pos, next_lit_len| self.best_match_rl::<ROW_LOG>(next_pos, next_lit_len),
         )
     }
 
@@ -849,7 +859,84 @@ impl RowMatchGenerator {
         )
     }
 
+    // Bounded `row_log` dispatchers. Each reads the runtime `row_log`
+    // (clamped to 4..=6 in `configure`) once and routes into the
+    // const-`ROW_LOG` monomorphisation, mirroring the donor's per-rowLog
+    // matchfinder variant table. The per-block / per-call dispatch cost is
+    // amortised over the whole block's hot loop. Callers (the driver and
+    // tests) use these bare names; the hot loops call the `_rl` siblings
+    // directly with the const already bound.
+    pub(crate) fn start_matching(&mut self, handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+        match self.row_log {
+            4 => self.start_matching_rl::<4>(handle_sequence),
+            5 => self.start_matching_rl::<5>(handle_sequence),
+            6 => self.start_matching_rl::<6>(handle_sequence),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    pub(crate) fn start_matching_greedy(
+        &mut self,
+        handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        match self.row_log {
+            4 => self.start_matching_greedy_rl::<4>(handle_sequence),
+            5 => self.start_matching_greedy_rl::<5>(handle_sequence),
+            6 => self.start_matching_greedy_rl::<6>(handle_sequence),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
+        match self.row_log {
+            4 => self.skip_matching_with_hint_rl::<4>(incompressible_hint),
+            5 => self.skip_matching_with_hint_rl::<5>(incompressible_hint),
+            6 => self.skip_matching_with_hint_rl::<6>(incompressible_hint),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn best_match(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
+        match self.row_log {
+            4 => self.best_match_rl::<4>(abs_pos, lit_len),
+            5 => self.best_match_rl::<5>(abs_pos, lit_len),
+            6 => self.best_match_rl::<6>(abs_pos, lit_len),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn pick_lazy_match(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+        best: Option<MatchCandidate>,
+    ) -> Option<MatchCandidate> {
+        match self.row_log {
+            4 => self.pick_lazy_match_rl::<4>(abs_pos, lit_len, best),
+            5 => self.pick_lazy_match_rl::<5>(abs_pos, lit_len, best),
+            6 => self.pick_lazy_match_rl::<6>(abs_pos, lit_len, best),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn row_candidate(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
+        match self.row_log {
+            4 => self.row_candidate_rl::<4>(abs_pos, lit_len),
+            5 => self.row_candidate_rl::<5>(abs_pos, lit_len),
+            6 => self.row_candidate_rl::<6>(abs_pos, lit_len),
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
+    }
+
+    pub(crate) fn row_candidate_rl<const ROW_LOG: usize>(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        debug_assert_eq!(ROW_LOG, self.row_log);
         let concat = self.live_history();
         let current_idx = abs_pos - self.history_abs_start;
         if current_idx + ROW_MIN_MATCH_LEN > concat.len() {
@@ -857,9 +944,9 @@ impl RowMatchGenerator {
         }
 
         let (row, tag) = self.hash_and_row(abs_pos)?;
-        let row_entries = 1usize << self.row_log;
+        let row_entries = 1usize << ROW_LOG;
         let row_mask = row_entries - 1;
-        let row_base = row << self.row_log;
+        let row_base = row << ROW_LOG;
         let head = self.row_heads[row] as usize;
         let max_walk = self.search_depth.min(row_entries);
 
@@ -935,9 +1022,9 @@ impl RowMatchGenerator {
         )
     }
 
-    fn insert_positions(&mut self, start: usize, end: usize) {
+    fn insert_positions<const ROW_LOG: usize>(&mut self, start: usize, end: usize) {
         for pos in start..end {
-            self.insert_position(pos);
+            self.insert_position::<ROW_LOG>(pos);
         }
     }
 
@@ -951,26 +1038,31 @@ impl RowMatchGenerator {
     /// entire block: that O(matchlen) fill, not the search, is what left
     /// the row backend ~11x slower than FFI on those streams. The donor
     /// caps the fill at 96 + 32 positions regardless of match length.
-    fn insert_match_span(&mut self, start: usize, end: usize) {
+    fn insert_match_span<const ROW_LOG: usize>(&mut self, start: usize, end: usize) {
         const SKIP_THRESHOLD: usize = 384;
         const MAX_START: usize = 96;
         const MAX_END: usize = 32;
         if end.saturating_sub(start) > SKIP_THRESHOLD {
-            self.insert_positions(start, start + MAX_START);
-            self.insert_positions(end - MAX_END, end);
+            self.insert_positions::<ROW_LOG>(start, start + MAX_START);
+            self.insert_positions::<ROW_LOG>(end - MAX_END, end);
         } else {
-            self.insert_positions(start, end);
+            self.insert_positions::<ROW_LOG>(start, end);
         }
     }
 
-    fn insert_positions_with_step(&mut self, start: usize, end: usize, step: usize) {
+    fn insert_positions_with_step<const ROW_LOG: usize>(
+        &mut self,
+        start: usize,
+        end: usize,
+        step: usize,
+    ) {
         if step <= 1 {
-            self.insert_positions(start, end);
+            self.insert_positions::<ROW_LOG>(start, end);
             return;
         }
         let mut pos = start;
         while pos < end {
-            self.insert_position(pos);
+            self.insert_position::<ROW_LOG>(pos);
             let next = pos.saturating_add(step);
             if next <= pos {
                 break;
@@ -980,13 +1072,17 @@ impl RowMatchGenerator {
     }
 
     #[inline]
-    fn insert_position(&mut self, abs_pos: usize) {
+    fn insert_position<const ROW_LOG: usize>(&mut self, abs_pos: usize) {
         let Some((row, tag)) = self.hash_and_row(abs_pos) else {
             return;
         };
-        let row_entries = 1usize << self.row_log;
+        // `ROW_LOG` is the compile-time row width for this monomorphisation;
+        // the dispatcher guarantees `ROW_LOG == self.row_log` so the table
+        // bounds (`ensure_tables` sized by `self.row_log`) hold.
+        debug_assert_eq!(ROW_LOG, self.row_log);
+        let row_entries = 1usize << ROW_LOG;
         let row_mask = row_entries - 1;
-        let row_base = row << self.row_log;
+        let row_base = row << ROW_LOG;
         // SAFETY: `hash_and_row` masks `row` to `row_hash_log` bits and
         // `row_heads.len() == 1 << row_hash_log` by `ensure_tables`.
         // `row_base = row << row_log = row * row_entries` and

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -347,6 +347,11 @@ pub(crate) struct RowMatchGenerator {
     pub(crate) row_log: usize,
     pub(crate) search_depth: usize,
     pub(crate) target_len: usize,
+    /// Regular-search min-match floor (donor `cParams.minMatch`). A row
+    /// candidate must extend to >= `mls` bytes to be accepted. Hoisted to
+    /// a local in the parse loops so the per-position compare reads a
+    /// register, not this field. Default `ROW_MIN_MATCH_LEN` (5).
+    pub(crate) mls: usize,
     pub(crate) lazy_depth: u8,
     /// Cached fastpath kernel for `hash_mix_u64`; see Dfast for rationale.
     pub(crate) hash_kernel: crate::encoding::fastpath::FastpathKernel,
@@ -372,6 +377,7 @@ impl RowMatchGenerator {
             row_log: ROW_LOG,
             search_depth: ROW_SEARCH_DEPTH,
             target_len: ROW_TARGET_LEN,
+            mls: ROW_MIN_MATCH_LEN,
             lazy_depth: 1,
             hash_kernel: crate::encoding::fastpath::select_kernel(),
             row_heads: Vec::new(),
@@ -396,6 +402,10 @@ impl RowMatchGenerator {
         self.row_log = config.row_log.clamp(4, 6);
         self.search_depth = config.search_depth;
         self.target_len = config.target_len;
+        // Clamp the min-match floor to >= the hash key width (a shorter
+        // floor can't be satisfied: the hash only surfaces candidates
+        // sharing the 4-byte key) and a sane upper bound.
+        self.mls = config.mls.clamp(ROW_HASH_KEY_LEN, 7);
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
@@ -558,9 +568,10 @@ impl RowMatchGenerator {
             self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
         }
 
+        let mls = self.mls;
         let mut pos = 0usize;
         let mut literals_start = 0usize;
-        while pos + ROW_MIN_MATCH_LEN <= current_len {
+        while pos + mls <= current_len {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
@@ -912,7 +923,7 @@ impl RowMatchGenerator {
             best,
             LazyMatchConfig {
                 target_len: self.target_len,
-                min_match_len: ROW_MIN_MATCH_LEN,
+                min_match_len: self.mls,
                 lazy_depth: self.lazy_depth,
                 history_abs_end: self.history_abs_end(),
             },
@@ -932,7 +943,7 @@ impl RowMatchGenerator {
             self.offset_hist,
             abs_pos,
             lit_len,
-            ROW_MIN_MATCH_LEN,
+            self.mls,
         )
     }
 
@@ -1016,9 +1027,10 @@ impl RowMatchGenerator {
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         debug_assert_eq!(ROW_LOG, self.row_log);
+        let mls = self.mls;
         let concat = self.live_history();
         let current_idx = abs_pos - self.history_abs_start;
-        if current_idx + ROW_MIN_MATCH_LEN > concat.len() {
+        if current_idx + mls > concat.len() {
             return None;
         }
 
@@ -1062,7 +1074,7 @@ impl RowMatchGenerator {
             }
             let candidate_idx = candidate_pos - self.history_abs_start;
             let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
-            if match_len >= ROW_MIN_MATCH_LEN {
+            if match_len >= mls {
                 let candidate = self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len);
                 best = best_len_offset_candidate(best, Some(candidate));
                 // Donor `ZSTD_RowFindBestMatch` walks every probed slot and

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -52,6 +52,78 @@ pub(crate) enum BackendTag {
     HashChain,
 }
 
+/// Parse strategy — what the outer match loop does with the candidates
+/// a search method produces. Orthogonal to [`SearchMethod`]: the same
+/// parse can run on top of any search backend (donor decouples these as
+/// `cParams.strategy`'s parse half vs the `useRowMatchFinder` switch).
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ParseMode {
+    /// Commit the first acceptable match (donor `ZSTD_greedy`, depth 0).
+    Greedy,
+    /// One-position lazy lookahead (donor `ZSTD_lazy`, depth 1).
+    Lazy,
+    /// Two-position lazy lookahead (donor `ZSTD_lazy2`, depth 2).
+    Lazy2,
+    /// Optimal cost-model parse (donor `ZSTD_btopt`/`btultra`/`btultra2`).
+    Optimal,
+}
+
+impl ParseMode {
+    /// Lazy lookahead depth for the greedy/lazy band (0/1/2). `Optimal`
+    /// has no lazy depth and returns 0.
+    pub(crate) const fn lazy_depth(self) -> u8 {
+        match self {
+            Self::Greedy => 0,
+            Self::Lazy => 1,
+            Self::Lazy2 => 2,
+            Self::Optimal => 0,
+        }
+    }
+
+    /// Derive the greedy/lazy parse from a lazy-lookahead depth. Depth >= 2
+    /// saturates to `Lazy2`. Used to read the existing `LevelParams.lazy_depth`
+    /// into the decoupled parse axis.
+    pub(crate) const fn from_lazy_depth(depth: u8) -> Self {
+        match depth {
+            0 => Self::Greedy,
+            1 => Self::Lazy,
+            _ => Self::Lazy2,
+        }
+    }
+}
+
+/// Search method — how match candidates are produced for a position.
+/// Orthogonal to [`ParseMode`] (donor `cParams.strategy` search half plus
+/// the `useRowMatchFinder` cParam that swaps `HashChain` for `RowHash` in
+/// the greedy/lazy band).
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum SearchMethod {
+    /// Single-table fast finder (donor `ZSTD_fast`).
+    Fast,
+    /// Two parallel hash tables (donor `ZSTD_dfast`).
+    DoubleFast,
+    /// Row-hash SIMD-tag finder (donor row matchfinder).
+    RowHash,
+    /// Hash-chain finder (donor `ZSTD_HcFindBestMatch`).
+    HashChain,
+    /// Binary-tree finder for the optimal parser (donor `ZSTD_BtGetAllMatches`).
+    BinaryTree,
+}
+
+impl SearchMethod {
+    /// Storage backend (matcher variant) this search method runs in.
+    /// `BinaryTree` shares the `HashChain` storage (the BT scratch lives
+    /// inside the hash-chain matcher, gated by `uses_bt`).
+    pub(crate) const fn backend(self) -> BackendTag {
+        match self {
+            Self::Fast => BackendTag::Simple,
+            Self::DoubleFast => BackendTag::Dfast,
+            Self::RowHash => BackendTag::Row,
+            Self::HashChain | Self::BinaryTree => BackendTag::HashChain,
+        }
+    }
+}
+
 /// Compile-time encoder strategy. Each concrete implementor is a ZST
 /// whose associated `const`s tell the optimal parser / match finder
 /// which donor-equivalent path to execute. Hot entry points are
@@ -338,6 +410,31 @@ impl StrategyTag {
             Self::Dfast => BackendTag::Dfast,
             Self::Greedy => BackendTag::Row,
             Self::Lazy | Self::BtOpt | Self::BtUltra | Self::BtUltra2 => BackendTag::HashChain,
+        }
+    }
+
+    /// Default search method this tag historically ran on. Used to seed
+    /// the decoupled [`SearchMethod`] axis from the legacy tag during
+    /// migration; once `LEVEL_TABLE` carries explicit configs this is the
+    /// fallback for tag-only call sites.
+    pub(crate) const fn search(self) -> SearchMethod {
+        match self {
+            Self::Fast => SearchMethod::Fast,
+            Self::Dfast => SearchMethod::DoubleFast,
+            Self::Greedy => SearchMethod::RowHash,
+            Self::Lazy => SearchMethod::HashChain,
+            Self::BtOpt | Self::BtUltra | Self::BtUltra2 => SearchMethod::BinaryTree,
+        }
+    }
+
+    /// Default parse mode for this tag, ignoring per-level lazy depth (the
+    /// lazy band's real depth comes from `LevelParams.lazy_depth` via
+    /// [`ParseMode::from_lazy_depth`]). The opt tags map to `Optimal`.
+    pub(crate) const fn parse_mode(self) -> ParseMode {
+        match self {
+            Self::Fast | Self::Dfast | Self::Greedy => ParseMode::Greedy,
+            Self::Lazy => ParseMode::Lazy,
+            Self::BtOpt | Self::BtUltra | Self::BtUltra2 => ParseMode::Optimal,
         }
     }
 }


### PR DESCRIPTION
## Summary

Post-split block splitting was gated to `Level(16..=22)` (btopt+), so greedy and lazy emitted whole 128 KiB blocks with a single HUF/FSE table over mixed local literal statistics. That one ill-fitting table is the dominant literal-section loss vs the C reference on mixed corpora.

On `decodecorpus-z000033` level 5: our literal section was 402986 B (8 blocks) vs the reference 370567 B (94 blocks) — a 32 KiB gap leaving us +5.7% larger overall.

Extend the post-split gate to every search-based strategy (greedy and up) with a >=128 KiB window. Fast/Dfast stay un-split (cheap match-finding makes the splitter's per-partition entropy probes cost more than the ratio they buy).

## Result (z000033 level 5, local, deterministic)

| | frame | blocks | literal section |
|---|---|---|---|
| before | 517080 | 8 | 402986 |
| after | **472060** | 189 | **353148** |
| C reference | 489007 | 94 | 370567 |

From **+5.7% larger** than the reference to **-3.5% smaller**.

## Validation

714 tests pass (roundtrip + cross-validation + param dispatch), clippy + fmt clean. The CI benchmark matrix validates ratio + speed across every corpus and level; the speed cost of the added splitter probes on greedy/lazy is the thing to watch in the bench report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved compression strategy selection logic for enhanced performance with larger window sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->