### PR TITLE
fix(decode): bound per-block output (decompression-bomb OOM) + L19 decode gap

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -6,6 +6,7 @@ use core::hash::Hasher;
 use super::buffer_backend::BufferBackend;
 use super::prefetch;
 use super::ringbuffer::RingBuffer;
+use crate::common::MAX_BLOCK_SIZE;
 use crate::decoding::errors::DecodeBufferError;
 
 /// Generic decode-side output buffer parameterised over the storage
@@ -29,6 +30,14 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 
     pub window_size: usize,
     total_output_counter: u64,
+    /// Upper bound on `buffer.len()` for the block currently being decoded.
+    /// Set per block to `len_at_block_start + MAX_BLOCK_SIZE` so a single
+    /// block cannot decompress to more than `MAX_BLOCK_SIZE` of output; a
+    /// `repeat` that would cross it is rejected before its `try_reserve`,
+    /// bounding the growable `RingBuffer` against decompression-bomb OOMs.
+    /// `usize::MAX` (the default) disables the check for non-block-decode
+    /// callers of `repeat`.
+    block_output_limit: usize,
     #[cfg(feature = "hash")]
     pub hash: twox_hash::XxHash64,
 }
@@ -77,6 +86,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             dict_content: Vec::new(),
             window_size,
             total_output_counter: 0,
+            block_output_limit: usize::MAX,
             #[cfg(feature = "hash")]
             hash: twox_hash::XxHash64::with_seed(0),
         }
@@ -101,9 +111,20 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             dict_content: Vec::new(),
             window_size,
             total_output_counter: 0,
+            block_output_limit: usize::MAX,
             #[cfg(feature = "hash")]
             hash: twox_hash::XxHash64::with_seed(0),
         }
+    }
+
+    /// Arm the per-block decompressed-output ceiling for the block about to
+    /// be decoded: a `repeat` whose match would push `buffer.len()` past
+    /// `current_len + MAX_BLOCK_SIZE` is rejected (see `block_output_limit`),
+    /// bounding the growable backend against decompression-bomb OOMs. Called
+    /// once per block by the sequence decoder, before the sequence loop.
+    #[inline]
+    pub(crate) fn set_block_output_ceiling(&mut self, max_block_output: usize) {
+        self.block_output_limit = self.buffer.len().saturating_add(max_block_output);
     }
 
     pub fn reset(&mut self, window_size: usize) {
@@ -120,6 +141,8 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // the frame will actually hit this buffer.
         self.dict_content.clear();
         self.total_output_counter = 0;
+        // Cleared per frame; re-armed per block by the sequence decoder.
+        self.block_output_limit = usize::MAX;
         #[cfg(feature = "hash")]
         {
             self.hash = twox_hash::XxHash64::with_seed(0);
@@ -337,6 +360,30 @@ impl<B: BufferBackend> DecodeBuffer<B> {
 
         if match_length == 0 {
             return Ok(());
+        }
+
+        // Bound the block's cumulative decompressed output. A single zstd
+        // block decompresses to at most MAX_BLOCK_SIZE; reject a match that
+        // would push this block's output past the per-block ceiling
+        // (`block_output_limit`, set per block by the sequence decoder)
+        // before its `try_reserve`. On the growable `RingBuffer` an
+        // over-producing malformed / adversarial block would otherwise grow
+        // the buffer to gigabytes inside the decode loop — a
+        // decompression-bomb OOM — before the post-block validity check can
+        // reject the frame. The default `usize::MAX` ceiling leaves
+        // non-block-decode callers of `repeat` unaffected.
+        if self.buffer.len().saturating_add(match_length) > self.block_output_limit {
+            let block_start = self
+                .block_output_limit
+                .saturating_sub(MAX_BLOCK_SIZE as usize);
+            return Err(DecodeBufferError::BlockOutputExceedsMax {
+                produced: self
+                    .buffer
+                    .len()
+                    .saturating_add(match_length)
+                    .saturating_sub(block_start),
+                max: MAX_BLOCK_SIZE as usize,
+            });
         }
 
         if offset > self.buffer.len() {
@@ -1227,6 +1274,27 @@ mod tests {
         assert!(matches!(
             err,
             crate::decoding::errors::DecodeBufferError::ZeroOffset
+        ));
+    }
+
+    #[test]
+    fn repeat_rejects_output_past_block_ceiling() {
+        // A single zstd block decompresses to at most MAX_BLOCK_SIZE. With
+        // the per-block ceiling armed, a `repeat` whose match would push the
+        // block's output past it must be rejected before its `try_reserve`.
+        // Without this guard the over-long match drives `try_reserve`
+        // unbounded on the growable `RingBuffer` — the artifact `oom-66db61d9…`
+        // grew the ring to ~0.5–2 GiB across many over-producing sequences
+        // before any post-block check ran (a decompression-bomb OOM,
+        // reproduced via the fuzz `decode` target). Pre-guard this `repeat`
+        // returned `Ok` (reserved + copied); it must now reject.
+        let mut decode_buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        decode_buf.push(b"abcdef"); // len = 6
+        decode_buf.set_block_output_ceiling(8); // ceiling = 6 + 8 = 14
+        let err = decode_buf.repeat(4, 16).unwrap_err(); // 6 + 16 = 22 > 14
+        assert!(matches!(
+            err,
+            crate::decoding::errors::DecodeBufferError::BlockOutputExceedsMax { .. }
         ));
     }
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -1296,6 +1296,12 @@ mod tests {
             err,
             crate::decoding::errors::DecodeBufferError::BlockOutputExceedsMax { .. }
         ));
+        // Display carries the produced bytes for diagnostics. `produced`
+        // is `(len + match_length) - block_start` = `22 - 0 = 22` (the
+        // ceiling of 14 sits below MAX_BLOCK_SIZE so `block_start`
+        // saturates to 0); `max` is always MAX_BLOCK_SIZE.
+        let rendered = alloc::format!("{err}");
+        assert!(rendered.contains("22"), "unexpected Display: {rendered}");
     }
 
     #[test]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -127,6 +127,26 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.block_output_limit = self.buffer.len().saturating_add(max_block_output);
     }
 
+    /// Cold-path error builder for the per-block output ceiling. Outlined
+    /// from `repeat_inner` so the hot per-match check stays a single
+    /// compare; the produced-byte arithmetic only runs on the
+    /// malformed-input rejection path.
+    #[cold]
+    #[inline(never)]
+    fn block_output_exceeded(&self, match_length: usize) -> DecodeBufferError {
+        let block_start = self
+            .block_output_limit
+            .saturating_sub(MAX_BLOCK_SIZE as usize);
+        DecodeBufferError::BlockOutputExceedsMax {
+            produced: self
+                .buffer
+                .len()
+                .saturating_add(match_length)
+                .saturating_sub(block_start),
+            max: MAX_BLOCK_SIZE as usize,
+        }
+    }
+
     pub fn reset(&mut self, window_size: usize) {
         self.window_size = window_size;
         self.buffer.clear();
@@ -373,17 +393,10 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // reject the frame. The default `usize::MAX` ceiling leaves
         // non-block-decode callers of `repeat` unaffected.
         if self.buffer.len().saturating_add(match_length) > self.block_output_limit {
-            let block_start = self
-                .block_output_limit
-                .saturating_sub(MAX_BLOCK_SIZE as usize);
-            return Err(DecodeBufferError::BlockOutputExceedsMax {
-                produced: self
-                    .buffer
-                    .len()
-                    .saturating_add(match_length)
-                    .saturating_sub(block_start),
-                max: MAX_BLOCK_SIZE as usize,
-            });
+            // Cold path outlined so the per-match hot check is just the
+            // compare above (the error-byte arithmetic must not bloat the
+            // sequence loop's inlined repeat path).
+            return Err(self.block_output_exceeded(match_length));
         }
 
         if offset > self.buffer.len() {

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -449,6 +449,19 @@ pub enum DecodeBufferError {
         requested: usize,
         capacity: usize,
     },
+    /// A block's cumulative decompressed output would exceed `MAX_BLOCK_SIZE`,
+    /// the most a single zstd block can produce. Surfaced by
+    /// [`super::decode_buffer::DecodeBuffer::repeat`] before the match copy
+    /// when the running block output plus this match would cross the
+    /// per-block ceiling. Without it a malformed / adversarial frame whose
+    /// sequences over-produce drives an unbounded `try_reserve` on a growable
+    /// backend (`RingBuffer`), which grows to gigabytes inside the
+    /// block-decode loop (a decompression-bomb OOM) before the post-block
+    /// validity check can reject the frame.
+    BlockOutputExceedsMax {
+        produced: usize,
+        max: usize,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -483,6 +496,12 @@ impl core::fmt::Display for DecodeBufferError {
                 write!(
                     f,
                     "Match repeat would write past fixed-capacity buffer: tail={tail}, requested={requested}, capacity={capacity}"
+                )
+            }
+            DecodeBufferError::BlockOutputExceedsMax { produced, max } => {
+                write!(
+                    f,
+                    "Block decompressed output {produced} exceeds the per-block maximum {max}"
                 )
             }
         }

--- a/zstd/src/decoding/seq_decoder_avx2.rs
+++ b/zstd/src/decoding/seq_decoder_avx2.rs
@@ -235,6 +235,11 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
     );
 
     buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
     let old_buffer_size = buffer.len();
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;

--- a/zstd/src/decoding/seq_decoder_avx2.rs
+++ b/zstd/src/decoding/seq_decoder_avx2.rs
@@ -20,15 +20,12 @@ use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::scratch::FSEScratch;
 use super::sequence_section_decoder::{
-    ADVANCE, ADVANCE_MASK, ExecSeq, compute_use_long_pipeline, maybe_update_fse_tables,
+    ADVANCE, ADVANCE_MASK, ExecSeq, SeqStreamSetup, init_sequence_stream,
 };
-use crate::bit_io::BitReaderReversed;
 use crate::blocks::sequence_section::{MAX_OFFSET_CODE, Sequence, SequencesHeader};
-use crate::common::MAX_BLOCK_SIZE;
 use crate::cpu_kernel::Avx2Kernel;
 use crate::decoding::errors::{DecodeSequenceError, DecompressBlockError, ExecuteSequencesError};
 use crate::decoding::sequence_execution::do_offset_history;
-use crate::fse::SeqFSEDecoder;
 
 /// Textual expansion of per-sequence decode. Reads LL/ML/OF state,
 /// performs triple-bit extract via `peek_bits_triple_bmi2` (`_pext_u64`
@@ -193,72 +190,22 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
 ) -> Result<(), DecompressBlockError> {
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
-
-    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
-    let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::<Avx2Kernel>::new(bit_stream);
-
-    let mut skipped_bits = 0;
-    loop {
-        let val = br.get_bits(1);
-        skipped_bits += 1;
-        if val == 1 || skipped_bits > 8 {
-            break;
-        }
-    }
-    if skipped_bits > 8 {
-        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
-    }
-
-    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
-    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
-    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
-
-    ll_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    of_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    ml_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-
-    let max_update_bits = fse.literal_lengths.accuracy_log
-        + fse.match_lengths.accuracy_log
-        + fse.offsets.accuracy_log;
-    debug_assert!(
-        max_update_bits <= 56,
-        "sequence section update bits exceed 56-bit budget"
-    );
-
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
-    // Arm the per-block output ceiling so a malformed / adversarial block
-    // whose sequences over-produce cannot grow the buffer past
-    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
-    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
-    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
-    let old_buffer_size = buffer.len();
+    let SeqStreamSetup {
+        mut br,
+        mut ll_dec,
+        mut ml_dec,
+        mut of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    } = init_sequence_stream::<B, Avx2Kernel>(section, source, fse, buffer)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
 
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
-    let num_sequences = section.num_sequences as usize;
-
-    // `saturating_add` defuses 32-bit `usize` wrap (see
-    // `sequence_section_decoder::compute_use_long_pipeline` for the
-    // gate semantics this feeds into).
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
-    let use_long_pipeline = compute_use_long_pipeline(
-        num_sequences,
-        ddict_is_cold,
-        total_history,
-        fse.offsets_long_share,
-    );
 
     if use_long_pipeline {
         // === Long-pipeline arm (8-deep lookahead ring) ===

--- a/zstd/src/decoding/seq_decoder_bmi2.rs
+++ b/zstd/src/decoding/seq_decoder_bmi2.rs
@@ -207,6 +207,11 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
     );
 
     buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
     let old_buffer_size = buffer.len();
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;

--- a/zstd/src/decoding/seq_decoder_bmi2.rs
+++ b/zstd/src/decoding/seq_decoder_bmi2.rs
@@ -11,15 +11,12 @@ use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::scratch::FSEScratch;
 use super::sequence_section_decoder::{
-    ADVANCE, ADVANCE_MASK, ExecSeq, compute_use_long_pipeline, maybe_update_fse_tables,
+    ADVANCE, ADVANCE_MASK, ExecSeq, SeqStreamSetup, init_sequence_stream,
 };
-use crate::bit_io::BitReaderReversed;
 use crate::blocks::sequence_section::{MAX_OFFSET_CODE, Sequence, SequencesHeader};
-use crate::common::MAX_BLOCK_SIZE;
 use crate::cpu_kernel::Bmi2Kernel;
 use crate::decoding::errors::{DecodeSequenceError, DecompressBlockError, ExecuteSequencesError};
 use crate::decoding::sequence_execution::do_offset_history;
-use crate::fse::SeqFSEDecoder;
 
 /// Textual decode-one body. PEXT-direct via `peek_bits_triple_bmi2`
 /// when vendor cache enables it.
@@ -165,72 +162,22 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
 ) -> Result<(), DecompressBlockError> {
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
-
-    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
-    let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::<Bmi2Kernel>::new(bit_stream);
-
-    let mut skipped_bits = 0;
-    loop {
-        let val = br.get_bits(1);
-        skipped_bits += 1;
-        if val == 1 || skipped_bits > 8 {
-            break;
-        }
-    }
-    if skipped_bits > 8 {
-        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
-    }
-
-    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
-    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
-    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
-
-    ll_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    of_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    ml_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-
-    let max_update_bits = fse.literal_lengths.accuracy_log
-        + fse.match_lengths.accuracy_log
-        + fse.offsets.accuracy_log;
-    debug_assert!(
-        max_update_bits <= 56,
-        "sequence section update bits exceed 56-bit budget"
-    );
-
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
-    // Arm the per-block output ceiling so a malformed / adversarial block
-    // whose sequences over-produce cannot grow the buffer past
-    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
-    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
-    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
-    let old_buffer_size = buffer.len();
+    let SeqStreamSetup {
+        mut br,
+        mut ll_dec,
+        mut ml_dec,
+        mut of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    } = init_sequence_stream::<B, Bmi2Kernel>(section, source, fse, buffer)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
 
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
-    let num_sequences = section.num_sequences as usize;
-
-    // `saturating_add` defuses 32-bit `usize` wrap (see
-    // `sequence_section_decoder::compute_use_long_pipeline` for the
-    // gate semantics this feeds into).
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
-    let use_long_pipeline = compute_use_long_pipeline(
-        num_sequences,
-        ddict_is_cold,
-        total_history,
-        fse.offsets_long_share,
-    );
 
     if use_long_pipeline {
         let mut prefetch_pos: usize = old_buffer_size;

--- a/zstd/src/decoding/seq_decoder_scalar.rs
+++ b/zstd/src/decoding/seq_decoder_scalar.rs
@@ -9,15 +9,12 @@ use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::scratch::FSEScratch;
 use super::sequence_section_decoder::{
-    ADVANCE, ADVANCE_MASK, ExecSeq, compute_use_long_pipeline, maybe_update_fse_tables,
+    ADVANCE, ADVANCE_MASK, ExecSeq, SeqStreamSetup, init_sequence_stream,
 };
-use crate::bit_io::BitReaderReversed;
 use crate::blocks::sequence_section::{MAX_OFFSET_CODE, Sequence, SequencesHeader};
-use crate::common::MAX_BLOCK_SIZE;
 use crate::cpu_kernel::ScalarKernel;
 use crate::decoding::errors::{DecodeSequenceError, DecompressBlockError, ExecuteSequencesError};
 use crate::decoding::sequence_execution::do_offset_history;
-use crate::fse::SeqFSEDecoder;
 
 macro_rules! decode_one_body {
     ($ll_dec:expr, $ml_dec:expr, $of_dec:expr, $br:expr) => {{
@@ -98,72 +95,22 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
 ) -> Result<(), DecompressBlockError> {
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
-
-    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
-    let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::<ScalarKernel>::new(bit_stream);
-
-    let mut skipped_bits = 0;
-    loop {
-        let val = br.get_bits(1);
-        skipped_bits += 1;
-        if val == 1 || skipped_bits > 8 {
-            break;
-        }
-    }
-    if skipped_bits > 8 {
-        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
-    }
-
-    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
-    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
-    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
-
-    ll_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    of_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    ml_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-
-    let max_update_bits = fse.literal_lengths.accuracy_log
-        + fse.match_lengths.accuracy_log
-        + fse.offsets.accuracy_log;
-    debug_assert!(
-        max_update_bits <= 56,
-        "sequence section update bits exceed 56-bit budget"
-    );
-
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
-    // Arm the per-block output ceiling so a malformed / adversarial block
-    // whose sequences over-produce cannot grow the buffer past
-    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
-    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
-    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
-    let old_buffer_size = buffer.len();
+    let SeqStreamSetup {
+        mut br,
+        mut ll_dec,
+        mut ml_dec,
+        mut of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    } = init_sequence_stream::<B, ScalarKernel>(section, source, fse, buffer)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
 
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
-    let num_sequences = section.num_sequences as usize;
-
-    // `saturating_add` defuses 32-bit `usize` wrap (see
-    // `sequence_section_decoder::compute_use_long_pipeline` for the
-    // gate semantics this feeds into).
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
-    let use_long_pipeline = compute_use_long_pipeline(
-        num_sequences,
-        ddict_is_cold,
-        total_history,
-        fse.offsets_long_share,
-    );
 
     if use_long_pipeline {
         let mut prefetch_pos: usize = old_buffer_size;

--- a/zstd/src/decoding/seq_decoder_scalar.rs
+++ b/zstd/src/decoding/seq_decoder_scalar.rs
@@ -140,6 +140,11 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
     );
 
     buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
     let old_buffer_size = buffer.len();
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;

--- a/zstd/src/decoding/seq_decoder_vbmi2.rs
+++ b/zstd/src/decoding/seq_decoder_vbmi2.rs
@@ -203,6 +203,11 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
     );
 
     buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
     let old_buffer_size = buffer.len();
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;

--- a/zstd/src/decoding/seq_decoder_vbmi2.rs
+++ b/zstd/src/decoding/seq_decoder_vbmi2.rs
@@ -11,15 +11,12 @@ use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::scratch::FSEScratch;
 use super::sequence_section_decoder::{
-    ADVANCE, ADVANCE_MASK, ExecSeq, compute_use_long_pipeline, maybe_update_fse_tables,
+    ADVANCE, ADVANCE_MASK, ExecSeq, SeqStreamSetup, init_sequence_stream,
 };
-use crate::bit_io::BitReaderReversed;
 use crate::blocks::sequence_section::{MAX_OFFSET_CODE, Sequence, SequencesHeader};
-use crate::common::MAX_BLOCK_SIZE;
 use crate::cpu_kernel::Vbmi2Kernel;
 use crate::decoding::errors::{DecodeSequenceError, DecompressBlockError, ExecuteSequencesError};
 use crate::decoding::sequence_execution::do_offset_history;
-use crate::fse::SeqFSEDecoder;
 
 macro_rules! decode_one_body {
     ($ll_dec:expr, $ml_dec:expr, $of_dec:expr, $br:expr) => {{
@@ -161,72 +158,22 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
 ) -> Result<(), DecompressBlockError> {
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
-
-    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
-    let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::<Vbmi2Kernel>::new(bit_stream);
-
-    let mut skipped_bits = 0;
-    loop {
-        let val = br.get_bits(1);
-        skipped_bits += 1;
-        if val == 1 || skipped_bits > 8 {
-            break;
-        }
-    }
-    if skipped_bits > 8 {
-        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
-    }
-
-    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
-    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
-    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
-
-    ll_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    of_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    ml_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-
-    let max_update_bits = fse.literal_lengths.accuracy_log
-        + fse.match_lengths.accuracy_log
-        + fse.offsets.accuracy_log;
-    debug_assert!(
-        max_update_bits <= 56,
-        "sequence section update bits exceed 56-bit budget"
-    );
-
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
-    // Arm the per-block output ceiling so a malformed / adversarial block
-    // whose sequences over-produce cannot grow the buffer past
-    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
-    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
-    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
-    let old_buffer_size = buffer.len();
+    let SeqStreamSetup {
+        mut br,
+        mut ll_dec,
+        mut ml_dec,
+        mut of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    } = init_sequence_stream::<B, Vbmi2Kernel>(section, source, fse, buffer)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
 
     let buffer_checkpoint = buffer.checkpoint();
     let saved_offset_hist = *offset_hist;
-    let num_sequences = section.num_sequences as usize;
-
-    // `saturating_add` defuses 32-bit `usize` wrap (see
-    // `sequence_section_decoder::compute_use_long_pipeline` for the
-    // gate semantics this feeds into).
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
-    let use_long_pipeline = compute_use_long_pipeline(
-        num_sequences,
-        ddict_is_cold,
-        total_history,
-        fse.offsets_long_share,
-    );
 
     if use_long_pipeline {
         let mut prefetch_pos: usize = old_buffer_size;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -2001,4 +2001,138 @@ mod init_sequence_stream_tests {
             "all-zero padding must be rejected as ExtraPadding"
         );
     }
+
+    /// One-sequence, all-Predefined header. Pairs with an ample non-zero
+    /// bitstream so `init_sequence_stream` returns `Ok` (the sequence loop
+    /// may still error afterwards). Used to drive the per-tier monolith
+    /// preambles directly: on x86_64 CI only the avx2 tier is selected at
+    /// runtime, so scalar / bmi2 / vbmi2 and the K-generic impl would
+    /// otherwise never execute their (shared) preamble.
+    fn predefined_one_sequence_header() -> SequencesHeader {
+        let mut header = SequencesHeader::new();
+        header.parse_from_header(&[0x01, 0x00]).unwrap();
+        header
+    }
+
+    /// Drives the always-available decoders (the portable scalar tier and
+    /// the K-generic impl that backs the aarch64 NEON/SVE path) through a
+    /// well-formed preamble. The result is intentionally ignored: a
+    /// crafted bitstream need not yield a valid sequence, only reach and
+    /// pass the preamble.
+    #[test]
+    fn scalar_tier_and_generic_impl_run_preamble() {
+        let header = predefined_one_sequence_header();
+        let source = [0xFFu8; 8];
+        let lits = [0u8; 32];
+
+        let mut fse = FSEScratch::new();
+        let mut buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        let mut offset_hist = [1u32, 4, 8];
+        let _ = crate::decoding::seq_decoder_scalar::decode_and_execute_sequences_scalar(
+            &header,
+            &source,
+            &mut fse,
+            &mut buf,
+            &mut offset_hist,
+            &lits,
+        );
+
+        let mut fse = FSEScratch::new();
+        let mut buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        let mut offset_hist = [1u32, 4, 8];
+        let _ = super::decode_and_execute_sequences_impl::<RingBuffer, ScalarKernel>(
+            &header,
+            &source,
+            &mut fse,
+            &mut buf,
+            &mut offset_hist,
+            &lits,
+        );
+    }
+
+    /// Drive the BMI2 monolith preamble directly. The runtime kernel
+    /// selector prefers the avx2 tier on any CPU that has BMI2, so this
+    /// tier never runs through the normal dispatch on CI hardware; call it
+    /// directly (guarded on the same feature it requires).
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_bmi2"))]
+    #[test]
+    fn bmi2_tier_runs_preamble() {
+        if !std::is_x86_feature_detected!("bmi2") {
+            return;
+        }
+        let header = predefined_one_sequence_header();
+        let source = [0xFFu8; 8];
+        let lits = [0u8; 32];
+        let mut fse = FSEScratch::new();
+        let mut buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        let mut offset_hist = [1u32, 4, 8];
+        // SAFETY: BMI2 confirmed available by the runtime check above.
+        let _ = unsafe {
+            crate::decoding::seq_decoder_bmi2::decode_and_execute_sequences_bmi2::<RingBuffer>(
+                &header,
+                &source,
+                &mut fse,
+                &mut buf,
+                &mut offset_hist,
+                &lits,
+            )
+        };
+    }
+
+    /// Drive the AVX2 monolith preamble directly. The avx2 tier is the
+    /// production path on AVX2 hardware, so this is usually also covered by
+    /// the normal decode tests; the explicit call keeps the preamble
+    /// covered even on a runner that lacks AVX2.
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_avx2"))]
+    #[test]
+    fn avx2_tier_runs_preamble() {
+        if !(std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("bmi2")) {
+            return;
+        }
+        let header = predefined_one_sequence_header();
+        let source = [0xFFu8; 8];
+        let lits = [0u8; 32];
+        let mut fse = FSEScratch::new();
+        let mut buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        let mut offset_hist = [1u32, 4, 8];
+        // SAFETY: AVX2 + BMI2 confirmed available by the runtime check.
+        let _ = unsafe {
+            crate::decoding::seq_decoder_avx2::decode_and_execute_sequences_avx2::<RingBuffer>(
+                &header,
+                &source,
+                &mut fse,
+                &mut buf,
+                &mut offset_hist,
+                &lits,
+            )
+        };
+    }
+
+    /// Drive the VBMI2 monolith preamble directly. Requires AVX-512 VBMI2,
+    /// which most CI runners lack; the test self-skips there, so this tier
+    /// is only covered on AVX-512 hardware.
+    #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_vbmi2"))]
+    #[test]
+    fn vbmi2_tier_runs_preamble() {
+        if !std::is_x86_feature_detected!("avx512vbmi2") {
+            return;
+        }
+        let header = predefined_one_sequence_header();
+        let source = [0xFFu8; 8];
+        let lits = [0u8; 32];
+        let mut fse = FSEScratch::new();
+        let mut buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        let mut offset_hist = [1u32, 4, 8];
+        // SAFETY: AVX-512 VBMI2 confirmed available by the runtime check.
+        let _ = unsafe {
+            crate::decoding::seq_decoder_vbmi2::decode_and_execute_sequences_vbmi2::<RingBuffer>(
+                &header,
+                &source,
+                &mut fse,
+                &mut buf,
+                &mut offset_hist,
+                &lits,
+            )
+        };
+    }
 }

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -2114,7 +2114,15 @@ mod init_sequence_stream_tests {
     #[cfg(all(feature = "std", target_arch = "x86_64", feature = "kernel_vbmi2"))]
     #[test]
     fn vbmi2_tier_runs_preamble() {
-        if !std::is_x86_feature_detected!("avx512vbmi2") {
+        // Mirror the production dispatch gate: the unsafe monolith is annotated
+        // `target_feature(bmi2,avx2,avx512vbmi2,avx512f,avx512vl,avx512bw)`, so a
+        // bare `avx512vbmi2` probe could SIGILL on a CPU that reports VBMI2 but
+        // lacks a companion feature. `detect_cpu_kernel() == Vbmi2` verifies the
+        // full set before we call it.
+        if !matches!(
+            crate::cpu_kernel::detect_cpu_kernel(),
+            crate::cpu_kernel::CpuKernelTag::Vbmi2
+        ) {
             return;
         }
         let header = predefined_one_sequence_header();

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -297,6 +297,11 @@ pub(crate) fn decode_and_execute_sequences_impl<
     );
 
     buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
     let old_buffer_size = buffer.len();
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1954,3 +1954,51 @@ mod compute_use_long_pipeline_tests {
         ));
     }
 }
+
+#[cfg(test)]
+mod init_sequence_stream_tests {
+    use super::super::scratch::FSEScratch;
+    use super::init_sequence_stream;
+    use crate::blocks::sequence_section::SequencesHeader;
+    use crate::cpu_kernel::ScalarKernel;
+    use crate::decoding::decode_buffer::DecodeBuffer;
+    use crate::decoding::errors::{DecodeSequenceError, DecompressBlockError};
+    use crate::decoding::ringbuffer::RingBuffer;
+
+    /// The sequence bitstream must end with a single `1` sentinel bit in
+    /// the final byte; the decoder skips trailing `0` padding looking for
+    /// it. A final byte (read first, MSB-down) that is all zeros has no
+    /// sentinel, so more than 8 padding bits are skipped — that must be
+    /// rejected as `ExtraPadding`, not decoded.
+    #[test]
+    fn rejects_bitstream_with_excess_padding() {
+        let mut header = SequencesHeader::new();
+        // `0x01` = one sequence; `0x00` modes byte = all axes Predefined,
+        // so `maybe_update_fse_tables` reads zero table bytes and the
+        // whole source is the (malformed) bitstream.
+        header.parse_from_header(&[0x01, 0x00]).unwrap();
+
+        let mut fse = FSEScratch::new();
+        let mut buffer = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        // All-zero bitstream: no sentinel `1` bit anywhere.
+        let source = [0u8; 2];
+
+        // `SeqStreamSetup` is not `Debug`, so assert on the `Result`
+        // directly via `matches!` rather than unwrapping the Ok side.
+        let result = init_sequence_stream::<RingBuffer, ScalarKernel>(
+            &header,
+            &source,
+            &mut fse,
+            &mut buffer,
+        );
+        assert!(
+            matches!(
+                result,
+                Err(DecompressBlockError::DecodeSequenceError(
+                    DecodeSequenceError::ExtraPadding { .. }
+                ))
+            ),
+            "all-zero padding must be rejected as ExtraPadding"
+        );
+    }
+}

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -62,6 +62,129 @@ pub(crate) fn compute_use_long_pipeline(
                 && offsets_long_share >= MIN_LONG_OFFSET_SHARE))
 }
 
+/// Cold per-block sequence-stream setup, returned by [`init_sequence_stream`].
+/// Carries the bit reader, the three FSE decoder states (with their
+/// initial states already read), and the scalar gate values the hot
+/// decode+execute loop needs. Only that loop diverges per CPU tier; this
+/// preamble is identical across tiers and lives in one place.
+pub(crate) struct SeqStreamSetup<'src, 'fse, K: crate::cpu_kernel::CpuKernel> {
+    pub(crate) br: BitReaderReversed<'src, K>,
+    pub(crate) ll_dec: SeqFSEDecoder<'fse>,
+    pub(crate) ml_dec: SeqFSEDecoder<'fse>,
+    pub(crate) of_dec: SeqFSEDecoder<'fse>,
+    pub(crate) max_update_bits: u8,
+    pub(crate) old_buffer_size: usize,
+    pub(crate) num_sequences: usize,
+    pub(crate) use_long_pipeline: bool,
+}
+
+/// Shared cold preamble for every CPU-tier sequence decoder (the
+/// `K`-generic [`decode_and_execute_sequences_impl`] and the per-tier
+/// x86 monoliths in `seq_decoder_{scalar,bmi2,avx2,vbmi2}`).
+///
+/// Consumes the one-shot `ddict_is_cold` flag, rebuilds the FSE tables
+/// if the block's mode bytes call for it, skips the start-of-stream
+/// padding, initialises the LL/OF/ML decoder states, reserves the
+/// block's output capacity AND arms the per-block output ceiling (the
+/// decompression-bomb guard that bounds growth at `len + MAX_BLOCK_SIZE`),
+/// and computes the long-pipeline gate.
+///
+/// Centralising this is what keeps the ceiling (and every other
+/// per-block invariant) from drifting between tiers — the per-tier
+/// copies previously each had to remember to arm it.
+pub(crate) fn init_sequence_stream<'src, 'fse, B, K>(
+    section: &SequencesHeader,
+    source: &'src [u8],
+    fse: &'fse mut FSEScratch,
+    buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+) -> Result<SeqStreamSetup<'src, 'fse, K>, DecompressBlockError>
+where
+    B: super::buffer_backend::BufferBackend,
+    K: crate::cpu_kernel::CpuKernel,
+{
+    // Consume the one-shot `ddict_is_cold` flag BEFORE any early return
+    // (padding validation) so a later block's gate can't mis-apply a
+    // cold-dict signal that no longer holds. Donor
+    // `ZSTD_decompressBlock_internal` clears `dctx->ddictIsCold = 0`
+    // unconditionally after the sequence-section dispatch decision.
+    let ddict_is_cold = fse.ddict_is_cold;
+    fse.ddict_is_cold = false;
+
+    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
+    vprintln!("Updating tables used {} bytes", bytes_read);
+
+    let bit_stream = &source[bytes_read..];
+    let mut br = BitReaderReversed::<K>::new(bit_stream);
+
+    // Skip the 0-padding at the end of the last byte and consume the
+    // start-of-stream `1` bit.
+    let mut skipped_bits = 0;
+    loop {
+        let val = br.get_bits(1);
+        skipped_bits += 1;
+        if val == 1 || skipped_bits > 8 {
+            break;
+        }
+    }
+    if skipped_bits > 8 {
+        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
+    }
+
+    // RLE-mode axes are handled uniformly: `maybe_update_fse_tables`
+    // builds a degenerate single-state table for them, so the fused
+    // decode reads every axis the same way (no separate fallback).
+    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
+    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
+    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
+
+    ll_dec
+        .init_state(&mut br)
+        .map_err(DecodeSequenceError::from)?;
+    of_dec
+        .init_state(&mut br)
+        .map_err(DecodeSequenceError::from)?;
+    ml_dec
+        .init_state(&mut br)
+        .map_err(DecodeSequenceError::from)?;
+
+    let max_update_bits = fse.literal_lengths.accuracy_log
+        + fse.match_lengths.accuracy_log
+        + fse.offsets.accuracy_log;
+    debug_assert!(
+        max_update_bits <= 56,
+        "sequence section update bits exceed 56-bit budget"
+    );
+
+    buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Arm the per-block output ceiling so a malformed / adversarial block
+    // whose sequences over-produce cannot grow the buffer past
+    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
+    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
+    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
+    let old_buffer_size = buffer.len();
+    let num_sequences = section.num_sequences as usize;
+
+    // `saturating_add` defuses 32-bit `usize` wrap.
+    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
+    let use_long_pipeline = compute_use_long_pipeline(
+        num_sequences,
+        ddict_is_cold,
+        total_history,
+        fse.offsets_long_share,
+    );
+
+    Ok(SeqStreamSetup {
+        br,
+        ll_dec,
+        ml_dec,
+        of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    })
+}
+
 /// Fused decode + execute pipeline: decodes each sequence from the FSE
 /// bitstream and immediately executes it (literal copy + match copy)
 /// without materialising the intermediate `Vec<Sequence>` round-trip.
@@ -248,61 +371,16 @@ pub(crate) fn decode_and_execute_sequences_impl<
     // cold-dict signal that no longer holds (FSE/HUF tables are now
     // warm regardless of how the previous block decoded its sequences,
     // including RLE-mode axes handled in-line via the fused table).
-    let ddict_is_cold = fse.ddict_is_cold;
-    fse.ddict_is_cold = false;
-
-    let bytes_read = maybe_update_fse_tables(section, source, fse)?;
-    vprintln!("Updating tables used {} bytes", bytes_read);
-
-    let bit_stream = &source[bytes_read..];
-    let mut br = BitReaderReversed::<K>::new(bit_stream);
-
-    // Skip the 0-padding at the end of the last byte and consume the
-    // start-of-stream `1` bit.
-    let mut skipped_bits = 0;
-    loop {
-        let val = br.get_bits(1);
-        skipped_bits += 1;
-        if val == 1 || skipped_bits > 8 {
-            break;
-        }
-    }
-    if skipped_bits > 8 {
-        return Err(DecodeSequenceError::ExtraPadding { skipped_bits }.into());
-    }
-
-    // RLE-mode axes are handled uniformly: `maybe_update_fse_tables`
-    // builds a degenerate single-state table for them, so the fused
-    // decode below reads every axis the same way (no separate fallback).
-    let mut ll_dec = SeqFSEDecoder::new(&fse.literal_lengths);
-    let mut ml_dec = SeqFSEDecoder::new(&fse.match_lengths);
-    let mut of_dec = SeqFSEDecoder::new(&fse.offsets);
-
-    ll_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    of_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-    ml_dec
-        .init_state(&mut br)
-        .map_err(DecodeSequenceError::from)?;
-
-    let max_update_bits = fse.literal_lengths.accuracy_log
-        + fse.match_lengths.accuracy_log
-        + fse.offsets.accuracy_log;
-    debug_assert!(
-        max_update_bits <= 56,
-        "sequence section update bits exceed 56-bit budget"
-    );
-
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
-    // Arm the per-block output ceiling so a malformed / adversarial block
-    // whose sequences over-produce cannot grow the buffer past
-    // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable
-    // RingBuffer); `DecodeBuffer::repeat` rejects the crossing match.
-    buffer.set_block_output_ceiling(MAX_BLOCK_SIZE as usize);
-    let old_buffer_size = buffer.len();
+    let SeqStreamSetup {
+        mut br,
+        mut ll_dec,
+        mut ml_dec,
+        mut of_dec,
+        max_update_bits,
+        old_buffer_size,
+        num_sequences,
+        use_long_pipeline,
+    } = init_sequence_stream::<B, K>(section, source, fse, buffer)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -333,8 +411,6 @@ pub(crate) fn decode_and_execute_sequences_impl<
     // bitstream-tail validation fails, covering the edge case where
     // every sequence succeeds but the bitstream has leftover bits.
 
-    let num_sequences = section.num_sequences as usize;
-
     // 8-slot software pipeline mirroring donor
     // `ZSTD_decompressSequencesLong_body`. Pre-decode `ADVANCE`
     // sequences ahead, prefetch each match source as we go, then
@@ -356,34 +432,6 @@ pub(crate) fn decode_and_execute_sequences_impl<
     // ADVANCE / ADVANCE_MASK hoisted to module scope so the extracted
     // `run_pipelined_sequence_loop` can reach them.
 
-    // Donor `ZSTD_getOffsetInfo` parity. The share of FSE offset
-    // codes > LONG_OFFSET_CODE_THRESHOLD (scaled to donor's
-    // OffFSELog = 8 reference) is computed once per table refresh
-    // and cached in `fse.offsets_long_share` — see
-    // `compute_offsets_long_share` and the `maybe_update_fse_tables`
-    // call sites. Repeat-mode blocks (the table didn't change)
-    // re-use the cached value without re-walking 32–256 table
-    // entries per block. Gate stays sequence-count-first so short /
-    // no-sequence blocks don't even read the cache.
-    //
-    // Donor `minShare = MEM_64bits() ? 7 : 20`: the 32-bit
-    // threshold is higher because the prefetch pipeline needs a
-    // stronger long-offset signal to outpace the narrower load
-    // window on those targets.
-    // `saturating_add` to defuse the 32-bit `usize` overflow path: a
-    // pathological frame header could combine a 4 GiB-class window_size
-    // with a non-trivial dict to wrap on i686, silently flipping the
-    // long-pipeline gate around `HISTORY_THRESHOLD_FOR_PREFETCH`. The
-    // saturating variant pins the wrap result at `usize::MAX`, which
-    // crosses the 16 MiB threshold cleanly — gate decision matches the
-    // real (non-wrapped) value's intent.
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
-    let use_long_pipeline = compute_use_long_pipeline(
-        num_sequences,
-        ddict_is_cold,
-        total_history,
-        fse.offsets_long_share,
-    );
     // The format-level `isLongOffset` shortcut from donor is
     // irrelevant on our u32-indexed decoder, so on top of the
     // long-offset share the cold-dict signal is the only other gate.

--- a/zstd/src/tests/fuzz_regressions.rs
+++ b/zstd/src/tests/fuzz_regressions.rs
@@ -171,12 +171,15 @@ fn over_producing_block_does_not_oom_via_unbounded_reserve() {
         0x0a, 0x0a, 0x0a, 0x0a, 0xb5, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0xe5, 0x0a, 0xb5,
     ];
 
-    // Frame headers are well-formed, so streaming construction succeeds; the
-    // over-producing block must surface a decode Err (not OOM, not panic).
-    if let Ok(mut decoder) = crate::decoding::StreamingDecoder::new(data) {
-        let mut output = alloc::vec::Vec::new();
-        let _: Result<_, _> = decoder.read_to_end(&mut output);
-    }
+    // Frame headers are well-formed, so streaming construction must
+    // succeed — make it mandatory so the test can't vacuously pass by
+    // skipping the OOM path if construction ever regresses. The decode
+    // result is ignored: the regression is "no OOM / no panic", not a
+    // specific Ok/Err.
+    let mut decoder = crate::decoding::StreamingDecoder::new(data)
+        .expect("regression artifact must pass frame-header construction");
+    let mut output = alloc::vec::Vec::new();
+    let _: Result<_, _> = decoder.read_to_end(&mut output);
 }
 
 #[test]

--- a/zstd/src/tests/fuzz_regressions.rs
+++ b/zstd/src/tests/fuzz_regressions.rs
@@ -148,6 +148,38 @@ fn malformed_block_does_not_panic_via_restore_checkpoint() {
 }
 
 #[test]
+fn over_producing_block_does_not_oom_via_unbounded_reserve() {
+    // Regression for libFuzzer artifact oom-66db61d9… (decode target). A
+    // crafted frame's sequences over-produce inside one block: every match
+    // is small, but cumulatively they drove `RingBuffer::reserve_amortized`
+    // to ~0.5–2 GiB *inside* the block-decode loop, before the post-block
+    // validity check ran and before the consumer's output cap could
+    // intervene (the OOM is upstream of any `Read::take`). A single block
+    // decompresses to at most MAX_BLOCK_SIZE, so the per-block output
+    // ceiling now rejects the over-producing match with a normal decode
+    // Err instead of growing the buffer unbounded.
+    extern crate std;
+    use std::io::Read;
+
+    let data: &[u8] = &[
+        0x28, 0xb5, 0x2f, 0xfd, 0x00, 0x30, 0xb5, 0x00, 0x00, 0x2d, 0x28, 0xb5, 0x2f, 0xfd, 0x00,
+        0x26, 0x02, 0x00, 0x04, 0x28, 0xb5, 0x2f, 0xfd, 0x34, 0x0e, 0x02, 0x00, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0x0a, 0x00, 0x0b, 0x0b, 0x19, 0x00, 0x02, 0xfc, 0xe9, 0x98, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0xd7, 0x0a, 0x0a, 0x0a, 0x0a, 0xd3, 0x4a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a,
+        0x0a, 0x0a, 0x0a, 0x0a, 0xb5, 0x0a, 0x0a, 0x0a, 0x0a, 0x0a, 0xe5, 0x0a, 0xb5,
+    ];
+
+    // Frame headers are well-formed, so streaming construction succeeds; the
+    // over-producing block must surface a decode Err (not OOM, not panic).
+    if let Ok(mut decoder) = crate::decoding::StreamingDecoder::new(data) {
+        let mut output = alloc::vec::Vec::new();
+        let _: Result<_, _> = decoder.read_to_end(&mut output);
+    }
+}
+
+#[test]
 fn multi_frame_flat_buf_path_does_not_panic() {
     // Regression for libFuzzer artifact crash-e33ba082... — a
     // multi-frame stream that hits the flat-buffer wiring landed in

--- a/zstd/src/tests/fuzz_regressions.rs
+++ b/zstd/src/tests/fuzz_regressions.rs
@@ -174,12 +174,16 @@ fn over_producing_block_does_not_oom_via_unbounded_reserve() {
     // Frame headers are well-formed, so streaming construction must
     // succeed — make it mandatory so the test can't vacuously pass by
     // skipping the OOM path if construction ever regresses. The decode
-    // result is ignored: the regression is "no OOM / no panic", not a
-    // specific Ok/Err.
+    // must surface a normal Err (the per-block ceiling rejecting the
+    // over-producing match), not just "no OOM": asserting Err also locks
+    // in that the decoder never silently accepts this malformed frame.
     let mut decoder = crate::decoding::StreamingDecoder::new(data)
         .expect("regression artifact must pass frame-header construction");
     let mut output = alloc::vec::Vec::new();
-    let _: Result<_, _> = decoder.read_to_end(&mut output);
+    assert!(
+        decoder.read_to_end(&mut output).is_err(),
+        "over-producing block must surface a decode Err, not decode successfully"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Decoder-side hardening + perf for `decodecorpus-z000033`. Independent of the
encoder work; the OOM is pre-existing on `main` (the decode path is unchanged
by recent encoder PRs).

### 1. Decompression-bomb OOM (done)

A crafted frame whose sequences over-produce within one block drove
`DecodeBuffer::repeat` → `RingBuffer::reserve_amortized` to 0.5-2 GiB *inside*
the block-decode loop — before the post-block validity check ran and upstream
of any consumer `Read::take` cap (the OOM is in the decoder, not the output).
Reproduced from the libFuzzer `decode` artifact `oom-66db61d9...`.

A single zstd block decompresses to at most `MAX_BLOCK_SIZE`. The decoder now
arms a per-block output ceiling (`len_at_block_start + MAX_BLOCK_SIZE`) on the
`DecodeBuffer` before the sequence loop and rejects, in `repeat`, any match
that would cross it (`BlockOutputExceedsMax`) instead of growing the buffer
unbounded. The default `usize::MAX` ceiling leaves non-block-decode callers
unaffected.

The ceiling is armed in the shared per-block preamble, which all CPU-tier
sequence decoders (scalar / bmi2 / avx2 / vbmi2) and the K-generic impl now
share via one `init_sequence_stream` helper (previously each had its own copy,
and the ceiling was armed in only one of them — the cause of the original
i686 CI failure). The per-match hot check is a single compare; the
produced-byte error arithmetic is outlined to a `#[cold]` builder.

Tests: a `decode_buffer` unit test (`repeat_rejects_output_past_block_ceiling`),
a fuzz regression replaying the artifact
(`over_producing_block_does_not_oom_via_unbounded_reserve`), an `ExtraPadding`
reject test, and direct-call tests exercising every CPU-tier preamble.
Reproduction verified out-of-band with a tracking allocator (pre-fix: 0.5 GiB
single reserve; post-fix: no allocation over 64 MiB).

### 2. decode-speed gap (Fast levels improved; btultra2 pending)

Bench host (i9, x86_64 glibc, AVX2), `decompress level_-5_fast
decodecorpus-z000033 c_stream`, c_ffi control flat at 514 us across runs:

| | decode time | vs c_ffi |
|---|---|---|
| c_ffi | 514 us | 1.00x |
| main | 758.9 us | 1.48x |
| this branch | 714.5 us | 1.39x |

The shared-preamble extraction plus the outlined cold ceiling path improve the
hot sequence-loop code layout: this branch decodes the gnu `-5_fast` outlier
~5.8% faster than `main` while adding the OOM guard, narrowing the gap to C
from 1.48x to 1.39x.

`level_19_btultra2` decode (`x86_64-musl` dashboard outlier) is unchanged
(1.585x): its time lives in the long-match copy path, not the per-sequence
overhead this change touches. It remains open for a separate, deeper pass.

## Testing

- 734 lib/integration tests + cross-validation pass; clippy + fmt clean on
  x86_64 and aarch64.
- Decode roundtrip / cross-validation unaffected (the ceiling never triggers
  on well-formed blocks: a valid block's output is <= `MAX_BLOCK_SIZE`).
- CI green incl. cross-i686 (the original failure), no-std, msrv, codecov/patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added per-block decompressed-output limits to prevent memory exhaustion and return a clear error when a block would exceed the ceiling.

* **Refactor**
  * Centralized sequence-stream initialization shared across decoder backends to reduce duplicated setup logic.

* **Tests**
  * Added regression tests verifying over-producing blocks are rejected and that the ceiling/error reporting behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->