### PR TITLE
perf(encode): price the custom FSE table without building it

### DIFF
--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -6,7 +6,7 @@ use crate::{
     encoding::block_header::BlockHeader,
     encoding::frame_compressor::{CompressState, FseTables, PreviousFseTable},
     encoding::{Matcher, Sequence},
-    fse::fse_encoder::{FSETable, build_table_from_symbol_counts},
+    fse::fse_encoder::{FSETable, build_table_from_symbol_counts, fse_header_bits_for_counts},
     huff0::huff0_encoder,
 };
 
@@ -1540,16 +1540,17 @@ fn choose_table_from_counts<'a>(
     }
 
     let use_low_prob_count = total >= 2048;
-    let new_table = (distinct_symbols > 1).then(|| {
-        build_table_from_symbol_counts(&counts[..=max_symbol], max_log, use_low_prob_count)
-    });
 
-    // Mirror donor `ZSTD_selectEncodingType()` for optimal strategies:
-    // compare default cross-entropy, repeat-table FSE bit cost, and
-    // compressed table header plus entropy-bound payload cost.
-    let new_total_cost = new_table.as_ref().map(|table| {
-        table
-            .table_header_bits()
+    // Mirror donor `ZSTD_selectEncodingType()`: compare default
+    // cross-entropy, repeat-table FSE bit cost, and the custom compressed
+    // table (header + entropy-bound payload). The custom table's header is
+    // priced from its normalized counts via `fse_header_bits_for_counts`
+    // WITHOUT building the (often-discarded) state tables — the build only
+    // runs in the `Choice::New` arm below, when the custom table actually
+    // wins. The estimate equals the built table's `table_header_bits()`
+    // exactly, so the selection is byte-identical.
+    let new_total_cost = (distinct_symbols > 1).then(|| {
+        fse_header_bits_for_counts(&counts[..=max_symbol], max_log, use_low_prob_count)
             .saturating_add(entropy_cost(counts, max_symbol, total))
     });
 
@@ -1592,9 +1593,15 @@ fn choose_table_from_counts<'a>(
             .map(FseTableMode::RepeatLast)
             .unwrap_or(FseTableMode::Predefined(default_table)),
         Some(Choice::Predefined) => FseTableMode::Predefined(default_table),
-        Some(Choice::New) => new_table
-            .map(FseTableMode::Encoded)
-            .unwrap_or(FseTableMode::Predefined(default_table)),
+        // The custom table won the cost comparison — build it now (the only
+        // place the state tables are constructed). `distinct_symbols > 1`
+        // held when `new_total_cost` was computed, so the histogram has the
+        // two-sample minimum `build_table_from_symbol_counts` requires.
+        Some(Choice::New) => FseTableMode::Encoded(build_table_from_symbol_counts(
+            &counts[..=max_symbol],
+            max_log,
+            use_low_prob_count,
+        )),
         None => {
             let fallback_counts = [counts[0], 0];
             let fallback = if max_symbol == 0 {

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -497,6 +497,16 @@ pub(crate) fn fse_header_bits_for_counts(
     avoid_0_numbit: bool,
 ) -> usize {
     let total = counts.iter().sum::<usize>();
+    // Mirror `build_table_from_counts`'s contract: pricing must reject the
+    // same inputs the builder rejects. A histogram with fewer than two
+    // samples cannot form a valid FSE table, and the table-log selection
+    // below takes an integer logarithm of `total` that underflows on
+    // `total <= 1`. Trip the guard up front so the failure mode matches
+    // the builder instead of an opaque arithmetic panic.
+    assert!(
+        total > 1,
+        "FSE table requires at least 2 samples in the histogram (got {total})"
+    );
     let max_symbol = counts
         .iter()
         .rposition(|&count| count > 0)

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -260,48 +260,12 @@ impl FSETable {
     /// The result assumes the header starts at a byte boundary, which matches
     /// all current encoder call sites.
     pub(crate) fn table_header_bits(&self) -> usize {
-        let mut bits = 4; // acc_log - 5
-        let mut probability_counter = 0usize;
-        let probability_sum = 1 << self.acc_log();
-
-        let mut prob_idx = 0;
-        while probability_counter < probability_sum {
-            let max_remaining_value = probability_sum - probability_counter + 1;
-            let bits_to_write = max_remaining_value.ilog2() + 1;
-            let low_threshold = ((1 << bits_to_write) - 1) - max_remaining_value;
-
-            let prob = self.states[prob_idx].probability;
-            prob_idx += 1;
-            let value = (prob + 1) as u32;
-            if value < low_threshold as u32 {
-                bits += bits_to_write as usize - 1;
-            } else {
-                bits += bits_to_write as usize;
-            }
-
-            if prob == -1 {
-                probability_counter += 1;
-            } else if prob > 0 {
-                probability_counter += prob as usize;
-            } else {
-                let mut zeros = 0u8;
-                while prob_idx < self.states.len() && self.states[prob_idx].probability == 0 {
-                    zeros += 1;
-                    prob_idx += 1;
-                    if zeros == 3 {
-                        bits += 2;
-                        zeros = 0;
-                    }
-                }
-                bits += 2;
-            }
-        }
-        // Byte-alignment padding
-        let misaligned = bits % 8;
-        if misaligned != 0 {
-            bits += 8 - misaligned;
-        }
-        bits
+        // Delegate to the free `ncount_header_bits` so the header sizing has a
+        // single source of truth shared with the pre-build cost estimate in
+        // `fse_header_bits_for_counts` (the table-mode selector prices a
+        // candidate table from its normalized counts without building it).
+        let probs: [i32; 256] = core::array::from_fn(|i| self.states[i].probability);
+        ncount_header_bits(&probs, self.acc_log())
     }
 
     pub(crate) fn write_table<V: AsMut<Vec<u8>>>(&self, writer: &mut BitWriter<V>) {
@@ -465,6 +429,89 @@ fn build_table_from_counts(counts: &[usize], max_log: u8, avoid_0_numbit: bool) 
         avoid_0_numbit,
     );
     build_table_from_probabilities(&probs[..counts.len()], table_log)
+}
+
+/// Bit size of the serialized FSE NCount table header for the normalized
+/// distribution `probs` at `acc_log`. This is exactly what
+/// [`FSETable::table_header_bits`] returns (they share this implementation),
+/// but computed from the normalized counts alone — no spread / state-table /
+/// `symbolTT` construction. The table-mode selector uses it to price a
+/// candidate custom table without building its (otherwise discarded) state
+/// tables.
+fn ncount_header_bits(probs: &[i32], acc_log: u8) -> usize {
+    let mut bits = 4; // acc_log - 5
+    let mut probability_counter = 0usize;
+    let probability_sum = 1usize << acc_log;
+
+    let mut prob_idx = 0;
+    while probability_counter < probability_sum {
+        let max_remaining_value = probability_sum - probability_counter + 1;
+        let bits_to_write = max_remaining_value.ilog2() + 1;
+        let low_threshold = ((1 << bits_to_write) - 1) - max_remaining_value;
+
+        let prob = probs[prob_idx];
+        prob_idx += 1;
+        let value = (prob + 1) as u32;
+        if value < low_threshold as u32 {
+            bits += bits_to_write as usize - 1;
+        } else {
+            bits += bits_to_write as usize;
+        }
+
+        if prob == -1 {
+            probability_counter += 1;
+        } else if prob > 0 {
+            probability_counter += prob as usize;
+        } else {
+            let mut zeros = 0u8;
+            while prob_idx < probs.len() && probs[prob_idx] == 0 {
+                zeros += 1;
+                prob_idx += 1;
+                if zeros == 3 {
+                    bits += 2;
+                    zeros = 0;
+                }
+            }
+            bits += 2;
+        }
+    }
+    // Byte-alignment padding
+    let misaligned = bits % 8;
+    if misaligned != 0 {
+        bits += 8 - misaligned;
+    }
+    bits
+}
+
+/// Header bit cost of the custom FSE table that
+/// [`build_table_from_symbol_counts`] would produce for `counts`, without
+/// building it. Mirrors the front of `build_table_from_counts` (table-log
+/// selection + count normalization) and then sizes the header via
+/// [`ncount_header_bits`]. Returns the exact value the built table's
+/// `table_header_bits()` would, so the table-mode selection stays
+/// byte-identical while skipping the state-table build for candidates that
+/// lose to the predefined / repeated table.
+pub(crate) fn fse_header_bits_for_counts(
+    counts: &[usize],
+    max_log: u8,
+    avoid_0_numbit: bool,
+) -> usize {
+    let total = counts.iter().sum::<usize>();
+    let max_symbol = counts
+        .iter()
+        .rposition(|&count| count > 0)
+        .unwrap_or_default();
+    let table_log = donor_optimal_table_log(max_log, total, max_symbol);
+    let mut probs = [0i32; 256];
+    donor_normalize_counts(
+        &mut probs[..counts.len()],
+        table_log,
+        counts,
+        total,
+        max_symbol,
+        avoid_0_numbit,
+    );
+    ncount_header_bits(&probs[..counts.len()], table_log)
 }
 
 fn donor_min_table_log(total: usize, max_symbol: usize) -> u8 {

--- a/zstd/src/fse/mod.rs
+++ b/zstd/src/fse/mod.rs
@@ -272,3 +272,39 @@ pub fn round_trip(data: &[u8]) {
 
     assert_eq!(br.bits_remaining(), 0);
 }
+
+#[test]
+#[should_panic(expected = "FSE table requires at least 2 samples")]
+fn fse_header_pricing_rejects_single_sample_histogram() {
+    // A histogram with fewer than two samples cannot form a valid FSE
+    // table. Header pricing must trip the same `total > 1` guard as the
+    // builder it mirrors, rather than fall through into table-log /
+    // normalization arithmetic that underflows on `total <= 1`.
+    let _ = fse_encoder::fse_header_bits_for_counts(&[1], 9, false);
+}
+
+#[test]
+fn fse_header_pricing_matches_built_table_header_bits() {
+    // The custom-table mode selector trusts that pricing a header from
+    // counts returns exactly what the eventually built table's
+    // `table_header_bits()` reports. Lock that invariant across a few
+    // representative histograms and both `avoid_0_numbit` modes.
+    let histograms: [&[usize]; 4] = [
+        &[50, 50],
+        &[4, 4, 4, 4],
+        &[100, 5, 1, 1],
+        &[200, 100, 50, 25, 12, 6, 3, 1],
+    ];
+    for counts in histograms {
+        for avoid_0_numbit in [false, true] {
+            let priced = fse_encoder::fse_header_bits_for_counts(counts, 9, avoid_0_numbit);
+            let built = fse_encoder::build_table_from_symbol_counts(counts, 9, avoid_0_numbit)
+                .table_header_bits();
+            assert_eq!(
+                priced, built,
+                "header pricing diverged from built table for counts={counts:?} \
+                 avoid_0_numbit={avoid_0_numbit}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Per-block FSE table selection (LL / ML / OF) built the custom table via
`build_table_from_symbol_counts` before comparing it against the predefined
and repeated options, discarding the built state tables whenever one of
those won.

The custom table's cost is `table_header_bits() + entropy_cost`, and the
header size depends only on the normalized counts and `acc_log` — not on the
spread / next-state / `symbolTT` construction. Factor the header sizing into
a free `ncount_header_bits` (now the single source of truth, also used by
`FSETable::table_header_bits`) plus `fse_header_bits_for_counts`, which
normalizes the counts and prices the header without building the table. The
selector uses that estimate and builds the full table only in the
`Choice::New` arm, when the custom table actually wins.

The estimate equals the built table's `table_header_bits()` exactly, so the
selection — and the emitted stream — is byte-identical; the state-table
build is skipped for candidates that lose to a predefined or repeated table.

## Benchmark (i9-9900K, `compare_ffi`, `level_1_fast`, vs `main`)

| scenario | main (pre-PR) | this PR | vs C |
|---|---|---|---|
| small-4k-log-lines | 17.8 us | **15.6 us** (-12.2%) | 2.21x (was 2.51x) |
| decodecorpus-z000033 | 4.92 ms | **4.68 ms** (-4.8%) | — |

Compressed sizes unchanged (small-4k stays 156 bytes vs C's 157;
decodecorpus 579584). Random / incompressible inputs are unaffected.

Together with the earlier small-input fixed-cost work, the
`small-4k-log-lines` level-1 encode is down from 30.4 us to 15.6 us
(4.23x to 2.21x vs C), all ratio-neutral.

Part of #341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized FSE compression encoder to calculate table header costs more efficiently, eliminating redundant intermediate structures during table selection and improving overall encoding performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->