### PR TITLE
perf(codec): warm dictionary reuse (decode + encode) + relocate decompression-bomb guard

### DIFF
--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -30,7 +30,7 @@ use structured_zstd::decoding::FrameDecoder;
 use structured_zstd::dictionary::{
     FastCoverOptions, FinalizeOptions, finalize_raw_dict, train_fastcover_raw_from_slice,
 };
-use structured_zstd::encoding::FrameCompressor;
+use structured_zstd::encoding::{EncoderDictionary, FrameCompressor};
 use support::{
     LevelConfig, Scenario, ScenarioClass, benchmark_scenarios, kernel_report_line,
     supported_levels_filtered,
@@ -651,60 +651,59 @@ fn bench_dictionary(c: &mut Criterion) {
                 })
             });
 
-            // c_ffi_with_dict + pure_rust_with_dict: both construct
-            // their compressor + attach dict INSIDE `b.iter` so the
-            // measurement covers the same shape on both sides.
-            // Asymmetric setup-vs-iter placement was flagged in
-            // PR #277 review (Copilot threads #2/#3/#4): the Rust
-            // FrameCompressor API stores `set_drain`'s `&mut Vec<u8>`
-            // inside the compressor for its full lifetime, so a
-            // "compressor outside b.iter, fresh Vec inside" pattern
-            // doesn't type-check. Rather than gymnast around that,
-            // match the per-iter shape on both arms — the FFI per-
-            // iter construction cost is small (`Compressor::with_
-            // dictionary` is a single CDict reference attach into a
-            // freshly-allocated CCtx) and stays comparable to the
-            // Rust per-iter `FrameCompressor::new +
-            // set_dictionary_from_bytes`.
+            // c_ffi_with_dict + pure_rust_with_dict: STEADY-STATE measurement.
+            // Both build the compressor + attach the dictionary ONCE before
+            // `b.iter`, then compress in the loop reusing that context — the
+            // real prepared-dictionary lifecycle (C `CDict` created once +
+            // `ZSTD_compress_usingCDict` per frame; Rust prepared
+            // `EncoderDictionary` + `compress_independent_frame` per frame).
+            // The earlier per-iter shape (fresh compressor + dict parse every
+            // iteration) measured one-time setup cost, not steady-state
+            // throughput, and unfairly penalised the side with heavier
+            // per-attach setup. `compress_independent_frame_into` reads the
+            // input in place and takes the output buffer per call, so it needs
+            // no `set_drain`/`set_source` — sidestepping the lifetime issue
+            // (PR #277) that forced the old per-iter shape.
             group.bench_function("c_ffi_with_dict", |b| {
-                b.iter(|| {
-                    let mut compressor =
-                        zstd::bulk::Compressor::with_dictionary(level.ffi_level, &ffi_dictionary)
-                            .unwrap();
-                    black_box(compressor.compress(&scenario.bytes).unwrap())
-                })
+                let mut compressor =
+                    zstd::bulk::Compressor::with_dictionary(level.ffi_level, &ffi_dictionary)
+                        .unwrap();
+                b.iter(|| black_box(compressor.compress(&scenario.bytes).unwrap()))
             });
 
             // Gate pure_rust_with_dict registration on the same
-            // `rust_dict_handle.is_some()` signal that
-            // decompress-dict uses below — if DictionaryHandle::
-            // decode_dict failed earlier (the per-scenario parse
-            // above), FrameCompressor::set_dictionary_from_bytes
-            // routes through the same Dictionary::decode_dict and
-            // would fail identically. An `.expect()` panic inside
-            // b.iter would abort the whole bench suite.
-            if let Some(preallocated_capacity) = rust_with_dict_len {
-                // `rust_with_dict_len` above already did the one-time
-                // pre-compress that learns the Rust encoder's actual output
-                // size at this (scenario, level, dict) — reuse it as the
-                // timing-loop preallocation hint. Using `with_dict_bytes.len()`
-                // (the FFI-side size) would under-allocate when Rust emits a
-                // slightly larger frame, forcing `Vec` reallocations inside the
-                // timing loop and skewing the measurement vs FFI (which always
-                // allocates exact output size internally).
+            // `rust_dict_handle.is_some()` signal that decompress-dict uses
+            // below — if the per-scenario dictionary parse failed earlier,
+            // `EncoderDictionary::from_bytes` routes through the same parse and
+            // would fail identically; an `.expect()` panic before `b.iter`
+            // would abort the whole bench suite.
+            if let Some(preallocated_capacity) = rust_with_dict_len
+                && EncoderDictionary::from_bytes(&ffi_dictionary).is_ok()
+            {
                 group.bench_function("pure_rust_with_dict", |b| {
+                    // `compress_independent_frame_into` reads input in
+                    // place + takes the output buffer per call, so neither
+                    // the source `R` nor drain `W` generic is ever bound by
+                    // a `set_source`/`set_drain` call — pin them to the
+                    // defaults so inference has a concrete type.
+                    let mut compressor: FrameCompressor = FrameCompressor::new(level.rust_level);
+                    compressor
+                        .set_encoder_dictionary(
+                            EncoderDictionary::from_bytes(&ffi_dictionary)
+                                .expect("dictionary parse checked above"),
+                        )
+                        .expect("prepared dictionary should attach");
+                    // Reuse one output buffer across iterations (the
+                    // CCtx-equivalent caller-owned `dst`). `rust_with_dict_len`
+                    // pre-sizes it so no realloc happens inside the loop.
+                    let mut compressed = Vec::with_capacity(preallocated_capacity);
                     b.iter(|| {
-                        let mut compressor = FrameCompressor::new(level.rust_level);
-                        compressor
-                            .set_dictionary_from_bytes(&ffi_dictionary)
-                            .expect("dictionary should attach");
-                        compressor.set_source_size_hint(scenario.bytes.len() as u64);
-                        compressor.set_source(scenario.bytes.as_slice());
-                        let mut compressed = Vec::with_capacity(preallocated_capacity);
-                        compressor.set_drain(&mut compressed);
-                        compressor.compress();
-                        black_box(compressed)
-                    })
+                        compressor.compress_independent_frame_into(
+                            scenario.bytes.as_slice(),
+                            &mut compressed,
+                        );
+                        black_box(&compressed);
+                    });
                 });
             }
 

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -39,6 +39,44 @@ use crate::io::{Error, Read};
 /// slack contract cannot drift between backends.
 pub(crate) const WILDCOPY_OVERLENGTH: usize = 32;
 
+/// Single-compare output-capacity guard for the inline sequence-exec hot
+/// path, shared by every [`BufferBackend::exec_sequence_inline`] /
+/// `exec_sequence_inline_avx2` override so the per-sequence bounds check has
+/// one implementation instead of a duplicated `checked_add` chain.
+///
+/// Returns `lit_length + match_length` when the literal+match write plus
+/// `overshoot` bytes of SIMD wildcopy slack fits within `cap - tail`;
+/// otherwise [`ExecuteSequencesError::OutputBufferOverflow`](super::errors::ExecuteSequencesError::OutputBufferOverflow).
+///
+/// # Preconditions
+/// - `tail <= cap`, so `cap - tail` cannot underflow. Holds for every
+///   backend: `Vec::len() <= Vec::capacity()` on the flat / growable buffers,
+///   and the user-slice tail only ever advances past this same check.
+/// - `lit_length` and `match_length` are each bounded by the maximum FSE
+///   LL/ML code expansion (~131 KB), so `total` and `total + overshoot`
+///   cannot overflow `usize` even on 32-bit.
+///
+/// Each caller documents why the first precondition holds at its site; the
+/// arithmetic safety of the second is the same FSE bound everywhere.
+#[inline(always)]
+pub(crate) fn sequence_output_fits(
+    lit_length: usize,
+    match_length: usize,
+    tail: usize,
+    cap: usize,
+    overshoot: usize,
+) -> Result<usize, super::errors::ExecuteSequencesError> {
+    let total = lit_length + match_length;
+    if total + overshoot > cap - tail {
+        return Err(super::errors::ExecuteSequencesError::OutputBufferOverflow {
+            tail,
+            requested: total,
+            capacity: cap,
+        });
+    }
+    Ok(total)
+}
+
 /// Storage operations the decoder needs from its output buffer.
 ///
 /// The trait surface mirrors the historical `RingBuffer` API the
@@ -227,12 +265,12 @@ pub(crate) trait BufferBackend: Sized {
     }
 
     /// Lower the per-block growth ceiling on backends whose `try_reserve`
-    /// may grow without bound (the streaming `RingBuffer`). The block
-    /// sequence decoder sets it to `len + MAX_BLOCK_SIZE` per block so an
-    /// over-producing match is rejected on the cold growth path,
-    /// bounding decompression-bomb OOMs. Default no-op: fixed-capacity
-    /// backends are already bounded, and the inline-exec (FCS-capped)
-    /// path never grows through `try_reserve`.
+    /// may grow without bound. The block sequence decoder sets it to
+    /// `len + MAX_BLOCK_SIZE` per block so an over-producing match is rejected
+    /// on the cold growth path, bounding decompression-bomb OOMs. Overridden by
+    /// the streaming `RingBuffer` and the growable `FlatBuf` (whose fallback
+    /// `push`/`repeat` path grows through `try_reserve`). Default no-op for
+    /// fixed-capacity backends (`UserSliceBackend`), which are already bounded.
     fn set_max_capacity(&mut self, _max_capacity: usize) {}
 
     /// Live byte count: bytes between the logical head and tail.

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -226,6 +226,15 @@ pub(crate) trait BufferBackend: Sized {
         Ok(())
     }
 
+    /// Lower the per-block growth ceiling on backends whose `try_reserve`
+    /// may grow without bound (the streaming `RingBuffer`). The block
+    /// sequence decoder sets it to `len + MAX_BLOCK_SIZE` per block so an
+    /// over-producing match is rejected on the cold growth path,
+    /// bounding decompression-bomb OOMs. Default no-op: fixed-capacity
+    /// backends are already bounded, and the inline-exec (FCS-capped)
+    /// path never grows through `try_reserve`.
+    fn set_max_capacity(&mut self, _max_capacity: usize) {}
+
     /// Live byte count: bytes between the logical head and tail.
     fn len(&self) -> usize;
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -26,7 +26,14 @@ use crate::decoding::errors::DecodeBufferError;
 ///   backlog item #132.
 pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
     buffer: B,
-    pub dict_content: Vec<u8>,
+    /// Active dictionary, held by shared handle (`Arc`/`Rc`) rather than a
+    /// per-frame owned copy. `repeat_from_dict` reads match bytes straight
+    /// out of the handle's content (donor `ZSTD_refDDict` semantics): one
+    /// dictionary copy is shared across every frame AND across decoder
+    /// instances on other threads (`Arc<Dictionary>` is `Send + Sync`), so
+    /// reusing a dictionary costs a refcount bump, never a content memcpy.
+    /// `None` = no dictionary (a no-dict frame can never read a stale one).
+    pub(crate) dict: Option<crate::decoding::dictionary::DictionaryHandle>,
 
     pub window_size: usize,
     total_output_counter: u64,
@@ -83,7 +90,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     pub fn new(window_size: usize) -> DecodeBuffer<B> {
         DecodeBuffer {
             buffer: B::new(),
-            dict_content: Vec::new(),
+            dict: None,
             window_size,
             total_output_counter: 0,
             block_output_limit: usize::MAX,
@@ -108,7 +115,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         buffer.clear();
         DecodeBuffer {
             buffer,
-            dict_content: Vec::new(),
+            dict: None,
             window_size,
             total_output_counter: 0,
             block_output_limit: usize::MAX,
@@ -159,7 +166,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // `DecoderScratchKind::reserve_buffer(window_size)` before any
         // block writes — that is the only call site that knows whether
         // the frame will actually hit this buffer.
-        self.dict_content.clear();
+        self.dict = None;
         self.total_output_counter = 0;
         // Cleared per frame; re-armed per block by the sequence decoder.
         self.block_output_limit = usize::MAX;
@@ -171,6 +178,25 @@ impl<B: BufferBackend> DecodeBuffer<B> {
 
     pub fn len(&self) -> usize {
         self.buffer.len()
+    }
+
+    /// Active dictionary content bytes, borrowed through the shared handle
+    /// (no copy). Empty slice when no dictionary is attached.
+    #[inline]
+    pub(crate) fn dict_content(&self) -> &[u8] {
+        match &self.dict {
+            Some(h) => &h.as_dict().dict_content,
+            None => &[],
+        }
+    }
+
+    /// Attach a dictionary by shared handle. This is a refcount bump
+    /// (`Arc`/`Rc` clone) — the dictionary content is shared, never copied,
+    /// so the same dictionary is free to reuse across frames and across
+    /// decoder instances on other threads.
+    #[inline]
+    pub(crate) fn set_dict(&mut self, handle: crate::decoding::dictionary::DictionaryHandle) {
+        self.dict = Some(handle);
     }
 
     /// Return the last `n` bytes of the visible buffer as two
@@ -775,24 +801,36 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();
 
-            if bytes_from_dict > self.dict_content.len() {
+            // Borrow the dictionary content through the shared handle as a
+            // field access (`self.dict`), kept disjoint from the `self.buffer`
+            // mutation below so the borrow checker allows the read+extend
+            // without an intermediate copy. `None` → empty slice → the
+            // length guard rejects (matches the old empty-`dict_content`
+            // behaviour on the direct/no-dict path).
+            let dict_content: &[u8] = match &self.dict {
+                Some(h) => &h.as_dict().dict_content,
+                None => &[],
+            };
+            let dict_len = dict_content.len();
+
+            if bytes_from_dict > dict_len {
                 return Err(DecodeBufferError::NotEnoughBytesInDictionary {
-                    got: self.dict_content.len(),
+                    got: dict_len,
                     need: bytes_from_dict,
                 });
             }
 
             if bytes_from_dict < match_length {
-                let dict_slice = &self.dict_content[self.dict_content.len() - bytes_from_dict..];
+                let dict_slice = &dict_content[dict_len - bytes_from_dict..];
                 prefetch::prefetch_slice(dict_slice);
                 self.buffer.extend(dict_slice);
 
                 self.total_output_counter += bytes_from_dict as u64;
                 return self.repeat(self.buffer.len(), match_length - bytes_from_dict);
             } else {
-                let low = self.dict_content.len() - bytes_from_dict;
+                let low = dict_len - bytes_from_dict;
                 let high = low + match_length;
-                let dict_slice = &self.dict_content[low..high];
+                let dict_slice = &dict_content[low..high];
                 prefetch::prefetch_slice(dict_slice);
                 self.buffer.extend(dict_slice);
                 self.total_output_counter += match_length as u64;
@@ -1320,7 +1358,15 @@ mod tests {
     #[test]
     fn repeat_from_dict_full_copy_updates_total_output_counter() {
         let mut decode_buf = DecodeBuffer::<RingBuffer>::new(1);
-        decode_buf.dict_content = b"0123456789".to_vec();
+        decode_buf.set_dict(
+            crate::decoding::dictionary::DictionaryHandle::from_dictionary(
+                crate::decoding::dictionary::Dictionary::from_raw_content(
+                    1,
+                    b"0123456789".to_vec(),
+                )
+                .unwrap(),
+            ),
+        );
 
         decode_buf.repeat(10, 2).unwrap();
         let err = decode_buf.repeat(10, 1).unwrap_err();

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -120,11 +120,18 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// cold growth path instead of growing the ring to gigabytes (a
     /// decompression-bomb OOM) before the post-block validity check runs.
     /// Called once per block by the sequence decoder, before the sequence
-    /// loop. Backends that cannot grow unbounded (fixed-capacity, or the
-    /// inline-exec FCS-capped path) take the trait's no-op default.
+    /// loop. The growable backends (`RingBuffer`, `FlatBuf`) enforce it in
+    /// `try_reserve`; fixed-capacity backends (`UserSliceBackend`) are already
+    /// bounded and take the trait's no-op default.
     #[inline]
     pub(crate) fn set_block_output_ceiling(&mut self, max_block_output: usize) {
-        let ceiling = self.buffer.len().saturating_add(max_block_output);
+        // Plain add (not saturating): `len()` is the bytes decoded so far and
+        // `max_block_output` is one block's `MAX_BLOCK_SIZE` (128 KiB), so the
+        // sum is nowhere near `usize::MAX` — overflow is unreachable. Saturating
+        // would silently turn the ceiling into `usize::MAX` (no guard at all)
+        // if that invariant were ever broken, masking the bug instead of
+        // tripping the debug overflow check at its cause.
+        let ceiling = self.buffer.len() + max_block_output;
         self.buffer.set_max_capacity(ceiling);
     }
 
@@ -788,6 +795,21 @@ impl<B: BufferBackend> DecodeBuffer<B> {
                 });
             }
 
+            // Enforce the per-block bomb ceiling on the dictionary-backed
+            // output too: the `extend` below appends `dict_slice` directly
+            // (the inline `push`/`repeat` guard never runs for it), so without
+            // this an over-producing match satisfied from the dictionary could
+            // grow past the armed ceiling. Reserving the full `match_length`
+            // covers both the dict portion here and the buffer-history
+            // remainder the recursive `repeat` appends.
+            self.buffer.try_reserve(match_length).map_err(|o| {
+                DecodeBufferError::OutputBufferOverflow {
+                    tail: o.tail,
+                    requested: o.requested,
+                    capacity: o.capacity,
+                }
+            })?;
+
             if bytes_from_dict < match_length {
                 let dict_slice = &dict_content[dict_len - bytes_from_dict..];
                 prefetch::prefetch_slice(dict_slice);
@@ -1333,6 +1355,51 @@ mod tests {
             .repeat(4, 8)
             .expect("6 + 8 = 14 == ceiling is allowed");
         assert_eq!(decode_buf.len(), 14);
+    }
+
+    #[test]
+    fn repeat_from_dict_rejects_output_past_block_ceiling() {
+        // A match satisfied (fully or partially) from the dictionary appends
+        // `dict_slice` directly via `buffer.extend`, bypassing the inline
+        // push/repeat guard. The per-block bomb ceiling must still bound it, so
+        // a dict-backed over-producing match returns `OutputBufferOverflow`
+        // instead of growing the buffer toward OOM.
+        let dict = || {
+            crate::decoding::dictionary::DictionaryHandle::from_dictionary(
+                crate::decoding::dictionary::Dictionary::from_raw_content(
+                    1,
+                    alloc::vec![0xABu8; 256],
+                )
+                .unwrap(),
+            )
+        };
+
+        // Fully-dictionary match: empty buffer, offset reaches into the dict.
+        let mut full = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        full.set_dict(dict());
+        full.set_block_output_ceiling(8); // max_capacity = 0 + 8 = 8
+        let err = full.repeat(200, 100).unwrap_err(); // 0 + 100 > 8, all from dict
+        assert!(
+            matches!(
+                err,
+                crate::decoding::errors::DecodeBufferError::OutputBufferOverflow { .. }
+            ),
+            "fully-dictionary over-producing match must be rejected, got {err:?}"
+        );
+
+        // Mixed match: part from dict, remainder from buffer history.
+        let mut mixed = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        mixed.set_dict(dict());
+        mixed.push(b"abcd"); // len = 4
+        mixed.set_block_output_ceiling(8); // max_capacity = 4 + 8 = 12
+        let err = mixed.repeat(10, 100).unwrap_err(); // 6 from dict + rest, 4 + 100 > 12
+        assert!(
+            matches!(
+                err,
+                crate::decoding::errors::DecodeBufferError::OutputBufferOverflow { .. }
+            ),
+            "mixed dict+buffer over-producing match must be rejected, got {err:?}"
+        );
     }
 
     #[test]

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -6,7 +6,6 @@ use core::hash::Hasher;
 use super::buffer_backend::BufferBackend;
 use super::prefetch;
 use super::ringbuffer::RingBuffer;
-use crate::common::MAX_BLOCK_SIZE;
 use crate::decoding::errors::DecodeBufferError;
 
 /// Generic decode-side output buffer parameterised over the storage
@@ -37,14 +36,6 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
 
     pub window_size: usize,
     total_output_counter: u64,
-    /// Upper bound on `buffer.len()` for the block currently being decoded.
-    /// Set per block to `len_at_block_start + MAX_BLOCK_SIZE` so a single
-    /// block cannot decompress to more than `MAX_BLOCK_SIZE` of output; a
-    /// `repeat` that would cross it is rejected before its `try_reserve`,
-    /// bounding the growable `RingBuffer` against decompression-bomb OOMs.
-    /// `usize::MAX` (the default) disables the check for non-block-decode
-    /// callers of `repeat`.
-    block_output_limit: usize,
     #[cfg(feature = "hash")]
     pub hash: twox_hash::XxHash64,
 }
@@ -93,7 +84,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             dict: None,
             window_size,
             total_output_counter: 0,
-            block_output_limit: usize::MAX,
             #[cfg(feature = "hash")]
             hash: twox_hash::XxHash64::with_seed(0),
         }
@@ -118,40 +108,24 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             dict: None,
             window_size,
             total_output_counter: 0,
-            block_output_limit: usize::MAX,
             #[cfg(feature = "hash")]
             hash: twox_hash::XxHash64::with_seed(0),
         }
     }
 
     /// Arm the per-block decompressed-output ceiling for the block about to
-    /// be decoded: a `repeat` whose match would push `buffer.len()` past
-    /// `current_len + MAX_BLOCK_SIZE` is rejected (see `block_output_limit`),
-    /// bounding the growable backend against decompression-bomb OOMs. Called
-    /// once per block by the sequence decoder, before the sequence loop.
+    /// be decoded: the growable backend is told it may grow only up to
+    /// `current_len + max_block_output`, so a match that would push this
+    /// block's output past `MAX_BLOCK_SIZE` fails its `try_reserve` on the
+    /// cold growth path instead of growing the ring to gigabytes (a
+    /// decompression-bomb OOM) before the post-block validity check runs.
+    /// Called once per block by the sequence decoder, before the sequence
+    /// loop. Backends that cannot grow unbounded (fixed-capacity, or the
+    /// inline-exec FCS-capped path) take the trait's no-op default.
     #[inline]
     pub(crate) fn set_block_output_ceiling(&mut self, max_block_output: usize) {
-        self.block_output_limit = self.buffer.len().saturating_add(max_block_output);
-    }
-
-    /// Cold-path error builder for the per-block output ceiling. Outlined
-    /// from `repeat_inner` so the hot per-match check stays a single
-    /// compare; the produced-byte arithmetic only runs on the
-    /// malformed-input rejection path.
-    #[cold]
-    #[inline(never)]
-    fn block_output_exceeded(&self, match_length: usize) -> DecodeBufferError {
-        let block_start = self
-            .block_output_limit
-            .saturating_sub(MAX_BLOCK_SIZE as usize);
-        DecodeBufferError::BlockOutputExceedsMax {
-            produced: self
-                .buffer
-                .len()
-                .saturating_add(match_length)
-                .saturating_sub(block_start),
-            max: MAX_BLOCK_SIZE as usize,
-        }
+        let ceiling = self.buffer.len().saturating_add(max_block_output);
+        self.buffer.set_max_capacity(ceiling);
     }
 
     pub fn reset(&mut self, window_size: usize) {
@@ -168,8 +142,9 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // the frame will actually hit this buffer.
         self.dict = None;
         self.total_output_counter = 0;
-        // Cleared per frame; re-armed per block by the sequence decoder.
-        self.block_output_limit = usize::MAX;
+        // Lift the per-block growth ceiling between frames; the sequence
+        // decoder re-arms it per block. Non-block callers stay unbounded.
+        self.buffer.set_max_capacity(usize::MAX);
         #[cfg(feature = "hash")]
         {
             self.hash = twox_hash::XxHash64::with_seed(0);
@@ -408,22 +383,14 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             return Ok(());
         }
 
-        // Bound the block's cumulative decompressed output. A single zstd
-        // block decompresses to at most MAX_BLOCK_SIZE; reject a match that
-        // would push this block's output past the per-block ceiling
-        // (`block_output_limit`, set per block by the sequence decoder)
-        // before its `try_reserve`. On the growable `RingBuffer` an
-        // over-producing malformed / adversarial block would otherwise grow
-        // the buffer to gigabytes inside the decode loop — a
-        // decompression-bomb OOM — before the post-block validity check can
-        // reject the frame. The default `usize::MAX` ceiling leaves
-        // non-block-decode callers of `repeat` unaffected.
-        if self.buffer.len().saturating_add(match_length) > self.block_output_limit {
-            // Cold path outlined so the per-match hot check is just the
-            // compare above (the error-byte arithmetic must not bloat the
-            // sequence loop's inlined repeat path).
-            return Err(self.block_output_exceeded(match_length));
-        }
+        // The per-block decompression-bomb ceiling is NOT checked here on
+        // every match (that compare bloated the inlined hot loop). It is
+        // enforced once on the cold growth path: `set_block_output_ceiling`
+        // lowers the backend's `max_capacity` per block, so the
+        // `try_reserve` below rejects an over-producing match exactly when
+        // it would have to grow the buffer past the ceiling — bounding the
+        // OOM on every target while a well-formed block (covered by the
+        // upfront `reserve(MAX_BLOCK_SIZE)`) never reaches the check.
 
         if offset > self.buffer.len() {
             self.repeat_from_dict(offset, match_length)
@@ -436,12 +403,13 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             // assumes the required free capacity exists; skipping it
             // would turn a malformed block (match_length past the
             // upfront `reserve(MAX_BLOCK_SIZE)`) into release-build
-            // UB. Use the fallible variant so fixed-capacity backends
-            // (`UserSliceBackend`) surface a structured error instead
-            // of panicking via the per-call `assert!` inside
-            // `extend_from_within_unchecked`. Growable backends'
-            // default impl never fails (allocation succeeds or
-            // aborts), so the conversion is a cheap no-op there.
+            // UB. The fallible variant surfaces a structured error for
+            // both fixed-capacity backends (`UserSliceBackend`: write
+            // past the user's slice) and the growable `RingBuffer` (a
+            // grow past the per-block `max_capacity` ceiling — the
+            // decompression-bomb guard). On the common path the upfront
+            // `reserve(MAX_BLOCK_SIZE)` already covers the write, so this
+            // is a cheap capacity check, not an allocation.
             self.buffer.try_reserve(match_length).map_err(|o| {
                 DecodeBufferError::OutputBufferOverflow {
                     tail: o.tail,
@@ -1330,29 +1298,41 @@ mod tests {
 
     #[test]
     fn repeat_rejects_output_past_block_ceiling() {
-        // A single zstd block decompresses to at most MAX_BLOCK_SIZE. With
-        // the per-block ceiling armed, a `repeat` whose match would push the
-        // block's output past it must be rejected before its `try_reserve`.
-        // Without this guard the over-long match drives `try_reserve`
-        // unbounded on the growable `RingBuffer` — the artifact `oom-66db61d9…`
-        // grew the ring to ~0.5–2 GiB across many over-producing sequences
-        // before any post-block check ran (a decompression-bomb OOM,
-        // reproduced via the fuzz `decode` target). Pre-guard this `repeat`
-        // returned `Ok` (reserved + copied); it must now reject.
+        // A single zstd block decompresses to at most MAX_BLOCK_SIZE. The
+        // per-block ceiling is enforced on the growable `RingBuffer`'s cold
+        // growth path: `set_block_output_ceiling` lowers `max_capacity`, so a
+        // `repeat` whose match would have to grow the buffer past the ceiling
+        // fails its `try_reserve` instead of growing the ring unbounded.
+        // Without this guard the over-long match drove `try_reserve` to
+        // ~0.5–2 GiB across many over-producing sequences (artifact
+        // `oom-66db61d9…`, fuzz `decode` target) before any post-block check
+        // ran — a decompression-bomb OOM. The match needing growth surfaces
+        // as `OutputBufferOverflow` (the backend's structured reject).
         let mut decode_buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
         decode_buf.push(b"abcdef"); // len = 6
-        decode_buf.set_block_output_ceiling(8); // ceiling = 6 + 8 = 14
+        decode_buf.set_block_output_ceiling(8); // max_capacity = 6 + 8 = 14
         let err = decode_buf.repeat(4, 16).unwrap_err(); // 6 + 16 = 22 > 14
-        assert!(matches!(
-            err,
-            crate::decoding::errors::DecodeBufferError::BlockOutputExceedsMax { .. }
-        ));
-        // Display carries the produced bytes for diagnostics. `produced`
-        // is `(len + match_length) - block_start` = `22 - 0 = 22` (the
-        // ceiling of 14 sits below MAX_BLOCK_SIZE so `block_start`
-        // saturates to 0); `max` is always MAX_BLOCK_SIZE.
-        let rendered = alloc::format!("{err}");
-        assert!(rendered.contains("22"), "unexpected Display: {rendered}");
+        assert!(
+            matches!(
+                err,
+                crate::decoding::errors::DecodeBufferError::OutputBufferOverflow { .. }
+            ),
+            "over-producing match must be rejected, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn repeat_within_block_ceiling_still_succeeds() {
+        // A match that keeps the block's output at/below the armed ceiling
+        // must NOT be rejected — the guard fires only on growth past the
+        // ceiling, never on legitimate in-bounds output.
+        let mut decode_buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
+        decode_buf.push(b"abcdef"); // len = 6
+        decode_buf.set_block_output_ceiling(8); // max_capacity = 14
+        decode_buf
+            .repeat(4, 8)
+            .expect("6 + 8 = 14 == ceiling is allowed");
+        assert_eq!(decode_buf.len(), 14);
     }
 
     #[test]

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -449,19 +449,6 @@ pub enum DecodeBufferError {
         requested: usize,
         capacity: usize,
     },
-    /// A block's cumulative decompressed output would exceed `MAX_BLOCK_SIZE`,
-    /// the most a single zstd block can produce. Surfaced by
-    /// [`super::decode_buffer::DecodeBuffer::repeat`] before the match copy
-    /// when the running block output plus this match would cross the
-    /// per-block ceiling. Without it a malformed / adversarial frame whose
-    /// sequences over-produce drives an unbounded `try_reserve` on a growable
-    /// backend (`RingBuffer`), which grows to gigabytes inside the
-    /// block-decode loop (a decompression-bomb OOM) before the post-block
-    /// validity check can reject the frame.
-    BlockOutputExceedsMax {
-        produced: usize,
-        max: usize,
-    },
 }
 
 #[cfg(feature = "std")]
@@ -496,12 +483,6 @@ impl core::fmt::Display for DecodeBufferError {
                 write!(
                     f,
                     "Match repeat would write past fixed-capacity buffer: tail={tail}, requested={requested}, capacity={capacity}"
-                )
-            }
-            DecodeBufferError::BlockOutputExceedsMax { produced, max } => {
-                write!(
-                    f,
-                    "Block decompressed output {produced} exceeds the per-block maximum {max}"
                 )
             }
         }

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -17,7 +17,7 @@
 use crate::io::{Error, Read};
 use alloc::vec::Vec;
 
-use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
+use super::buffer_backend::{BackendOverflow, BufferBackend, WILDCOPY_OVERLENGTH};
 
 pub(crate) struct FlatBuf {
     buf: Vec<u8>,
@@ -42,6 +42,14 @@ pub(crate) struct FlatBuf {
     /// path can't observe a streaming-drain scenario where the
     /// distinction would matter.
     head: usize,
+    /// Per-block decompression-bomb growth ceiling, mirroring
+    /// [`super::ringbuffer::RingBuffer`]. `usize::MAX` is unbounded; the
+    /// sequence decoder lowers it to `len + MAX_BLOCK_SIZE` per block via
+    /// [`BufferBackend::set_max_capacity`]. `FlatBuf` is growable (the inline
+    /// exec path is capacity-bounded, but the fallback `push`/`repeat` route
+    /// grows through `try_reserve`), so it must honour this ceiling to bound a
+    /// malformed single-segment block's output instead of growing toward OOM.
+    max_capacity: usize,
 }
 
 impl FlatBuf {
@@ -59,6 +67,7 @@ impl FlatBuf {
         Self {
             buf: Vec::with_capacity(cap + WILDCOPY_OVERLENGTH),
             head: 0,
+            max_capacity: usize::MAX,
         }
     }
 }
@@ -86,7 +95,7 @@ impl BufferBackend for FlatBuf {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
@@ -98,35 +107,19 @@ impl BufferBackend for FlatBuf {
         // headroom. Surface that as `OutputBufferOverflow` (mirrors
         // `UserSliceBackend::exec_sequence_inline`) so the safe
         // public decode APIs see a structured error instead of UB
-        // from writing past `Vec::capacity()`. All sums use
-        // `checked_*` against adversarial input that could wrap
-        // `usize`.
+        // from writing past `Vec::capacity()`.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.buf.capacity();
         let buf_len = self.buf.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = buf_len
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        match cap_required {
-            Some(v) if v <= cap => {}
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        }
+        // `buf.len() <= buf.capacity()` (a `Vec` invariant) satisfies the
+        // `tail <= cap` precondition; see `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            buf_len,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
         let live_len = buf_len - self.head;
@@ -181,7 +174,7 @@ impl BufferBackend for FlatBuf {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::portable::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
@@ -193,29 +186,15 @@ impl BufferBackend for FlatBuf {
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.buf.capacity();
         let buf_len = self.buf.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = buf_len
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        match cap_required {
-            Some(v) if v <= cap => {}
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        }
+        // `buf.len() <= buf.capacity()` (a `Vec` invariant) satisfies the
+        // `tail <= cap` precondition; see `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            buf_len,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
         let live_len = buf_len - self.head;
@@ -271,7 +250,7 @@ impl BufferBackend for FlatBuf {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_no_overlap_avx2,
             wildcopy_overlap_8byte_stride,
@@ -285,29 +264,15 @@ impl BufferBackend for FlatBuf {
         const MAX_WILDCOPY_OVERSHOOT: usize = 31;
         let cap = self.buf.capacity();
         let buf_len = self.buf.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = buf_len
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        match cap_required {
-            Some(v) if v <= cap => {}
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: buf_len,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        }
+        // `buf.len() <= buf.capacity()` (a `Vec` invariant) satisfies the
+        // `tail <= cap` precondition; see `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            buf_len,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
         let live_len = buf_len - self.head;
@@ -351,6 +316,7 @@ impl BufferBackend for FlatBuf {
         Self {
             buf: Vec::new(),
             head: 0,
+            max_capacity: usize::MAX,
         }
     }
 
@@ -380,7 +346,58 @@ impl BufferBackend for FlatBuf {
         // `dst_off + len <= capacity` debug assert.
         // libFuzzer artifact crash-e33ba082… exercises exactly that
         // shape.
-        self.buf.reserve(n.saturating_add(WILDCOPY_OVERLENGTH));
+        //
+        // `checked_add` (not `saturating_add`): callers reserve a bounded
+        // amount (a block's `MAX_BLOCK_SIZE`, or a `try_reserve` amount already
+        // gated by the per-block ceiling), so `n + WILDCOPY_OVERLENGTH` cannot
+        // overflow in practice. If it ever did, saturating to `usize::MAX`
+        // would silently mask the bad input before `Vec::reserve` panicked on
+        // it anyway — fail loudly at the cause instead.
+        let additional = n
+            .checked_add(WILDCOPY_OVERLENGTH)
+            .expect("FlatBuf::reserve amount + wildcopy slack overflows usize");
+        self.buf.reserve(additional);
+    }
+
+    #[inline]
+    fn set_max_capacity(&mut self, max_capacity: usize) {
+        self.max_capacity = max_capacity;
+    }
+
+    #[inline]
+    fn try_reserve(&mut self, n: usize) -> Result<(), BackendOverflow> {
+        // Enforce the per-block ceiling FIRST, before the no-growth fast path:
+        // the ceiling bounds this block's OUTPUT, not just allocation, so a
+        // write that would push live output past it must be rejected even when
+        // it fits the current capacity (e.g. a large pre-reserved FCS buffer
+        // whose spare exceeds `MAX_BLOCK_SIZE`). This is where the
+        // decompression bomb is bounded on FlatBuf's fallback push/repeat path
+        // (the inline exec path is already capacity-bounded by
+        // `sequence_output_fits`). `max_capacity = usize::MAX` between blocks
+        // makes this a no-op for unbounded callers.
+        if self
+            .len()
+            .checked_add(n)
+            .is_none_or(|needed| needed > self.max_capacity)
+        {
+            return Err(BackendOverflow {
+                tail: self.buf.len(),
+                requested: n,
+                capacity: self.max_capacity,
+            });
+        }
+        // Within the ceiling: if the live region plus this write (and the
+        // wildcopy slack `reserve` adds) already fits the current allocation,
+        // no growth is needed. `capacity >= len` is a `Vec` invariant, so the
+        // subtraction cannot underflow.
+        let free = self.buf.capacity() - self.buf.len();
+        if n.checked_add(WILDCOPY_OVERLENGTH)
+            .is_some_and(|need| free >= need)
+        {
+            return Ok(());
+        }
+        self.reserve(n);
+        Ok(())
     }
 
     #[inline]
@@ -697,8 +714,11 @@ mod tests {
         let mut f = FlatBuf::with_capacity(32);
         f.extend(&[0u8; 16]);
         // Request `lit_length + match_length + 15 = 17 + 100 + 15 = 132`
-        // bytes past tail; well over the 64-byte allocation.
-        let lits = [0xAAu8; 16];
+        // bytes past tail; well over the 64-byte allocation. The literal
+        // buffer is `lit_length.next_multiple_of(16) = 32` bytes so the call
+        // satisfies the inline read-slack precondition even if the capacity
+        // guard later moves past the first literal read.
+        let lits = [0xAAu8; 32];
         // SAFETY: error-returning path; no writes performed.
         let result = unsafe { f.exec_sequence_inline(lits.as_ptr(), 17, 8, 100) };
         assert!(
@@ -707,6 +727,81 @@ mod tests {
                 Err(super::super::errors::ExecuteSequencesError::OutputBufferOverflow { .. })
             ),
             "expected OutputBufferOverflow, got {result:?}"
+        );
+    }
+
+    /// AVX2 analogue of the capacity guard: the 32-byte-stride variant MUST
+    /// also return `OutputBufferOverflow` (not write past `Vec::capacity()`)
+    /// when the requested write plus the 31-byte overshoot exceeds the
+    /// remaining headroom. Guards the single-compare bounds check on the AVX2
+    /// hot path.
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn exec_sequence_inline_avx2_capacity_overflow_returns_err() {
+        if !std::arch::is_x86_feature_detected!("avx2") {
+            return;
+        }
+        let mut f = FlatBuf::with_capacity(32);
+        f.extend(&[0u8; 16]);
+        // 32-byte literal buffer = `lit_length.next_multiple_of(16)`, so the
+        // call satisfies the inline read-slack precondition even if the guard
+        // later moves past the first literal read.
+        let lits = [0xAAu8; 32];
+        // SAFETY: AVX2 detected above; error-returning path performs no writes.
+        let result = unsafe { f.exec_sequence_inline_avx2(lits.as_ptr(), 17, 8, 100) };
+        assert!(
+            matches!(
+                result,
+                Err(super::super::errors::ExecuteSequencesError::OutputBufferOverflow { .. })
+            ),
+            "expected OutputBufferOverflow, got {result:?}"
+        );
+    }
+
+    /// `FlatBuf` is growable, so the per-block decompression-bomb ceiling
+    /// (`set_max_capacity`) MUST be honoured on its `try_reserve` growth path —
+    /// the fallback `push`/`repeat` route a malformed single-segment block can
+    /// take when the inline slack gate fails. A reserve that would grow live
+    /// output past the ceiling must return `BackendOverflow` instead of growing
+    /// the `Vec` toward a decompression-bomb OOM.
+    #[test]
+    fn try_reserve_rejects_growth_past_block_ceiling() {
+        let mut f = FlatBuf::with_capacity(64);
+        f.extend(&[0u8; 32]);
+        let ceiling = f.len() + 100; // 132
+        f.set_max_capacity(ceiling);
+        // Within the ceiling: succeeds (32 + 50 = 82 <= 132).
+        assert!(f.try_reserve(50).is_ok());
+        // Past the ceiling (32 + 200 = 232 > 132): rejected, no growth.
+        assert!(
+            matches!(
+                f.try_reserve(200),
+                Err(super::super::buffer_backend::BackendOverflow { .. })
+            ),
+            "reserve past the per-block ceiling must be rejected, not grown"
+        );
+    }
+
+    /// The ceiling bounds this block's OUTPUT, so a reserve past it must be
+    /// rejected even when it FITS the existing allocation (no growth needed).
+    /// A large pre-reserved buffer (e.g. a known-FCS single-segment frame) has
+    /// spare capacity beyond `MAX_BLOCK_SIZE`; without checking the ceiling
+    /// ahead of the no-growth fast path, an over-producing block could write
+    /// into that spare and bypass the decompression-bomb guard.
+    #[test]
+    fn try_reserve_rejects_within_capacity_but_past_ceiling() {
+        let mut f = FlatBuf::with_capacity(4096);
+        f.extend(&[0u8; 32]);
+        let ceiling = f.len() + 100; // 132, far below the 4 KiB allocation
+        f.set_max_capacity(ceiling);
+        // 32 + 500 = 532 <= 4096 capacity (no growth) but > 132 ceiling.
+        assert!(
+            matches!(
+                f.try_reserve(500),
+                Err(super::super::buffer_backend::BackendOverflow { .. })
+            ),
+            "a reserve past the ceiling must be rejected even when it fits the \
+             current capacity without growth"
         );
     }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -145,7 +145,11 @@ fn block_body_decode_error(
 /// ```
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
-    owned_dicts: BTreeMap<u32, Dictionary>,
+    // Registered dictionaries are stored by shared handle (Arc/Rc) so a
+    // single content copy is referenced by every frame the decoder decodes
+    // (donor `ZSTD_refDDict`), rather than re-copied into the decode buffer
+    // per frame. `add_dict` wraps an owned `Dictionary` into a handle.
+    owned_dicts: BTreeMap<u32, DictionaryHandle>,
     #[cfg(target_has_atomic = "ptr")]
     shared_dicts: BTreeMap<u32, DictionaryHandle>,
     #[cfg(not(target_has_atomic = "ptr"))]
@@ -257,7 +261,7 @@ impl DecoderScratchKind {
         }
     }
 
-    fn init_from_dict(&mut self, dict: &Dictionary) {
+    fn init_from_dict(&mut self, dict: &DictionaryHandle) {
         match self {
             Self::Ring(s) => s.init_from_dict(dict),
             Self::Flat(s) => s.init_from_dict(dict),
@@ -774,7 +778,7 @@ impl FrameDecoder {
                 .or_else(|| {
                     #[cfg(target_has_atomic = "ptr")]
                     {
-                        shared_dicts.get(&dict_id).map(DictionaryHandle::as_dict)
+                        shared_dicts.get(&dict_id)
                     }
                     #[cfg(not(target_has_atomic = "ptr"))]
                     {
@@ -855,7 +859,7 @@ impl FrameDecoder {
                 provided: dict.id(),
             });
         }
-        state.decoder_scratch.init_from_dict(dict.as_dict());
+        state.decoder_scratch.init_from_dict(dict);
         state.using_dict = Some(dict.id());
         Ok(())
     }
@@ -870,7 +874,8 @@ impl FrameDecoder {
         if self.owned_dicts.contains_key(&dict_id) || self.shared_dict_exists(dict_id) {
             return Err(FrameDecoderError::DictAlreadyRegistered { dict_id });
         }
-        self.owned_dicts.insert(dict_id, dict);
+        self.owned_dicts
+            .insert(dict_id, DictionaryHandle::from_dictionary(dict));
         Ok(())
     }
 
@@ -910,7 +915,7 @@ impl FrameDecoder {
             .or_else(|| {
                 #[cfg(target_has_atomic = "ptr")]
                 {
-                    shared_dicts.get(&dict_id).map(DictionaryHandle::as_dict)
+                    shared_dicts.get(&dict_id)
                 }
                 #[cfg(not(target_has_atomic = "ptr"))]
                 {

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -29,6 +29,17 @@ pub struct RingBuffer {
     cap: usize,
     head: usize,
     tail: usize,
+    /// Upper bound on the live byte count (`len()`) that a *growing*
+    /// reserve may target. `usize::MAX` (the default) leaves growth
+    /// unbounded. The block sequence decoder lowers it to
+    /// `len_at_block_start + MAX_BLOCK_SIZE` before each block so a
+    /// match that would push output past the per-block ceiling fails its
+    /// `try_reserve` (cold growth path) instead of growing the ring to
+    /// gigabytes — a decompression-bomb OOM — before the post-block
+    /// validity check runs. Enforced only when a reserve actually has to
+    /// grow, so well-formed blocks (covered by the upfront
+    /// `reserve(MAX_BLOCK_SIZE)`) never pay for the check.
+    max_capacity: usize,
 }
 
 // SAFETY: RingBuffer does not hold any thread specific values -> it can be sent to another thread -> RingBuffer is Send
@@ -46,6 +57,7 @@ impl RingBuffer {
             // SAFETY: Upholds invariant 2-4
             head: 0,
             tail: 0,
+            max_capacity: usize::MAX,
         }
     }
 
@@ -171,6 +183,51 @@ impl RingBuffer {
         }
 
         self.reserve_amortized(amount - free);
+    }
+
+    /// Lower the growth ceiling (see [`Self::max_capacity`]). `usize::MAX`
+    /// restores unbounded growth.
+    #[inline]
+    pub fn set_max_capacity(&mut self, max_capacity: usize) {
+        self.max_capacity = max_capacity;
+    }
+
+    /// Fallible [`Self::reserve`]: identical fast path, but when the
+    /// reserve would have to *grow* the ring it first rejects any target
+    /// `len() + amount` past [`Self::max_capacity`]. This is where the
+    /// per-block decompression-bomb ceiling is enforced — on the cold
+    /// growth path only, so well-formed blocks never pay for it.
+    #[inline]
+    pub fn try_reserve(
+        &mut self,
+        amount: usize,
+    ) -> Result<(), super::buffer_backend::BackendOverflow> {
+        // Flat fast path (mirrors `reserve`): no wrap and the write fits
+        // below `cap` — capacity already present, no growth, no ceiling
+        // check.
+        if self.head <= self.tail && amount < self.cap.saturating_sub(self.tail) {
+            return Ok(());
+        }
+        let free = self.free();
+        if free >= amount {
+            return Ok(());
+        }
+        // Growth is required. Reject if it would cross the per-block
+        // ceiling before allocating (bounds the bomb on every target,
+        // unlike a 32-bit-only assert).
+        if self
+            .len()
+            .checked_add(amount)
+            .is_none_or(|needed| needed > self.max_capacity)
+        {
+            return Err(super::buffer_backend::BackendOverflow {
+                tail: self.tail,
+                requested: amount,
+                capacity: self.max_capacity,
+            });
+        }
+        self.reserve_amortized(amount - free);
+        Ok(())
     }
 
     #[inline(never)]
@@ -860,6 +917,14 @@ impl super::buffer_backend::BufferBackend for RingBuffer {
     #[inline]
     fn reserve(&mut self, n: usize) {
         Self::reserve(self, n);
+    }
+    #[inline]
+    fn try_reserve(&mut self, n: usize) -> Result<(), super::buffer_backend::BackendOverflow> {
+        Self::try_reserve(self, n)
+    }
+    #[inline]
+    fn set_max_capacity(&mut self, max_capacity: usize) {
+        Self::set_max_capacity(self, max_capacity);
     }
     #[inline]
     fn len(&self) -> usize {

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -202,19 +202,13 @@ impl RingBuffer {
         &mut self,
         amount: usize,
     ) -> Result<(), super::buffer_backend::BackendOverflow> {
-        // Flat fast path (mirrors `reserve`): no wrap and the write fits
-        // below `cap` — capacity already present, no growth, no ceiling
-        // check.
-        if self.head <= self.tail && amount < self.cap.saturating_sub(self.tail) {
-            return Ok(());
-        }
-        let free = self.free();
-        if free >= amount {
-            return Ok(());
-        }
-        // Growth is required. Reject if it would cross the per-block
-        // ceiling before allocating (bounds the bomb on every target,
-        // unlike a 32-bit-only assert).
+        // Enforce the per-block ceiling FIRST, before the no-growth fast
+        // paths: the ceiling bounds this block's OUTPUT, not just allocation,
+        // so a write past it must be rejected even when it fits the ring's
+        // current capacity (a large window or an over-allocated ring can have
+        // more than `MAX_BLOCK_SIZE` of slack). Bounds the bomb on every target
+        // unlike a 32-bit-only assert; `max_capacity = usize::MAX` between
+        // blocks makes this a no-op for unbounded callers.
         if self
             .len()
             .checked_add(amount)
@@ -225,6 +219,16 @@ impl RingBuffer {
                 requested: amount,
                 capacity: self.max_capacity,
             });
+        }
+        // Within the ceiling: fast paths when capacity is already present.
+        // Flat fast path (mirrors `reserve`): no wrap and the write fits below
+        // `cap` — capacity already present, no growth.
+        if self.head <= self.tail && amount < self.cap.saturating_sub(self.tail) {
+            return Ok(());
+        }
+        let free = self.free();
+        if free >= amount {
+            return Ok(());
         }
         self.reserve_amortized(amount - free);
         Ok(())

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -3,7 +3,7 @@
 use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::ringbuffer::RingBuffer;
-use crate::decoding::dictionary::Dictionary;
+use crate::decoding::dictionary::DictionaryHandle;
 use crate::fse::SeqFSETable;
 use crate::huff0::HuffmanTable;
 use alloc::vec::Vec;
@@ -222,14 +222,15 @@ impl<B: BufferBackend> DecoderScratch<B> {
         self.huf.table.reset();
     }
 
-    pub fn init_from_dict(&mut self, dict: &Dictionary) {
-        self.fse.reinit_from(&dict.fse);
-        self.huf.table.reinit_from(&dict.huf.table);
-        self.offset_hist = dict.offset_hist;
-        self.buffer.dict_content.clear();
-        self.buffer
-            .dict_content
-            .extend_from_slice(&dict.dict_content);
+    pub fn init_from_dict(&mut self, dict: &DictionaryHandle) {
+        let d = dict.as_dict();
+        self.fse.reinit_from(&d.fse);
+        self.huf.table.reinit_from(&d.huf.table);
+        self.offset_hist = d.offset_hist;
+        // Share the dictionary content by handle (Arc/Rc clone = refcount
+        // bump) instead of copying it into a per-frame buffer; the decoder
+        // reads match bytes straight out of the shared content.
+        self.buffer.set_dict(dict.clone());
         // Donor parity: `ZSTD_decompressBegin_usingDDict` sets
         // `dctx->ddictIsCold = 1` so the first block of the frame
         // engages the prefetch decoder regardless of long-offset
@@ -365,7 +366,9 @@ mod tests {
         extern crate std;
         let dict_raw =
             std::fs::read("./dict_tests/dictionary").expect("dictionary fixture should load");
-        let dict = Dictionary::decode_dict(&dict_raw).expect("dictionary should parse");
+        let dict = DictionaryHandle::from_dictionary(
+            Dictionary::decode_dict(&dict_raw).expect("dictionary should parse"),
+        );
         let mut scratch: DecoderScratch = DecoderScratch::new(1024);
         assert!(
             !scratch.fse.ddict_is_cold,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -164,8 +164,14 @@ where
     let old_buffer_size = buffer.len();
     let num_sequences = section.num_sequences as usize;
 
-    // `saturating_add` defuses 32-bit `usize` wrap.
-    let total_history = buffer.window_size.saturating_add(buffer.dict_content.len());
+    // Overflow is only reachable on 32-bit `usize` (a 4 GiB-class
+    // window_size plus a dict). The gate below asks "does history exceed
+    // the prefetch threshold", so on the overflow path the clamped maximum
+    // is the correct answer, not a wrapped small value.
+    let total_history = match buffer.window_size.checked_add(buffer.dict_content().len()) {
+        Some(sum) => sum,
+        None => usize::MAX,
+    };
     let use_long_pipeline = compute_use_long_pipeline(
         num_sequences,
         ddict_is_cold,

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -169,7 +169,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
@@ -190,39 +190,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // unsafe pointer math go out of bounds.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.slice.len();
-        // `requested` reports the LOGICAL write length
-        // (`lit_length + match_length`) to stay consistent with
-        // `BackendOverflow.requested` on the `try_*` paths. The
-        // capacity check itself uses `tail + total + overshoot`
-        // because the unconditional 16-byte `copy16` over-reaches
-        // `tail + total` by up to 15 bytes — but that overshoot is
-        // an artefact of the SIMD copy shape, NOT a value the
-        // caller can act on, so it doesn't belong in the diagnostic.
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = self
-            .tail
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        let cap_required = match cap_required {
-            Some(v) if v <= cap => v,
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        };
-        let _ = cap_required;
+        // `self.tail <= cap` holds on entry (`from_slice` starts at 0 and
+        // every prior sequence advanced `tail` only after this same check),
+        // satisfying the `tail <= cap` precondition; see `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            self.tail,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
@@ -303,36 +280,21 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::portable::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.slice.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = self
-            .tail
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        match cap_required {
-            Some(v) if v <= cap => {}
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        }
+        // `self.tail <= cap` precondition holds as in the SSE2 arm; see
+        // `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            self.tail,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
@@ -413,7 +375,7 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), super::errors::ExecuteSequencesError> {
-        use super::errors::ExecuteSequencesError;
+        use super::buffer_backend::sequence_output_fits;
         use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_no_overlap_avx2,
             wildcopy_overlap_8byte_stride,
@@ -425,31 +387,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // this overshoot for well-formed frames.
         const MAX_WILDCOPY_OVERSHOOT: usize = 31;
         let cap = self.slice.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = self
-            .tail
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        let cap_required = match cap_required {
-            Some(v) if v <= cap => v,
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        };
-        let _ = cap_required;
+        // `self.tail <= cap` holds on entry (`from_slice` starts at 0 and every
+        // prior sequence advanced `tail` only after this same check), satisfying
+        // the `tail <= cap` precondition; see `sequence_output_fits`.
+        let total = sequence_output_fits(
+            lit_length,
+            match_length,
+            self.tail,
+            cap,
+            MAX_WILDCOPY_OVERSHOOT,
+        )?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -4,7 +4,7 @@ use crate::{
     bit_io::BitWriter,
     blocks::block::BlockType,
     encoding::block_header::BlockHeader,
-    encoding::frame_compressor::{CompressState, FseTables, PreviousFseTable},
+    encoding::frame_compressor::{CompressState, FseTables, PreviousFseTable, SharedFseTable},
     encoding::{Matcher, Sequence},
     fse::fse_encoder::{FSETable, build_table_from_symbol_counts, fse_header_bits_for_counts},
     huff0::huff0_encoder,
@@ -1668,7 +1668,7 @@ fn remember_last_used_table(slot: &mut Option<PreviousFseTable>, next: Option<Pr
 
 fn into_last_used_table(mode: FseTableMode<'_>) -> Option<PreviousFseTable> {
     match mode {
-        FseTableMode::Encoded(table) => Some(PreviousFseTable::Custom(Box::new(table))),
+        FseTableMode::Encoded(table) => Some(PreviousFseTable::Custom(SharedFseTable::new(table))),
         FseTableMode::Predefined(_) => Some(PreviousFseTable::Default),
         FseTableMode::Rle(symbol) => Some(PreviousFseTable::Rle(symbol)),
         FseTableMode::RepeatLast(_) => None,
@@ -2200,7 +2200,6 @@ fn compress_literals(
 
 #[cfg(test)]
 mod tests {
-    use alloc::boxed::Box;
 
     use super::{
         FseTableMode, RawSequence, choose_table, emit_single_sequence_block, encode_match_len,
@@ -2693,7 +2692,8 @@ mod tests {
     fn fast_band_strategies_prefer_repeat_fse_table() {
         use crate::encoding::strategy::StrategyTag;
         let prev = build_table_from_symbol_counts(&[8, 1], 9, false);
-        let previous = PreviousFseTable::Custom(Box::new(prev));
+        let previous =
+            PreviousFseTable::Custom(crate::encoding::frame_compressor::SharedFseTable::new(prev));
         let fse_tables = FseTables::new();
         // Distribution over symbols {0,1}, both covered by `previous`.
         let mut counts = [0usize; 256];
@@ -2724,7 +2724,9 @@ mod tests {
     fn remember_last_used_tables_reuses_existing_custom_slot_for_repeat() {
         let mut fse_tables = FseTables::new();
         let custom = build_table_from_symbol_counts(&[1, 1], 5, false);
-        fse_tables.ll_previous = Some(PreviousFseTable::Custom(Box::new(custom)));
+        fse_tables.ll_previous = Some(PreviousFseTable::Custom(
+            crate::encoding::frame_compressor::SharedFseTable::new(custom),
+        ));
 
         let before = core::ptr::from_ref(
             previous_table(fse_tables.ll_previous.as_ref(), fse_tables.ll_default_ref()).unwrap(),

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -36,7 +36,6 @@ pub(crate) const HC3_MAX_OFFSET: usize = 1 << 18;
 /// `BtUltra2` parse modes. Owns the cost model and the per-frame
 /// scratch arenas; the actual BT pointer-pair table lives on the
 /// shared [`super::match_table::storage::MatchTable`].
-#[derive(Clone)]
 pub(crate) struct BtMatcher {
     /// Donor `optStatePtr_t` — Huffman / FSE-derived literal and
     /// sequence-symbol cost tables that drive the optimal parser.

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -36,6 +36,7 @@ pub(crate) const HC3_MAX_OFFSET: usize = 1 << 18;
 /// `BtUltra2` parse modes. Owns the cost model and the per-frame
 /// scratch arenas; the actual BT pointer-pair table lives on the
 /// shared [`super::match_table::storage::MatchTable`].
+#[derive(Clone)]
 pub(crate) struct BtMatcher {
     /// Donor `optStatePtr_t` — Huffman / FSE-derived literal and
     /// sequence-symbol cost tables that drive the optimal parser.

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -51,7 +51,6 @@ const HASH_READ_SIZE: usize = 8;
 /// rep emissions that upstream produces.
 const DFAST_REP_MIN_MATCH_LEN: usize = 4;
 
-#[derive(Clone)]
 pub(crate) struct DfastMatchGenerator {
     pub(crate) max_window_size: usize,
     /// Per-block length queue. Previously held the raw input

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -51,6 +51,7 @@ const HASH_READ_SIZE: usize = 8;
 /// rep emissions that upstream produces.
 const DFAST_REP_MIN_MATCH_LEN: usize = 4;
 
+#[derive(Clone)]
 pub(crate) struct DfastMatchGenerator {
     pub(crate) max_window_size: usize,
     /// Per-block length queue. Previously held the raw input

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1067,15 +1067,42 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             uncompressed_data.extend_from_slice(&pending_input);
             let mut filled = pending_input.len();
             pending_input.clear();
-            if uncompressed_data.len() < block_capacity {
-                uncompressed_data.resize(block_capacity, 0);
+            // Size the read buffer to the bytes this block actually expects
+            // rather than always zero-filling a full MAX_BLOCK_SIZE: a small
+            // frame otherwise pays a 128 KiB `resize(_, 0)` memset per block
+            // just to read a few KiB (the zero-fill past `filled` is then
+            // truncated away). Bound the initial fill by the source-size hint
+            // (exact for the slice entry points), and grow toward
+            // `block_capacity` only if the hint under-counted, so an inexact /
+            // unknown (`None` → full `block_capacity`) hint stays correct.
+            let initial_target = initial_size_hint
+                .map(|h| {
+                    let remaining = (h as usize).saturating_sub(total_uncompressed as usize);
+                    filled
+                        .saturating_add(remaining)
+                        .clamp(filled.max(1), block_capacity)
+                })
+                .unwrap_or(block_capacity);
+            if uncompressed_data.len() < initial_target {
+                uncompressed_data.resize(initial_target, 0);
             }
             'read_loop: loop {
                 if reached_eof || filled == block_capacity {
                     break 'read_loop;
                 }
+                if filled == uncompressed_data.len() {
+                    // Hint under-counted the block; grow toward block_capacity
+                    // (doubling, capped) so reading continues without paying a
+                    // full-buffer zero up front.
+                    let grow_to = uncompressed_data
+                        .len()
+                        .saturating_mul(2)
+                        .clamp(filled + 1, block_capacity);
+                    uncompressed_data.resize(grow_to, 0);
+                }
+                let read_end = uncompressed_data.len();
                 let new_bytes = source
-                    .read(&mut uncompressed_data[filled..block_capacity])
+                    .read(&mut uncompressed_data[filled..read_end])
                     .unwrap();
                 if new_bytes == 0 {
                     reached_eof = true;

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2512,6 +2512,68 @@ mod tests {
     }
 
     #[test]
+    fn dict_primed_matcher_cache_reused_across_small_attach_frames_is_byte_identical() {
+        // CDict-equivalent ATTACH path (small source, at/below the Fast 8 KiB
+        // attach cutoff): frames 2..N re-prime — re-committing the dict bytes
+        // to history — but reuse the already-built dict table instead of
+        // re-hashing it. The cached-table frame must reproduce the
+        // freshly-primed first frame byte-for-byte, and a fresh single-frame
+        // compressor (no prior dict cache) must produce the identical bytes
+        // too, proving the cache changes timing, not output.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        // Stay under the 8 KiB cutoff so the attach (re-prime) path is taken
+        // every frame rather than the copy-snapshot restore.
+        let mut payload = Vec::new();
+        while payload.len() < 2 * 1024 {
+            payload.extend_from_slice(b"tenant=demo op=put key=1 value=aaaaabbbbbcccccddddd\n");
+        }
+
+        let prepared =
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");
+        let dict_id = prepared.id();
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor
+            .set_encoder_dictionary(prepared)
+            .expect("prepared dictionary should attach");
+
+        // Frame 1 builds + marks the dict table; frame 2 reuses it.
+        let frame1 = compressor.compress_independent_frame(payload.as_slice());
+        let frame2 = compressor.compress_independent_frame(payload.as_slice());
+        assert_eq!(
+            frame1, frame2,
+            "reused dict table (attach path) must reproduce the freshly-built frame byte-for-byte"
+        );
+
+        // A fresh compressor (cold dict cache) must emit the same bytes — the
+        // cache is a timing optimization, never a content change.
+        let fresh_prepared =
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");
+        let mut fresh: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Fastest);
+        fresh
+            .set_encoder_dictionary(fresh_prepared)
+            .expect("prepared dictionary should attach");
+        let fresh_frame = fresh.compress_independent_frame(payload.as_slice());
+        assert_eq!(
+            fresh_frame, frame1,
+            "cold-cache compressor must match the warm-cache frame byte-for-byte"
+        );
+
+        for frame in [&frame1, &frame2] {
+            let (hdr, _) =
+                crate::decoding::frame::read_frame_header(frame.as_slice()).expect("frame header");
+            assert_eq!(hdr.dictionary_id(), Some(dict_id));
+            let mut decoder = FrameDecoder::new();
+            decoder
+                .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
+                .unwrap();
+            let mut decoded = Vec::with_capacity(payload.len());
+            decoder.decode_all_to_vec(frame, &mut decoded).unwrap();
+            assert_eq!(decoded.as_slice(), payload.as_slice());
+        }
+    }
+
+    #[test]
     fn set_dictionary_from_bytes_matches_full_decode_byte_for_byte() {
         // The encoder-only dict parse (`decode_dict_for_encoding`, used by
         // `set_dictionary_from_bytes`) skips the FSE/HUF decoder-table build and

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1073,16 +1073,24 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // just to read a few KiB (the zero-fill past `filled` is then
             // truncated away). Bound the initial fill by the source-size hint
             // (exact for the slice entry points), and grow toward
-            // `block_capacity` only if the hint under-counted, so an inexact /
-            // unknown (`None` → full `block_capacity`) hint stays correct.
-            let initial_target = initial_size_hint
-                .map(|h| {
-                    let remaining = (h as usize).saturating_sub(total_uncompressed as usize);
-                    filled
-                        .saturating_add(remaining)
-                        .clamp(filled.max(1), block_capacity)
-                })
-                .unwrap_or(block_capacity);
+            // `block_capacity` only if the hint under-counted.
+            //
+            // Overflow-free by construction (no `saturating_*` masking):
+            // `filled <= block_capacity` always (the read only ever targets
+            // `[filled..len]` with `len <= block_capacity`, and a carried-over
+            // `pending_input` is a `split_off` below `block_capacity`), so
+            // `block_capacity - filled` never underflows; pinning `remaining`
+            // to `block_capacity` before the `usize` cast keeps the cast and
+            // the final add within `usize` on every target.
+            let initial_target = match initial_size_hint {
+                Some(hint) if hint > total_uncompressed => {
+                    let remaining = (hint - total_uncompressed).min(block_capacity as u64) as usize;
+                    filled + remaining.min(block_capacity - filled)
+                }
+                // Unknown hint, or an inexact hint already met by prior blocks:
+                // read against the full block window.
+                _ => block_capacity,
+            };
             if uncompressed_data.len() < initial_target {
                 uncompressed_data.resize(initial_target, 0);
             }
@@ -1093,11 +1101,11 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 if filled == uncompressed_data.len() {
                     // Hint under-counted the block; grow toward block_capacity
                     // (doubling, capped) so reading continues without paying a
-                    // full-buffer zero up front.
-                    let grow_to = uncompressed_data
-                        .len()
-                        .saturating_mul(2)
-                        .clamp(filled + 1, block_capacity);
+                    // full-buffer zero up front. `len <= block_capacity` so the
+                    // double stays well within `usize`; `filled < block_capacity`
+                    // here (the `== block_capacity` break fired otherwise), so
+                    // `filled + 1 <= block_capacity`.
+                    let grow_to = (uncompressed_data.len() * 2).clamp(filled + 1, block_capacity);
                     uncompressed_data.resize(grow_to, 0);
                 }
                 let read_end = uncompressed_data.len();

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -924,9 +924,25 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // This state drives sequence encoding, while matcher priming below updates
             // the match generator's internal repeat-offset history for match finding.
             self.state.offset_hist = dict.inner.offset_hist;
-            self.state
+            // CDict fast path (donor `ZSTD_compressBegin_usingCDict`): restore
+            // the precomputed primed matcher state (a table copy) instead of
+            // re-hashing every dictionary position into the match tables. The
+            // snapshot is captured on the first prime and reused while the
+            // dictionary + level stay the same; `restore` returns false when
+            // it must be (re)built.
+            if !self
+                .state
                 .matcher
-                .prime_with_dictionary(dict.inner.dict_content.as_slice(), dict.inner.offset_hist);
+                .restore_primed_dictionary(self.compression_level)
+            {
+                self.state.matcher.prime_with_dictionary(
+                    dict.inner.dict_content.as_slice(),
+                    dict.inner.offset_hist,
+                );
+                self.state
+                    .matcher
+                    .capture_primed_dictionary(self.compression_level);
+            }
         }
         if let Some(cache) = cached_entropy {
             self.state.last_huff_table.clone_from(&cache.huff);
@@ -1486,6 +1502,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// Remove the attached dictionary, returning it as an [`EncoderDictionary`].
     pub fn clear_dictionary(&mut self) -> Option<EncoderDictionary> {
         self.dictionary_entropy_cache = None;
+        // Drop the CDict prime snapshot — it is keyed to the dictionary
+        // being removed and must not be restored against a different (or no)
+        // dictionary on the next frame.
+        self.state.matcher.invalidate_primed_dictionary();
         self.dictionary.take()
     }
 
@@ -1526,6 +1546,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 .to_encoder_table()
                 .map(|table| PreviousFseTable::Custom(Box::new(table))),
         });
+        // A previously-captured CDict prime snapshot belongs to the OLD
+        // dictionary; drop it so the first frame with the new dictionary
+        // re-primes (and re-captures) instead of restoring stale tables.
+        self.state.matcher.invalidate_primed_dictionary();
         Ok(self.dictionary.replace(enc))
     }
 }
@@ -2360,6 +2384,51 @@ mod tests {
             with_dict2, with_dict,
             "reattached prepared dict must produce an identical frame"
         );
+    }
+
+    #[test]
+    fn dict_primed_matcher_snapshot_reused_across_frames_is_byte_identical() {
+        // CDict-equivalent: a compressor reused across frames with the same
+        // dictionary restores the primed matcher snapshot on frames 2..N
+        // (a table copy) instead of re-hashing the dictionary. The restored
+        // state must reproduce the first-frame (freshly-primed) output
+        // byte-for-byte, and every frame must round-trip through a
+        // dict-primed decoder.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n\
+              tenant=demo table=orders op=put key=2 value=aaaaabbbbbcccccdddddeeeee\n";
+
+        let prepared =
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");
+        let dict_id = prepared.id();
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor
+            .set_encoder_dictionary(prepared)
+            .expect("prepared dictionary should attach");
+
+        // Frame 1 primes + captures the snapshot; frame 2 restores it.
+        let frame1 = compressor.compress_independent_frame(payload.as_slice());
+        let frame2 = compressor.compress_independent_frame(payload.as_slice());
+        assert_eq!(
+            frame1, frame2,
+            "restored prime snapshot must reproduce the freshly-primed frame byte-for-byte"
+        );
+
+        // Both frames advertise the dict id and round-trip through a
+        // dict-primed decoder.
+        for frame in [&frame1, &frame2] {
+            let (hdr, _) =
+                crate::decoding::frame::read_frame_header(frame.as_slice()).expect("frame header");
+            assert_eq!(hdr.dictionary_id(), Some(dict_id));
+            let mut decoder = FrameDecoder::new();
+            decoder
+                .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
+                .unwrap();
+            let mut decoded = Vec::with_capacity(payload.len());
+            decoder.decode_all_to_vec(frame, &mut decoded).unwrap();
+            assert_eq!(decoded.as_slice(), payload.as_slice());
+        }
     }
 
     #[test]

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -953,17 +953,27 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             //     whole table would cost MORE than the sparse re-prime here,
             //     which is exactly why the donor attaches by reference instead).
             // `attachDictSizeCutoffs` per strategy: fast 8K, dfast 16K,
-            // greedy/lazy/btopt 32K, btultra/btultra2 8K.
-            let cutoff = match self.state.strategy_tag {
+            // greedy/lazy/btopt 32K, btultra/btultra2 8K. Expressed as the
+            // ceil-log bucket (8K = 2^13, 16K = 2^14, 32K = 2^15) so the
+            // decision uses the SAME bucketed representation as the driver's
+            // attach/copy gate (`reset_size_log`) — comparing
+            // `source_size_ceil_log(hint)` on the full u64 avoids the `as usize`
+            // truncation that could diverge from the driver on 32-bit targets.
+            // For a power-of-two cutoff `2^k`, `ceil_log2(hint) > k` is exactly
+            // `hint > 2^k`, so this is identical to the raw `hint > cutoff` on
+            // 64-bit.
+            let cutoff_log = match self.state.strategy_tag {
                 crate::encoding::strategy::StrategyTag::Fast
                 | crate::encoding::strategy::StrategyTag::BtUltra
-                | crate::encoding::strategy::StrategyTag::BtUltra2 => 8 * 1024,
-                crate::encoding::strategy::StrategyTag::Dfast => 16 * 1024,
+                | crate::encoding::strategy::StrategyTag::BtUltra2 => 13,
+                crate::encoding::strategy::StrategyTag::Dfast => 14,
                 crate::encoding::strategy::StrategyTag::Greedy
                 | crate::encoding::strategy::StrategyTag::Lazy
-                | crate::encoding::strategy::StrategyTag::BtOpt => 32 * 1024,
+                | crate::encoding::strategy::StrategyTag::BtOpt => 15,
             };
-            let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| s as usize > cutoff);
+            let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| {
+                crate::encoding::match_generator::source_size_ceil_log(s) > cutoff_log
+            });
             let restored = prefer_copy_snapshot
                 && self
                     .state

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1,6 +1,6 @@
 //! Utilities and interfaces for encoding an entire frame. Allows reusing resources
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 use core::convert::TryInto;
 #[cfg(feature = "hash")]
 use twox_hash::XxHash64;
@@ -132,12 +132,28 @@ struct CachedDictionaryEntropy {
     of_previous: Option<PreviousFseTable>,
 }
 
+/// Shared owner for a custom "previous" FSE encoder table. `Arc` on
+/// atomic-pointer targets, `Rc` otherwise (keeps `no_std` no-atomics
+/// builds compiling, single-thread there anyway), mirroring
+/// `decoding::dictionary::SharedDictionary`. Cloning the cached
+/// dictionary entropy into the per-frame state is then a refcount bump,
+/// not a full `FSETable` copy — the donor references `cdict->cBlockState`
+/// instead of rebuilding it per frame.
+#[cfg(target_has_atomic = "ptr")]
+pub(crate) type SharedFseTable = alloc::sync::Arc<FSETable>;
+#[cfg(not(target_has_atomic = "ptr"))]
+pub(crate) type SharedFseTable = alloc::rc::Rc<FSETable>;
+
 #[derive(Clone)]
 pub(crate) enum PreviousFseTable {
     // Default tables are immutable and already stored alongside the state, so
     // repeating them only needs a lightweight marker instead of cloning FSETable.
     Default,
-    Custom(Box<FSETable>),
+    // Shared handle: cloning (per-frame dictionary entropy seed) is a refcount
+    // bump. The table is only ever read or REPLACED wholesale (a block that
+    // builds a new table swaps in a fresh `SharedFseTable`), never mutated in
+    // place, so sharing is sound.
+    Custom(SharedFseTable),
     Rle(u8),
 }
 
@@ -1590,17 +1606,17 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 .fse
                 .literal_lengths
                 .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(Box::new(table))),
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
             ml_previous: dictionary
                 .fse
                 .match_lengths
                 .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(Box::new(table))),
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
             of_previous: dictionary
                 .fse
                 .offsets
                 .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(Box::new(table))),
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
         });
         // A previously-captured CDict prime snapshot belongs to the OLD
         // dictionary; drop it so the first frame with the new dictionary

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -924,24 +924,45 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // This state drives sequence encoding, while matcher priming below updates
             // the match generator's internal repeat-offset history for match finding.
             self.state.offset_hist = dict.inner.offset_hist;
-            // CDict fast path (donor `ZSTD_compressBegin_usingCDict`): restore
-            // the precomputed primed matcher state (a table copy) instead of
-            // re-hashing every dictionary position into the match tables. The
-            // snapshot is captured on the first prime and reused while the
-            // dictionary + level stay the same; `restore` returns false when
-            // it must be (re)built.
-            if !self
-                .state
-                .matcher
-                .restore_primed_dictionary(self.compression_level)
-            {
+            // Donor `ZSTD_shouldAttachDict` (`zstd_compress.c`): a
+            // precomputed-dictionary table is COPIED into the working context
+            // only when the source is larger than a per-strategy cutoff; at or
+            // below it (and for unknown size) the donor ATTACHES the dictionary
+            // tables by reference (no per-frame table touch at all). We don't
+            // have an attach-by-reference path yet, so:
+            //   - large source (> cutoff): reuse the captured prime snapshot
+            //     (a table copy) instead of re-hashing the dictionary — the
+            //     donor COPY regime, where the copy is cheaper than re-priming;
+            //   - small / unknown source: re-prime (the snapshot copy of the
+            //     whole table would cost MORE than the sparse re-prime here,
+            //     which is exactly why the donor attaches by reference instead).
+            // `attachDictSizeCutoffs` per strategy: fast 8K, dfast 16K,
+            // greedy/lazy/btopt 32K, btultra/btultra2 8K.
+            let cutoff = match self.state.strategy_tag {
+                crate::encoding::strategy::StrategyTag::Fast
+                | crate::encoding::strategy::StrategyTag::BtUltra
+                | crate::encoding::strategy::StrategyTag::BtUltra2 => 8 * 1024,
+                crate::encoding::strategy::StrategyTag::Dfast => 16 * 1024,
+                crate::encoding::strategy::StrategyTag::Greedy
+                | crate::encoding::strategy::StrategyTag::Lazy
+                | crate::encoding::strategy::StrategyTag::BtOpt => 32 * 1024,
+            };
+            let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| s as usize > cutoff);
+            let restored = prefer_copy_snapshot
+                && self
+                    .state
+                    .matcher
+                    .restore_primed_dictionary(self.compression_level);
+            if !restored {
                 self.state.matcher.prime_with_dictionary(
                     dict.inner.dict_content.as_slice(),
                     dict.inner.offset_hist,
                 );
-                self.state
-                    .matcher
-                    .capture_primed_dictionary(self.compression_level);
+                if prefer_copy_snapshot {
+                    self.state
+                        .matcher
+                        .capture_primed_dictionary(self.compression_level);
+                }
             }
         }
         if let Some(cache) = cached_entropy {
@@ -2395,8 +2416,16 @@ mod tests {
         // byte-for-byte, and every frame must round-trip through a
         // dict-primed decoder.
         let dict_raw = include_bytes!("../../dict_tests/dictionary");
-        let payload = b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n\
-              tenant=demo table=orders op=put key=2 value=aaaaabbbbbcccccdddddeeeee\n";
+        // Source must exceed the Fast strategy's 8 KiB attach cutoff so the
+        // copy-snapshot (restore) path is taken on frame 2 — at or below the
+        // cutoff the donor attaches by reference and we fall back to re-prime,
+        // which would not exercise restore.
+        let mut payload = Vec::new();
+        while payload.len() < 16 * 1024 {
+            payload.extend_from_slice(
+                b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n",
+            );
+        }
 
         let prepared =
             super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -924,25 +924,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // This state drives sequence encoding, while matcher priming below updates
             // the match generator's internal repeat-offset history for match finding.
             self.state.offset_hist = dict.inner.offset_hist;
-            // CDict fast path (donor `ZSTD_compressBegin_usingCDict`): restore
-            // the precomputed primed matcher state (a table copy) instead of
-            // re-hashing every dictionary position into the match tables. The
-            // snapshot is captured on the first prime and reused while the
-            // dictionary + level stay the same; `restore` returns false when
-            // it must be (re)built.
-            if !self
-                .state
+            self.state
                 .matcher
-                .restore_primed_dictionary(self.compression_level)
-            {
-                self.state.matcher.prime_with_dictionary(
-                    dict.inner.dict_content.as_slice(),
-                    dict.inner.offset_hist,
-                );
-                self.state
-                    .matcher
-                    .capture_primed_dictionary(self.compression_level);
-            }
+                .prime_with_dictionary(dict.inner.dict_content.as_slice(), dict.inner.offset_hist);
         }
         if let Some(cache) = cached_entropy {
             self.state.last_huff_table.clone_from(&cache.huff);
@@ -1502,10 +1486,6 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// Remove the attached dictionary, returning it as an [`EncoderDictionary`].
     pub fn clear_dictionary(&mut self) -> Option<EncoderDictionary> {
         self.dictionary_entropy_cache = None;
-        // Drop the CDict prime snapshot — it is keyed to the dictionary
-        // being removed and must not be restored against a different (or no)
-        // dictionary on the next frame.
-        self.state.matcher.invalidate_primed_dictionary();
         self.dictionary.take()
     }
 
@@ -1546,10 +1526,6 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 .to_encoder_table()
                 .map(|table| PreviousFseTable::Custom(Box::new(table))),
         });
-        // A previously-captured CDict prime snapshot belongs to the OLD
-        // dictionary; drop it so the first frame with the new dictionary
-        // re-primes (and re-captures) instead of restoring stale tables.
-        self.state.matcher.invalidate_primed_dictionary();
         Ok(self.dictionary.replace(enc))
     }
 }
@@ -2384,51 +2360,6 @@ mod tests {
             with_dict2, with_dict,
             "reattached prepared dict must produce an identical frame"
         );
-    }
-
-    #[test]
-    fn dict_primed_matcher_snapshot_reused_across_frames_is_byte_identical() {
-        // CDict-equivalent: a compressor reused across frames with the same
-        // dictionary restores the primed matcher snapshot on frames 2..N
-        // (a table copy) instead of re-hashing the dictionary. The restored
-        // state must reproduce the first-frame (freshly-primed) output
-        // byte-for-byte, and every frame must round-trip through a
-        // dict-primed decoder.
-        let dict_raw = include_bytes!("../../dict_tests/dictionary");
-        let payload = b"tenant=demo table=orders op=put key=1 value=aaaaabbbbbcccccdddddeeeee\n\
-              tenant=demo table=orders op=put key=2 value=aaaaabbbbbcccccdddddeeeee\n";
-
-        let prepared =
-            super::EncoderDictionary::from_bytes(dict_raw).expect("dict bytes should parse");
-        let dict_id = prepared.id();
-        let mut compressor: FrameCompressor =
-            FrameCompressor::new(super::CompressionLevel::Fastest);
-        compressor
-            .set_encoder_dictionary(prepared)
-            .expect("prepared dictionary should attach");
-
-        // Frame 1 primes + captures the snapshot; frame 2 restores it.
-        let frame1 = compressor.compress_independent_frame(payload.as_slice());
-        let frame2 = compressor.compress_independent_frame(payload.as_slice());
-        assert_eq!(
-            frame1, frame2,
-            "restored prime snapshot must reproduce the freshly-primed frame byte-for-byte"
-        );
-
-        // Both frames advertise the dict id and round-trip through a
-        // dict-primed decoder.
-        for frame in [&frame1, &frame2] {
-            let (hdr, _) =
-                crate::decoding::frame::read_frame_header(frame.as_slice()).expect("frame header");
-            assert_eq!(hdr.dictionary_id(), Some(dict_id));
-            let mut decoder = FrameDecoder::new();
-            decoder
-                .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
-                .unwrap();
-            let mut decoded = Vec::with_capacity(payload.len());
-            decoder.decode_all_to_vec(frame, &mut decoded).unwrap();
-            assert_eq!(decoded.as_slice(), payload.as_slice());
-        }
     }
 
     #[test]

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -35,6 +35,7 @@ pub(crate) const MAX_HC_SEARCH_DEPTH: usize = 512;
 /// tables live on the shared
 /// [`super::match_table::storage::MatchTable`] that this matcher
 /// borrows when it runs.
+#[derive(Clone)]
 pub(crate) struct HcMatcher {
     /// Lookahead depth (1 = lazy, 2 = lazy2). Donor parity:
     /// `params->cParams.strategy >= ZSTD_lazy2`.

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -35,7 +35,6 @@ pub(crate) const MAX_HC_SEARCH_DEPTH: usize = 512;
 /// tables live on the shared
 /// [`super::match_table::storage::MatchTable`] that this matcher
 /// borrows when it runs.
-#[derive(Clone)]
 pub(crate) struct HcMatcher {
     /// Lookahead depth (1 = lazy, 2 = lazy2). Donor parity:
     /// `params->cParams.strategy >= ZSTD_lazy2`.

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -95,7 +95,6 @@ const LDM_XXH64_SEED: u64 = 0;
 /// [`Self::clear`] only when starting a new frame (so the
 /// long-range history accumulated across blocks is preserved
 /// within a frame, mirroring donor's `ldmState_t` lifecycle).
-#[derive(Clone)]
 pub(crate) struct LdmProducer {
     /// Parameter set this producer was built with. Used by the
     /// split walker (next commit) to honour `min_match_length` /

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -95,6 +95,7 @@ const LDM_XXH64_SEED: u64 = 0;
 /// [`Self::clear`] only when starting a new frame (so the
 /// long-range history accumulated across blocks is preserved
 /// within a frame, mirroring donor's `ldmState_t` lifecycle).
+#[derive(Clone)]
 pub(crate) struct LdmProducer {
     /// Parameter set this producer was built with. Used by the
     /// split walker (next commit) to honour `min_match_length` /

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -91,6 +91,7 @@ const REBASE_GUARD_BAND: u32 = 1u32 << 30;
 /// [`LdmHashTable::insert_absolute`] / [`LdmHashTable::resolve`]
 /// helpers so absolute-position support extends past `u32::MAX`
 /// transparently — same pattern as `MatchTable`'s chain rebase.
+#[derive(Clone)]
 pub(crate) struct LdmHashTable {
     entries: Vec<LdmEntry>,
     bucket_offsets: Vec<u8>,

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -91,7 +91,6 @@ const REBASE_GUARD_BAND: u32 = 1u32 << 30;
 /// [`LdmHashTable::insert_absolute`] / [`LdmHashTable::resolve`]
 /// helpers so absolute-position support extends past `u32::MAX`
 /// transparently — same pattern as `MatchTable`'s chain rebase.
-#[derive(Clone)]
 pub(crate) struct LdmHashTable {
     entries: Vec<LdmEntry>,
     bucket_offsets: Vec<u8>,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -615,6 +615,7 @@ pub(crate) fn level_pre_split(level: CompressionLevel) -> Option<usize> {
 /// number of arms, but `storage.backend()` is now the canonical source
 /// of truth and dead variants are dropped when the active backend
 /// changes.
+#[derive(Clone)]
 enum MatcherStorage {
     /// Donor `ZSTD_fast` family. Constructed by
     /// [`MatchGeneratorDriver::new`] as the initial variant and
@@ -716,6 +717,16 @@ pub struct MatchGeneratorDriver {
     // committed-block path; consumed (reset to `None`) by the routed
     // call. Always `None` on the owned streaming path.
     borrowed_pending: Option<(usize, usize)>,
+    /// CDict-equivalent: snapshot of the post-prime matcher state taken
+    /// once after the first dictionary prime — the backend `storage`
+    /// (hash tables + dictionary history + offset history + window) plus
+    /// the driver-level `dictionary_retained_budget`, the only two pieces
+    /// `prime_with_dictionary` writes. Subsequent frames restore this
+    /// (a table memcpy) instead of re-hashing every dictionary position,
+    /// mirroring donor `ZSTD_compressBegin_usingCDict` copying the
+    /// precomputed `cdict->matchState`. Invalidated when the dictionary or
+    /// level changes (keyed by the captured `CompressionLevel`).
+    primed: Option<(MatcherStorage, usize, super::CompressionLevel)>,
 }
 
 impl MatchGeneratorDriver {
@@ -798,6 +809,7 @@ impl MatchGeneratorDriver {
             dictionary_retained_budget: 0,
             source_size_hint: None,
             borrowed_pending: None,
+            primed: None,
         }
     }
 
@@ -1453,6 +1465,31 @@ impl Matcher for MatchGeneratorDriver {
         }
     }
 
+    fn restore_primed_dictionary(&mut self, level: super::CompressionLevel) -> bool {
+        // Only the (storage, dictionary_retained_budget) pair is what
+        // `prime_with_dictionary` writes; restoring them reproduces the
+        // post-prime state exactly. Gated on the captured level so a driver
+        // reused at a different level (different backend / params) re-primes
+        // instead of restoring a mismatched table.
+        let (storage, budget) = match &self.primed {
+            Some((storage, budget, captured_level)) if *captured_level == level => {
+                (storage.clone(), *budget)
+            }
+            _ => return false,
+        };
+        self.storage = storage;
+        self.dictionary_retained_budget = budget;
+        true
+    }
+
+    fn capture_primed_dictionary(&mut self, level: super::CompressionLevel) {
+        self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, level));
+    }
+
+    fn invalidate_primed_dictionary(&mut self) {
+        self.primed = None;
+    }
+
     fn seed_dictionary_entropy(
         &mut self,
         huff: Option<&crate::huff0::huff0_encoder::HuffmanTable>,
@@ -1757,6 +1794,7 @@ impl MatchGeneratorDriver {
 /// The discriminator lives next to `parse_mode` so `configure()` can
 /// promote between the two on a level change without touching the
 /// `MatchTable` storage.
+#[derive(Clone)]
 pub(crate) enum HcBackend {
     /// Lazy / lazy2 modes — no per-frame backend state.
     Hc,
@@ -1782,6 +1820,7 @@ impl HcBackend {
     }
 }
 
+#[derive(Clone)]
 struct HcMatchGenerator {
     /// Shared match-finder storage (window, history, hash / chain /
     /// hash3 tables, dictionary-priming flags). Used identically by HC

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -971,18 +971,32 @@ impl MatchGeneratorDriver {
         match self.active_backend() {
             super::strategy::BackendTag::Simple => {
                 let matcher = self.simple_mut();
+                // `reclaimed` can exceed the CURRENT `max_window_size`: the
+                // retained dict budget is tracked independently and the
+                // window may already have been shrunk by a prior eviction,
+                // so the floor at 0 is the correct clamp, not a masked bug.
                 matcher.max_window_size = matcher.max_window_size.saturating_sub(reclaimed);
             }
             super::strategy::BackendTag::Dfast => {
                 let matcher = self.dfast_matcher_mut();
+                // `reclaimed` can exceed the CURRENT `max_window_size`: the
+                // retained dict budget is tracked independently and the
+                // window may already have been shrunk by a prior eviction,
+                // so the floor at 0 is the correct clamp, not a masked bug.
                 matcher.max_window_size = matcher.max_window_size.saturating_sub(reclaimed);
             }
             super::strategy::BackendTag::Row => {
                 let matcher = self.row_matcher_mut();
+                // `reclaimed` can exceed the CURRENT `max_window_size`: the
+                // retained dict budget is tracked independently and the
+                // window may already have been shrunk by a prior eviction,
+                // so the floor at 0 is the correct clamp, not a masked bug.
                 matcher.max_window_size = matcher.max_window_size.saturating_sub(reclaimed);
             }
             super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
+                // See the Simple arm: `reclaimed` may exceed the current
+                // window, so saturating to 0 is the correct clamp.
                 matcher.table.max_window_size =
                     matcher.table.max_window_size.saturating_sub(reclaimed);
             }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1401,12 +1401,16 @@ impl Matcher for MatchGeneratorDriver {
         // Record the resolved matcher shape for the primed-snapshot key. Captured
         // here (post-resolution, after the test-only param override) so the key
         // reflects exactly the geometry the restored `storage` must match. The
-        // Fast attach-vs-copy mode is part of the shape (it decides whether a
-        // dict table is built), and matches the decision `prime_with_dictionary`
-        // makes from the same `reset_size_log`.
-        let fast_attach = self
-            .reset_size_log
-            .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
+        // Fast attach-vs-copy mode is part of the shape ONLY for the Simple
+        // backend (it decides whether a separate dict table is built); the other
+        // backends prime the dictionary the same way regardless, so including
+        // the bit there would over-key identical resolved shapes. When it
+        // applies it matches the decision `prime_with_dictionary` makes from the
+        // same `reset_size_log`.
+        let fast_attach = matches!(next_backend, super::strategy::BackendTag::Simple)
+            && self
+                .reset_size_log
+                .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
         self.reset_shape = Some((params, resolved_table_bits, fast_attach));
     }
 
@@ -7046,6 +7050,43 @@ fn primed_snapshot_not_restored_across_fast_attach_copy_boundary() {
         "a copy-mode snapshot (8193 B hint) must NOT be restored into an \
          attach-mode reset (8192 B hint) that resolves to the same params but a \
          different dict-table shape"
+    );
+}
+
+#[test]
+fn primed_snapshot_fast_attach_does_not_over_key_non_simple_backends() {
+    // `fast_attach` is a Simple/Fast-backend concept (the 8 KiB attach-vs-copy
+    // table split). On the HashChain/Dfast/Row backends the dictionary is
+    // always primed the same way, so the bit must NOT enter their snapshot key
+    // — otherwise an unhinted capture (which would record `fast_attach = true`)
+    // and a hinted reset that resolves to the IDENTICAL `LevelParams` would key
+    // differently and force a needless re-prime. `Best` is a HashChain level.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    let level = CompressionLevel::Best;
+
+    // Capture with no hint.
+    driver.reset(level);
+    let window_a = driver.window_size();
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    driver.capture_primed_dictionary(level);
+
+    // Reset with a hint large enough to resolve to the same window/params as
+    // the unhinted level (>= 2^window_log, so the source-size cap is a no-op).
+    driver.set_source_size_hint(64 * 1024 * 1024);
+    driver.reset(level);
+    let window_b = driver.window_size();
+    assert_eq!(
+        window_a, window_b,
+        "precondition: the large hint must resolve to the same window as the \
+         unhinted level (a={window_a}, b={window_b})"
+    );
+
+    let restored = driver.restore_primed_dictionary(level);
+    assert!(
+        restored,
+        "a HashChain snapshot must restore across an unhinted vs large-hinted \
+         reset that resolves to the identical matcher — `fast_attach` is a Fast \
+         backend concept and must not over-key non-Simple shapes"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -151,7 +151,7 @@ use super::hc::MAX_HC_SEARCH_DEPTH;
 
 /// Bundled tuning knobs for the hash-chain matcher. Using a typed config
 /// instead of positional `usize` args eliminates parameter-order hazards.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct HcConfig {
     hash_log: usize,
     chain_log: usize,
@@ -159,7 +159,7 @@ struct HcConfig {
     target_len: usize,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) struct RowConfig {
     pub(crate) hash_bits: usize,
     pub(crate) row_log: usize,
@@ -250,7 +250,7 @@ const ROW_L5: RowConfig = RowConfig {
 /// family and the compile-time strategy consts; the runtime
 /// [`BackendTag`] used by the driver dispatcher is derived via
 /// [`StrategyTag::backend`] so the two cannot drift.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 struct LevelParams {
     strategy_tag: super::strategy::StrategyTag,
     /// Decoupled search-method axis. Independent of `strategy_tag`'s
@@ -327,6 +327,31 @@ impl LevelParams {
         }
     }
 }
+
+/// `ceil(log2(size))` of a source-size hint, with a zero hint floored to
+/// [`MIN_WINDOW_LOG`]. This is the single quantization every hint-dependent
+/// matcher parameter is derived from: the window-log cap, the HC / Fast hash
+/// and chain widths, the Dfast / Row table widths, the L22 config buckets, and
+/// the Fast attach-vs-copy cutoff. Two hints sharing this value resolve to the
+/// identical matcher shape, which is why it (not the raw byte count) keys the
+/// primed-dictionary snapshot — see [`PrimedKey`]. Operates on the full `u64`
+/// so callers comparing a hint against a cutoff get the same bucketed decision
+/// here and at the driver, with no `as usize` truncation on 32-bit targets.
+pub(crate) fn source_size_ceil_log(size: u64) -> u8 {
+    if size == 0 {
+        MIN_WINDOW_LOG
+    } else {
+        (64 - (size - 1).leading_zeros()) as u8
+    }
+}
+
+/// Donor `ZSTD_shouldAttachDict` cutoff for the Fast strategy, as a ceil-log
+/// bucket: 8 KiB = `2^13`, and `bucket <= 13` is exactly `hint <= 8192` because
+/// the bucket is monotone in the hint. A hint at or below this (or unknown,
+/// `None`) ATTACHES the dictionary (a separate immutable table); a larger hint
+/// COPIES it into the live table. Shared by `reset` (which records the mode in
+/// the primed-snapshot key) and `prime_with_dictionary` (which acts on it).
+const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 13;
 
 fn dfast_hash_bits_for_window(max_window_size: usize) -> usize {
     let window_log = (usize::BITS - 1 - max_window_size.leading_zeros()) as usize;
@@ -417,11 +442,7 @@ fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> Leve
     // (a decoder-interop requirement on the wire format), but the hash /
     // chain table widths are internal and never appear in the frame, so they
     // can track the actual source size below that floor.
-    let raw_src_log = if src_size == 0 {
-        MIN_WINDOW_LOG
-    } else {
-        (64 - (src_size - 1).leading_zeros()) as u8 // ceil_log2
-    };
+    let raw_src_log = source_size_ceil_log(src_size);
     let src_log = raw_src_log.max(MIN_WINDOW_LOG).max(MIN_HINTED_WINDOW_LOG);
     if src_log < params.window_log {
         params.window_log = src_log;
@@ -470,11 +491,7 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
     if let Some(size) = source_size
         && size > 256 * 1024
     {
-        let src_log = if size == 0 {
-            MIN_WINDOW_LOG
-        } else {
-            (64 - (size - 1).leading_zeros()) as u8
-        };
+        let src_log = source_size_ceil_log(size);
         window_log = window_log.min(src_log.max(MIN_WINDOW_LOG));
         let adjusted_table_log = window_log as usize + 1;
         hc.hash_log = hc.hash_log.min(adjusted_table_log);
@@ -703,13 +720,21 @@ pub struct MatchGeneratorDriver {
     dictionary_retained_budget: usize,
     // Source size hint for next frame (set via set_source_size_hint, cleared on reset).
     source_size_hint: Option<u64>,
-    // Snapshot of the frame's source-size hint captured at `reset` (where
-    // `source_size_hint` is consumed). Read by `prime_with_dictionary` to pick
-    // the donor `ZSTD_shouldAttachDict` dict mode for the Simple/Fast backend:
-    // `None` (unknown) or `<= FAST_ATTACH_DICT_CUTOFF` → attach (separate dict
-    // table, 2-cursor `compress_block_fast_dict`); larger → copy (dictionary
-    // primed into the live table, 4-cursor `compress_block_fast`).
-    reset_source_size: Option<u64>,
+    // Normalized `ceil_log2` bucket of the frame's source-size hint, captured at
+    // `reset` (where `source_size_hint` is consumed) via [`source_size_ceil_log`].
+    // `None` means the frame was unhinted. Drives `prime_with_dictionary`'s donor
+    // `ZSTD_shouldAttachDict` mode for the Simple/Fast backend: `None` (unknown)
+    // or `<= FAST_ATTACH_DICT_CUTOFF_LOG` → attach (separate dict table, 2-cursor
+    // `compress_block_fast_dict`); larger → copy (dictionary primed into the live
+    // table, 4-cursor `compress_block_fast`). The primed-snapshot key is the
+    // resolved shape ([`reset_shape`](Self::reset_shape)), not this bucket.
+    reset_size_log: Option<u8>,
+    // Hint-resolved matcher shape from the last `reset`: the [`LevelParams`], the
+    // active backend's applied Dfast/Row hash-table width (`0` for HC/Fast), and
+    // the Fast attach-vs-copy mode. Combined with the frame's level into the
+    // [`PrimedKey`] that keys the primed snapshot, so it is only restored into a
+    // reset that resolved the identical matcher. `None` before the first `reset`.
+    reset_shape: Option<(LevelParams, usize, bool)>,
     // One-shot borrowed block range `[start, end)` staged by the borrowed
     // Fast frame path (`set_borrowed_block`) for the NEXT
     // `start_matching` / `skip_matching_with_hint`. `Some` routes that
@@ -724,9 +749,59 @@ pub struct MatchGeneratorDriver {
     /// `prime_with_dictionary` writes. Subsequent frames restore this
     /// (a table memcpy) instead of re-hashing every dictionary position,
     /// mirroring donor `ZSTD_compressBegin_usingCDict` copying the
-    /// precomputed `cdict->matchState`. Invalidated when the dictionary or
-    /// level changes (keyed by the captured `CompressionLevel`).
-    primed: Option<(MatcherStorage, usize, super::CompressionLevel)>,
+    /// precomputed `cdict->matchState`. Invalidated when the dictionary
+    /// changes; keyed by the [`PrimedKey`] resolved matcher shape so a snapshot
+    /// is only restored into a reset that produces the same matcher — see
+    /// `restore_primed_dictionary`.
+    primed: Option<(MatcherStorage, usize, PrimedKey)>,
+}
+
+/// Identity of the matcher configuration a primed snapshot was captured under:
+/// the FULLY RESOLVED matcher shape, not the raw source-size hint.
+///
+/// `reset()` resolves the hint into a [`LevelParams`] (window_log cap, the
+/// HC/Fast table and search geometry, the parse depth/target-length that get
+/// baked into the restored `storage`) plus, for the Dfast/Row backends, a
+/// table-width derived from the hint's ceil-log bucket. The mapping from hint
+/// to resolved shape is many-to-one: the source-size adjustment is monotone in
+/// `ceil_log2(hint)`, and Level 22 additionally collapses several buckets onto
+/// one donor tier (its `<= 16/128/256 KiB` thresholds). Keying on the raw hint
+/// (or even its ceil-log bucket) therefore over-keys — two hints that resolve
+/// to the identical matcher would each force a full re-prime. Keying on the
+/// resolved (`params`, `table_bits`) pair restores across them.
+///
+/// `table_bits` is the hint-dependent hash-table width the ACTIVE backend
+/// applied (`set_hash_bits` value for Dfast/Row; `0` for HC/Fast, whose widths
+/// already live in `params`). The snapshot is only ever captured on the COPY
+/// path (a hinted, above-cutoff frame), so `table_bits` is always the resolved
+/// Dfast/Row value there, never the unhinted default.
+///
+/// `level` is kept alongside the resolved `params` because some stored matcher
+/// state is derived from the level DIRECTLY, not through `params`: e.g. Dfast's
+/// `use_fast_loop` is true for L3 but false for L4, yet L3 and L4 resolve to
+/// byte-identical `params`. Without `level` a snapshot captured at L3 could be
+/// restored into an L4 reset, installing the wrong `use_fast_loop`.
+///
+/// `fast_attach` records the Fast backend's attach-vs-copy mode
+/// ([`FAST_ATTACH_DICT_CUTOFF_LOG`]) because that cutoff (8 KiB) falls INSIDE a
+/// single resolved shape: an 8192- and an 8193-byte Level 1 hint both clamp to
+/// window_log 14 with identical `params`/`table_bits`, yet 8192 attaches (a
+/// separate dict table) while 8193 copies into the live table — two different
+/// `storage` shapes. The frame compressor only captures/restores snapshots on
+/// the copy path today, but keying on the mode keeps the snapshot identity
+/// self-sufficient rather than relying on that external gate.
+///
+/// Restoring a snapshot whose key differs would reinstate the old `storage`
+/// (and its `max_window_size` / table dimensions / parse params / dict-table
+/// shape) under a reset that resolved a different shape — the encoder could
+/// then search past the frame header's window and emit an undecodable match.
+/// All fields must match before a restore is allowed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct PrimedKey {
+    level: super::CompressionLevel,
+    params: LevelParams,
+    table_bits: usize,
+    fast_attach: bool,
 }
 
 impl MatchGeneratorDriver {
@@ -805,7 +880,8 @@ impl MatchGeneratorDriver {
             // the first `reset()` overwrites both sides from the
             // resolved LevelParams.
             reported_window_size: next_pow2,
-            reset_source_size: None,
+            reset_size_log: None,
+            reset_shape: None,
             dictionary_retained_budget: 0,
             source_size_hint: None,
             borrowed_pending: None,
@@ -1090,11 +1166,10 @@ impl MatchGeneratorDriver {
                 // matches against it as window history — the path that already
                 // matches/beats the donor on large corpora). The dispatch in
                 // `start_matching` keys off `dict_table.is_some()`, which only
-                // the attach path populates.
-                const FAST_ATTACH_DICT_CUTOFF: u64 = 8 * 1024;
+                // the attach path populates. See [`FAST_ATTACH_DICT_CUTOFF_LOG`].
                 let attach = self
-                    .reset_source_size
-                    .is_none_or(|n| n <= FAST_ATTACH_DICT_CUTOFF);
+                    .reset_size_log
+                    .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
                 if attach {
                     self.simple_mut().skip_matching_for_dict_prime();
                 } else {
@@ -1124,9 +1199,12 @@ impl Matcher for MatchGeneratorDriver {
 
     fn reset(&mut self, level: CompressionLevel) {
         let hint = self.source_size_hint.take();
-        // Snapshot for prime_with_dictionary's attach/copy mode decision (the
-        // hint is consumed here, but priming happens just after reset).
-        self.reset_source_size = hint;
+        // Snapshot the hint's normalized ceil-log bucket for the primed-snapshot
+        // key and prime_with_dictionary's attach/copy mode decision (the hint is
+        // consumed here, but priming happens just after reset). Storing the
+        // bucket rather than the raw bytes means two hints that resolve to the
+        // same matcher shape share one snapshot instead of each re-priming.
+        self.reset_size_log = hint.map(source_size_ceil_log);
         let hinted = hint.is_some();
         #[cfg_attr(not(test), allow(unused_mut))]
         let mut params = Self::level_params(level, hint);
@@ -1250,11 +1328,7 @@ impl Matcher for MatchGeneratorDriver {
         // small frame zeroes a small table; it never exceeds the real window.
         let table_window_size = match hint {
             Some(h) => {
-                let raw_log = if h == 0 {
-                    MIN_WINDOW_LOG
-                } else {
-                    (64 - (h - 1).leading_zeros()) as u8
-                };
+                let raw_log = source_size_ceil_log(h);
                 // Clamp the shift below the pointer width before `1usize <<`:
                 // an oversized hint (>= 2^63 + 1, and on 32-bit usize any hint
                 // >= 2^32) drives `raw_log` to 64 / >= 32, and the shift would
@@ -1266,6 +1340,11 @@ impl Matcher for MatchGeneratorDriver {
             }
             None => max_window_size,
         };
+        // The hint-dependent hash-table width the active backend applies, for
+        // the primed-snapshot key. Dfast/Row compute it from `table_window_size`
+        // below; HC/Fast leave it `0` because their widths live in `params`
+        // (`hc.{hash,chain}_log` / `fast_hash_log`) — already part of the key.
+        let mut resolved_table_bits: usize = 0;
         match &mut self.storage {
             MatcherStorage::Simple(m) => {
                 // Per-level Fast cParams threaded from
@@ -1287,11 +1366,12 @@ impl Matcher for MatchGeneratorDriver {
                         | CompressionLevel::Level(0)
                         | CompressionLevel::Level(3)
                 );
-                dfast.set_hash_bits(if hinted {
+                resolved_table_bits = if hinted {
                     dfast_hash_bits_for_window(table_window_size)
                 } else {
                     DFAST_HASH_BITS
-                });
+                };
+                dfast.set_hash_bits(resolved_table_bits);
                 // Dfast holds no per-block input Vecs (history owns the
                 // bytes and `add_data` returns each Vec eagerly), so
                 // `reset` takes no `reuse_space` callback.
@@ -1302,7 +1382,8 @@ impl Matcher for MatchGeneratorDriver {
                 row.lazy_depth = params.lazy_depth;
                 row.configure(params.row);
                 if hinted {
-                    row.set_hash_bits(row_hash_bits_for_window(table_window_size));
+                    resolved_table_bits = row_hash_bits_for_window(table_window_size);
+                    row.set_hash_bits(resolved_table_bits);
                 }
                 row.reset();
             }
@@ -1317,6 +1398,16 @@ impl Matcher for MatchGeneratorDriver {
                 });
             }
         }
+        // Record the resolved matcher shape for the primed-snapshot key. Captured
+        // here (post-resolution, after the test-only param override) so the key
+        // reflects exactly the geometry the restored `storage` must match. The
+        // Fast attach-vs-copy mode is part of the shape (it decides whether a
+        // dict table is built), and matches the decision `prime_with_dictionary`
+        // makes from the same `reset_size_log`.
+        let fast_attach = self
+            .reset_size_log
+            .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
+        self.reset_shape = Some((params, resolved_table_bits, fast_attach));
     }
 
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
@@ -1490,11 +1581,25 @@ impl Matcher for MatchGeneratorDriver {
     fn restore_primed_dictionary(&mut self, level: super::CompressionLevel) -> bool {
         // Only the (storage, dictionary_retained_budget) pair is what
         // `prime_with_dictionary` writes; restoring them reproduces the
-        // post-prime state exactly. Gated on the captured level so a driver
-        // reused at a different level (different backend / params) re-primes
-        // instead of restoring a mismatched table.
+        // post-prime state exactly. Gated on the FULL resolved key (level + the
+        // resolved `LevelParams` + the active backend's table width), not just
+        // the level: `reset` resolves the hint into a window/table geometry, so a
+        // same-level snapshot taken at a hint that resolved to a different shape
+        // carries a `storage.max_window_size` / table dimensions that no longer
+        // match this reset. Restoring it would let the encoder search past the
+        // frame header's window (an undecodable match), so on a key mismatch we
+        // refuse and the caller re-primes.
+        let Some((params, table_bits, fast_attach)) = self.reset_shape else {
+            return false;
+        };
+        let key = PrimedKey {
+            level,
+            params,
+            table_bits,
+            fast_attach,
+        };
         let (storage, budget) = match &self.primed {
-            Some((storage, budget, captured_level)) if *captured_level == level => {
+            Some((storage, budget, captured_key)) if *captured_key == key => {
                 (storage.clone(), *budget)
             }
             _ => return false,
@@ -1505,7 +1610,18 @@ impl Matcher for MatchGeneratorDriver {
     }
 
     fn capture_primed_dictionary(&mut self, level: super::CompressionLevel) {
-        self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, level));
+        // No resolved shape means `reset` has not run for this frame — nothing
+        // valid to key a snapshot on, so skip the capture.
+        let Some((params, table_bits, fast_attach)) = self.reset_shape else {
+            return;
+        };
+        let key = PrimedKey {
+            level,
+            params,
+            table_bits,
+            fast_attach,
+        };
+        self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, key));
     }
 
     fn invalidate_primed_dictionary(&mut self) {
@@ -6784,6 +6900,152 @@ fn prime_with_dictionary_does_not_inflate_reported_window_size() {
     assert_eq!(
         after, before,
         "dictionary retention budget must not change reported frame window size"
+    );
+}
+
+#[test]
+fn primed_snapshot_not_restored_when_window_hint_differs() {
+    // The copy-snapshot must be keyed on the resolved reset parameters, not
+    // just the CompressionLevel. `reset()` caps window_log by the source-size
+    // hint, so two same-level frames with different hints resolve to different
+    // windows. Restoring a snapshot captured at the larger hint into a reset
+    // for the smaller hint would advertise the smaller window in the frame
+    // header while the matcher's `max_window_size` (from the restored storage)
+    // still spans the larger window — the encoder could then emit a match
+    // (e.g. into the dictionary) past the advertised window, producing an
+    // undecodable frame. Restore must REFUSE when the resolved window differs.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    let level = CompressionLevel::Best;
+
+    // Frame A: large hint → larger resolved window. Prime + capture.
+    driver.set_source_size_hint(256 * 1024);
+    driver.reset(level);
+    let big_window = driver.window_size();
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    driver.capture_primed_dictionary(level);
+
+    // Frame B: smaller hint, SAME level → smaller resolved window.
+    driver.set_source_size_hint(48 * 1024);
+    driver.reset(level);
+    let small_window = driver.window_size();
+    assert!(
+        small_window < big_window,
+        "precondition: the two hints must resolve to different windows \
+         (small={small_window}, big={big_window})"
+    );
+
+    let restored = driver.restore_primed_dictionary(level);
+    assert!(
+        !restored,
+        "snapshot captured at window {big_window} must NOT be restored into a \
+         reset advertising window {small_window} (level alone is an insufficient key)"
+    );
+}
+
+#[test]
+fn primed_snapshot_restored_for_hints_in_same_window_bucket() {
+    // The snapshot key must normalize the source-size hint to the resolved
+    // matcher geometry, not the raw hinted byte count. `reset()` derives every
+    // hint-dependent parameter (window_log cap, HC/Fast/Dfast/Row table widths,
+    // the Fast attach-vs-copy cutoff) from `ceil_log2(hint)`, so two distinct
+    // hints that share a ceil-log bucket resolve to the *identical* matcher
+    // shape. Keying on the raw bytes over-keys: it forces a full re-prime on the
+    // second frame even though the cached snapshot is a perfect fit. Restore
+    // must SUCCEED across same-bucket hints.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    let level = CompressionLevel::Best;
+
+    // Both hints fall in ceil_log2 bucket 19 (2^18 < n <= 2^19): 300 KiB and
+    // 400 KiB resolve to the same window and table widths.
+    driver.set_source_size_hint(300 * 1024);
+    driver.reset(level);
+    let window_a = driver.window_size();
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    driver.capture_primed_dictionary(level);
+
+    driver.set_source_size_hint(400 * 1024);
+    driver.reset(level);
+    let window_b = driver.window_size();
+    assert_eq!(
+        window_a, window_b,
+        "precondition: same-bucket hints must resolve to the same window \
+         (a={window_a}, b={window_b})"
+    );
+
+    let restored = driver.restore_primed_dictionary(level);
+    assert!(
+        restored,
+        "snapshot captured at a 300 KiB hint must be restored into a 400 KiB \
+         hint that resolves to the identical matcher shape (raw bytes over-key)"
+    );
+}
+
+#[test]
+fn primed_snapshot_restored_across_level22_donor_tier_hints() {
+    // Level 22 collapses several ceil-log buckets onto one donor source-size
+    // tier: `resolve_level_params(Level(22), ..)` selects the HC config and
+    // window_log by raw `<= 16 KiB / 128 KiB / 256 KiB` thresholds, so a 20 KiB
+    // and a 100 KiB hint (ceil-log buckets 15 and 17) both land in the
+    // `<= 128 KiB` tier and resolve to the IDENTICAL matcher (same window_log,
+    // same HC hash/chain/search geometry). Keying on the raw ceil-log bucket
+    // would still reject the restore here because the buckets differ; the key
+    // must compare the resolved matcher shape so these share one snapshot.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    let level = CompressionLevel::Level(22);
+
+    driver.set_source_size_hint(20 * 1024);
+    driver.reset(level);
+    let window_a = driver.window_size();
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    driver.capture_primed_dictionary(level);
+
+    driver.set_source_size_hint(100 * 1024);
+    driver.reset(level);
+    let window_b = driver.window_size();
+    assert_eq!(
+        window_a, window_b,
+        "precondition: both hints must land in the same Level 22 donor tier \
+         (a={window_a}, b={window_b})"
+    );
+
+    let restored = driver.restore_primed_dictionary(level);
+    assert!(
+        restored,
+        "Level 22 snapshot captured at a 20 KiB hint must be restored into a \
+         100 KiB hint that resolves to the same donor tier (different ceil-log \
+         buckets, identical matcher shape)"
+    );
+}
+
+#[test]
+fn primed_snapshot_not_restored_across_fast_attach_copy_boundary() {
+    // The Fast attach-vs-copy cutoff (8 KiB) falls INSIDE a single resolved
+    // matcher shape: a 8192-byte and a 8193-byte hint both clamp Level 1 to
+    // window_log 14 and the same Fast table widths, so `LevelParams` +
+    // `table_bits` are identical, yet 8192 attaches (separate dict table) while
+    // 8193 copies (dict primed into the live table). The snapshot key must
+    // therefore carry the attach/copy mode itself; without it the two resets
+    // would share a key and a copy-mode snapshot could be restored into an
+    // attach-mode reset (a different `storage` shape). Restore must REFUSE
+    // across the boundary.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    let level = CompressionLevel::Level(1);
+
+    // Copy side (hint > 8 KiB): prime + capture.
+    driver.set_source_size_hint(8193);
+    driver.reset(level);
+    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+    driver.capture_primed_dictionary(level);
+
+    // Attach side (hint <= 8 KiB), same resolved window/table shape.
+    driver.set_source_size_hint(8192);
+    driver.reset(level);
+    let restored = driver.restore_primed_dictionary(level);
+    assert!(
+        !restored,
+        "a copy-mode snapshot (8193 B hint) must NOT be restored into an \
+         attach-mode reset (8192 B hint) that resolves to the same params but a \
+         different dict-table shape"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -615,7 +615,6 @@ pub(crate) fn level_pre_split(level: CompressionLevel) -> Option<usize> {
 /// number of arms, but `storage.backend()` is now the canonical source
 /// of truth and dead variants are dropped when the active backend
 /// changes.
-#[derive(Clone)]
 enum MatcherStorage {
     /// Donor `ZSTD_fast` family. Constructed by
     /// [`MatchGeneratorDriver::new`] as the initial variant and
@@ -717,16 +716,6 @@ pub struct MatchGeneratorDriver {
     // committed-block path; consumed (reset to `None`) by the routed
     // call. Always `None` on the owned streaming path.
     borrowed_pending: Option<(usize, usize)>,
-    /// CDict-equivalent: snapshot of the post-prime matcher state taken
-    /// once after the first dictionary prime — the backend `storage`
-    /// (hash tables + dictionary history + offset history + window) plus
-    /// the driver-level `dictionary_retained_budget`, the only two pieces
-    /// `prime_with_dictionary` writes. Subsequent frames restore this
-    /// (a table memcpy) instead of re-hashing every dictionary position,
-    /// mirroring donor `ZSTD_compressBegin_usingCDict` copying the
-    /// precomputed `cdict->matchState`. Invalidated when the dictionary or
-    /// level changes (keyed by the captured `CompressionLevel`).
-    primed: Option<(MatcherStorage, usize, super::CompressionLevel)>,
 }
 
 impl MatchGeneratorDriver {
@@ -809,7 +798,6 @@ impl MatchGeneratorDriver {
             dictionary_retained_budget: 0,
             source_size_hint: None,
             borrowed_pending: None,
-            primed: None,
         }
     }
 
@@ -1465,31 +1453,6 @@ impl Matcher for MatchGeneratorDriver {
         }
     }
 
-    fn restore_primed_dictionary(&mut self, level: super::CompressionLevel) -> bool {
-        // Only the (storage, dictionary_retained_budget) pair is what
-        // `prime_with_dictionary` writes; restoring them reproduces the
-        // post-prime state exactly. Gated on the captured level so a driver
-        // reused at a different level (different backend / params) re-primes
-        // instead of restoring a mismatched table.
-        let (storage, budget) = match &self.primed {
-            Some((storage, budget, captured_level)) if *captured_level == level => {
-                (storage.clone(), *budget)
-            }
-            _ => return false,
-        };
-        self.storage = storage;
-        self.dictionary_retained_budget = budget;
-        true
-    }
-
-    fn capture_primed_dictionary(&mut self, level: super::CompressionLevel) {
-        self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, level));
-    }
-
-    fn invalidate_primed_dictionary(&mut self) {
-        self.primed = None;
-    }
-
     fn seed_dictionary_entropy(
         &mut self,
         huff: Option<&crate::huff0::huff0_encoder::HuffmanTable>,
@@ -1794,7 +1757,6 @@ impl MatchGeneratorDriver {
 /// The discriminator lives next to `parse_mode` so `configure()` can
 /// promote between the two on a level change without touching the
 /// `MatchTable` storage.
-#[derive(Clone)]
 pub(crate) enum HcBackend {
     /// Lazy / lazy2 modes — no per-frame backend state.
     Hc,
@@ -1820,7 +1782,6 @@ impl HcBackend {
     }
 }
 
-#[derive(Clone)]
 struct HcMatchGenerator {
     /// Shared match-finder storage (window, history, hash / chain /
     /// hash3 tables, dictionary-priming flags). Used identically by HC

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1463,6 +1463,14 @@ impl Matcher for MatchGeneratorDriver {
                 .table
                 .set_dictionary_limit_from_primed_bytes(committed_dict_budget);
         }
+        // CDict-equivalent: now that every dict chunk is indexed, mark the
+        // Fast-backend dict table primed so the next frame's re-prime reuses
+        // it (skips the re-hash) while still re-committing the dict bytes to
+        // history. No-op when the attach path built no table (copy mode or a
+        // sub-8-byte dict) — `mark_dict_primed` self-guards on table presence.
+        if self.active_backend() == super::strategy::BackendTag::Simple {
+            self.simple_mut().mark_dict_primed();
+        }
     }
 
     fn restore_primed_dictionary(&mut self, level: super::CompressionLevel) -> bool {
@@ -1488,6 +1496,13 @@ impl Matcher for MatchGeneratorDriver {
 
     fn invalidate_primed_dictionary(&mut self) {
         self.primed = None;
+        // Drop the Fast-backend CDict-equivalent table cache too: it is keyed
+        // to the dictionary being removed / replaced. Left in place, the next
+        // same-params `reset` would retain it and the kernel would probe a
+        // dict region whose bytes are no longer re-committed to history.
+        if self.active_backend() == super::strategy::BackendTag::Simple {
+            self.simple_mut().invalidate_dict_cache();
+        }
     }
 
     fn seed_dictionary_entropy(

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -214,7 +214,6 @@ pub(crate) const HC3_HASH_LOG: usize = 17;
 /// tables. Methods on this struct contain only logic that's identical
 /// between HC and BT modes — backend-specific table interpretation
 /// lives in the matcher modules.
-#[derive(Clone)]
 pub(crate) struct MatchTable {
     pub(crate) max_window_size: usize,
     /// Per-chunk lengths of the live window, in add order. The bytes

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -214,6 +214,7 @@ pub(crate) const HC3_HASH_LOG: usize = 17;
 /// tables. Methods on this struct contain only logic that's identical
 /// between HC and BT modes — backend-specific table interpretation
 /// lives in the matcher modules.
+#[derive(Clone)]
 pub(crate) struct MatchTable {
     pub(crate) max_window_size: usize,
     /// Per-chunk lengths of the live window, in add order. The bytes

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -197,7 +197,7 @@ pub fn compress_slice_to_vec(source: &[u8], level: CompressionLevel) -> Vec<u8> 
 /// The compression mode used impacts the speed of compression,
 /// and resulting compression ratios. Faster compression will result
 /// in worse compression ratios, and vice versa.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug)]
 pub enum CompressionLevel {
     /// This level does not compress the data at all, and simply wraps
     /// it in a Zstandard frame.
@@ -344,21 +344,6 @@ pub trait Matcher {
     /// Prime matcher state with dictionary history before compressing the next frame.
     /// Default implementation is a no-op for custom matchers that do not support this.
     fn prime_with_dictionary(&mut self, _dict_content: &[u8], _offset_hist: [u32; 3]) {}
-    /// CDict-equivalent fast path for repeated frames sharing one dictionary.
-    /// Restore the matcher state captured by [`Self::capture_primed_dictionary`]
-    /// at the SAME level (a table copy) instead of re-running
-    /// [`Self::prime_with_dictionary`] (which re-hashes every dictionary
-    /// position). Returns `true` when a matching snapshot was restored;
-    /// `false` (the default) means the caller must prime then capture.
-    fn restore_primed_dictionary(&mut self, _level: CompressionLevel) -> bool {
-        false
-    }
-    /// Snapshot the post-prime matcher state for the given level so later
-    /// frames can [`Self::restore_primed_dictionary`] it. Default no-op.
-    fn capture_primed_dictionary(&mut self, _level: CompressionLevel) {}
-    /// Drop any captured prime snapshot (dictionary or level changed).
-    /// Default no-op.
-    fn invalidate_primed_dictionary(&mut self) {}
     /// Seed matcher cost model with dictionary entropy tables before the next frame.
     /// Default implementation is a no-op for custom matchers.
     fn seed_dictionary_entropy(

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -197,7 +197,7 @@ pub fn compress_slice_to_vec(source: &[u8], level: CompressionLevel) -> Vec<u8> 
 /// The compression mode used impacts the speed of compression,
 /// and resulting compression ratios. Faster compression will result
 /// in worse compression ratios, and vice versa.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CompressionLevel {
     /// This level does not compress the data at all, and simply wraps
     /// it in a Zstandard frame.
@@ -344,6 +344,21 @@ pub trait Matcher {
     /// Prime matcher state with dictionary history before compressing the next frame.
     /// Default implementation is a no-op for custom matchers that do not support this.
     fn prime_with_dictionary(&mut self, _dict_content: &[u8], _offset_hist: [u32; 3]) {}
+    /// CDict-equivalent fast path for repeated frames sharing one dictionary.
+    /// Restore the matcher state captured by [`Self::capture_primed_dictionary`]
+    /// at the SAME level (a table copy) instead of re-running
+    /// [`Self::prime_with_dictionary`] (which re-hashes every dictionary
+    /// position). Returns `true` when a matching snapshot was restored;
+    /// `false` (the default) means the caller must prime then capture.
+    fn restore_primed_dictionary(&mut self, _level: CompressionLevel) -> bool {
+        false
+    }
+    /// Snapshot the post-prime matcher state for the given level so later
+    /// frames can [`Self::restore_primed_dictionary`] it. Default no-op.
+    fn capture_primed_dictionary(&mut self, _level: CompressionLevel) {}
+    /// Drop any captured prime snapshot (dictionary or level changed).
+    /// Default no-op.
+    fn invalidate_primed_dictionary(&mut self) {}
     /// Seed matcher cost model with dictionary entropy tables before the next frame.
     /// Default implementation is a no-op for custom matchers.
     fn seed_dictionary_entropy(

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -335,6 +335,7 @@ unsafe fn row_tag_match_mask_neon(tags: &[u8], tag: u8) -> u64 {
     mask
 }
 
+#[derive(Clone)]
 pub(crate) struct RowMatchGenerator {
     pub(crate) max_window_size: usize,
     /// Per-committed-block lengths of the live window, mirroring the

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -335,7 +335,6 @@ unsafe fn row_tag_match_mask_neon(tags: &[u8], tag: u8) -> u64 {
     mask
 }
 
-#[derive(Clone)]
 pub(crate) struct RowMatchGenerator {
     pub(crate) max_window_size: usize,
     /// Per-committed-block lengths of the live window, mirroring the

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -53,6 +53,7 @@ const PRIME_8_BYTES: u64 = 0xCF1BBCDCB7A56463;
 /// initial prefix (where the `+= (ip0 == prefixStart)` adjustment at
 /// loop entry skips it) or is below `prefixStartIndex` and filtered by
 /// the in-range check.
+#[derive(Clone)]
 pub(crate) struct FastHashTable {
     table: Vec<u32>,
     /// Donor `hash_log` — number of bits the hash output is reduced to.

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -53,7 +53,6 @@ const PRIME_8_BYTES: u64 = 0xCF1BBCDCB7A56463;
 /// initial prefix (where the `+= (ip0 == prefixStart)` adjustment at
 /// loop entry skips it) or is below `prefixStartIndex` and filtered by
 /// the in-range check.
-#[derive(Clone)]
 pub(crate) struct FastHashTable {
     table: Vec<u32>,
     /// Donor `hash_log` — number of bits the hash output is reduced to.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -249,6 +249,15 @@ pub(crate) struct FastKernelMatcher {
     /// dict kernel uses to separate main-table (input) from dict-table
     /// matches. `0` when no dictionary is primed.
     dict_region_len: usize,
+    /// CDict-equivalent cache flag: `true` once [`Self::dict_table`] has been
+    /// fully built for the attached dictionary. A reused compressor keeps the
+    /// built `dict_table` across the per-frame `reset` (the dictionary
+    /// re-commits to the same absolute history positions, so the hashed
+    /// positions stay valid) and skips re-hashing it — the donor copies /
+    /// references the precomputed `cdict->matchState` rather than rebuilding
+    /// it per frame. Cleared on parameter change, history eviction, or
+    /// dictionary attach/clear (see `invalidate_dict_cache`).
+    dict_primed: bool,
 }
 
 impl FastKernelMatcher {
@@ -338,6 +347,7 @@ impl FastKernelMatcher {
             last_borrowed_block: None,
             dict_table: None,
             dict_region_len: 0,
+            dict_primed: false,
         }
     }
 
@@ -360,12 +370,20 @@ impl FastKernelMatcher {
         );
         if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
             // Parameters changed — rebuild the table at the new size.
-            // Cannot reuse the old allocation because the donor-shape
-            // hash table dimensions are baked in at construction.
+            // Cannot reuse the old allocation because the hash table
+            // dimensions are baked in at construction. A reshape also
+            // invalidates the cached dict table: its absolute positions
+            // index a table whose shape no longer matches.
             self.hash_table = FastHashTable::new(hash_log, mls);
+            self.dict_table = None;
+            self.dict_region_len = 0;
+            self.dict_primed = false;
         } else {
             // Same shape — keep the allocation, zero the entries via
-            // `memset` (donor's `ZSTD_window_clear` cadence).
+            // `memset` (ZSTD_window_clear cadence). A primed dict table
+            // is retained: the dictionary lands at the same absolute
+            // history positions every frame, so its hashes stay valid
+            // and the per-frame re-hash is skipped (CDict-equivalent).
             self.hash_table.clear();
         }
         // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
@@ -387,11 +405,6 @@ impl FastKernelMatcher {
         // different allocation, so a stale (ptr, len) would dangle.
         self.borrowed = None;
         self.last_borrowed_block = None;
-        // Drop any primed dictionary state: the next frame re-primes (or
-        // not) from scratch, and stale absolute dict positions must not
-        // leak across frames.
-        self.dict_table = None;
-        self.dict_region_len = 0;
     }
 
     /// Reported decoder-side window size (bytes) — test-only.
@@ -630,6 +643,7 @@ impl FastKernelMatcher {
         // reachable anyway.
         self.dict_table = None;
         self.dict_region_len = 0;
+        self.dict_primed = false;
         self.hash_table.clear();
         self.last_block_start = self.last_block_start.saturating_sub(drop_n);
         // Skip position 0 — `prefix_start_index = 1` means the kernel
@@ -1156,6 +1170,27 @@ impl FastKernelMatcher {
         self.prime_dict_table_for_range(block_start);
     }
 
+    /// Mark the dict table as fully built (CDict-equivalent). Called by the
+    /// driver after the final dictionary chunk has been primed, so the next
+    /// frame's [`Self::prime_dict_table_for_range`] skips the re-hash while
+    /// the dict bytes are still re-committed to history. Only marks when a
+    /// table actually exists — a sub-8-byte dict builds no table and must
+    /// re-run the (cheap, no-op) prime path each frame.
+    pub(crate) fn mark_dict_primed(&mut self) {
+        if self.dict_table.is_some() {
+            self.dict_primed = true;
+        }
+    }
+
+    /// Drop the cached dict table and its primed flag. Called by the driver
+    /// when the next frame carries no dictionary, so the kernel never probes
+    /// a stale dict region whose bytes are no longer re-committed.
+    pub(crate) fn invalidate_dict_cache(&mut self) {
+        self.dict_table = None;
+        self.dict_region_len = 0;
+        self.dict_primed = false;
+    }
+
     /// Build (or extend) [`Self::dict_table`] over `history[range_start..]`,
     /// the freshly-appended dictionary bytes. Lazily allocates the dict table
     /// at the same `(hash_log, mls)` as the main table so one hash keys both.
@@ -1165,6 +1200,13 @@ impl FastKernelMatcher {
         // Record the dict/input boundary regardless of whether any position
         // is hashable (a sub-8-byte dict still bounds the input floor).
         self.dict_region_len = history_len;
+        if self.dict_primed {
+            // CDict-equivalent fast path: `dict_table` was built over the
+            // identical dictionary bytes on a prior frame, and those bytes
+            // sit at the same absolute history positions now (the dict is
+            // re-committed before this call). Skip the re-hash entirely.
+            return;
+        }
         if history_len < HASH_READ_SIZE {
             return;
         }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -137,6 +137,7 @@ const INITIAL_PREFIX_START_INDEX: u32 = 1;
 ///   across blocks (cleared only on full `reset`).
 /// - `pending` holds the most recently `commit_space`'d block before
 ///   `start_matching` appends it onto `history` and runs the kernel.
+#[derive(Clone)]
 pub(crate) struct FastKernelMatcher {
     /// Concatenated input history: prior-block bytes followed by the
     /// most-recently-committed (still pending-matching) tail.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -137,7 +137,6 @@ const INITIAL_PREFIX_START_INDEX: u32 = 1;
 ///   across blocks (cleared only on full `reset`).
 /// - `pending` holds the most recently `commit_space`'d block before
 ///   `start_matching` appends it onto `history` and runs the kernel.
-#[derive(Clone)]
 pub(crate) struct FastKernelMatcher {
     /// Concatenated input history: prior-block bytes followed by the
     /// most-recently-committed (still pending-matching) tail.

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -288,10 +288,13 @@ impl<E: FseEntry> FSETableImpl<E> {
     /// but skip the bytes copy.
     pub fn reinit_from(&mut self, other: &Self) {
         self.reset();
-        self.symbol_probabilities
-            .extend_from_slice(&other.symbol_probabilities);
-        self.symbol_spread_buffer
-            .reserve(other.symbol_spread_buffer.len());
+        // Copy ONLY the decode-time state. `symbol_probabilities` and
+        // `symbol_spread_buffer` are build-time scratch ("used while building
+        // the decode Vector"): the decode hot path and Repeat-mode reuse read
+        // only `decode` + `accuracy_log`, and any block that rebuilds the
+        // table (`build_decoder`) repopulates the scratch itself. Skipping
+        // them mirrors the donor copying just the FSE decode table per frame
+        // instead of the full build workspace.
         self.decode.extend_from_slice(&other.decode);
         self.accuracy_log = other.accuracy_log;
     }

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -356,13 +356,15 @@ impl HuffmanTable {
     /// of `other`.
     pub fn reinit_from(&mut self, other: &Self) {
         self.reset();
+        // Copy ONLY the decode-time state. `weights` / `bits` /
+        // `rank_indexes` and the weight-decoding `fse_table` are build-time
+        // scratch (repopulated when a block carries a new HUF table); the
+        // literal-decode hot path reads only `packed_decode` + `max_num_bits`
+        // + `state_mask`. Skipping the rest mirrors the donor copying just the
+        // HUF decode table per frame, not the full build workspace.
         self.packed_decode.extend_from_slice(&other.packed_decode);
-        self.weights.extend_from_slice(&other.weights);
         self.max_num_bits = other.max_num_bits;
         self.state_mask = other.state_mask;
-        self.bits.extend_from_slice(&other.bits);
-        self.rank_indexes.extend_from_slice(&other.rank_indexes);
-        self.fse_table.reinit_from(&other.fse_table);
     }
 
     /// Completely empty the table of all data.


### PR DESCRIPTION
## Summary

Cuts the per-frame cost of reusing a dictionary across frames on both the decode and encode sides, and moves the per-block decompression-bomb ceiling off the per-match decode hot path.

### Decode: share the dictionary by handle
- `DecodeBuffer` holds the dictionary as a refcounted handle (`Option<DictionaryHandle>`) instead of an owned per-frame `Vec<u8>` copy. Reusing a dictionary across frames (and across decoder instances/threads) now costs a refcount bump, never a content memcpy. `repeat_from_dict` reads match bytes straight out of the handle.
- Dictionary re-init copies only the decode-essential entropy (FSE `decode` table + accuracy_log; HUF `packed_decode` + max_num_bits + state_mask) rather than the full table set.

### Encode: warm dictionary reuse
- Share the dictionary entropy tables (HUF/LL/ML/OF) by handle instead of cloning them into every frame.
- CDict-equivalent for the Fast attach path: small-source dictionary frames (at/below the Fast 8 KiB attach cutoff) re-prime each frame, which re-committed the dict bytes to history AND re-hashed every position. The built dict table is now retained across a same-shape reset and the per-frame re-hash is skipped (the dictionary lands at identical absolute history positions every frame, so the cached hashes stay valid). The dict bytes are still re-committed (needed for match extension); only the hashing is elided. Output is byte-identical (cold-cache == warm-cache, verified by test).
- Key the prime snapshot on the fully resolved matcher shape, not the raw source-size hint. The key is the resolved `LevelParams` (window-log cap, HC/Fast table and search geometry, parse depth) plus the active backend's applied Dfast/Row hash-table width, the level, and the Fast attach-vs-copy mode. Two hints that resolve to the identical matcher now share one snapshot instead of each forcing a full re-prime: same-bucket hints (e.g. 300 KiB / 400 KiB) and, for Level 22, hints that land in the same donor source-size tier across different ceil-log buckets (e.g. 20 KiB / 100 KiB). Hints that resolve to a different shape still refuse a restore, preserving the window-mismatch guard. The attach/copy mode is in the key because the 8 KiB cutoff falls inside a single resolved shape (an 8192- vs 8193-byte L1 hint resolves to identical params but a different dict-table shape), so the snapshot identity stays self-sufficient.
- Gate the prime-snapshot copy to large sources (the copy regime is only cheaper than re-priming above the cutoff).
- Size the per-block read buffer to the source-size hint instead of always zero-filling a full `MAX_BLOCK_SIZE` per block, without saturating arithmetic.

### Decode: relocate the decompression-bomb ceiling
The per-block output ceiling (guards a crafted frame whose sequences over-produce within one block, which would drive the growable `RingBuffer` to gigabytes before the post-block check runs) was checked in `repeat_inner` on **every** match copy. That compare bloated the `#[inline(always)]` repeat path inlined into the pipelined sequence loop.

It is now enforced on the cold growth path: the growable backends (`RingBuffer` and `FlatBuf`) carry a `max_capacity` lowered per block via `set_max_capacity`, and their `try_reserve` rejects a reserve that would have to **grow** past it. A well-formed block is fully covered by the upfront `reserve(MAX_BLOCK_SIZE)`, so its matches never reach the check; only an over-producing match forces a grow and is rejected (`OutputBufferOverflow`). `FlatBuf` is included because its inline exec path is capacity-bounded but the fallback `push`/`repeat` route (taken when the inline literal-slack gate fails) grows through `try_reserve` — without the override a malformed single-segment block could still grow past the ceiling. The per-match `BlockOutputExceedsMax` variant is removed; `DecodeBufferError` is `#[non_exhaustive]`. The ceiling is checked BEFORE the no-growth fast path in both backends, so a write that fits existing capacity (a large pre-reserved FCS buffer, or an over-allocated ring) but exceeds the per-block ceiling is still rejected rather than silently admitted. `repeat_from_dict` also `try_reserve`s before appending dictionary bytes, so a match satisfied from the dictionary is bounded too instead of bypassing the guard via a direct `extend`. The length sums in these growth paths use checked/plain arithmetic, not `saturating_add`, so a broken bound fails at its cause instead of silently clamping.

### Decode: single-compare sequence bounds check
The per-sequence output-capacity guard on the inline `exec_sequence` hot path is unified into `sequence_output_fits` in `buffer_backend`, shared by all six inline variants (`FlatBuf` and `UserSliceBackend`, each SSE2 / portable / AVX2). The per-variant `checked_add` chain (overflow check + tail + total + overshoot, two match branches) becomes one subtraction and one compare on plain arithmetic: `lit_length`/`match_length` are each bounded by the maximum FSE LL/ML code expansion (~131 KB) so the sums cannot overflow `usize` even on 32-bit, and `tail <= cap` holds on entry (`Vec` len ≤ capacity for the flat buffer; the user-slice tail only advances past this same check) so `cap - tail` cannot underflow.

## Testing
- Full unit + cross-validation + roundtrip suite passes (740 on x86_64); clippy + fmt clean; i686 builds (the over-producing-block fuzz regression still surfaces a decode `Err`, and the `reserve_amortized` 32-bit debug-assert panic path is no longer reached for over-production).
- i9 compress bench vs `main` (small-1k-random + decodecorpus-synthetic-1m, c_ffi control arm flat across both runs): no regression on any cutoff-strategy level. On the 1 KiB fixture L1 is unchanged and L3–L22 are 12–35% faster; on the 1 MiB corpus all levels are within ±1% (noise).
- New tests: warm-cache dict frame byte-identical to cold-cache and to a fresh single-frame compressor; in-bounds match still succeeds under an armed block ceiling; same-bucket source-size hints share the prime snapshot while different-shape hints refuse the restore; two Level 22 hints in the same donor tier (20 KiB / 100 KiB, different ceil-log buckets) share one snapshot; the AVX2 `FlatBuf` inline exec still returns `OutputBufferOverflow` on an over-producing sequence under the single-compare guard; a `FlatBuf` reserve past the armed per-block ceiling is rejected both with and without growth; a dict-backed match (fully or mixed dictionary+buffer) past the ceiling is rejected instead of bypassing the guard; and a copy-mode snapshot is not restored into an attach-mode reset across the 8 KiB boundary.
- i9 bench (small-4k-log-lines lazy decode): the OOM-guard relocation is perf-neutral (decode ~2.5 us measured identically pre-guard, with the per-match guard, and on this branch). The dashboard "-31%" lazy-decode alert is a re-baselining artifact (per-kernel attribution + bench corpus-masking fix), not a code regression: measured decode time is constant across the relevant commits.

## Notes
- `retire_dictionary_budget` keeps `saturating_sub`: the reclaimed budget can legitimately exceed the current `max_window_size` after a prior eviction, so the floor at 0 is the correct clamp (documented inline; `checked_sub` would panic on the real reclaim>window case exercised by `dfast_commit_space_eviction_uses_window_size_delta`).

Closes #349

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter output-capacity checks with clearer overflow errors to reject oversized decompression outputs earlier.

* **Performance**
  * Reduced per-frame work and fewer allocations via reuse of prepared tables, cached primed state, and dictionary snapshots.
  * Streaming memory growth is now capped to prevent unbounded allocation.
  * Benchmarks adjusted for fairer steady-state dictionary compression comparisons.

* **Improvements**
  * More reliable dictionary priming and snapshot restore for consistent, byte-identical outputs across frames.

* **Tests**
  * Added/updated tests validating primed-dictionary reuse and overflow behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




