### PR TITLE
perf(encode): store row match positions as u32 to cut peak memory

### DIFF
--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1017,17 +1017,19 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // suffix, top it back up before compressing the next block, matching
             // ZSTD_compress_frameChunk() over a contiguous input buffer.
             let block_capacity = MAX_BLOCK_SIZE as usize;
-            let had_pending = !pending_input.is_empty();
-            let mut uncompressed_data = if had_pending {
-                core::mem::take(&mut pending_input)
-            } else {
-                self.state.matcher.get_next_space()
-            };
-            let mut filled = if had_pending {
-                uncompressed_data.len()
-            } else {
-                0
-            };
+            // Always draw the block buffer from the matcher's recycled pool
+            // (its capacity already covers the block size, so the resize below
+            // stays in-place). Any carried pre-split suffix is copied in, and
+            // `pending_input` is retained as a reusable carry buffer. The prior
+            // approach `split_off`'d a fresh suffix Vec per pre-split and
+            // `reserve_exact`-grew it to `block_capacity` every block; on a
+            // heavily pre-split frame that churned one block-sized allocation
+            // per split (~12 MB over ~90 splits on a 1 MiB corpus input).
+            let mut uncompressed_data = self.state.matcher.get_next_space();
+            uncompressed_data.clear();
+            uncompressed_data.extend_from_slice(&pending_input);
+            let mut filled = pending_input.len();
+            pending_input.clear();
             if uncompressed_data.len() < block_capacity {
                 uncompressed_data.resize(block_capacity, 0);
             }
@@ -1063,16 +1065,14 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     savings,
                 );
                 if block_len < uncompressed_data.len() {
-                    pending_input = uncompressed_data.split_off(block_len);
-                    // `split_off` returns a Vec whose capacity is typically
-                    // close to its length. Next iteration's `had_pending`
-                    // branch moves `pending_input` into `uncompressed_data`
-                    // and resizes to `block_capacity`, which would reallocate
-                    // from scratch on every pre-split. Pre-reserve here so
-                    // the resize stays in-place.
-                    if pending_input.capacity() < block_capacity {
-                        pending_input.reserve_exact(block_capacity - pending_input.len());
-                    }
+                    // Carry the kept suffix into the reusable `pending_input`
+                    // buffer (cleared, capacity retained) instead of allocating
+                    // a fresh Vec via `split_off`. Next iteration copies it back
+                    // into a pooled block buffer. The block currently being
+                    // compressed is truncated to the chosen split length.
+                    pending_input.clear();
+                    pending_input.extend_from_slice(&uncompressed_data[block_len..]);
+                    uncompressed_data.truncate(block_len);
                     last_block = false;
                 }
             }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1542,11 +1542,24 @@ impl Matcher for MatchGeneratorDriver {
                 evicted_bytes += pre.saturating_add(space_len).saturating_sub(m.window_size);
             }
             MatcherStorage::Row(m) => {
-                m.add_data(space, |mut data| {
-                    evicted_bytes += data.len();
-                    data.resize(data.capacity(), 0);
+                // RowMatchGenerator::add_data recycles the *input* buffer
+                // through this callback every commit (its bytes are mirrored
+                // into `history`), not the evicted chunks. Derive the eviction
+                // delta from `window_size` before/after — `evicted = pre +
+                // space_len - post` — exactly like the Simple / HashChain arms.
+                // Counting the callback argument as evicted would charge the
+                // whole committed block as evicted and prematurely retire
+                // dictionary budget on a window that evicts nothing.
+                let pre = m.window_size;
+                let space_len = space.len();
+                m.add_data(space, |data| {
+                    // Recycle the spent buffer as-is; `add_data` runs this for
+                    // every committed block, so zero-filling to capacity here
+                    // would be hot-path waste (`get_next_space` zeroes at most
+                    // `slice_size` on reuse).
                     vec_pool.push(data);
                 });
+                evicted_bytes += pre.saturating_add(space_len).saturating_sub(m.window_size);
             }
             MatcherStorage::HashChain(m) => {
                 // MatchTable::add_data now recycles the *incoming* buffer

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7829,6 +7829,41 @@ fn hc_commit_without_eviction_retires_no_dictionary_budget() {
 }
 
 #[test]
+fn row_commit_without_eviction_retires_no_dictionary_budget() {
+    // Regression for the Row arm of commit_space after the window ->
+    // chunk_lens migration: RowMatchGenerator::add_data now invokes its
+    // reuse_space callback for the *input* buffer (per-commit recycle),
+    // not for evicted chunks. The Row arm must derive eviction bytes from
+    // the window_size delta like the Dfast / HashChain arms — counting the
+    // callback argument as evicted charges the whole committed block as
+    // "evicted" and prematurely retires dictionary budget even when the
+    // window is nowhere near full.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    driver.reset(CompressionLevel::Level(5));
+    assert!(matches!(driver.storage, MatcherStorage::Row(_)));
+    // A large live window so a small committed block evicts nothing.
+    driver.row_matcher_mut().max_window_size = 1 << 20;
+    driver.reported_window_size = 1 << 20;
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    let budget_after_prime = driver.dictionary_retained_budget;
+    assert!(
+        budget_after_prime > 0,
+        "priming must retain a non-zero dictionary budget"
+    );
+
+    let mut space = driver.get_next_space();
+    space.clear();
+    space.extend_from_slice(b"AAAAAAAA");
+    driver.commit_space(space);
+    driver.skip_matching_with_hint(None);
+
+    assert_eq!(
+        driver.dictionary_retained_budget, budget_after_prime,
+        "a Row commit that evicts nothing must retire no dictionary budget"
+    );
+}
+
+#[test]
 fn hc_rebases_positions_after_u32_boundary() {
     let mut matcher = HcMatchGenerator::new(64);
     matcher.table.add_data(b"abcdeabcdeabcde".to_vec(), |_| {});

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7913,6 +7913,12 @@ fn hc_rebases_positions_after_u32_boundary() {
     );
 }
 
+// 64-bit only: the >4 GiB absolute cursor this test fabricates cannot exist on
+// a 32-bit target (usize == u32 can't address that much), and setting
+// `history_abs_start` near `u32::MAX` there overflows `usize` in the
+// `check_stream_abs_headroom` guard before the rebase path is reached. Mirrors
+// the `try_into()` early-return guard on `hc_rebases_positions_after_u32_boundary`.
+#[cfg(target_pointer_width = "64")]
 #[test]
 fn row_rebases_positions_after_u32_boundary() {
     // Row stores absolute match positions as u32. On a long stream the

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7914,6 +7914,38 @@ fn hc_rebases_positions_after_u32_boundary() {
 }
 
 #[test]
+fn row_rebases_positions_after_u32_boundary() {
+    // Row stores absolute match positions as u32. On a long stream the
+    // cumulative absolute cursor crosses the u32 range even while the live
+    // window stays bounded; `add_data` must rebase the coordinate origin
+    // down to the oldest live byte instead of asserting. Before the rebase
+    // landed this panicked on the `< u32::MAX` assertion, dropping valid
+    // long Row-backed frames.
+    let mut m = RowMatchGenerator::new(64);
+    m.add_data(b"abcdeabcdeabcde".to_vec(), |_| {});
+
+    // Simulate ~4 GiB of stream behind a bounded window: the live bytes now
+    // sit just under the u32 absolute ceiling.
+    let near_ceiling = (u32::MAX as usize) - 16;
+    m.history_abs_start = near_ceiling;
+
+    // The next commit would push a u32 position past the ceiling; add_data
+    // must rebase the origin rather than panic.
+    m.add_data(b"fghij".to_vec(), |_| {});
+
+    assert!(
+        m.history_abs_start < near_ceiling,
+        "add_data must rebase the absolute origin down when the cursor nears \
+         u32::MAX (got {})",
+        m.history_abs_start
+    );
+    assert!(
+        (m.history_abs_start + m.window_size) < u32::MAX as usize,
+        "after rebase the live window must fit below the u32 position ceiling"
+    );
+}
+
+#[test]
 fn hc_rebase_rebuilds_only_inserted_prefix() {
     let mut matcher = HcMatchGenerator::new(64);
     matcher.table.add_data(b"abcdeabcdeabcde".to_vec(), |_| {});

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -112,7 +112,7 @@ pub(crate) const ROW_LOG: usize = 5;
 pub(crate) const ROW_SEARCH_DEPTH: usize = 16;
 pub(crate) const ROW_TARGET_LEN: usize = 48;
 pub(crate) const ROW_TAG_BITS: usize = 8;
-pub(crate) const ROW_EMPTY_SLOT: usize = usize::MAX;
+pub(crate) const ROW_EMPTY_SLOT: u32 = u32::MAX;
 pub(crate) const ROW_HASH_KEY_LEN: usize = 4;
 // HASH_MIX_PRIME now lives in `crate::encoding::fastpath::scalar`; the four
 // per-CPU `hash_mix_u64` variants share it via that module.

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1013,15 +1013,14 @@ impl MatchGeneratorDriver {
                     evicted_bytes += pre - dfast.window_size;
                 }
                 super::strategy::BackendTag::Row => {
-                    let mut retired = Vec::new();
-                    self.row_matcher_mut().trim_to_window(|data| {
-                        evicted_bytes += data.len();
-                        retired.push(data);
-                    });
-                    for mut data in retired {
-                        data.resize(data.capacity(), 0);
-                        self.vec_pool.push(data);
-                    }
+                    // Row keeps bytes only in the contiguous `history` mirror
+                    // (block buffers are returned to the pool per block in
+                    // `add_data`), so derive the eviction count from the
+                    // `window_size` delta, mirroring the Dfast / HashChain arms.
+                    let row = self.row_matcher_mut();
+                    let pre = row.window_size;
+                    row.trim_to_window();
+                    evicted_bytes += pre - row.window_size;
                 }
                 super::strategy::BackendTag::HashChain => {
                     // HC keeps bytes only in the contiguous `history` mirror
@@ -1161,11 +1160,7 @@ impl Matcher for MatchGeneratorDriver {
                     m.row_heads = Vec::new();
                     m.row_positions = Vec::new();
                     m.row_tags = Vec::new();
-                    let vec_pool = &mut self.vec_pool;
-                    m.reset(|mut data| {
-                        data.resize(data.capacity(), 0);
-                        vec_pool.push(data);
-                    });
+                    m.reset();
                 }
                 MatcherStorage::HashChain(m) => {
                     // Release oversized tables when switching away from
@@ -1262,11 +1257,7 @@ impl Matcher for MatchGeneratorDriver {
                 if hinted {
                     row.set_hash_bits(row_hash_bits_for_window(max_window_size));
                 }
-                let vec_pool = &mut self.vec_pool;
-                row.reset(|mut data| {
-                    data.resize(data.capacity(), 0);
-                    vec_pool.push(data);
-                });
+                row.reset();
             }
             MatcherStorage::HashChain(hc) => {
                 hc.table.max_window_size = max_window_size;
@@ -6816,8 +6807,8 @@ fn prime_with_dictionary_budget_shrinks_after_row_eviction() {
 /// the swap, so there is nothing to inspect by accessor; the "window
 /// cleared" invariant is replaced by "variant dropped", and a
 /// subsequent `row_matcher()` call would panic by design. The
-/// pool-recycling side of the same transition is covered by
-/// [`driver_reset_from_row_backend_recycles_row_buffers_into_pool`].
+/// pool-recycling side of the row backend is covered by
+/// [`driver_row_commit_recycles_block_buffer_into_pool`].
 #[test]
 fn row_get_last_space_then_reset_to_fastest_drops_row_variant() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
@@ -6835,41 +6826,38 @@ fn row_get_last_space_then_reset_to_fastest_drops_row_variant() {
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Simple);
 }
 
-/// Switching from Row to Simple drains row-side buffers into `vec_pool`
-/// before swapping the storage variant. With the [`MatcherStorage`] enum
-/// the old [`RowMatchGenerator`] is dropped on swap, so this test
-/// guards only the pool-recycling side of the transition. The
-/// pre-enum tests (`…reclaims_row_buffer_pool` /
-/// `…tolerates_missing_row_matcher`) checked that the row matcher
-/// stayed allocated across the switch with its internals cleared —
-/// the new invariant is "dead variants are dropped", and the
-/// `row_match_generator: Option<_>` field whose lazy-init recovery
-/// they exercised no longer exists.
+/// Committing a Row block must return the input buffer to `vec_pool`
+/// immediately (the bytes are mirrored into the contiguous `history`,
+/// so there is no reason to retain a second copy in the window). This
+/// guards the chunk-length window: the previous `VecDeque<Vec<u8>>`
+/// window retained a full `block_capacity` buffer per committed block,
+/// which on a heavily pre-split frame ballooned peak memory to many
+/// times the live byte count. With the buffer recycled at commit time
+/// the pool grows by exactly one Vec per committed block.
 #[test]
-fn driver_reset_from_row_backend_recycles_row_buffers_into_pool() {
+fn driver_row_commit_recycles_block_buffer_into_pool() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
     driver.reset(CompressionLevel::Level(5));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
 
+    let before_pool = driver.vec_pool.len();
     let mut space = driver.get_next_space();
+    space.clear();
     space.extend_from_slice(b"row-data-to-recycle");
     driver.commit_space(space);
 
-    let before_pool = driver.vec_pool.len();
-    driver.reset(CompressionLevel::Fastest);
-
-    assert_eq!(driver.active_backend(), super::strategy::BackendTag::Simple);
     // `>` not `>=`: a fresh driver starts with `before_pool == 0`, so the
-    // weaker bound passes even if the Row→Simple transition failed to
-    // drain the committed buffer back into `vec_pool`. Strict growth
-    // proves the drain ran. Single fixture buffer → exactly one Vec
-    // returned to the pool.
+    // weaker bound passes even if the commit failed to recycle. Strict
+    // growth proves the buffer was returned to the pool at commit time
+    // rather than retained in the window (the pre-`chunk_lens` bug).
     assert!(
         driver.vec_pool.len() > before_pool,
-        "row reset must recycle the committed row history buffer into vec_pool \
+        "row commit must recycle the committed block buffer into vec_pool \
          (before_pool = {before_pool}, after = {})",
         driver.vec_pool.len()
     );
+    // The bytes still resolve through the contiguous history mirror.
+    assert_eq!(driver.get_last_space(), b"row-data-to-recycle");
 }
 
 #[test]

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -365,10 +365,13 @@ pub(crate) struct RowMatchGenerator {
     pub(crate) row_heads: Vec<u8>,
     // Absolute match positions, one per row slot. Stored as `u32` (not
     // `usize`): this is the largest match-finder array, and `u32` halves its
-    // footprint vs the donor-parity `U32` layout. The encoder caps a single
-    // Row frame below `u32::MAX` in `add_data` (so every stored position is
-    // representable and `ROW_EMPTY_SLOT == u32::MAX` stays an unambiguous
-    // sentinel); the absolute cursor resets to 0 per frame.
+    // footprint vs the donor-parity `U32` layout. `ROW_EMPTY_SLOT == u32::MAX`
+    // is the empty sentinel, so every stored position must stay strictly below
+    // it. On a long stream the cumulative absolute cursor would cross `u32::MAX`
+    // even while the live window is bounded; `add_data` rebases the coordinate
+    // origin down to the oldest live byte before that happens (see
+    // [`Self::rebase_positions`]), keeping positions representable without
+    // capping frame length.
     pub(crate) row_positions: Vec<u32>,
     pub(crate) row_tags: Vec<u8>,
     /// Cached tag-match SIMD kernel; CPU features are fixed per process, so

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -448,17 +448,17 @@ impl RowMatchGenerator {
             self.window_size,
             data.len(),
         );
-        // Row stores absolute match positions as `u32` with `u32::MAX`
-        // reserved as the empty sentinel, so a single frame's absolute cursor
-        // must stay below `u32::MAX`. The cursor resets to 0 per frame, so
-        // this only bounds a single >= ~4 GiB frame — far beyond the
-        // decoder's window cap. `check_stream_abs_headroom` above already
-        // guaranteed this sum does not overflow `usize`.
-        assert!(
-            self.history_abs_start + self.window_size + data.len() < u32::MAX as usize,
-            "structured-zstd: a Row-strategy frame exceeded the u32 match-position \
-             limit; split the input into smaller frames or use a higher level"
-        );
+        // Row stores absolute match positions as `u32` (with `u32::MAX` the
+        // empty sentinel). On a long stream the cumulative absolute cursor
+        // crosses the u32 range even while the live window stays bounded, so
+        // rebase the coordinate origin down to the oldest live byte before the
+        // upcoming block's positions would overflow. Cold path — fires at most
+        // once per ~4 GiB of stream, and one rebase always suffices because the
+        // live window is far smaller than u32::MAX. `check_stream_abs_headroom`
+        // above already guards the 32-bit-target `usize` overflow separately.
+        if self.history_abs_start + self.window_size + data.len() >= u32::MAX as usize - 1 {
+            self.rebase_positions();
+        }
         while self.window_size + data.len() > self.max_window_size {
             let removed_len = self.chunk_lens.pop_front().unwrap();
             self.window_size -= removed_len;
@@ -482,6 +482,35 @@ impl RowMatchGenerator {
             self.history_start += removed_len;
             self.history_abs_start += removed_len;
         }
+    }
+
+    /// Rebase the absolute coordinate origin down to the oldest live byte so
+    /// stored `u32` match positions stay representable on long (multi-GiB)
+    /// streams. Cold path, driven from [`Self::add_data`] when the cursor
+    /// nears `u32::MAX`. Subtracts the current `history_abs_start` from every
+    /// live `row_positions` entry; entries older than the new origin (already
+    /// unreachable through the `candidate_pos < history_abs_start` read guard)
+    /// collapse to `ROW_EMPTY_SLOT`. The shift is uniform across the origin and
+    /// every stored position, so every match offset is preserved and matching
+    /// is unaffected. `row_heads` (slot cursors) and `row_tags` (hash tags)
+    /// hold no absolute positions and are left untouched.
+    fn rebase_positions(&mut self) {
+        let delta = self.history_abs_start;
+        if delta == 0 {
+            return;
+        }
+        for slot in self.row_positions.iter_mut() {
+            if *slot == ROW_EMPTY_SLOT {
+                continue;
+            }
+            let abs = *slot as usize;
+            *slot = if abs < delta {
+                ROW_EMPTY_SLOT
+            } else {
+                (abs - delta) as u32
+            };
+        }
+        self.history_abs_start -= delta;
     }
 
     pub(crate) fn skip_matching_with_hint_rl<const ROW_LOG: usize>(

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -356,7 +356,13 @@ pub(crate) struct RowMatchGenerator {
     /// Cached fastpath kernel for `hash_mix_u64`; see Dfast for rationale.
     pub(crate) hash_kernel: crate::encoding::fastpath::FastpathKernel,
     pub(crate) row_heads: Vec<u8>,
-    pub(crate) row_positions: Vec<usize>,
+    // Absolute match positions, one per row slot. Stored as `u32` (not
+    // `usize`): this is the largest match-finder array, and `u32` halves its
+    // footprint vs the donor-parity `U32` layout. The encoder caps a single
+    // Row frame below `u32::MAX` in `add_data` (so every stored position is
+    // representable and `ROW_EMPTY_SLOT == u32::MAX` stays an unambiguous
+    // sentinel); the absolute cursor resets to 0 per frame.
+    pub(crate) row_positions: Vec<u32>,
     pub(crate) row_tags: Vec<u8>,
     /// Cached tag-match SIMD kernel; CPU features are fixed per process, so
     /// resolve once instead of querying per `row_candidate` call.
@@ -434,6 +440,17 @@ impl RowMatchGenerator {
             self.history_abs_start,
             self.window_size,
             data.len(),
+        );
+        // Row stores absolute match positions as `u32` with `u32::MAX`
+        // reserved as the empty sentinel, so a single frame's absolute cursor
+        // must stay below `u32::MAX`. The cursor resets to 0 per frame, so
+        // this only bounds a single >= ~4 GiB frame — far beyond the
+        // decoder's window cap. `check_stream_abs_headroom` above already
+        // guaranteed this sum does not overflow `usize`.
+        assert!(
+            self.history_abs_start + self.window_size + data.len() < u32::MAX as usize,
+            "structured-zstd: a Row-strategy frame exceeded the u32 match-position \
+             limit; split the input into smaller frames or use a higher level"
         );
         while self.window_size + data.len() > self.max_window_size {
             let removed = self.window.pop_front().unwrap();
@@ -1065,11 +1082,14 @@ impl RowMatchGenerator {
             if !matched {
                 continue;
             }
-            let candidate_pos = self.row_positions[idx];
-            if candidate_pos == ROW_EMPTY_SLOT
-                || candidate_pos < self.history_abs_start
-                || candidate_pos >= abs_pos
-            {
+            let raw_pos = self.row_positions[idx];
+            if raw_pos == ROW_EMPTY_SLOT {
+                continue;
+            }
+            // Stored positions are absolute (`< u32::MAX`, capped per frame in
+            // `add_data`); widen to `usize` for the window-bound checks.
+            let candidate_pos = raw_pos as usize;
+            if candidate_pos < self.history_abs_start || candidate_pos >= abs_pos {
                 continue;
             }
             let candidate_idx = candidate_pos - self.history_abs_start;
@@ -1185,7 +1205,10 @@ impl RowMatchGenerator {
             let next = head.wrapping_sub(1) & row_mask;
             *self.row_heads.get_unchecked_mut(row) = next as u8;
             *self.row_tags.get_unchecked_mut(row_base + next) = tag;
-            *self.row_positions.get_unchecked_mut(row_base + next) = abs_pos;
+            // `abs_pos < u32::MAX` holds: `add_data` caps a Row frame's
+            // absolute cursor below `u32::MAX`, so the cast is lossless and
+            // never collides with the `ROW_EMPTY_SLOT == u32::MAX` sentinel.
+            *self.row_positions.get_unchecked_mut(row_base + next) = abs_pos as u32;
         }
     }
 }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -337,7 +337,14 @@ unsafe fn row_tag_match_mask_neon(tags: &[u8], tag: u8) -> u64 {
 
 pub(crate) struct RowMatchGenerator {
     pub(crate) max_window_size: usize,
-    pub(crate) window: VecDeque<Vec<u8>>,
+    /// Per-committed-block lengths of the live window, mirroring the
+    /// `HashChain` backend's `chunk_lens`. The block bytes themselves live
+    /// only in the contiguous `history` mirror; the input buffers are handed
+    /// straight back to the caller's pool in `add_data` rather than retained
+    /// here. Retaining them (the old `VecDeque<Vec<u8>>`) held a full
+    /// `block_capacity`-sized buffer per committed block, which on a heavily
+    /// pre-split frame ballooned the window to many times the live byte count.
+    pub(crate) chunk_lens: VecDeque<usize>,
     pub(crate) window_size: usize,
     pub(crate) history: Vec<u8>,
     pub(crate) history_start: usize,
@@ -373,7 +380,7 @@ impl RowMatchGenerator {
     pub(crate) fn new(max_window_size: usize) -> Self {
         Self {
             max_window_size,
-            window: VecDeque::new(),
+            chunk_lens: VecDeque::new(),
             window_size: 0,
             history: Vec::new(),
             history_start: 0,
@@ -415,7 +422,7 @@ impl RowMatchGenerator {
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
-    pub(crate) fn reset(&mut self, mut reuse_space: impl FnMut(Vec<u8>)) {
+    pub(crate) fn reset(&mut self) {
         self.window_size = 0;
         self.history.clear();
         self.history_start = 0;
@@ -424,14 +431,14 @@ impl RowMatchGenerator {
         self.row_heads.fill(0);
         self.row_positions.fill(ROW_EMPTY_SLOT);
         self.row_tags.fill(0);
-        for mut data in self.window.drain(..) {
-            data.resize(data.capacity(), 0);
-            reuse_space(data);
-        }
+        // Block buffers are returned to the caller's pool per block in
+        // `add_data`, so there is nothing window-side to recycle here.
+        self.chunk_lens.clear();
     }
 
     pub(crate) fn get_last_space(&self) -> &[u8] {
-        self.window.back().unwrap().as_slice()
+        let last = *self.chunk_lens.back().unwrap();
+        &self.history[self.history.len() - last..]
     }
 
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
@@ -453,25 +460,27 @@ impl RowMatchGenerator {
              limit; split the input into smaller frames or use a higher level"
         );
         while self.window_size + data.len() > self.max_window_size {
-            let removed = self.window.pop_front().unwrap();
-            self.window_size -= removed.len();
-            self.history_start += removed.len();
-            self.history_abs_start += removed.len();
-            reuse_space(removed);
+            let removed_len = self.chunk_lens.pop_front().unwrap();
+            self.window_size -= removed_len;
+            self.history_start += removed_len;
+            self.history_abs_start += removed_len;
         }
         self.compact_history();
+        let added = data.len();
         self.history.extend_from_slice(&data);
-        self.window_size += data.len();
-        self.window.push_back(data);
+        self.window_size += added;
+        self.chunk_lens.push_back(added);
+        // The bytes now live in `history`; return the input buffer to the
+        // caller's pool instead of holding a second copy in the window.
+        reuse_space(data);
     }
 
-    pub(crate) fn trim_to_window(&mut self, mut reuse_space: impl FnMut(Vec<u8>)) {
+    pub(crate) fn trim_to_window(&mut self) {
         while self.window_size > self.max_window_size {
-            let removed = self.window.pop_front().unwrap();
-            self.window_size -= removed.len();
-            self.history_start += removed.len();
-            self.history_abs_start += removed.len();
-            reuse_space(removed);
+            let removed_len = self.chunk_lens.pop_front().unwrap();
+            self.window_size -= removed_len;
+            self.history_start += removed_len;
+            self.history_abs_start += removed_len;
         }
     }
 
@@ -481,7 +490,7 @@ impl RowMatchGenerator {
     ) {
         debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
-        let current_len = self.window.back().unwrap().len();
+        let current_len = *self.chunk_lens.back().unwrap();
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
         let current_abs_end = current_abs_start + current_len;
         let backfill_start = self.backfill_start(current_abs_start);
@@ -575,7 +584,7 @@ impl RowMatchGenerator {
         debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
 
-        let current_len = self.window.back().unwrap().len();
+        let current_len = *self.chunk_lens.back().unwrap();
         if current_len == 0 {
             return;
         }
@@ -595,7 +604,7 @@ impl RowMatchGenerator {
             let best = self.best_match_rl::<K, ROW_LOG>(abs_pos, lit_len);
             if let Some(candidate) = self.pick_lazy_match_rl::<K, ROW_LOG>(abs_pos, lit_len, best) {
                 self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
-                let current = self.window.back().unwrap().as_slice();
+                let current = &self.history[self.history.len() - current_len..];
                 let start = candidate.start - current_abs_start;
                 let literals = &current[literals_start..start];
                 handle_sequence(Sequence::Triple {
@@ -622,7 +631,7 @@ impl RowMatchGenerator {
         }
 
         if literals_start < current_len {
-            let current = self.window.back().unwrap().as_slice();
+            let current = &self.history[self.history.len() - current_len..];
             handle_sequence(Sequence::Literals {
                 literals: &current[literals_start..],
             });
@@ -697,7 +706,7 @@ impl RowMatchGenerator {
         debug_assert_eq!(ROW_LOG, self.row_log);
         self.ensure_tables();
 
-        let current_len = self.window.back().unwrap().len();
+        let current_len = *self.chunk_lens.back().unwrap();
         if current_len == 0 {
             return;
         }
@@ -817,7 +826,7 @@ impl RowMatchGenerator {
             // ~+447 over `abs_pos` (537897 -> 538344), so the
             // narrower range is intentional.
             self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
-            let current = self.window.back().unwrap().as_slice();
+            let current = &self.history[self.history.len() - current_len..];
             let literals = &current[literals_start..start];
             handle_sequence(Sequence::Triple {
                 literals,
@@ -854,7 +863,7 @@ impl RowMatchGenerator {
         }
 
         if literals_start < current_len {
-            let current = self.window.back().unwrap().as_slice();
+            let current = &self.history[self.history.len() - current_len..];
             handle_sequence(Sequence::Literals {
                 literals: &current[literals_start..],
             });


### PR DESCRIPTION
## Summary

Three encode-path memory improvements for the Row (greedy) levels. On a
1 MiB corpus input at level 5 the compress peak drops from 24.3 MB to
8.0 MB (-67%), closing the gap to the C reference from 4.76x to 1.56x.

### 1. Row match positions as `u32`

The Row backend stored absolute match positions in `row_positions:
Vec<usize>` — 8 bytes per slot, the largest match-finder allocation.
Store them as `u32` (the donor `U32` layout), halving that table. When
the cumulative absolute cursor nears `u32::MAX`, `add_data` performs a
cold rebase: it subtracts `history_abs_start` from the coordinate origin
and from every live slot (stale entries collapse to the sentinel), so
multi-GiB Row-backed streams stay representable without panicking. This
mirrors the HashChain backend's `u32`-boundary rebase; one rebase per
~4 GiB always suffices because the live window is far smaller than
`u32::MAX`. `ROW_EMPTY_SLOT` becomes `u32::MAX` and every stored position stays
strictly below it, so the sentinel is unambiguous.

### 2. Row window as chunk lengths, not retained buffers

The Row backend kept every committed block in a `VecDeque<Vec<u8>>`
window while *also* mirroring the bytes into the contiguous `history`
buffer. Each retained `Vec` carried its full `block_capacity`, so on a
heavily pre-split frame the window held many block-sized buffers for far
fewer live bytes (~12 MB of window for a 1 MiB input split into ~90
sub-blocks). Mirror the HashChain backend: keep only per-block lengths in
a `VecDeque<usize>` and return the input buffer to the pool at commit
time. Match bytes already live in the contiguous mirror; the current
block resolves as its tail slice. This is the dominant term in the
decodecorpus reduction.

### 3. Reuse the pre-split carry buffer

The owned block loop split the kept pre-split suffix into a fresh `Vec`
via `split_off` and `reserve_exact`-grew it to `block_capacity` every
split. The block buffer is now drawn from the matcher pool and the suffix
carried in a retained, reused `pending_input`. This removes transient
`malloc`/`realloc` pressure on split-heavy frames (a churn cleanup; it
does not move the reported peak on its own).

All three are byte-identical (same positions / same bytes) — ratio and
the full roundtrip / cross-validation suite are unaffected.

## Peak memory (i9, `compare_ffi_memory`, level_5_greedy compress, vs `main`)

| scenario | main | this PR | vs C |
|---|---|---|---|
| decodecorpus-z000033 (1 MiB) | 24.3 MB | **8.0 MB** (-67%) | 1.56x (was 4.76x) |
| large-log-stream | ~22 MB | **14.3 MB** | 2.54x |
| small-10k-random | 0.325 MB | **0.259 MB** (-20%) | below C |
| small-4k-log-lines | 0.325 MB | **0.259 MB** (-20%) | — |

The residual gap to C (most visible on `large-log-stream`) is the Row
table's slot count (`row_count * row_entries`), larger than the
reference's packed layout — a separate, ratio-sensitive follow-up tracked
in #341.

Part of #341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced per-split allocations and improved buffer reuse in the compressor for lower memory churn and faster throughput.
  * More efficient pooling and recycling of block buffers to reduce peak memory and latency.
  * Improved handling of large-stream positions and window bookkeeping for more consistent behavior on very large inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
