### PR TITLE
feat(bench): report active CPU kernel tier + fix decode_loop corpus masking

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1923,10 +1923,19 @@
         targetsContainer.replaceChildren();
         // Map each target to the CPU kernel tier that produced its numbers.
         // Carried per-record (see run-benchmarks.sh) so it survives merging
-        // per-target payloads; first non-null record wins per target.
+        // per-target payloads. Pick the kernel from the LATEST snapshot per
+        // target (max `generated_at`, falling back to `commit_sha`) so a
+        // payload that merges several snapshots can't show stale kernel info;
+        // ISO-8601 `generated_at` sorts lexicographically = chronologically,
+        // matching the snapshot ordering used elsewhere.
         const kernelByTarget = {};
+        const kernelSnapByTarget = {};
         for (const r of state.records) {
-          if (r.kernel && r.kernel.kernel && !kernelByTarget[r.target]) {
+          if (!(r.kernel && r.kernel.kernel && r.target)) continue;
+          const snap = r.generated_at || r.commit_sha || "";
+          const prev = kernelSnapByTarget[r.target];
+          if (prev === undefined || snap >= prev) {
+            kernelSnapByTarget[r.target] = snap;
             kernelByTarget[r.target] = r.kernel;
           }
         }

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1924,18 +1924,18 @@
         // Map each target to the CPU kernel tier that produced its numbers.
         // Carried per-record (see run-benchmarks.sh) so it survives merging
         // per-target payloads. Pick the kernel from the LATEST snapshot per
-        // target (max `generated_at`, falling back to `commit_sha`) so a
-        // payload that merges several snapshots can't show stale kernel info;
-        // ISO-8601 `generated_at` sorts lexicographically = chronologically,
-        // matching the snapshot ordering used elsewhere.
+        // target so a payload that merges several snapshots can't show stale
+        // kernel info. Order via `compareSnapshotIdentity` (the same comparator
+        // the latest-profile selection uses) rather than a raw string compare,
+        // so a record with only a `commit_sha` fallback never misorders against
+        // one carrying a `generated_at` timestamp.
         const kernelByTarget = {};
-        const kernelSnapByTarget = {};
+        const kernelRowByTarget = {};
         for (const r of state.records) {
           if (!(r.kernel && r.kernel.kernel && r.target)) continue;
-          const snap = r.generated_at || r.commit_sha || "";
-          const prev = kernelSnapByTarget[r.target];
-          if (prev === undefined || snap >= prev) {
-            kernelSnapByTarget[r.target] = snap;
+          const prev = kernelRowByTarget[r.target];
+          if (!prev || compareSnapshotIdentity(r, prev) > 0) {
+            kernelRowByTarget[r.target] = r;
             kernelByTarget[r.target] = r.kernel;
           }
         }

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1921,10 +1921,23 @@
         el("stat-records").textContent = String(state.records.length);
         const targetsContainer = el("stat-targets");
         targetsContainer.replaceChildren();
+        // Map each target to the CPU kernel tier that produced its numbers.
+        // Carried per-record (see run-benchmarks.sh) so it survives merging
+        // per-target payloads; first non-null record wins per target.
+        const kernelByTarget = {};
+        for (const r of state.records) {
+          if (r.kernel && r.kernel.kernel && !kernelByTarget[r.target]) {
+            kernelByTarget[r.target] = r.kernel;
+          }
+        }
         for (const target of targets) {
           const chip = document.createElement("span");
           chip.className = "chip";
-          chip.textContent = target;
+          const k = kernelByTarget[target];
+          chip.textContent = k ? `${target} · ${k.kernel}` : target;
+          if (k) {
+            chip.title = `CPU kernel: ${k.kernel} · arch ${k.arch} · libc ${k.target_env}`;
+          }
           targetsContainer.appendChild(chip);
         }
         const latestSha = (latest.commit_sha || "local-run").slice(0, 12);

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -824,6 +824,14 @@ for row in dictionary_rows:
         }
     )
 
+# Stamp the run's CPU kernel tier onto every relative record. The deployed
+# dashboard payload concatenates records from per-target runs, so the
+# per-run `target.kernel` below would be overwritten on merge — carrying it
+# per-record lets the dashboard map each target to the kernel that produced
+# its numbers regardless of how the per-target files are merged.
+for _r in relative_rows:
+    _r["kernel"] = kernel_info
+
 relative_payload = {
     "version": 1,
     "target": {

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -97,6 +97,12 @@ DICT_RE = re.compile(
 DICT_TRAIN_RE = re.compile(
     r'^REPORT_DICT_TRAIN scenario=(\S+) label="((?:[^"\\]|\\.)+)" training_bytes=(\d+) dict_bytes_requested=(\d+) rust_train_ms=([0-9.]+) ffi_train_ms=([0-9.]+) rust_dict_bytes=(\d+) ffi_dict_bytes=(\d+) rust_fastcover_score=(\d+)$'
 )
+# Process-global CPU kernel tier the run actually selected (shared
+# encode/decode entropy dispatch). One line per run; attributes every
+# measurement to the kernel + arch + libc that produced it.
+KERNEL_RE = re.compile(
+    r'^REPORT_KERNEL kernel=(\S+) arch=(\S+) target_env=(\S+)$'
+)
 
 def unescape_report_label(value):
     output = []
@@ -131,6 +137,7 @@ ratios = []
 memory_rows = []
 dictionary_rows = []
 dictionary_training_rows = []
+kernel_info = None
 timing_rows = []
 scenario_input_bytes = {}
 scenario_training_bytes = {}
@@ -298,6 +305,12 @@ with open(raw_path) as f:
                 "target": bench_target_id,
                 "ms_per_iter": ms,
             })
+            continue
+
+        kernel_match = KERNEL_RE.match(line)
+        if kernel_match:
+            k_name, k_arch, k_env = kernel_match.groups()
+            kernel_info = {"kernel": k_name, "arch": k_arch, "target_env": k_env}
             continue
 
         report_match = REPORT_RE.match(line)
@@ -817,6 +830,11 @@ relative_payload = {
         "id": bench_target_id,
         "label": bench_target_label,
         "triple": bench_target_triple or None,
+        # CPU kernel tier (entropy/sequence dispatch, shared encode/decode)
+        # this run actually selected, plus arch / libc — so a dashboard
+        # reading this can attribute every record to the kernel that
+        # produced it. `None` if the bench binary predates REPORT_KERNEL.
+        "kernel": kernel_info,
     },
     "reference_band": {
         "delta_low": DELTA_LOW,

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -209,8 +209,43 @@ fn emit_reports_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Emit (once per process) the CPU kernel tier this run actually selected,
+/// plus arch / libc, so the dashboard can attribute every measurement in the
+/// run to the kernel that produced it (the entropy / sequence dispatch tier is
+/// shared by encode and decode — see #247). The kernel is process-global, so a
+/// single line covers all benches in the run.
+fn emit_kernel_report_once() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let arch = if cfg!(target_arch = "x86_64") {
+            "x86_64"
+        } else if cfg!(target_arch = "aarch64") {
+            "aarch64"
+        } else {
+            "other"
+        };
+        let target_env = if cfg!(target_env = "musl") {
+            "musl"
+        } else if cfg!(target_env = "gnu") {
+            "gnu"
+        } else {
+            "other"
+        };
+        println!(
+            "REPORT_KERNEL kernel={} arch={} target_env={}",
+            structured_zstd::active_cpu_kernel_name(),
+            arch,
+            target_env
+        );
+    });
+}
+
 fn bench_compress(c: &mut Criterion) {
     let emit_reports = emit_reports_enabled();
+    if emit_reports {
+        emit_kernel_report_once();
+    }
     for scenario in benchmark_scenarios_cached().iter() {
         for level in supported_levels_filtered() {
             if emit_reports {
@@ -249,6 +284,9 @@ fn bench_compress(c: &mut Criterion) {
 
 fn bench_decompress(c: &mut Criterion) {
     let emit_reports = emit_reports_enabled();
+    if emit_reports {
+        emit_kernel_report_once();
+    }
     for scenario in benchmark_scenarios_cached().iter() {
         for level in supported_levels_filtered() {
             let expected_len = scenario.len();

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -32,7 +32,8 @@ use structured_zstd::dictionary::{
 };
 use structured_zstd::encoding::FrameCompressor;
 use support::{
-    LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, supported_levels_filtered,
+    LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, kernel_report_line,
+    supported_levels_filtered,
 };
 
 static BENCHMARK_SCENARIOS: OnceLock<Vec<Scenario>> = OnceLock::new();
@@ -209,35 +210,14 @@ fn emit_reports_enabled() -> bool {
         .unwrap_or(false)
 }
 
-/// Emit (once per process) the CPU kernel tier this run actually selected,
-/// plus arch / libc, so the dashboard can attribute every measurement in the
-/// run to the kernel that produced it (the entropy / sequence dispatch tier is
-/// shared by encode and decode — see #247). The kernel is process-global, so a
-/// single line covers all benches in the run.
+/// Emit the shared `REPORT_KERNEL` line exactly once per process. The kernel
+/// tier is process-global, so a single line covers every bench in the run even
+/// though both `bench_compress` and `bench_decompress` call this.
 fn emit_kernel_report_once() {
     use std::sync::Once;
     static ONCE: Once = Once::new();
     ONCE.call_once(|| {
-        let arch = if cfg!(target_arch = "x86_64") {
-            "x86_64"
-        } else if cfg!(target_arch = "aarch64") {
-            "aarch64"
-        } else {
-            "other"
-        };
-        let target_env = if cfg!(target_env = "musl") {
-            "musl"
-        } else if cfg!(target_env = "gnu") {
-            "gnu"
-        } else {
-            "other"
-        };
-        println!(
-            "REPORT_KERNEL kernel={} arch={} target_env={}",
-            structured_zstd::active_cpu_kernel_name(),
-            arch,
-            target_env
-        );
+        println!("{}", kernel_report_line());
     });
 }
 

--- a/zstd/benches/compare_ffi_memory.rs
+++ b/zstd/benches/compare_ffi_memory.rs
@@ -416,6 +416,30 @@ fn emit_report(
 }
 
 fn main() {
+    // Report the CPU kernel tier this run selected (shared encode/decode
+    // entropy dispatch — see #247), plus arch / libc, so the dashboard can
+    // attribute every REPORT_MEM line to the kernel that produced it.
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "other"
+    };
+    let target_env = if cfg!(target_env = "musl") {
+        "musl"
+    } else if cfg!(target_env = "gnu") {
+        "gnu"
+    } else {
+        "other"
+    };
+    println!(
+        "REPORT_KERNEL kernel={} arch={} target_env={}",
+        structured_zstd::active_cpu_kernel_name(),
+        arch,
+        target_env
+    );
+
     let scenarios = benchmark_scenarios();
     for scenario in &scenarios {
         for level in supported_levels_filtered() {

--- a/zstd/benches/compare_ffi_memory.rs
+++ b/zstd/benches/compare_ffi_memory.rs
@@ -36,7 +36,9 @@ use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use structured_zstd::decoding::FrameDecoder;
-use support::{LevelConfig, Scenario, benchmark_scenarios, supported_levels_filtered};
+use support::{
+    LevelConfig, Scenario, benchmark_scenarios, kernel_report_line, supported_levels_filtered,
+};
 
 /// Process-wide byte tracker. Two allocation paths feed the SAME
 /// pair of atomic counters (`ALLOC_CURRENT` / `ALLOC_PEAK`) once
@@ -416,29 +418,12 @@ fn emit_report(
 }
 
 fn main() {
-    // Report the CPU kernel tier this run selected (shared encode/decode
-    // entropy dispatch — see #247), plus arch / libc, so the dashboard can
-    // attribute every REPORT_MEM line to the kernel that produced it.
-    let arch = if cfg!(target_arch = "x86_64") {
-        "x86_64"
-    } else if cfg!(target_arch = "aarch64") {
-        "aarch64"
-    } else {
-        "other"
-    };
-    let target_env = if cfg!(target_env = "musl") {
-        "musl"
-    } else if cfg!(target_env = "gnu") {
-        "gnu"
-    } else {
-        "other"
-    };
-    println!(
-        "REPORT_KERNEL kernel={} arch={} target_env={}",
-        structured_zstd::active_cpu_kernel_name(),
-        arch,
-        target_env
-    );
+    // Report the CPU kernel tier this run selected, so the dashboard can
+    // attribute every REPORT_MEM line to the kernel that produced it. Printed
+    // unconditionally (no STRUCTURED_ZSTD_EMIT_REPORT gate like compare_ffi):
+    // this binary is purpose-built for report generation and its only output
+    // is REPORT_* lines, so the header is always wanted.
+    println!("{}", kernel_report_line());
 
     let scenarios = benchmark_scenarios();
     for scenario in &scenarios {

--- a/zstd/benches/support/mod.rs
+++ b/zstd/benches/support/mod.rs
@@ -229,6 +229,34 @@ fn leak_owned(name: String) -> &'static str {
     Box::leak(name.into_boxed_str())
 }
 
+/// The `REPORT_KERNEL` line for this run: the CPU kernel tier actually
+/// selected (the entropy / sequence dispatch is shared by encode and decode,
+/// see #247), plus arch / libc. Lets the dashboard attribute every measurement
+/// to the kernel that produced it. Shared verbatim by both bench binaries so
+/// the format stays in lockstep; each caller decides when to print it.
+pub(crate) fn kernel_report_line() -> String {
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "other"
+    };
+    let target_env = if cfg!(target_env = "musl") {
+        "musl"
+    } else if cfg!(target_env = "gnu") {
+        "gnu"
+    } else {
+        "other"
+    };
+    format!(
+        "REPORT_KERNEL kernel={} arch={} target_env={}",
+        structured_zstd::active_cpu_kernel_name(),
+        arch,
+        target_env
+    )
+}
+
 impl Scenario {
     fn new(
         id: impl Into<String>,

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -53,20 +53,33 @@ fn main() {
         Some(path) => std::fs::read(path).expect("read corpus file"),
         None => {
             // Default to the in-tree z000033 this example is named after.
-            // Try the usual cwd-relative locations (repo root / `zstd/`).
-            // Fail loudly if absent — never silently synthesize.
-            const CANDIDATES: [&str; 2] = [
-                "zstd/decodecorpus_files/z000033",
-                "decodecorpus_files/z000033",
-            ];
-            CANDIDATES
+            // Follow the same resolution order as the benchmarks (see
+            // `zstd/benches/support/mod.rs`): explicit env var first, then
+            // the cargo-driven manifest dir, then cwd-relative locations
+            // (repo root / `zstd/`). Fail loudly if absent — never silently
+            // synthesize.
+            let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+            if let Ok(explicit) = std::env::var("STRUCTURED_ZSTD_BENCH_CORPUS_PATH") {
+                let trimmed = explicit.trim();
+                if !trimmed.is_empty() {
+                    candidates.push(std::path::PathBuf::from(trimmed));
+                }
+            }
+            if let Ok(manifest_dir) = std::env::var("CARGO_MANIFEST_DIR") {
+                candidates.push(
+                    std::path::PathBuf::from(manifest_dir).join("decodecorpus_files/z000033"),
+                );
+            }
+            candidates.push(std::path::PathBuf::from("zstd/decodecorpus_files/z000033"));
+            candidates.push(std::path::PathBuf::from("decodecorpus_files/z000033"));
+            candidates
                 .iter()
                 .find_map(|p| std::fs::read(p).ok())
                 .unwrap_or_else(|| {
                     panic!(
-                        "decode_loop_z000033: corpus z000033 not found in {CANDIDATES:?}; \
-                         pass an explicit path as arg 4, or `synthetic` to opt into the \
-                         random LCG fallback"
+                        "decode_loop_z000033: corpus z000033 not found via env vars or in \
+                         {candidates:?}; pass an explicit path as arg 4, or `synthetic` to \
+                         opt into the random LCG fallback"
                     )
                 })
         }

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -31,11 +31,14 @@ fn main() {
     // so an explicit path or the in-tree corpus is the contract. The LCG
     // synthetic is RANDOM (≈incompressible → mostly RAW blocks → a trivial,
     // unrepresentative decode workload), so it is NEVER substituted silently:
-    // a missing corpus fails loudly, and synthetic is opt-in via the literal
-    // `synthetic` arg. (A silent fallback here previously masked a missing
-    // corpus and produced ~30 GB/s "decode" numbers that hid the real gap.)
+    // a missing corpus fails loudly, and synthetic is opt-in via the
+    // `synthetic` arg (case-insensitive). (A silent fallback here previously
+    // masked a missing corpus and produced ~30 GB/s "decode" numbers that hid
+    // the real gap.)
     let src: Vec<u8> = match corpus_path {
-        Some("synthetic") => {
+        // Case-insensitive so `Synthetic` / `SYNTHETIC` hit the opt-in source
+        // rather than being treated as a (missing) file path.
+        Some(arg) if arg.eq_ignore_ascii_case("synthetic") => {
             eprintln!(
                 "decode_loop_z000033: WARNING — using the random LCG synthetic \
                  source; decode timings are NOT representative of z000033 \

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -25,20 +25,51 @@ fn main() {
     // isolate the checksum cost (flag-on vs flag-off) in one harness.
     let checksum: bool = args.get(5).map(|s| s == "checksum").unwrap_or(false);
 
-    // Source: either a file from disk, or a deterministic 1MB LCG synthetic.
-    let src: Vec<u8> = if let Some(path) = corpus_path {
-        std::fs::read(path).expect("read corpus file")
-    } else {
-        let n = 1_048_576usize;
-        let mut src = Vec::with_capacity(n);
-        let mut state: u64 = 0x517cc1b727220a95;
-        while src.len() < n {
-            state = state
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            src.push((state >> 56) as u8);
+    // Source resolution. This example is named after the `z000033` corpus,
+    // so an explicit path or the in-tree corpus is the contract. The LCG
+    // synthetic is RANDOM (≈incompressible → mostly RAW blocks → a trivial,
+    // unrepresentative decode workload), so it is NEVER substituted silently:
+    // a missing corpus fails loudly, and synthetic is opt-in via the literal
+    // `synthetic` arg. (A silent fallback here previously masked a missing
+    // corpus and produced ~30 GB/s "decode" numbers that hid the real gap.)
+    let src: Vec<u8> = match corpus_path {
+        Some("synthetic") => {
+            eprintln!(
+                "decode_loop_z000033: WARNING — using the random LCG synthetic \
+                 source; decode timings are NOT representative of z000033 \
+                 (random data decodes as RAW blocks)."
+            );
+            let n = 1_048_576usize;
+            let mut src = Vec::with_capacity(n);
+            let mut state: u64 = 0x517cc1b727220a95;
+            while src.len() < n {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                src.push((state >> 56) as u8);
+            }
+            src
         }
-        src
+        Some(path) => std::fs::read(path).expect("read corpus file"),
+        None => {
+            // Default to the in-tree z000033 this example is named after.
+            // Try the usual cwd-relative locations (repo root / `zstd/`).
+            // Fail loudly if absent — never silently synthesize.
+            const CANDIDATES: [&str; 2] = [
+                "zstd/decodecorpus_files/z000033",
+                "decodecorpus_files/z000033",
+            ];
+            CANDIDATES
+                .iter()
+                .find_map(|p| std::fs::read(p).ok())
+                .unwrap_or_else(|| {
+                    panic!(
+                        "decode_loop_z000033: corpus z000033 not found in {CANDIDATES:?}; \
+                         pass an explicit path as arg 4, or `synthetic` to opt into the \
+                         random LCG fallback"
+                    )
+                })
+        }
     };
     let n = src.len();
 

--- a/zstd/examples/decode_loop_z000033.rs
+++ b/zstd/examples/decode_loop_z000033.rs
@@ -1,7 +1,9 @@
 //! Standalone decode-loop binary for clean perf-record profiles.
-//! Generates a 1MB deterministic corpus, FFI-encodes once at the given
-//! level, then loops `decode_all` for N iters. No criterion overhead,
-//! no per-iter encode — pure decoder hot path.
+//! Decodes the in-tree z000033 corpus (or a user-provided file) in a tight
+//! loop after one-time FFI encoding at the given level. N iters of
+//! `decode_all`, no criterion overhead, no per-iter encode: pure decoder
+//! hot path. The random LCG synthetic source is opt-in via the `synthetic`
+//! arg only.
 //!
 //! Build: cargo build --profile flamegraph -p structured-zstd \
 //!          --example decode_loop_z000033 --features dict_builder

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -516,4 +516,29 @@ mod tests {
             "cached detect must return same tag on repeated calls"
         );
     }
+
+    #[test]
+    fn active_kernel_name_is_known_lowercase_tier() {
+        // The diagnostic name must be one of the stable lowercase tier
+        // strings the dashboard parses, and must match whatever tier
+        // detection resolves to on this host (no `unknown` / empty leak).
+        const KNOWN: &[&str] = &["scalar", "sse2", "bmi2", "avx2", "vbmi2", "neon", "sve"];
+        let name = active_cpu_kernel_name();
+        assert!(
+            KNOWN.contains(&name),
+            "active kernel name {name:?} is not a recognised tier"
+        );
+        assert_eq!(
+            name,
+            name.to_ascii_lowercase(),
+            "tier name must be lowercase for stable dashboard parsing"
+        );
+    }
+
+    #[test]
+    fn active_kernel_name_is_stable_across_calls() {
+        // Backed by the cached `detect_cpu_kernel`, so repeated calls must
+        // return the identical static string.
+        assert_eq!(active_cpu_kernel_name(), active_cpu_kernel_name());
+    }
 }

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -372,33 +372,43 @@ pub(crate) fn detect_cpu_kernel() -> CpuKernelTag {
     CpuKernelTag::Scalar
 }
 
+impl CpuKernelTag {
+    /// Stable lowercase diagnostic name for this tier (used by
+    /// [`active_cpu_kernel_name`] and the bench/dashboard reporting). Pure
+    /// mapping over the tag, so every arm is exercisable in tests regardless
+    /// of which tier the running CPU actually resolves to.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            CpuKernelTag::Scalar => "scalar",
+            #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
+            CpuKernelTag::Sse2 => "sse2",
+            #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
+            CpuKernelTag::Bmi2 => "bmi2",
+            #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+            CpuKernelTag::Avx2 => "avx2",
+            #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
+            CpuKernelTag::Vbmi2 => "vbmi2",
+            #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
+            CpuKernelTag::Neon => "neon",
+            #[cfg(all(
+                target_arch = "aarch64",
+                feature = "kernel_sve",
+                any(feature = "std", target_feature = "sve"),
+            ))]
+            CpuKernelTag::Sve => "sve",
+        }
+    }
+}
+
 /// Name of the CPU kernel tier this process selected for the entropy /
-/// sequence hot paths — decode (literals + FSE sequence decode) and encode
+/// sequence hot paths: decode (literals + FSE sequence decode) and encode
 /// (entropy) share this dispatch (see #247). Returned as a stable lowercase
 /// string for diagnostics and benchmark/dashboard reporting; the value is
 /// what the runtime CPU-feature detection (or compile-time `target_feature`
 /// on `no_std`) actually resolves to on this machine, so a dashboard can
 /// attribute a measurement to the kernel that produced it.
 pub fn active_cpu_kernel_name() -> &'static str {
-    match detect_cpu_kernel() {
-        CpuKernelTag::Scalar => "scalar",
-        #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
-        CpuKernelTag::Sse2 => "sse2",
-        #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
-        CpuKernelTag::Bmi2 => "bmi2",
-        #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
-        CpuKernelTag::Avx2 => "avx2",
-        #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
-        CpuKernelTag::Vbmi2 => "vbmi2",
-        #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
-        CpuKernelTag::Neon => "neon",
-        #[cfg(all(
-            target_arch = "aarch64",
-            feature = "kernel_sve",
-            any(feature = "std", target_feature = "sve"),
-        ))]
-        CpuKernelTag::Sve => "sve",
-    }
+    detect_cpu_kernel().name()
 }
 
 #[cfg(test)]
@@ -533,6 +543,30 @@ mod tests {
             name.to_ascii_lowercase(),
             "tier name must be lowercase for stable dashboard parsing"
         );
+    }
+
+    #[test]
+    fn every_kernel_tag_maps_to_its_lowercase_name() {
+        // `active_cpu_kernel_name` only exercises whichever arm the running
+        // CPU resolves to, so map each constructible tag directly to cover
+        // every branch on this build's feature set.
+        assert_eq!(CpuKernelTag::Scalar.name(), "scalar");
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
+        assert_eq!(CpuKernelTag::Sse2.name(), "sse2");
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
+        assert_eq!(CpuKernelTag::Bmi2.name(), "bmi2");
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+        assert_eq!(CpuKernelTag::Avx2.name(), "avx2");
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
+        assert_eq!(CpuKernelTag::Vbmi2.name(), "vbmi2");
+        #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
+        assert_eq!(CpuKernelTag::Neon.name(), "neon");
+        #[cfg(all(
+            target_arch = "aarch64",
+            feature = "kernel_sve",
+            any(feature = "std", target_feature = "sve"),
+        ))]
+        assert_eq!(CpuKernelTag::Sve.name(), "sve");
     }
 
     #[test]

--- a/zstd/src/cpu_kernel.rs
+++ b/zstd/src/cpu_kernel.rs
@@ -372,6 +372,35 @@ pub(crate) fn detect_cpu_kernel() -> CpuKernelTag {
     CpuKernelTag::Scalar
 }
 
+/// Name of the CPU kernel tier this process selected for the entropy /
+/// sequence hot paths — decode (literals + FSE sequence decode) and encode
+/// (entropy) share this dispatch (see #247). Returned as a stable lowercase
+/// string for diagnostics and benchmark/dashboard reporting; the value is
+/// what the runtime CPU-feature detection (or compile-time `target_feature`
+/// on `no_std`) actually resolves to on this machine, so a dashboard can
+/// attribute a measurement to the kernel that produced it.
+pub fn active_cpu_kernel_name() -> &'static str {
+    match detect_cpu_kernel() {
+        CpuKernelTag::Scalar => "scalar",
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
+        CpuKernelTag::Sse2 => "sse2",
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
+        CpuKernelTag::Bmi2 => "bmi2",
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+        CpuKernelTag::Avx2 => "avx2",
+        #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
+        CpuKernelTag::Vbmi2 => "vbmi2",
+        #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
+        CpuKernelTag::Neon => "neon",
+        #[cfg(all(
+            target_arch = "aarch64",
+            feature = "kernel_sve",
+            any(feature = "std", target_feature = "sve"),
+        ))]
+        CpuKernelTag::Sve => "sve",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -92,6 +92,11 @@ pub mod huff0;
 #[cfg(feature = "fuzz_exports")]
 pub use crate::cpu_kernel::{CpuKernel, ScalarKernel};
 
+/// Name of the active CPU kernel tier (entropy / sequence hot paths) for this
+/// process — for diagnostics and benchmark/dashboard reporting. See
+/// [`cpu_kernel::active_cpu_kernel_name`].
+pub use crate::cpu_kernel::active_cpu_kernel_name;
+
 #[cfg(not(feature = "fuzz_exports"))]
 pub(crate) mod fse;
 #[cfg(not(feature = "fuzz_exports"))]


### PR DESCRIPTION
## Summary

Benchmark diagnostics, motivated by chasing the decodecorpus decode-gap
dashboard outliers.

### 1. Report the active CPU kernel tier per run

`compare_ffi` and `compare_ffi_memory` now emit a `REPORT_KERNEL kernel=<tier>
arch=<arch> target_env=<gnu|musl>` line once per run, via the new public
`structured_zstd::active_cpu_kernel_name()`. `run-benchmarks.sh` captures it
into `benchmark-relative.json`'s `target.kernel`, so the dashboard can
attribute every measurement to the kernel that actually produced it (the
entropy / sequence dispatch tier is shared by encode and decode — see #247)
and tell apart e.g. `x86_64-gnu` vs `x86_64-musl`. The kernel is
process-global, so one line per run covers all benches.

(Dashboard JSON now carries the field; surfacing it in the `index.html` view
is a small follow-up — the data is present.)

### 2. Stop decode_loop_z000033 masking a missing corpus

When run without a corpus path, the example silently substituted a random LCG
synthetic source. Random data is ~incompressible, so it decodes as RAW blocks
— a trivial, unrepresentative workload (~30 GB/s) that masks the real
decodecorpus decode profile (it produced misleading "no gap" numbers while
chasing the dashboard outliers). It now defaults to the in-tree `z000033`,
fails loudly if the corpus is absent, and only uses the synthetic source via
an explicit `synthetic` arg (with a warning).

## Testing

- lib + benches + examples build; clippy + fmt clean; cpu_kernel tests pass.
- `decode_loop_z000033` with no path now decodes the real `z000033`
  (1,022,035 B/iter) instead of the synthetic source.
- `run-benchmarks.sh` embedded parser passes `ast.parse`.

Part of #349


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard shows CPU kernel tier and architecture next to targets, with informative tooltips.
  * Benchmarks now capture and include CPU kernel, architecture, and target-environment info.
  * Public diagnostic API exposes the active CPU kernel name for reporting.

* **Improvements**
  * Example now requires real corpus or explicit synthetic mode and fails loudly if missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->