### PR TITLE
feat(decoding): block-subset partial decode + per-block decompressed byte ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,11 @@ to interleave application metadata with zstd data, plus a
 block-subset partial decoder: `FrameDecoder::decode_blocks_partial(src,
 start_block, end_block)` decodes only the inner blocks covering a
 requested range (skipping the trailing ones) and preserves the clean
-prefix on a corrupt block, while `FrameEmitInfo::decompressed_byte_range`
-maps a decompressed byte offset to the block index a range query should
-ask for. Enable on the command line:
+prefix on a corrupt block, while
+`FrameEmitInfo::decompressed_byte_range(block_index)` returns the
+decompressed byte range of a given block, so a range query can locate
+which inner blocks cover a target byte window. Enable on the command
+line:
 
 ```bash
 cargo add structured-zstd --features lsm

--- a/README.md
+++ b/README.md
@@ -173,8 +173,13 @@ stream.read_to_end(&mut sink).unwrap();
 Behind the `lsm` Cargo feature (default **off**), `structured-zstd`
 exposes a typed `SkippableFrame` API
 (`structured_zstd::skippable`) for storage-format authors who need
-to interleave application metadata with zstd data. Enable on the
-command line:
+to interleave application metadata with zstd data, plus a
+block-subset partial decoder: `FrameDecoder::decode_blocks_partial(src,
+start_block, end_block)` decodes only the inner blocks covering a
+requested range (skipping the trailing ones) and preserves the clean
+prefix on a corrupt block, while `FrameEmitInfo::decompressed_byte_range`
+maps a decompressed byte offset to the block index a range query should
+ask for. Enable on the command line:
 
 ```bash
 cargo add structured-zstd --features lsm

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -912,6 +912,24 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         }
     }
 
+    /// Drop the first `n` visible bytes from the front without producing
+    /// them to any sink (advances the head, like the beyond-window drop in
+    /// [`Self::drop_to_window_size`] but for an exact count). Used by the
+    /// subset partial-decode path to discard the window-context bytes of the
+    /// skipped leading blocks once every in-range block is decoded and match
+    /// resolution is complete: they were retained only to back the in-range
+    /// blocks' match copies, never to be emitted. Does NOT mutate
+    /// `total_output_counter` (same rationale as `drop_to_window_size`).
+    ///
+    /// `n` must be `<= self.len()`.
+    #[cfg(feature = "lsm")]
+    pub(crate) fn discard_front(&mut self, n: usize) {
+        debug_assert!(n <= self.buffer.len());
+        if n != 0 {
+            self.buffer.drop_first_n(n);
+        }
+    }
+
     /// drain the buffer completely
     pub fn drain(&mut self) -> Vec<u8> {
         let (slice1, slice2) = self.buffer.as_slices();

--- a/zstd/src/decoding/errors.rs
+++ b/zstd/src/decoding/errors.rs
@@ -645,6 +645,17 @@ pub enum FrameDecoderError {
         frame_offset: u32,
         block: crate::encoding::frame_emit_info::FrameBlock,
     },
+    /// `FrameDecoder::decode_blocks_partial` was called with
+    /// `start_block > end_block` (the half-open block range is
+    /// empty-or-inverted and cannot describe a valid subset). API
+    /// misuse, surfaced as `Err` rather than a `PartialDecode`
+    /// outcome — distinct from a corrupt-frame stop, which is
+    /// reported via `PartialDecode::stopped_at`.
+    #[cfg(feature = "lsm")]
+    InvalidBlockRange {
+        start_block: u32,
+        end_block: u32,
+    },
 }
 
 #[cfg(feature = "std")]
@@ -791,6 +802,16 @@ impl core::fmt::Display for FrameDecoderError {
                     Some(byte) => write!(f, "0x{byte:02X}"),
                     None => write!(f, "<none> (single-segment frame omits window_descriptor)"),
                 }
+            }
+            #[cfg(feature = "lsm")]
+            FrameDecoderError::InvalidBlockRange {
+                start_block,
+                end_block,
+            } => {
+                write!(
+                    f,
+                    "Invalid block range for partial decode: start_block {start_block} > end_block {end_block}"
+                )
             }
         }
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -76,6 +76,10 @@ fn block_body_decode_error(
             block_size_field,
             block_type: header.block_type,
             last_block: header.last_block,
+            // Raw/RLE carry their regenerated size in the header;
+            // a Compressed block's is unknown until decoded, so
+            // `read_block_header` leaves `decompressed_size` 0 here.
+            decompressed_size: header.decompressed_size,
         },
     }
 }
@@ -363,6 +367,30 @@ impl DecoderScratchKind {
         }
     }
 
+    /// Drop visible output beyond `window_size` without producing it,
+    /// keeping the most recent `window_size` bytes available to back
+    /// future match copies. Used by `decode_blocks_partial` to bound
+    /// memory while decoding the leading (skipped) blocks into the window.
+    #[cfg(feature = "lsm")]
+    fn buffer_drop_to_window_size(&mut self) -> usize {
+        match self {
+            Self::Ring(s) => s.buffer.drop_to_window_size(),
+            Self::Flat(s) => s.buffer.drop_to_window_size(),
+        }
+    }
+
+    /// Drop exactly `n` bytes from the front of the visible output without
+    /// producing them. Used by `decode_blocks_partial` to discard the
+    /// leading blocks' window-context bytes once the in-range blocks are
+    /// decoded (match resolution complete), leaving only the in-range output.
+    #[cfg(feature = "lsm")]
+    fn buffer_discard_front(&mut self, n: usize) {
+        match self {
+            Self::Ring(s) => s.buffer.discard_front(n),
+            Self::Flat(s) => s.buffer.discard_front(n),
+        }
+    }
+
     fn decode_block_content<R: Read>(
         &mut self,
         decoder: &mut BlockDecoder,
@@ -399,6 +427,38 @@ pub enum BlockDecodingStrategy {
     All,
     UptoBlocks(usize),
     UptoBytes(usize),
+}
+
+/// Outcome of [`FrameDecoder::decode_blocks_partial`]: the decompressed
+/// bytes of the requested inner-block range plus where (if anywhere)
+/// decoding stopped early.
+///
+/// Behind the `lsm` Cargo feature.
+#[cfg(feature = "lsm")]
+#[derive(Debug)]
+pub struct PartialDecode {
+    /// Decompressed bytes of the in-range blocks actually decoded, in
+    /// frame order, as one contiguous buffer. `data.len()` equals the sum
+    /// of the decompressed sizes of blocks `start_block .. start_block +
+    /// blocks_decoded`.
+    pub data: alloc::vec::Vec<u8>,
+    /// First block whose output is in [`data`](Self::data) (equals the
+    /// requested `start_block`).
+    pub start_block: u32,
+    /// Number of in-range blocks successfully decoded into
+    /// [`data`](Self::data).
+    pub blocks_decoded: u32,
+    /// `Some((block_index, error))` if decoding stopped on a failing block
+    /// before reaching `end_block` (a corrupt block inside the range, or a
+    /// leading block needed for window context). `None` if the requested
+    /// range decoded cleanly or the frame's last block was reached first.
+    ///
+    /// When the failing block is a leading context block
+    /// (`block_index < start_block`), the in-range window could not be
+    /// built so [`data`](Self::data) is empty and `blocks_decoded` is 0.
+    pub stopped_at: Option<(u32, FrameDecoderError)>,
+    /// `true` if the frame's last block was reached during this decode.
+    pub frame_finished: bool,
 }
 
 impl FrameDecoderState {
@@ -1114,6 +1174,183 @@ impl FrameDecoder {
         }
 
         Ok(state.frame_finished)
+    }
+
+    /// Decode the inner blocks `[start_block, end_block)` of the current
+    /// frame and return their decompressed bytes as one contiguous buffer.
+    ///
+    /// Serves two consumer needs with one call:
+    ///
+    /// - **Range-query performance:** decode only the inner zstd blocks that
+    ///   cover a key range instead of the whole frame. Blocks before
+    ///   `start_block` are decoded into the window (zstd blocks share one
+    ///   window, so a leading block's bytes may be the match source for an
+    ///   in-range block and cannot simply be skipped) but their output is not
+    ///   returned; blocks at or after `end_block` are not decoded at all,
+    ///   which is the trailing-block work saving. Map a decompressed byte
+    ///   offset to a block index with
+    ///   [`FrameEmitInfo::decompressed_byte_range`].
+    /// - **Best-effort recovery:** if a block decode fails, decoding stops,
+    ///   the clean prefix of in-range output is preserved in
+    ///   [`PartialDecode::data`], and the failure is reported via
+    ///   [`PartialDecode::stopped_at`]. Passing `(0, u32::MAX)` decodes the
+    ///   whole frame, stopping at the first corrupt block (pure recovery).
+    ///
+    /// `end_block` is exclusive; pass `u32::MAX` to decode to the end of the
+    /// frame. Call on a freshly [`reset`](Self::reset) decoder (it decodes
+    /// from the frame's first block).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FrameDecoderError::NotYetInitialized`] if the decoder has not
+    /// been reset, and [`FrameDecoderError::InvalidBlockRange`] if
+    /// `start_block > end_block`. A corrupt block is NOT an `Err` here: it is
+    /// reported via [`PartialDecode::stopped_at`] so the clean prefix survives.
+    ///
+    /// [`FrameEmitInfo::decompressed_byte_range`]: crate::encoding::frame_emit_info::FrameEmitInfo::decompressed_byte_range
+    #[cfg(feature = "lsm")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lsm")))]
+    pub fn decode_blocks_partial(
+        &mut self,
+        mut source: impl Read,
+        start_block: u32,
+        end_block: u32,
+    ) -> Result<PartialDecode, FrameDecoderError> {
+        use FrameDecoderError as err;
+        if start_block > end_block {
+            return Err(err::InvalidBlockRange {
+                start_block,
+                end_block,
+            });
+        }
+        let state = self.state.as_mut().ok_or(err::NotYetInitialized)?;
+
+        // Mirror `decode_blocks`: pre-reserve the backing buffer to
+        // `window_size` so multi-block frames don't pay repeated grow steps.
+        let window_size = state.frame_header.window_size().unwrap_or(0) as usize;
+        state.decoder_scratch.reserve_buffer(window_size);
+
+        let mut block_dec = decoding::block_decoder::new();
+
+        // Bytes of prefix-window output that physically precede the first
+        // in-range block in the buffer. Captured at the prefix → in-range
+        // transition (after leading blocks were dropped to the window) so we
+        // can discard exactly those bytes once decoding is done. `None` until
+        // the first in-range block is reached.
+        let mut prefix_window_len: Option<usize> = None;
+        // Exact count of clean in-range decompressed bytes (sum of per-block
+        // length deltas of the in-range blocks that succeeded). Any partial
+        // bytes of a failing in-range block are excluded — the fused executor
+        // rolls the buffer back to the pre-block checkpoint on a sequence
+        // error, and anything left over is never counted here, so it is not
+        // drained into `data`.
+        let mut subset_bytes: u64 = 0;
+        let mut blocks_decoded: u32 = 0;
+        let mut stopped_at: Option<(u32, FrameDecoderError)> = None;
+
+        loop {
+            let block_index = state.block_counter as u32;
+            // Stop before decoding `end_block`: the trailing blocks are never
+            // touched (the perf win), and the frame's tail is left unread.
+            if block_index >= end_block || state.frame_finished {
+                break;
+            }
+            let in_range = block_index >= start_block;
+            // Snapshot the window length at the prefix → in-range boundary.
+            if in_range && prefix_window_len.is_none() {
+                prefix_window_len = Some(state.decoder_scratch.buffer_len());
+            }
+
+            let block_frame_offset = state.bytes_read_counter as u32;
+            let (block_header, block_header_size) = match block_dec.read_block_header(&mut source) {
+                Ok(v) => v,
+                Err(e) => {
+                    stopped_at = Some((
+                        block_index,
+                        block_header_decode_error(e, block_index, block_frame_offset),
+                    ));
+                    break;
+                }
+            };
+            state.bytes_read_counter += u64::from(block_header_size);
+
+            let len_before = state.decoder_scratch.buffer_len();
+            match state.decoder_scratch.decode_block_content(
+                &mut block_dec,
+                &block_header,
+                &mut source,
+            ) {
+                Ok(body_read) => state.bytes_read_counter += body_read,
+                Err(e) => {
+                    stopped_at = Some((
+                        block_index,
+                        block_body_decode_error(
+                            e,
+                            block_index,
+                            block_frame_offset,
+                            &block_header,
+                            block_header_size,
+                        ),
+                    ));
+                    break;
+                }
+            }
+            let produced = state.decoder_scratch.buffer_len() - len_before;
+            state.block_counter += 1;
+            if in_range {
+                subset_bytes += produced as u64;
+                blocks_decoded += 1;
+            }
+
+            if block_header.last_block {
+                state.frame_finished = true;
+                if state.frame_header.descriptor.content_checksum_flag() {
+                    let mut chksum = [0u8; 4];
+                    match source.read_exact(&mut chksum) {
+                        Ok(()) => {
+                            state.bytes_read_counter += 4;
+                            state.check_sum = Some(u32::from_le_bytes(chksum));
+                        }
+                        // A trailing-checksum read failure does not invalidate
+                        // the decoded bytes; surface it so the caller knows the
+                        // frame tail was truncated, but keep `data`.
+                        Err(e) => {
+                            stopped_at = Some((block_index, err::FailedToReadChecksum(e)));
+                        }
+                    }
+                }
+                break;
+            }
+
+            // Leading (out-of-range) block: bound memory to the window. We
+            // must NOT drop once in-range, or the in-range output we are about
+            // to return would be discarded.
+            if !in_range {
+                state.decoder_scratch.buffer_drop_to_window_size();
+            }
+        }
+
+        // The visible buffer is now `[prefix window][in-range clean][maybe
+        // trailing garbage from a failed in-range block]`. Drop the prefix
+        // window from the front (match resolution is complete, so it is no
+        // longer needed), then drain exactly the clean in-range byte count —
+        // any trailing garbage is left undrained and cleared on the next
+        // `reset`.
+        let w = prefix_window_len.unwrap_or(0);
+        state.decoder_scratch.buffer_discard_front(w);
+        let mut data = alloc::vec![0u8; subset_bytes as usize];
+        state
+            .decoder_scratch
+            .buffer_read_all(&mut data)
+            .map_err(err::FailedToDrainDecodebuffer)?;
+
+        Ok(PartialDecode {
+            data,
+            start_block,
+            blocks_decoded,
+            stopped_at,
+            frame_finished: state.frame_finished,
+        })
     }
 
     /// Collect bytes and retain window_size bytes while decoding is still going on.
@@ -2897,5 +3134,225 @@ mod tests {
 
         let decoder_checksums = decoder.computed_block_checksums();
         assert_eq!(decoder_checksums, encoder_checksums.as_slice());
+    }
+
+    // ── decode_blocks_partial (block-subset partial decode, lsm) ──
+
+    /// Build a multi-block compressible frame and return
+    /// `(compressed, full_decode, emit_info)`. The emit info's
+    /// `decompressed_byte_range` maps decompressed offsets to block indices.
+    #[cfg(feature = "lsm")]
+    fn multi_block_fixture() -> (
+        Vec<u8>,
+        Vec<u8>,
+        crate::encoding::frame_emit_info::FrameEmitInfo,
+    ) {
+        let mut data: Vec<u8> = Vec::with_capacity(400 * 1024);
+        let mut x = 0x9E37_79B9u32;
+        while data.len() < 400 * 1024 {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            let run = 16 + (x as usize % 48);
+            let byte = (x >> 24) as u8;
+            for _ in 0..run {
+                data.push(byte);
+            }
+            data.extend_from_slice(b"the quick brown fox jumps over the lazy dog\n");
+        }
+
+        let mut compressed = Vec::new();
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(data.as_slice());
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+        let info = compressor
+            .last_frame_emit_info()
+            .expect("emit info populated")
+            .clone();
+        drop(compressor);
+
+        let mut dec = FrameDecoder::new();
+        let mut full = alloc::vec![0u8; data.len()];
+        let n = dec
+            .decode_all(compressed.as_slice(), &mut full)
+            .expect("full decode");
+        full.truncate(n);
+        assert_eq!(full, data, "fixture must round-trip");
+        (compressed, full, info)
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_subset_matches_full_decode() {
+        let (compressed, full, info) = multi_block_fixture();
+        let nblocks = info.blocks.len() as u32;
+        assert!(
+            nblocks >= 4,
+            "fixture must have several blocks, got {nblocks}"
+        );
+        let half = nblocks / 2;
+        // Boundaries: 1 block, 2 blocks, half, all, and a non-zero start.
+        for &(s, e) in &[
+            (0u32, 1u32),
+            (0, 2),
+            (0, half),
+            (0, nblocks),
+            (1, 2),
+            (half, nblocks),
+        ] {
+            let mut source = compressed.as_slice();
+            let mut dec = FrameDecoder::new();
+            dec.reset(&mut source).unwrap();
+            let pd = dec
+                .decode_blocks_partial(&mut source, s, e)
+                .unwrap_or_else(|err| panic!("range [{s},{e}) errored: {err:?}"));
+
+            let start = info.decompressed_byte_range(s as usize).unwrap().start as usize;
+            let end = info.decompressed_byte_range((e - 1) as usize).unwrap().end as usize;
+            assert_eq!(
+                pd.data.as_slice(),
+                &full[start..end],
+                "subset bytes must equal the full-decode slice for [{s},{e})"
+            );
+            assert_eq!(pd.start_block, s);
+            assert_eq!(pd.blocks_decoded, e - s);
+            assert!(pd.stopped_at.is_none(), "clean range [{s},{e})");
+        }
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_recovers_clean_prefix_on_truncated_block() {
+        let (compressed, full, info) = multi_block_fixture();
+        let nblocks = info.blocks.len();
+        let k = nblocks / 2;
+        assert!(k >= 1, "need a clean prefix before the failing block");
+
+        // Truncate the source right after block k's 3-byte header, so its body
+        // read fails regardless of block type (0 body bytes available).
+        let cut = info.blocks[k].offset_in_frame as usize + info.blocks[k].header_size as usize;
+        let truncated = &compressed[..cut];
+
+        let mut source = truncated;
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let pd = dec.decode_blocks_partial(&mut source, 0, u32::MAX).unwrap();
+
+        let (idx, _err) = pd.stopped_at.expect("must stop on the truncated block");
+        assert_eq!(idx, k as u32, "stopped at the truncated block index");
+        assert_eq!(pd.blocks_decoded, k as u32, "blocks 0..k decoded cleanly");
+        assert!(!pd.frame_finished);
+        let clean_end = info.decompressed_byte_range(k).unwrap().start as usize;
+        assert_eq!(
+            pd.data.as_slice(),
+            &full[..clean_end],
+            "clean prefix preserved through the failure"
+        );
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_invalid_range_errors() {
+        let (compressed, _full, _info) = multi_block_fixture();
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let err = dec
+            .decode_blocks_partial(&mut source, 5, 2)
+            .expect_err("start > end must error");
+        assert!(matches!(
+            err,
+            crate::decoding::errors::FrameDecoderError::InvalidBlockRange {
+                start_block: 5,
+                end_block: 2,
+            }
+        ));
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_skips_trailing_blocks() {
+        let (compressed, full, info) = multi_block_fixture();
+        assert!(info.blocks.len() >= 3);
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let pd = dec.decode_blocks_partial(&mut source, 0, 1).unwrap();
+
+        assert_eq!(pd.blocks_decoded, 1);
+        assert!(pd.stopped_at.is_none());
+        assert!(!pd.frame_finished, "block 0 is not the last block");
+        let end = info.decompressed_byte_range(0).unwrap().end as usize;
+        assert_eq!(pd.data.as_slice(), &full[..end]);
+        // The trailing blocks + checksum were never consumed from the source.
+        assert!(
+            dec.bytes_read_from_source() < u64::from(info.total_size),
+            "only block 0's region should be consumed, read {} of {}",
+            dec.bytes_read_from_source(),
+            info.total_size
+        );
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn lsm_style_range_query_partial_recovery() {
+        // Simulates lsm-tree's range-query path: a key range resolves to a
+        // decompressed byte window, which maps to inner zstd block indices via
+        // `decompressed_byte_range`; decode only the covering blocks and check
+        // the wanted window is recovered exactly (no key outside, all inside).
+        let (compressed, full, info) = multi_block_fixture();
+        let total = full.len() as u64;
+        let want_start = total / 3;
+        let want_end = (total * 2) / 3;
+
+        // Map [want_start, want_end) to covering block indices.
+        let nblocks = info.blocks.len();
+        let mut start_block = 0u32;
+        let mut end_block = nblocks as u32;
+        for i in 0..nblocks {
+            let r = info.decompressed_byte_range(i).unwrap();
+            if r.start <= want_start && want_start < r.end {
+                start_block = i as u32;
+            }
+            if r.start < want_end && want_end <= r.end {
+                end_block = i as u32 + 1;
+                break;
+            }
+        }
+
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let pd = dec
+            .decode_blocks_partial(&mut source, start_block, end_block)
+            .unwrap();
+        assert!(pd.stopped_at.is_none());
+
+        let covered_start = info
+            .decompressed_byte_range(start_block as usize)
+            .unwrap()
+            .start;
+        let covered_end = info
+            .decompressed_byte_range((end_block - 1) as usize)
+            .unwrap()
+            .end;
+        assert!(
+            covered_start <= want_start && want_end <= covered_end,
+            "covering blocks must contain the wanted window"
+        );
+        assert_eq!(
+            pd.data.as_slice(),
+            &full[covered_start as usize..covered_end as usize],
+            "covered subset must equal the full-decode slice"
+        );
+        // Slice the exact key range out of the covered subset.
+        let off = (want_start - covered_start) as usize;
+        let len = (want_end - want_start) as usize;
+        assert_eq!(
+            &pd.data[off..off + len],
+            &full[want_start as usize..want_end as usize],
+            "exact key range recovered from the partial decode"
+        );
     }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -3213,14 +3213,20 @@ mod tests {
         );
         let half = nblocks / 2;
         // Boundaries: 1 block, 2 blocks, half, all, and a non-zero start.
+        // `(0, u32::MAX)` exercises the "decode to end of frame" sentinel,
+        // a distinct public contract from an explicit upper bound.
         for &(s, e) in &[
-            (0u32, 1u32),
+            (0u32, u32::MAX),
+            (0, 1),
             (0, 2),
             (0, half),
             (0, nblocks),
             (1, 2),
             (half, nblocks),
         ] {
+            // The sentinel decodes through the last block; map it to nblocks
+            // for the expected-slice / block-count arithmetic below.
+            let effective_end = if e == u32::MAX { nblocks } else { e };
             let mut source = compressed.as_slice();
             let mut dec = FrameDecoder::new();
             dec.reset(&mut source).unwrap();
@@ -3229,14 +3235,17 @@ mod tests {
                 .unwrap_or_else(|err| panic!("range [{s},{e}) errored: {err:?}"));
 
             let start = info.decompressed_byte_range(s as usize).unwrap().start as usize;
-            let end = info.decompressed_byte_range((e - 1) as usize).unwrap().end as usize;
+            let end = info
+                .decompressed_byte_range((effective_end - 1) as usize)
+                .unwrap()
+                .end as usize;
             assert_eq!(
                 pd.data.as_slice(),
                 &full[start..end],
                 "subset bytes must equal the full-decode slice for [{s},{e})"
             );
             assert_eq!(pd.start_block, s);
-            assert_eq!(pd.blocks_decoded, e - s);
+            assert_eq!(pd.blocks_decoded, effective_end - s);
             assert!(pd.stopped_at.is_none(), "clean range [{s},{e})");
         }
     }
@@ -3402,6 +3411,35 @@ mod tests {
             dec.can_collect(),
             0,
             "context bytes must not leak via collect()/read() when data is empty"
+        );
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_empty_range_leaves_no_residual() {
+        // Companion to the start-past-EOF case: an in-frame empty range `[k, k)`
+        // (k < EOF) takes the same `prefix_window_len == None` path but with
+        // `frame_finished == false` and up to `window_size` context bytes still
+        // physically present. Assert the buffer is fully cleared directly (a
+        // `can_collect()` check alone would pass even with <= window_size bytes
+        // retained, because it holds the window back).
+        let (compressed, _full, info) = multi_block_fixture();
+        let k = ((info.blocks.len() as u32) / 2).max(1);
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let pd = dec.decode_blocks_partial(&mut source, k, k).unwrap();
+
+        assert!(pd.data.is_empty(), "empty range must yield empty data");
+        assert_eq!(pd.blocks_decoded, 0);
+        assert!(
+            !pd.frame_finished,
+            "frame should still have trailing blocks"
+        );
+        assert_eq!(
+            dec.state.as_ref().unwrap().decoder_scratch.buffer_len(),
+            0,
+            "empty-range partial decode must not retain context bytes"
         );
     }
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -3355,4 +3355,69 @@ mod tests {
             "exact key range recovered from the partial decode"
         );
     }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn decode_blocks_partial_leaves_no_residual_when_no_in_range_block() {
+        // Regression: when the requested range reaches no in-range block (here
+        // start_block is past EOF, so every block is decoded only as window
+        // context), `PartialDecode::data` is empty — but the context bytes must
+        // NOT linger in the decoder buffer, or a later collect()/read() on the
+        // same decoder returns out-of-range data.
+        let (compressed, _full, info) = multi_block_fixture();
+        let nblocks = info.blocks.len() as u32;
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.reset(&mut source).unwrap();
+        let pd = dec
+            .decode_blocks_partial(&mut source, nblocks + 5, u32::MAX)
+            .unwrap();
+        assert!(pd.data.is_empty(), "no in-range block → empty data");
+        assert_eq!(pd.blocks_decoded, 0);
+        assert!(
+            pd.frame_finished,
+            "frame's last block was reached as context"
+        );
+        assert_eq!(
+            dec.can_collect(),
+            0,
+            "context bytes must not leak via collect()/read() when data is empty"
+        );
+    }
+
+    #[cfg(all(feature = "lsm", feature = "hash"))]
+    #[test]
+    fn decode_blocks_partial_captures_per_block_checksums() {
+        // Regression: with per-block checksums enabled, decode_blocks_partial
+        // must populate computed_block_checksums just like decode_blocks /
+        // decode_all — otherwise callers verifying per-block digests silently
+        // lose them on the partial path.
+        let (compressed, full, _info) = multi_block_fixture();
+
+        // Reference digests via decode_blocks (the path that captures them).
+        let mut ref_dec = FrameDecoder::new();
+        ref_dec.enable_per_block_checksums();
+        let mut rsrc = compressed.as_slice();
+        ref_dec.reset(&mut rsrc).unwrap();
+        while !ref_dec.is_finished() {
+            ref_dec
+                .decode_blocks(&mut rsrc, crate::decoding::BlockDecodingStrategy::All)
+                .unwrap();
+        }
+        let expected = ref_dec.computed_block_checksums().to_vec();
+        assert!(!expected.is_empty(), "fixture must have multiple blocks");
+        let _ = full;
+
+        // Partial decode of the whole frame must capture the same digests.
+        let mut source = compressed.as_slice();
+        let mut dec = FrameDecoder::new();
+        dec.enable_per_block_checksums();
+        dec.reset(&mut source).unwrap();
+        let _ = dec.decode_blocks_partial(&mut source, 0, u32::MAX).unwrap();
+        assert_eq!(
+            dec.computed_block_checksums(),
+            expected.as_slice(),
+            "partial decode must capture the same per-block checksums as full decode"
+        );
+    }
 }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1296,6 +1296,20 @@ impl FrameDecoder {
                 }
             }
             let produced = state.decoder_scratch.buffer_len() - len_before;
+            // Per-block XXH64 capture, mirroring `decode_blocks`: hash this
+            // block's just-decoded bytes BEFORE any window drop so the digest
+            // count stays 1:1 with the blocks decoded on this path too. Covers
+            // context (out-of-range) blocks as well, matching `decode_blocks`
+            // which hashes every block it decodes.
+            #[cfg(all(feature = "lsm", feature = "hash"))]
+            if self.per_block_checksums_enabled {
+                use core::hash::Hasher;
+                let (s1, s2) = state.decoder_scratch.last_n_as_slices(produced);
+                let mut h = twox_hash::XxHash64::with_seed(0);
+                h.write(s1);
+                h.write(s2);
+                self.computed_block_checksums.push(h.finish() as u32);
+            }
             state.block_counter += 1;
             if in_range {
                 subset_bytes += produced as u64;
@@ -1333,9 +1347,7 @@ impl FrameDecoder {
         // The visible buffer is now `[prefix window][in-range clean][maybe
         // trailing garbage from a failed in-range block]`. Drop the prefix
         // window from the front (match resolution is complete, so it is no
-        // longer needed), then drain exactly the clean in-range byte count —
-        // any trailing garbage is left undrained and cleared on the next
-        // `reset`.
+        // longer needed), then drain exactly the clean in-range byte count.
         let w = prefix_window_len.unwrap_or(0);
         state.decoder_scratch.buffer_discard_front(w);
         let mut data = alloc::vec![0u8; subset_bytes as usize];
@@ -1343,6 +1355,14 @@ impl FrameDecoder {
             .decoder_scratch
             .buffer_read_all(&mut data)
             .map_err(err::FailedToDrainDecodebuffer)?;
+
+        // Clear anything still buffered so a later `read()`/`collect()` on this
+        // decoder cannot surface out-of-range bytes: the leading-block window
+        // when no in-range block was reached (`prefix_window_len` stayed
+        // `None`, so `w` was 0), or trailing garbage from a failed in-range
+        // block. Only the returned `data` is the partial decode's output.
+        let residual = state.decoder_scratch.buffer_len();
+        state.decoder_scratch.buffer_discard_front(residual);
 
         Ok(PartialDecode {
             data,

--- a/zstd/src/decoding/mod.rs
+++ b/zstd/src/decoding/mod.rs
@@ -34,6 +34,8 @@ mod frame_decoder;
 mod streaming_decoder;
 
 pub use dictionary::{Dictionary, DictionaryHandle};
+#[cfg(feature = "lsm")]
+pub use frame_decoder::PartialDecode;
 pub use frame_decoder::{BlockDecodingStrategy, FrameDecoder};
 pub use streaming_decoder::StreamingDecoder;
 

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -249,12 +249,17 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     state: &mut CompressState<M>,
     last_block: bool,
     output: &mut Vec<u8>,
+    #[cfg(feature = "lsm")] mut block_decompressed_sizes: Option<&mut Vec<u32>>,
     #[cfg(all(feature = "lsm", feature = "hash"))] mut block_checksums: Option<&mut Vec<u32>>,
 ) {
     let mut scratch = core::mem::take(&mut state.block_scratch);
     collect_block_parts(state, &mut scratch.parts);
     if scratch.parts.sequences.len() <= 4 {
         let source_len = state.matcher.get_last_space().len();
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes.as_deref_mut() {
+            sink.push(source_len as u32);
+        }
         // `block_checksums: Option<&mut Vec<u32>>`; `as_deref_mut` unwraps
         // exactly one level of `&mut`, yielding `Option<&mut Vec<u32>>` here
         // (the blanket `impl<T: ?Sized> Deref for &mut T` has
@@ -334,6 +339,10 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         } else {
             chunk_lit_len + chunk_match_len
         };
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes.as_deref_mut() {
+            sink.push(src_size as u32);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums.as_deref_mut() {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -3141,21 +3141,7 @@ mod tests {
         // A multi-block compressible payload exercises the Compressed-block
         // path (whose regenerated size is NOT on the wire, so it relies on the
         // encode-side capture this test guards).
-        let mut data: Vec<u8> = Vec::with_capacity(400 * 1024);
-        let mut x = 0x9E37_79B9u32;
-        // Semi-repetitive: long runs interleaved with stride patterns so the
-        // encoder produces several Compressed blocks rather than one giant Raw.
-        while data.len() < 400 * 1024 {
-            x ^= x << 13;
-            x ^= x >> 17;
-            x ^= x << 5;
-            let run = 16 + (x as usize % 48);
-            let byte = (x >> 24) as u8;
-            for _ in 0..run {
-                data.push(byte);
-            }
-            data.extend_from_slice(b"the quick brown fox jumps over the lazy dog\n");
-        }
+        let data = emit_info_fixture_data();
 
         // Cover both the single-block-per-chunk path (Default) and the
         // Level(16..=22) post-split path (multiple physical partitions per
@@ -3203,6 +3189,22 @@ mod tests {
                 info.blocks.last().unwrap().last_block,
                 "final block must carry last_block ({level:?})"
             );
+
+            // Pin the Level(22) post-split path: the owned loop feeds the
+            // encoder MAX_BLOCK_SIZE input chunks, so without post-split the
+            // block count cannot exceed the chunk count. More blocks than
+            // chunks proves at least one chunk was split into multiple physical
+            // partitions (the per-partition `src_size` capture under test).
+            if matches!(level, super::CompressionLevel::Level(22)) {
+                let max_block = crate::common::MAX_BLOCK_SIZE as usize;
+                let n_chunks = data.len().div_ceil(max_block);
+                assert!(
+                    info.blocks.len() > n_chunks,
+                    "Level(22) must exercise post-split: {} blocks for {} input chunks",
+                    info.blocks.len(),
+                    n_chunks
+                );
+            }
 
             // Per-block ranges: contiguous, zero-based, summing to the full output.
             let mut expected_start = 0u64;
@@ -3252,6 +3254,90 @@ mod tests {
                 "out-of-range index yields None ({level:?})"
             );
         }
+    }
+
+    /// ~400 KiB semi-repetitive payload (long runs interleaved with a stride
+    /// phrase) that compresses into several multi-block frames across levels.
+    #[cfg(feature = "lsm")]
+    fn emit_info_fixture_data() -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::with_capacity(400 * 1024);
+        let mut x = 0x9E37_79B9u32;
+        while data.len() < 400 * 1024 {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            let run = 16 + (x as usize % 48);
+            let byte = (x >> 24) as u8;
+            for _ in 0..run {
+                data.push(byte);
+            }
+            data.extend_from_slice(b"the quick brown fox jumps over the lazy dog\n");
+        }
+        data
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn frame_emit_info_decompressed_ranges_match_on_borrowed_oneshot_path() {
+        // The borrowed one-shot path (`compress_independent_frame` ->
+        // `run_borrowed_block_loop` -> `compress_block_encoded_borrowed`)
+        // threads the decompressed-size sidecar through a DIFFERENT emit site
+        // than the owned/streaming loop, so it needs its own per-block mapping
+        // check. A Fast level keeps the encoder on the borrowed-eligible
+        // (Simple matcher) path.
+        let data = emit_info_fixture_data();
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        let compressed = compressor.compress_independent_frame(data.as_slice());
+        let info = compressor
+            .last_frame_emit_info()
+            .expect("emit info populated after compress_independent_frame")
+            .clone();
+        assert!(
+            info.blocks.len() >= 2,
+            "borrowed fixture must span multiple blocks (got {})",
+            info.blocks.len()
+        );
+        assert!(info.blocks.last().unwrap().last_block);
+
+        // Full decode reference.
+        let mut decoder = FrameDecoder::new();
+        let mut source = compressed.as_slice();
+        decoder.reset(&mut source).unwrap();
+        while !decoder.is_finished() {
+            decoder
+                .decode_blocks(&mut source, crate::decoding::BlockDecodingStrategy::All)
+                .unwrap();
+        }
+        let mut decoded = Vec::new();
+        decoder.collect_to_writer(&mut decoded).unwrap();
+        assert_eq!(decoded, data, "borrowed one-shot frame must round-trip");
+
+        // Each block's mapping must match real per-block bytes.
+        let mut expected_start = 0u64;
+        for i in 0..info.blocks.len() {
+            let range = info.decompressed_byte_range(i).unwrap();
+            assert_eq!(range.start, expected_start, "block {i} range contiguity");
+            let mut psrc = compressed.as_slice();
+            let mut pdec = FrameDecoder::new();
+            pdec.reset(&mut psrc).unwrap();
+            let pd = pdec
+                .decode_blocks_partial(&mut psrc, i as u32, i as u32 + 1)
+                .unwrap();
+            assert!(pd.stopped_at.is_none(), "block {i} must decode cleanly");
+            assert_eq!(
+                pd.data.as_slice(),
+                &decoded[range.start as usize..range.end as usize],
+                "borrowed block {i} partial-decode bytes must equal the full-decode slice"
+            );
+            expected_start = range.end;
+        }
+        assert_eq!(
+            expected_start,
+            decoded.len() as u64,
+            "ranges sum to full length"
+        );
     }
 
     #[cfg(feature = "std")]

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -122,6 +122,14 @@ pub struct FrameCompressor<
     /// Gated on `all(lsm, hash)` (see `per_block_checksums_enabled`).
     #[cfg(all(feature = "lsm", feature = "hash"))]
     block_checksums: Option<alloc::vec::Vec<u32>>,
+    /// Per-physical-block decompressed (regenerated) sizes captured
+    /// during `compress()`, in block-emit order (1:1 with
+    /// `frame_emit_info.blocks`). Always captured under `lsm` (no
+    /// opt-in, unlike `block_checksums`) because `FrameEmitInfo` is
+    /// always built under `lsm` and `decompressed_byte_range` needs
+    /// the per-block sizes. Cleared and refilled per frame.
+    #[cfg(feature = "lsm")]
+    block_decompressed_sizes: alloc::vec::Vec<u32>,
 }
 
 #[derive(Clone, Default)]
@@ -592,6 +600,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             per_block_checksums_enabled: false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             block_checksums: None,
+            #[cfg(feature = "lsm")]
+            block_decompressed_sizes: alloc::vec::Vec::new(),
         }
     }
 
@@ -740,6 +750,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 block_size: 0,
             };
             header.serialize(&mut all_blocks);
+            #[cfg(feature = "lsm")]
+            self.block_decompressed_sizes.push(0);
             #[cfg(all(feature = "lsm", feature = "hash"))]
             if let Some(checksums) = self.block_checksums.as_mut() {
                 checksums.push(xxh64_block_low32(&[]));
@@ -800,6 +812,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 start,
                 end,
                 &mut all_blocks,
+                #[cfg(feature = "lsm")]
+                Some(&mut self.block_decompressed_sizes),
                 #[cfg(all(feature = "lsm", feature = "hash"))]
                 self.block_checksums.as_mut(),
             );
@@ -839,6 +853,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             per_block_checksums_enabled: false,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             block_checksums: None,
+            #[cfg(feature = "lsm")]
+            block_decompressed_sizes: alloc::vec::Vec::new(),
         }
     }
 
@@ -915,6 +931,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         #[cfg(feature = "lsm")]
         {
             self.frame_emit_info = None;
+            // Always captured under lsm (drives `decompressed_byte_range`);
+            // clear, keep the allocation for a reused compressor.
+            self.block_decompressed_sizes.clear();
         }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         {
@@ -1207,6 +1226,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     block_size: 0,
                 };
                 header.serialize(&mut all_blocks);
+                #[cfg(feature = "lsm")]
+                self.block_decompressed_sizes.push(0);
                 #[cfg(all(feature = "lsm", feature = "hash"))]
                 if let Some(checksums) = self.block_checksums.as_mut() {
                     checksums.push(xxh64_block_low32(&[]));
@@ -1222,6 +1243,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                         block_size: uncompressed_data.len().try_into().unwrap(),
                     };
                     header.serialize(&mut all_blocks);
+                    #[cfg(feature = "lsm")]
+                    self.block_decompressed_sizes
+                        .push(uncompressed_data.len() as u32);
                     #[cfg(all(feature = "lsm", feature = "hash"))]
                     if let Some(checksums) = self.block_checksums.as_mut() {
                         checksums.push(xxh64_block_low32(&uncompressed_data));
@@ -1254,6 +1278,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                         uncompressed_data,
                         &mut all_blocks,
                         dict_active,
+                        #[cfg(feature = "lsm")]
+                        Some(&mut self.block_decompressed_sizes),
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         self.block_checksums.as_mut(),
                     );
@@ -1409,6 +1435,19 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 Some(v) => v,
                 None => return,
             };
+            // Decompressed (regenerated) size, captured per physical block
+            // during emit (1:1 with the wire blocks scanned here). Raw/RLE
+            // are also wire-derivable (`block_size_field`); fall back to that
+            // if the sidecar is somehow short, and to 0 for a Compressed
+            // block whose size is not on the wire.
+            let decompressed_size = self
+                .block_decompressed_sizes
+                .get(blocks.len())
+                .copied()
+                .unwrap_or(match block_type {
+                    BT::Raw | BT::RLE => block_size_field,
+                    _ => 0,
+                });
             blocks.push(FrameBlock {
                 offset_in_frame,
                 header_size: 3,
@@ -1416,6 +1455,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 block_size_field,
                 block_type,
                 last_block,
+                decompressed_size,
             });
             cursor += 3 + physical_body as usize;
             if last_block {
@@ -3080,6 +3120,109 @@ mod tests {
             chksum_from_data1, chksum_from_data2,
             "frame 1 and frame 2 should have the same checksum (same data, hash must reset per frame)"
         );
+    }
+
+    #[cfg(feature = "lsm")]
+    #[test]
+    fn frame_emit_info_decompressed_ranges_match_decoded_output() {
+        // Part A correctness: the per-block `decompressed_size` captured during
+        // encode (and the `decompressed_byte_range` prefix sum derived from it)
+        // must describe the real decoded output exactly — one entry per
+        // physical block, contiguous, summing to the full decompressed length.
+        // A multi-block compressible payload exercises the Compressed-block
+        // path (whose regenerated size is NOT on the wire, so it relies on the
+        // encode-side capture this test guards).
+        let mut data: Vec<u8> = Vec::with_capacity(400 * 1024);
+        let mut x = 0x9E37_79B9u32;
+        // Semi-repetitive: long runs interleaved with stride patterns so the
+        // encoder produces several Compressed blocks rather than one giant Raw.
+        while data.len() < 400 * 1024 {
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            let run = 16 + (x as usize % 48);
+            let byte = (x >> 24) as u8;
+            for _ in 0..run {
+                data.push(byte);
+            }
+            data.extend_from_slice(b"the quick brown fox jumps over the lazy dog\n");
+        }
+
+        // Cover both the single-block-per-chunk path (Default) and the
+        // Level(16..=22) post-split path (multiple physical partitions per
+        // input chunk), since lsm-tree compresses at zstd:22 and post-split
+        // is the riskiest capture site (per-partition `src_size`).
+        for level in [
+            super::CompressionLevel::Default,
+            super::CompressionLevel::Level(22),
+        ] {
+            let mut compressed = Vec::new();
+            let mut compressor = FrameCompressor::new(level);
+            // Pledge the source size so the high-level (22) window shrinks to
+            // fit the payload — otherwise level 22's default 128 MiB window
+            // exceeds the decoder's MAXIMUM_ALLOWED_WINDOW_SIZE cap. Still
+            // >= 128 KiB, so post-split eligibility is preserved.
+            compressor.set_source_size_hint(data.len() as u64);
+            compressor.set_source(data.as_slice());
+            compressor.set_drain(&mut compressed);
+            compressor.compress();
+
+            let info = compressor
+                .last_frame_emit_info()
+                .expect("emit info populated after compress")
+                .clone();
+
+            // Reference: full decode of the same frame.
+            let mut decoder = FrameDecoder::new();
+            let mut source = compressed.as_slice();
+            decoder.reset(&mut source).unwrap();
+            while !decoder.is_finished() {
+                decoder
+                    .decode_blocks(&mut source, crate::decoding::BlockDecodingStrategy::All)
+                    .unwrap();
+            }
+            let mut decoded = Vec::new();
+            decoder.collect_to_writer(&mut decoded).unwrap();
+            assert_eq!(decoded, data, "sanity: frame must round-trip ({level:?})");
+
+            assert!(
+                info.blocks.len() >= 2,
+                "fixture must span multiple blocks to exercise the mapping ({level:?}, got {})",
+                info.blocks.len()
+            );
+            assert!(
+                info.blocks.last().unwrap().last_block,
+                "final block must carry last_block ({level:?})"
+            );
+
+            // Per-block ranges: contiguous, zero-based, summing to the full output.
+            let mut expected_start = 0u64;
+            for i in 0..info.blocks.len() {
+                let range = info
+                    .decompressed_byte_range(i)
+                    .expect("in-bounds block has a range");
+                assert_eq!(
+                    range.start, expected_start,
+                    "block {i} range must start where the previous ended ({level:?})"
+                );
+                assert_eq!(
+                    u64::from(info.blocks[i].decompressed_size),
+                    range.end - range.start,
+                    "block {i} decompressed_size must equal its range width ({level:?})"
+                );
+                expected_start = range.end;
+            }
+            assert_eq!(
+                expected_start,
+                decoded.len() as u64,
+                "block decompressed sizes must sum to the full decoded length ({level:?})"
+            );
+            assert_eq!(
+                info.decompressed_byte_range(info.blocks.len()),
+                None,
+                "out-of-range index yields None ({level:?})"
+            );
+        }
     }
 
     #[cfg(feature = "std")]

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1471,6 +1471,23 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 break;
             }
         }
+        // Fail closed on a structurally incomplete scan: the loop must have
+        // consumed the whole block section AND ended on a parsed last block.
+        // A premature `last_block` (bytes left over) or a run-off without any
+        // last block would otherwise publish an invalid public `FrameEmitInfo`.
+        // Unreachable for a well-formed self-produced frame (debug_assert
+        // catches a regression); on release we bail, leaving `frame_emit_info`
+        // at `None` rather than handing back a corrupt layout.
+        if cursor != all_blocks.len() || !blocks.last().is_some_and(|b| b.last_block) {
+            debug_assert!(
+                false,
+                "incomplete block scan in populate_frame_emit_info: cursor={} len={} last_block={:?}",
+                cursor,
+                all_blocks.len(),
+                blocks.last().map(|b| b.last_block)
+            );
+            return;
+        }
         let checksum_range = if cfg!(feature = "hash") {
             let cs_start = match frame_header_len.checked_add(all_blocks_len_u32) {
                 Some(v) => v,
@@ -3294,6 +3311,16 @@ mod tests {
             .last_frame_emit_info()
             .expect("emit info populated after compress_independent_frame")
             .clone();
+        // Pin the compressed-block path: without this the fixture could regress
+        // into the raw-fast fallback and still pass via the Raw wire-size
+        // fallback in populate_frame_emit_info, never exercising the borrowed
+        // compressed-block sidecar capture this test targets.
+        assert!(
+            info.blocks
+                .iter()
+                .any(|b| matches!(b.block_type, crate::blocks::block::BlockType::Compressed)),
+            "borrowed-path fixture must emit at least one compressed block"
+        );
         assert!(
             info.blocks.len() >= 2,
             "borrowed fixture must span multiple blocks (got {})",

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1436,18 +1436,27 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 None => return,
             };
             // Decompressed (regenerated) size, captured per physical block
-            // during emit (1:1 with the wire blocks scanned here). Raw/RLE
-            // are also wire-derivable (`block_size_field`); fall back to that
-            // if the sidecar is somehow short, and to 0 for a Compressed
-            // block whose size is not on the wire.
-            let decompressed_size = self
-                .block_decompressed_sizes
-                .get(blocks.len())
-                .copied()
-                .unwrap_or(match block_type {
-                    BT::Raw | BT::RLE => block_size_field,
-                    _ => 0,
-                });
+            // during emit (1:1 with the wire blocks scanned here). Raw/RLE are
+            // wire-derivable (`block_size_field`), so a short sidecar still
+            // yields the correct value for them. A Compressed block's size is
+            // NOT on the wire: if the sidecar is missing its entry, fabricating
+            // 0 would publish a silently-wrong `decompressed_byte_range`. Since
+            // this metadata is the authoritative mapping for a successful
+            // encode, bail out (leave `frame_emit_info` at `None`) rather than
+            // hand back a corrupt layout; the 1:1 push invariant makes this
+            // unreachable in practice (debug_assert catches a regression).
+            let decompressed_size = match self.block_decompressed_sizes.get(blocks.len()).copied() {
+                Some(size) => size,
+                None if matches!(block_type, BT::Raw | BT::RLE) => block_size_field,
+                None => {
+                    debug_assert!(
+                        false,
+                        "missing decompressed-size sidecar entry for compressed block {}",
+                        blocks.len()
+                    );
+                    return;
+                }
+            };
             blocks.push(FrameBlock {
                 offset_in_frame,
                 header_size: 3,
@@ -3209,6 +3218,26 @@ mod tests {
                     u64::from(info.blocks[i].decompressed_size),
                     range.end - range.start,
                     "block {i} decompressed_size must equal its range width ({level:?})"
+                );
+                // Validate the mapping against REAL per-block bytes, not just
+                // prefix-sum consistency: decode block `i` alone and require it
+                // to equal the corresponding slice of the full decode. A
+                // sidecar that swapped sizes between adjacent blocks (same sum,
+                // same contiguity) would fail here.
+                let mut psrc = compressed.as_slice();
+                let mut pdec = FrameDecoder::new();
+                pdec.reset(&mut psrc).unwrap();
+                let pd = pdec
+                    .decode_blocks_partial(&mut psrc, i as u32, i as u32 + 1)
+                    .unwrap();
+                assert!(
+                    pd.stopped_at.is_none(),
+                    "block {i} must decode cleanly ({level:?})"
+                );
+                assert_eq!(
+                    pd.data.as_slice(),
+                    &decoded[range.start as usize..range.end as usize],
+                    "block {i} partial-decode bytes must equal the full-decode slice ({level:?})"
                 );
                 expected_start = range.end;
             }

--- a/zstd/src/encoding/frame_emit_info.rs
+++ b/zstd/src/encoding/frame_emit_info.rs
@@ -66,6 +66,22 @@ pub struct FrameBlock {
     /// `true` only on the final block of the frame (matches the
     /// `Last_Block` flag in `Block_Header`).
     pub last_block: bool,
+    /// Decompressed (regenerated) size of this block's output in bytes.
+    ///
+    /// For Raw and RLE blocks this is recoverable from the wire
+    /// (`block_size_field`), but a Compressed block's regenerated size is
+    /// NOT in its `Block_Header` (the header's `Block_Size` is the
+    /// *compressed* length), so the encoder captures it from the input
+    /// chunk that produced the block. Consumers map a decompressed byte
+    /// offset to a block index via the prefix sum of this field; see
+    /// [`FrameEmitInfo::decompressed_byte_range`].
+    ///
+    /// On the decode error path ([`FailedToReadBlockBodyAt`]), where the
+    /// regenerated size of a failed Compressed block is unknown, this is
+    /// `0` for Compressed blocks (Raw/RLE still carry their wire size).
+    ///
+    /// [`FailedToReadBlockBodyAt`]: crate::decoding::errors::FrameDecoderError::FailedToReadBlockBodyAt
+    pub decompressed_size: u32,
 }
 
 /// Complete layout of an emitted zstd frame.
@@ -92,4 +108,54 @@ pub struct FrameEmitInfo {
     /// Total emitted frame size in bytes (one past the last byte of
     /// the frame).
     pub total_size: u32,
+}
+
+impl FrameEmitInfo {
+    /// Half-open decompressed byte range `[start, end)` of `blocks[block_index]`
+    /// within the frame's full decompressed output, computed as the prefix
+    /// sum of every preceding block's [`FrameBlock::decompressed_size`].
+    ///
+    /// This is the mapping a range-query consumer uses to turn a
+    /// decompressed byte offset into the inner-block index needed by
+    /// [`FrameDecoder::decode_blocks_partial`]: find the first block whose
+    /// range contains the offset.
+    ///
+    /// Returns `None` if `block_index` is out of bounds.
+    ///
+    /// [`FrameDecoder::decode_blocks_partial`]: crate::decoding::FrameDecoder::decode_blocks_partial
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(feature = "lsm")] {
+    /// use structured_zstd::encoding::frame_emit_info::{FrameBlock, FrameEmitInfo, BlockType};
+    /// let info = FrameEmitInfo {
+    ///     frame_header_range: 0..6,
+    ///     blocks: vec![
+    ///         FrameBlock { offset_in_frame: 6, header_size: 3, body_size: 10,
+    ///             block_size_field: 10, block_type: BlockType::Compressed,
+    ///             last_block: false, decompressed_size: 100 },
+    ///         FrameBlock { offset_in_frame: 19, header_size: 3, body_size: 20,
+    ///             block_size_field: 20, block_type: BlockType::Compressed,
+    ///             last_block: true, decompressed_size: 40 },
+    ///     ],
+    ///     checksum_range: None,
+    ///     total_size: 42,
+    /// };
+    /// assert_eq!(info.decompressed_byte_range(0), Some(0..100));
+    /// assert_eq!(info.decompressed_byte_range(1), Some(100..140));
+    /// assert_eq!(info.decompressed_byte_range(2), None);
+    /// # }
+    /// ```
+    pub fn decompressed_byte_range(&self, block_index: usize) -> Option<core::ops::Range<u64>> {
+        let target = self.blocks.get(block_index)?;
+        // Prefix sum over preceding blocks. Block count is bounded by the
+        // frame's block count (each block is >= 3 wire bytes), so the
+        // accumulator stays well within u64.
+        let start: u64 = self.blocks[..block_index]
+            .iter()
+            .map(|b| u64::from(b.decompressed_size))
+            .sum();
+        Some(start..start + u64::from(target.decompressed_size))
+    }
 }

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -29,6 +29,12 @@ use alloc::vec::Vec;
 /// - `uncompressed_data`: A block's worth of uncompressed data, taken from the
 ///   larger input
 /// - `output`: As `uncompressed_data` is compressed, it's appended to `output`.
+// Mirrors the per-block sidecar plumbing of its borrowed sibling
+// (`compress_block_encoded_borrowed`): the lsm decompressed-size and
+// optional XXH64 checksum out-params push the arg count past the lint's
+// threshold. Bundling them into a struct would diverge from the established
+// emit-fn shape for no readability gain.
+#[allow(clippy::too_many_arguments)]
 #[inline]
 pub(crate) fn compress_block_encoded<M: Matcher>(
     state: &mut CompressState<M>,
@@ -42,12 +48,22 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
     // dictionary is never searched and the block is emitted raw. C always
     // searches and only falls back to raw post-hoc; we mirror that here.
     dict_active: bool,
+    // Per-physical-block decompressed (regenerated) size sidecar, in
+    // block-emit order — 1:1 with `FrameEmitInfo.blocks`, same cardinality
+    // discipline as the XXH64 checksum sidecar. Captured under `lsm` alone
+    // (not gated on `hash`, not opt-in) because `FrameEmitInfo` is always
+    // built under `lsm` and every block needs its `decompressed_size`.
+    #[cfg(feature = "lsm")] block_decompressed_sizes: Option<&mut Vec<u32>>,
     #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = uncompressed_data.len() as u32;
     // First check to see if run length encoding can be used for the entire block
     if uncompressed_data.iter().all(|x| uncompressed_data[0].eq(x)) {
         let rle_byte = uncompressed_data[0];
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
@@ -72,6 +88,10 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
             &uncompressed_data,
         )
     {
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(
@@ -97,14 +117,27 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
             && state.matcher.window_size() >= (1 << 17)
         {
             // This helper may emit multiple physical blocks (compressed or raw)
-            // into `output`; checksums (if requested) are pushed per physical
-            // block from inside the partition loop so the cardinality matches
-            // the decoder's per-block hash count exactly.
+            // into `output`; the decompressed-size and (if requested) checksum
+            // sidecars are pushed per physical block from inside the partition
+            // loop so the cardinality matches the decoder's per-block count
+            // exactly.
             #[cfg(all(feature = "lsm", feature = "hash"))]
-            compress_block_with_post_split(state, last_block, output, block_checksums);
-            #[cfg(not(all(feature = "lsm", feature = "hash")))]
+            compress_block_with_post_split(
+                state,
+                last_block,
+                output,
+                block_decompressed_sizes,
+                block_checksums,
+            );
+            #[cfg(all(feature = "lsm", not(feature = "hash")))]
+            compress_block_with_post_split(state, last_block, output, block_decompressed_sizes);
+            #[cfg(not(feature = "lsm"))]
             compress_block_with_post_split(state, last_block, output);
             return BlockType::Compressed;
+        }
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
         }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
@@ -190,11 +223,16 @@ pub(crate) fn compress_block_encoded_borrowed(
     block_start: usize,
     block_end: usize,
     output: &mut Vec<u8>,
+    #[cfg(feature = "lsm")] block_decompressed_sizes: Option<&mut Vec<u32>>,
     #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
 ) -> BlockType {
     let block_size = block.len() as u32;
     if !block.is_empty() && block.iter().all(|x| block[0].eq(x)) {
         let rle_byte = block[0];
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(block));
@@ -210,6 +248,10 @@ pub(crate) fn compress_block_encoded_borrowed(
         output.push(rle_byte);
         BlockType::RLE
     } else if should_emit_raw_fast_path(compression_level, state.matcher.window_size(), block) {
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             sink.push(crate::encoding::frame_compressor::xxh64_block_low32(block));
@@ -233,6 +275,10 @@ pub(crate) fn compress_block_encoded_borrowed(
         // Stage the borrowed range so `compress_block`'s internal
         // `start_matching` scans it in place (no `commit_space` copy).
         state.matcher.set_borrowed_block(block_start, block_end);
+        #[cfg(feature = "lsm")]
+        if let Some(sink) = block_decompressed_sizes {
+            sink.push(block_size);
+        }
         #[cfg(all(feature = "lsm", feature = "hash"))]
         if let Some(sink) = block_checksums {
             // Hash the block bytes directly: the staged borrowed range is
@@ -350,6 +396,8 @@ mod tests {
             vec![0xAB; 1024],
             &mut output,
             false,
+            #[cfg(feature = "lsm")]
+            None,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );
@@ -394,6 +442,8 @@ mod tests {
             block.clone(),
             &mut output,
             false,
+            #[cfg(feature = "lsm")]
+            None,
             #[cfg(all(feature = "lsm", feature = "hash"))]
             None,
         );

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -431,6 +431,10 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         // The streaming encoder has no dictionary state, so the
                         // raw-fast-path stays enabled (no dict to match against).
                         false,
+                        // No FrameEmitInfo on the streaming encoder path — it
+                        // does not surface per-block layout, so no sidecar.
+                        #[cfg(feature = "lsm")]
+                        None,
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         None,
                     );


### PR DESCRIPTION
## Summary

Implements #175 as a **block-subset partial decode** primitive (serves range-query performance first, best-effort recovery as a secondary mode of the same call), plus the encode-side mapping a consumer needs to drive it. All new surface is gated behind the `lsm` Cargo feature (default off); the default build stays byte-identical and drop-in for `libzstd` v1.5.7.

### Decode side
- `FrameDecoder::decode_blocks_partial(src, start_block, end_block) -> Result<PartialDecode, _>`
  - Blocks before `start_block` are decoded into the window (zstd blocks share one window, so a leading block can be a match source and cannot be skipped) but their output is not returned; blocks at/after `end_block` are not decoded at all (the trailing-block work saving).
  - Returns the in-range decompressed bytes as one contiguous `Vec` (a range query needs contiguous bytes anyway; avoids the ring's two-slice + window-retention ambiguity).
  - On a corrupt block, stops and preserves the clean in-range prefix in `PartialDecode::data`, reporting the failure via `PartialDecode::stopped_at`. `(0, u32::MAX)` = decode the whole frame, stop at first corruption (pure recovery).
  - Drives the existing decode machinery (`decode_block_content`, ring/flat dispatch, FSE/HUF/SIMD kernels, the fused executor's checkpoint-rollback) rather than bypassing it.

### Encode side (mapping prerequisite)
- `FrameBlock::decompressed_size` + `FrameEmitInfo::decompressed_byte_range(i) -> Option<Range<u64>>` let a consumer map a decompressed byte offset to the block index to request. Captured encode-side because a Compressed block's regenerated size is not on the wire; threaded through both emit paths including post-split partitions, 1:1 with the physical blocks.

## Testing
- default (no `lsm`): 714/714 pass, output byte-identical (drop-in surface untouched).
- `lsm`: 749/749 pass, incl. 6 new tests: subset == full-decode slice across `{1, 2, half, all, start>0}` boundaries; clean-prefix recovery on a truncated block; `InvalidBlockRange`; trailing-blocks-not-consumed; an lsm-style range-query integration test; and Part A range-mapping verified against the real decoded output on Default **and** Level-22 post-split.
- `lsm` without `hash`: new tests pass (the size sidecar exists without the checksum one).
- `cargo clippy -D warnings` clean (default + `lsm`); `decompressed_byte_range` doctest passes; `cargo doc` renders the new items.

## Notes
- Downstream consumer: lsm-tree #257 (updated to this final API).
- Pre-existing `cargo doc -D warnings` broken intra-doc links (README `LICENSE`/`dictionary`, `OutputBufferOverflow`, etc.) are unrelated to this change and left for a separate docs pass.

Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Partial block decoding: decode a specified block range and return the decoded contiguous prefix
  * Per-block decompressed-size metadata and a decompressed-byte-range lookup to map bytes ↔ blocks
  * Encoding records per-block decompressed sizes to support precise range mapping

* **Documentation**
  * Expanded README LSM section with skippable-frame details, partial-decoding behavior, and enablement placement

* **Bug Fixes**
  * Preserve clean decoded prefix on truncated/corrupt blocks; surface invalid block-range errors

* **Tests**
  * Added tests for subset decoding, clean-prefix recovery, invalid-range handling, and byte-range mapping
<!-- end of auto-generated comment: release notes by coderabbit.ai -->