### PR TITLE
perf(decode): single-compare bounds check in exec_sequence_inline_avx2

### DIFF
--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -425,31 +425,23 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // this overshoot for well-formed frames.
         const MAX_WILDCOPY_OVERSHOOT: usize = 31;
         let cap = self.slice.len();
-        let total = match lit_length.checked_add(match_length) {
-            Some(v) => v,
-            None => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: usize::MAX,
-                    capacity: cap,
-                });
-            }
-        };
-        let cap_required = self
-            .tail
-            .checked_add(total)
-            .and_then(|new_tail| new_tail.checked_add(MAX_WILDCOPY_OVERSHOOT));
-        let cap_required = match cap_required {
-            Some(v) if v <= cap => v,
-            _ => {
-                return Err(ExecuteSequencesError::OutputBufferOverflow {
-                    tail: self.tail,
-                    requested: total,
-                    capacity: cap,
-                });
-            }
-        };
-        let _ = cap_required;
+        // `lit_length` and `match_length` are each bounded by the maximum
+        // FSE LL/ML code expansion (~131 KB), so `total` and
+        // `total + MAX_WILDCOPY_OVERSHOOT` cannot overflow `usize` (even on
+        // 32-bit). `self.tail <= cap` holds on entry: `from_slice` starts at
+        // 0 and every prior sequence only advanced `tail` after passing the
+        // same check below (`total + overshoot <= cap - tail` ⇒
+        // `new_tail < cap`), so `cap - self.tail` cannot underflow. This
+        // single subtraction + compare replaces a per-sequence `checked_add`
+        // chain (runs on every sequence on the decode hot path).
+        let total = lit_length + match_length;
+        if total + MAX_WILDCOPY_OVERSHOOT > cap - self.tail {
+            return Err(ExecuteSequencesError::OutputBufferOverflow {
+                tail: self.tail,
+                requested: total,
+                capacity: cap,
+            });
+        }
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);


### PR DESCRIPTION
## Summary

Cuts per-sequence overhead on the direct-decode hot path. `exec_sequence_inline_avx2` (UserSliceBackend, ~15% decoder self-time on z000033) validated output-buffer capacity with a `checked_add` chain on every sequence: a `total` overflow check, a `tail + total + overshoot` checked chain, and two match branches.

`lit_length` and `match_length` are each bounded by the maximum FSE LL/ML code expansion (~131 KiB), so `total` and `total + overshoot` cannot overflow `usize` even on 32-bit; `tail <= cap` holds on entry (`from_slice` starts at 0 and every prior sequence advanced `tail` only after the same check), so `cap - tail` cannot underflow. The chain collapses to one subtraction and one compare with plain arithmetic.

## Result (i9-9900K, compare_ffi decompress c_stream, pure_rust)

Baseline = cascade base, candidate = this branch, same SSH session, p<0.05:

| scenario | baseline | candidate | delta |
|---|---|---|---|
| decodecorpus-z000033 level_3_dfast | 1.5817 ms | 1.5546 ms | **-1.72%** |
| decodecorpus-z000033 level_4_dfast | 1.5943 ms | 1.5664 ms | **-1.75%** |
| decodecorpus-z000033 level_5_greedy | 1.6292 ms | 1.5967 ms | **-1.99%** |

## Testing
- 124 exec/roundtrip/cross-validation tests pass; clippy + fmt clean; i686 builds.
- Behaviour unchanged: an over-producing sequence still returns `OutputBufferOverflow` (the single compare rejects it before the unsafe wildcopy).

Stacked on #352.