### PR TITLE
perf: dict-attach across match finders + decode peak-alloc

### DIFF
--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -552,34 +552,6 @@ for row in ratios:
         "status": classify_ratio_delta(ratio_delta),
     }
 
-# Dictionary-path ratio (`REPORT_DICT`) → `compress-dict` stage so the
-# `*_dict` / `*_ldm_dict` levels carry a rust-vs-ffi ratio on the relative
-# dashboard. The plain `compress/` group skips dict levels (they emit only
-# `REPORT_DICT`, never a plain `REPORT`), so without this they'd appear with
-# speed only — or, for dict-only levels like `level_22_btultra2_ldm_dict`,
-# not at all. The Rust side is comparable only when the Rust dict path
-# produced a frame (`rust_with_dict_bytes > 0` → ratio > 0); when it's
-# unavailable the bench logs `0` and we skip the row rather than plot a
-# bogus delta. Keyed on the same `(compress-dict, scenario, level, None)`
-# tuple the `compress-dict` timing rows use, so ratio + speed join.
-for row in dictionary_rows:
-    if row["rust_with_dict_ratio"] <= 0.0 or row["ffi_with_dict_ratio"] <= 0.0:
-        continue
-    key = canonical_key("compress-dict", row["scenario"], row["level"], None)
-    ratio_delta = row["rust_with_dict_ratio"] / row["ffi_with_dict_ratio"]
-    ratio_index[key] = {
-        "meta": {
-            "stage": "compress-dict",
-            "scenario": row["scenario"],
-            "level": row["level"],
-            "source": None,
-        },
-        "rust_ratio": row["rust_with_dict_ratio"],
-        "ffi_ratio": row["ffi_with_dict_ratio"],
-        "delta": ratio_delta,
-        "status": classify_ratio_delta(ratio_delta),
-    }
-
 speed_index = defaultdict(dict)
 key_meta = {}
 for row in timing_rows:

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -552,6 +552,34 @@ for row in ratios:
         "status": classify_ratio_delta(ratio_delta),
     }
 
+# Dictionary-path ratio (`REPORT_DICT`) → `compress-dict` stage so the
+# `*_dict` / `*_ldm_dict` levels carry a rust-vs-ffi ratio on the relative
+# dashboard. The plain `compress/` group skips dict levels (they emit only
+# `REPORT_DICT`, never a plain `REPORT`), so without this they'd appear with
+# speed only — or, for dict-only levels like `level_22_btultra2_ldm_dict`,
+# not at all. The Rust side is comparable only when the Rust dict path
+# produced a frame (`rust_with_dict_bytes > 0` → ratio > 0); when it's
+# unavailable the bench logs `0` and we skip the row rather than plot a
+# bogus delta. Keyed on the same `(compress-dict, scenario, level, None)`
+# tuple the `compress-dict` timing rows use, so ratio + speed join.
+for row in dictionary_rows:
+    if row["rust_with_dict_ratio"] <= 0.0 or row["ffi_with_dict_ratio"] <= 0.0:
+        continue
+    key = canonical_key("compress-dict", row["scenario"], row["level"], None)
+    ratio_delta = row["rust_with_dict_ratio"] / row["ffi_with_dict_ratio"]
+    ratio_index[key] = {
+        "meta": {
+            "stage": "compress-dict",
+            "scenario": row["scenario"],
+            "level": row["level"],
+            "source": None,
+        },
+        "rust_ratio": row["rust_with_dict_ratio"],
+        "ffi_ratio": row["ffi_with_dict_ratio"],
+        "delta": ratio_delta,
+        "status": classify_ratio_delta(ratio_delta),
+    }
+
 speed_index = defaultdict(dict)
 key_meta = {}
 for row in timing_rows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,28 +47,22 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust_core: ${{ steps.filter.outputs.rust_core }}
-      wasm_core: ${{ steps.filter.outputs.wasm_core }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
+            # `rust_core` gates BOTH bench pipelines (native `bench-matrix`
+            # and the wasm-vs-bokuweb `bench-wasm` shard). The wasm payload
+            # compiles the core crate to wasm32, so the numbers it tracks
+            # move exactly when the core crate / manifests / toolchain move,
+            # NOT when the wasm-crate / npm glue changes (that path is
+            # validated by the always-on `wasm` job instead). A push that
+            # touches only wasm / npm / ts / js / CI / docs cannot move the
+            # compression behaviour, so both bench cascades skip it.
             rust_core:
               - 'zstd/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
-              - 'rust-toolchain.toml'
-            # The wasm-vs-bokuweb dashboard shard (`bench-wasm`) only needs
-            # to re-run when something that can move the wasm payloads'
-            # speed/ratio changed: the core crate (compiled into the wasm
-            # module), the wasm crate / npm glue itself, the bench harness,
-            # or the dep/toolchain pins. A push touching only the native
-            # bench scripts, docs, or unrelated CI leaves the wasm numbers
-            # untouched, so the wasm shard stays green-skipped on it.
-            wasm_core:
-              - 'zstd/**'
-              - 'zstd-wasm/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -318,16 +312,16 @@ jobs:
     # locally before an npm publish.
     #
     # Push-to-main only (consistent with the rest of the bench pipeline
-    # being push-only — #362) and gated on `wasm_core` so it skips pushes
-    # that can't move the wasm numbers. It is INDEPENDENT of the native
-    # `bench-matrix` cascade (which is `rust_core`-gated): a wasm-only
-    # change must still update the dashboard. It publishes only
+    # being push-only — #362) and gated on `rust_core`, the SAME gate as
+    # the native `bench-matrix` cascade: the wasm payload compiles the core
+    # crate to wasm32, so its numbers move when the Rust compressor changes,
+    # not when the wasm-crate / npm glue changes. It publishes only
     # `benchmark-wasm.json` to gh-pages — `index.html` stays owned by
     # `benchmark-pages` / `pages-only.yml` — so the two publishers write
     # disjoint files and never race for the same blob.
     name: Bench wasm vs bokuweb (dashboard shard)
     needs: [lint, changes]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.wasm_core == 'true'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.rust_core == 'true'
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ on:
       - 'docs/**'
       - 'LICENSE*'
       - '.gitignore'
+  # Manual trigger: lets the wasm dashboard shard (`bench-wasm`) be
+  # refreshed on demand for changes the push path doesn't auto-gate on
+  # — e.g. a wasm bench-harness / parser edit that moves the published
+  # numbers without touching the `rust_core` paths that gate the shard.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -321,7 +326,7 @@ jobs:
     # disjoint files and never race for the same blob.
     name: Bench wasm vs bokuweb (dashboard shard)
     needs: [lint, changes]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.rust_core == 'true'
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.rust_core == 'true')
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+# Coverage is collected on a single x86_64 Linux job. The codec carries
+# arch-specific kernel tiers — aarch64 NEON and wasm32 `simd128` — behind
+# `#[cfg(target_arch = ...)]`, so on the x86_64 coverage run that code is
+# compiled out and its source lines can never be executed. codecov still
+# sees those lines in a PR diff and counts them as "missing", which
+# structurally drags patch coverage down on any change that touches a
+# mixed-arch module (e.g. `encoding/row/mod.rs`, which interleaves the
+# SSE4.2 / AVX2 / NEON / simd128 row tiers in one file).
+#
+# Keep the patch status INFORMATIONAL (posted for visibility, never
+# blocking) rather than gating PRs on structurally-uncoverable arch code.
+# The project status still enforces the overall coverage trend, so a real
+# drop in covered native code is still caught.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true
+
+# Whole-file arch-only modules: NEON fastpath kernels are aarch64-only, so
+# they are never compiled on the x86_64 coverage job. Exclude them outright
+# so they neither count as missing nor dilute the project number.
+ignore:
+  - "zstd/src/encoding/fastpath/neon.rs"
+  - "zstd/benches/**"
+  - "zstd/fuzz/**"

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -566,6 +566,14 @@ fn bench_dictionary(c: &mut Criterion) {
             continue;
         };
         let ffi_train_ms = ffi_train_started.elapsed().as_secs_f64() * 1_000.0;
+        // Diagnostic: dump the exact trained dict per scenario so the
+        // sequence comparator can diff against the SAME dict the
+        // compress-dict bench/REPORT use. Gated on an env var so normal
+        // bench runs are unaffected.
+        if let Ok(dir) = std::env::var("STRUCTURED_ZSTD_DUMP_DICT_DIR") {
+            let path = format!("{dir}/{}.dict", scenario.id);
+            std::fs::write(&path, &ffi_dictionary).expect("dump dict");
+        }
 
         if emit_reports {
             emit_dictionary_training_report(

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -60,7 +60,7 @@ use std::path::Path;
 
 use structured_zstd::encoding::CompressionLevel;
 use structured_zstd::encoding::sequence_capture::{
-    CapturedRawSequence, compress_and_collect_sequences,
+    CapturedRawSequence, compress_and_collect_sequences, compress_and_collect_sequences_with_dict,
 };
 
 /// Default level set when `STRUCTURED_ZSTD_BENCH_LEVEL` is unset.
@@ -126,16 +126,23 @@ fn main() {
         .ok()
         .and_then(|s| s.trim().parse::<usize>().ok())
         .unwrap_or(default_rows);
+    // Optional dictionary: `STRUCTURED_ZSTD_BENCH_DICT=<path>` attaches
+    // the (serialized or raw-content) dict to BOTH sides before capturing
+    // sequences, so the diff reflects the dict-primed match decisions.
+    let dict_bytes: Option<Vec<u8>> = std::env::var("STRUCTURED_ZSTD_BENCH_DICT")
+        .ok()
+        .map(|p| fs::read(p.trim()).expect("read STRUCTURED_ZSTD_BENCH_DICT path"));
     let fixtures = collect_fixtures();
     println!(
-        "=== compare_ffi_sequences (levels={}, Rust vs C FFI) ===",
+        "=== compare_ffi_sequences (levels={}, dict={}, Rust vs C FFI) ===",
         fmt_levels(&levels),
+        if dict_bytes.is_some() { "yes" } else { "no" },
     );
     println!();
     for (name, bytes) in &fixtures {
         println!("=== fixture: {name} ===");
         for &level in &levels {
-            run_one(name, bytes, level, max_rows);
+            run_one(name, bytes, level, max_rows, dict_bytes.as_deref());
         }
         println!();
     }
@@ -287,7 +294,39 @@ fn collect_fixtures() -> Vec<(String, Vec<u8>)> {
     let log = build_low_entropy_log(16 * 1024);
     out.push((format!("low-entropy log ({} bytes)", log.len()), log));
 
+    // Byte-for-byte the bench `small-4k-log-lines` scenario so the
+    // dict-primed diff reproduces the L3 dfast compress-dict ratio gap
+    // exactly (pair with a dict trained on the same 4 log lines via
+    // `STRUCTURED_ZSTD_BENCH_DICT`).
+    let logs4k = repeated_log_lines(4096);
+    out.push((
+        format!("small-4k-log-lines ({} bytes)", logs4k.len()),
+        logs4k,
+    ));
+
     out
+}
+
+/// Byte-for-byte the bench `repeated_log_lines(len)` fixture (and the
+/// `encode_loop_dict` example's `logs<N>` input).
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        for line in LINES {
+            if bytes.len() == len {
+                break;
+            }
+            let remaining = len - bytes.len();
+            bytes.extend_from_slice(&line.as_bytes()[..line.len().min(remaining)]);
+        }
+    }
+    bytes
 }
 
 /// Synthesize repeating log-line shapes for `byte_budget` bytes.
@@ -316,9 +355,14 @@ fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
     out
 }
 
-fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize) {
-    let rust_capture = compress_and_collect_sequences(input, CompressionLevel::Level(level));
-    let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, level);
+fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize, dict: Option<&[u8]>) {
+    let rust_capture = match dict {
+        Some(d) => {
+            compress_and_collect_sequences_with_dict(input, CompressionLevel::Level(level), d)
+        }
+        None => compress_and_collect_sequences(input, CompressionLevel::Level(level)),
+    };
+    let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, level, dict);
     let rust_seqs = &rust_capture.sequences;
     let rust_tail_lengths = &rust_capture.block_tail_lengths;
 
@@ -588,7 +632,11 @@ fn align_and_diff(
 /// Without this, FFI runs behind Rust by exactly the trailing-literal
 /// count after every block boundary on multi-block inputs (PR #149
 /// review #1-#3).
-fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
+fn ffi_generate_sequences(
+    input: &[u8],
+    level: i32,
+    dict: Option<&[u8]>,
+) -> (Vec<FfiSeq>, Vec<u32>) {
     use zstd::zstd_safe::{self, zstd_sys};
     // Mirror of `assert_zstd_ok` in `encoding/match_generator.rs` —
     // surfaces libzstd's symbolic error name in the panic message
@@ -630,6 +678,20 @@ fn ffi_generate_sequences(input: &[u8], level: i32) -> (Vec<FfiSeq>, Vec<u32>) {
                 14,
             );
             assert_zstd_ok(rc, "ZSTD_CCtx_setParameter(ZSTD_c_windowLog=14)");
+        }
+        // Attach the dictionary so the donor parser sees the same primed
+        // state the Rust `set_dictionary_from_bytes` path applies.
+        // `ZSTD_CCtx_loadDictionary` auto-detects a serialized dict
+        // (magic) vs raw content and seeds the matcher tables, offset
+        // history, and entropy tables — the same priming the Rust
+        // capture's dict variant reproduces.
+        if let Some(d) = dict {
+            let rc = zstd_sys::ZSTD_CCtx_loadDictionary(
+                cctx,
+                d.as_ptr() as *const core::ffi::c_void,
+                d.len(),
+            );
+            assert_zstd_ok(rc, "ZSTD_CCtx_loadDictionary");
         }
         let n = zstd_sys::ZSTD_generateSequences(
             cctx,

--- a/zstd/src/decoding/exec_sequence_inline.rs
+++ b/zstd/src/decoding/exec_sequence_inline.rs
@@ -26,6 +26,49 @@
 //! See the [`portable`] module doc for how the inline path is reached
 //! per target.
 
+/// Exact, non-overshooting literal+match copy of one sequence at
+/// `base[tail..]` — the cold-path twin of the SIMD wildcopy bodies. Every
+/// inline-exec site (the per-kernel macros below and
+/// [`super::user_slice_buf::UserSliceBackend::exec_sequence_bounded`])
+/// routes its tight-tail branch here: the trailing sequence(s) of an
+/// exact-fit output slice, where the wildcopy overshoot would run past the
+/// buffer end. Portable (`core::ptr` only), so it is shared across all
+/// kernel tiers; the per-tier divergence lives only in the fast path.
+///
+/// # Safety
+/// - `base` is valid for writes over `[tail, tail + lit_length + match_length)`.
+/// - `lit_src` is valid for reads of exactly `lit_length` bytes.
+/// - `offset >= 1` and `offset <= tail + lit_length` (match source stays
+///   inside the already-written region).
+#[inline]
+pub(crate) unsafe fn exec_sequence_bounded_copy(
+    base: *mut u8,
+    tail: usize,
+    lit_src: *const u8,
+    lit_length: usize,
+    offset: usize,
+    match_length: usize,
+) {
+    unsafe {
+        let op_lit = base.add(tail);
+        core::ptr::copy_nonoverlapping(lit_src, op_lit, lit_length);
+        let op_match = base.add(tail + lit_length);
+        let match_src = base.cast_const().add(tail + lit_length - offset);
+        if offset >= match_length {
+            // No overlap: source range ends before destination starts.
+            core::ptr::copy_nonoverlapping(match_src, op_match, match_length);
+        } else {
+            // Overlapping LZ copy: forward byte-by-byte replicates the
+            // `offset`-periodic pattern (donor `ZSTD_overlapCopy`, scalar form).
+            let mut i = 0usize;
+            while i < match_length {
+                *op_match.add(i) = *match_src.add(i);
+                i += 1;
+            }
+        }
+    }
+}
+
 /// Textual expansion of the AVX2 `ZSTD_execSequence` body at the call
 /// site, fusing the match-copy into a per-tier sequence monolith. A
 /// `#[target_feature(avx2)]` function cannot be `#[inline(always)]`
@@ -62,13 +105,10 @@ macro_rules! exec_sequence_avx2_inline {
         let backend = $buffer.buffer_mut();
         let cap = backend.cap();
         let tail = backend.tail();
-        match sequence_output_fits(
-            lit_length_v,
-            match_length_v,
-            tail,
-            cap,
-            MAX_WILDCOPY_OVERSHOOT,
-        ) {
+        // Hard guard with `overshoot = 0`; the <=31-byte wildcopy slack is
+        // handled by the tight-tail branch below so an exact-fit output
+        // slice (no `WILDCOPY_OVERLENGTH` trailing room) stays correct.
+        match sequence_output_fits(lit_length_v, match_length_v, tail, cap, 0) {
             Err(e) => Err(e),
             Ok(total) => {
                 // SAFETY: the enclosing fn carries
@@ -76,24 +116,42 @@ macro_rules! exec_sequence_avx2_inline {
                 // path is gated on `B::SUPPORTS_INLINE_SEQUENCE_EXEC`, so the
                 // backend is linear and overrides `inline_exec_base_ptr` /
                 // `inline_exec_commit`. `sequence_output_fits` validated
-                // `tail + total + overshoot <= cap`.
+                // `tail + total <= cap`.
                 unsafe {
                     let base = backend.inline_exec_base_ptr();
-                    let op_lit = base.add(tail);
-                    copy16(op_lit, lit_src_v);
-                    if lit_length_v > 16 {
-                        wildcopy_no_overlap(op_lit.add(16), lit_src_v.add(16), lit_length_v - 16);
-                    }
-                    let op_match = base.add(tail + lit_length_v);
-                    let match_src = base.cast_const().add(tail + lit_length_v - offset_v);
-                    if offset_v >= 32 {
-                        wildcopy_no_overlap_avx2(op_match, match_src, match_length_v);
-                    } else if offset_v >= 16 {
-                        wildcopy_no_overlap(op_match, match_src, match_length_v);
+                    if total + MAX_WILDCOPY_OVERSHOOT > cap - tail {
+                        // Tight tail: literal+match fit exactly but the
+                        // wildcopy overshoot would write past `cap`. Shared
+                        // exact, non-overshooting copy.
+                        $crate::decoding::exec_sequence_inline::exec_sequence_bounded_copy(
+                            base,
+                            tail,
+                            lit_src_v,
+                            lit_length_v,
+                            offset_v,
+                            match_length_v,
+                        );
                     } else {
-                        let (op2, ip2) = overlap_copy8(op_match, match_src, offset_v);
-                        if match_length_v > 8 {
-                            wildcopy_overlap_8byte_stride(op2, ip2, match_length_v - 8);
+                        let op_lit = base.add(tail);
+                        let op_match = base.add(tail + lit_length_v);
+                        let match_src = base.cast_const().add(tail + lit_length_v - offset_v);
+                        copy16(op_lit, lit_src_v);
+                        if lit_length_v > 16 {
+                            wildcopy_no_overlap(
+                                op_lit.add(16),
+                                lit_src_v.add(16),
+                                lit_length_v - 16,
+                            );
+                        }
+                        if offset_v >= 32 {
+                            wildcopy_no_overlap_avx2(op_match, match_src, match_length_v);
+                        } else if offset_v >= 16 {
+                            wildcopy_no_overlap(op_match, match_src, match_length_v);
+                        } else {
+                            let (op2, ip2) = overlap_copy8(op_match, match_src, offset_v);
+                            if match_length_v > 8 {
+                                wildcopy_overlap_8byte_stride(op2, ip2, match_length_v - 8);
+                            }
                         }
                     }
                     backend.inline_exec_commit(tail + total);
@@ -131,34 +189,47 @@ macro_rules! exec_sequence_sse2_inline {
         let backend = $buffer.buffer_mut();
         let cap = backend.cap();
         let tail = backend.tail();
-        match sequence_output_fits(
-            lit_length_v,
-            match_length_v,
-            tail,
-            cap,
-            MAX_WILDCOPY_OVERSHOOT,
-        ) {
+        // Hard guard with `overshoot = 0`; the <=15-byte wildcopy slack is
+        // handled by the tight-tail branch below so an exact-fit output
+        // slice stays correct (see the AVX2 twin for rationale).
+        match sequence_output_fits(lit_length_v, match_length_v, tail, cap, 0) {
             Err(e) => Err(e),
             Ok(total) => {
                 // SAFETY: inline path gated on `B::SUPPORTS_INLINE_SEQUENCE_EXEC`
                 // (linear backend, overrides the accessors);
-                // `sequence_output_fits` validated `tail + total + 15 <= cap`.
+                // `sequence_output_fits` validated `tail + total <= cap`.
                 // All copy primitives are SSE2 baseline (no target_feature).
                 unsafe {
                     let base = backend.inline_exec_base_ptr();
-                    let op_lit = base.add(tail);
-                    copy16(op_lit, lit_src_v);
-                    if lit_length_v > 16 {
-                        wildcopy_no_overlap(op_lit.add(16), lit_src_v.add(16), lit_length_v - 16);
-                    }
-                    let op_match = base.add(tail + lit_length_v);
-                    let match_src = base.cast_const().add(tail + lit_length_v - offset_v);
-                    if offset_v >= 16 {
-                        wildcopy_no_overlap(op_match, match_src, match_length_v);
+                    if total + MAX_WILDCOPY_OVERSHOOT > cap - tail {
+                        // Tight tail: shared exact, non-overshooting copy.
+                        $crate::decoding::exec_sequence_inline::exec_sequence_bounded_copy(
+                            base,
+                            tail,
+                            lit_src_v,
+                            lit_length_v,
+                            offset_v,
+                            match_length_v,
+                        );
                     } else {
-                        let (op2, ip2) = overlap_copy8(op_match, match_src, offset_v);
-                        if match_length_v > 8 {
-                            wildcopy_overlap_8byte_stride(op2, ip2, match_length_v - 8);
+                        let op_lit = base.add(tail);
+                        let op_match = base.add(tail + lit_length_v);
+                        let match_src = base.cast_const().add(tail + lit_length_v - offset_v);
+                        copy16(op_lit, lit_src_v);
+                        if lit_length_v > 16 {
+                            wildcopy_no_overlap(
+                                op_lit.add(16),
+                                lit_src_v.add(16),
+                                lit_length_v - 16,
+                            );
+                        }
+                        if offset_v >= 16 {
+                            wildcopy_no_overlap(op_match, match_src, match_length_v);
+                        } else {
+                            let (op2, ip2) = overlap_copy8(op_match, match_src, offset_v);
+                            if match_length_v > 8 {
+                                wildcopy_overlap_8byte_stride(op2, ip2, match_length_v - 8);
+                            }
                         }
                     }
                     backend.inline_exec_commit(tail + total);

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -52,18 +52,19 @@ pub(crate) struct FlatBuf {
     max_capacity: usize,
 }
 
+#[cfg(test)]
 impl FlatBuf {
-    pub fn with_capacity(cap: usize) -> Self {
-        // +WILDCOPY_OVERLENGTH so any future SIMD overshoot write from
-        // a `push` / `repeat` near the buffer boundary lands inside
-        // the allocation. The slack region is intentionally left
-        // uninitialised: FlatBuf's current API only reads bytes
-        // inside `head..buf.len()` (`as_slices`, drain helpers), and
-        // its mutating helpers (`extend`, `extend_and_fill`,
-        // `extend_from_within_unchecked`) only WRITE past `len`
-        // before any matching `set_len`, never read it. Skipping the
-        // zero pass is intentional — it avoids paying O(cap) on every
-        // small single-segment frame reset.
+    /// Test-only pre-sized constructor. Production frame setup builds a
+    /// lazy zero-capacity `FlatBuf` (see `DecoderScratchKind::new_flat`)
+    /// and reserves it on demand; only the unit tests below want a
+    /// backend pre-grown to a known capacity.
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        // +WILDCOPY_OVERLENGTH so any SIMD overshoot write from a
+        // `push` / `repeat` near the buffer boundary lands inside the
+        // allocation. The slack region is intentionally left
+        // uninitialised: `FlatBuf` only reads bytes inside
+        // `head..buf.len()`, and its mutating helpers only WRITE past
+        // `len` before any matching `set_len`, never read it.
         Self {
             buf: Vec::with_capacity(cap + WILDCOPY_OVERLENGTH),
             head: 0,
@@ -79,9 +80,11 @@ impl BufferBackend for FlatBuf {
     /// architecture-agnostic `portable` module (the `cfg(not(x86_64))`
     /// arm below). FlatBuf is selected for single-segment frames
     /// (frame_content_size known up-front, single block of
-    /// literals+matches). Its `with_capacity(cap + WILDCOPY_OVERLENGTH)`
-    /// reserve already carries the SIMD overshoot slack the inline path
-    /// requires. Both arms are gated on this const, which is
+    /// literals+matches). Production sizing goes through `reserve`
+    /// (which adds `WILDCOPY_OVERLENGTH`); the SIMD overshoot the inline
+    /// path may emit is additionally bounded by the tight-tail copy in
+    /// the inline-exec sites, so a tight buffer never overshoots. Both
+    /// arms are gated on this const, which is
     /// unconditionally `true` because FlatBuf provides an override for
     /// every target.
     const SUPPORTS_INLINE_SEQUENCE_EXEC: bool = true;
@@ -101,7 +104,7 @@ impl BufferBackend for FlatBuf {
         };
         // Fallible capacity check. The caller's per-block
         // `reserve(MAX_BLOCK_SIZE)` plus the `WILDCOPY_OVERLENGTH`
-        // slack baked into `with_capacity` covers well-formed frames,
+        // slack `reserve` adds covers well-formed frames,
         // but a malformed sequence stream can produce a
         // `lit_length + match_length` that exceeds the reserved
         // headroom. Surface that as `OutputBufferOverflow` (mirrors
@@ -180,7 +183,7 @@ impl BufferBackend for FlatBuf {
         };
         // Fallible capacity check mirrors the x86 arm: the 16-byte
         // wildcopy overshoots up to 15 bytes past `tail + total`, which
-        // `with_capacity(... + WILDCOPY_OVERLENGTH)` covers for
+        // the `WILDCOPY_OVERLENGTH` slack `reserve` adds covers for
         // well-formed frames; malformed input surfaces as
         // `OutputBufferOverflow` instead of a write past capacity.
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
@@ -256,8 +259,8 @@ impl BufferBackend for FlatBuf {
             wildcopy_overlap_8byte_stride,
         };
         // Fallible capacity check. AVX2 32-byte stride overshoots up
-        // to 31 bytes past `tail + total`; FlatBuf's
-        // `with_capacity(... + WILDCOPY_OVERLENGTH = 32)` covers
+        // to 31 bytes past `tail + total`; the
+        // `WILDCOPY_OVERLENGTH = 32` slack `reserve` adds covers
         // well-formed frames, but malformed inputs that exceed the
         // reserved headroom surface as `OutputBufferOverflow` instead
         // of UB.
@@ -511,7 +514,7 @@ impl BufferBackend for FlatBuf {
         // `total_writable >= len` because Vec capacity covers the
         // upfront reserve. The helper may overshoot up to
         // `total_writable` (= cap - dst_off, which includes the
-        // WILDCOPY_OVERLENGTH slack baked into with_capacity).
+        // WILDCOPY_OVERLENGTH slack `reserve` adds).
         unsafe {
             let base = self.buf.as_mut_ptr();
             super::simd_copy::copy_bytes_overshooting(

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -255,11 +255,13 @@ impl DecoderScratchKind {
             match self {
                 Self::Flat(s) => {
                     s.reset(window_size);
-                    // DecodeBuffer::reset clears + reserves
-                    // window_size; FlatBuf's reserve grows the
-                    // backing Vec if the new FCS is larger than
-                    // what's already allocated. No alloc when the
-                    // previous flat frame had >= this capacity.
+                    // `DecoderScratch::reset` clears the backing buffer and
+                    // updates `window_size` WITHOUT reserving it (it may still
+                    // resize the per-block scratch Vecs up to
+                    // `min(window_size, MAX_BLOCK_SIZE)`). Backing-buffer
+                    // capacity is decided one layer up: direct-eligible frames
+                    // never touch it, and the non-direct path pre-reserves once
+                    // via `reserve_buffer(window_size)` at frame entry.
                 }
                 Self::Ring(_) => *self = Self::new_flat(window_size),
             }
@@ -297,6 +299,14 @@ impl DecoderScratchKind {
     /// `new_flat` are each lazy (no pre-reserve), so a direct-eligible
     /// frame writes only through `UserSliceBackend` and leaves this
     /// buffer empty.
+    /// `window_size` is the ADDITIONAL-bytes argument the backend `reserve`
+    /// contract expects (Vec-style `reserve(additional)` → `capacity >= len +
+    /// additional`, plus the backend's wildcopy slack). This is always called at
+    /// frame entry on a freshly-reset buffer (`len == 0`), so the additional
+    /// request equals the desired total window capacity. Do NOT pass
+    /// `window_size - buffer.len()`: when `len == 0` it's identical, and the
+    /// backend `reserve` impls deliberately reject that form because it
+    /// under-reserves on reused buffers (see `FlatBuf::reserve`).
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
         match self {

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -8,7 +8,6 @@ use super::frame;
 use crate::decoding;
 use crate::decoding::block_decoder::BlockDecoder;
 use crate::decoding::buffer_backend::BufferBackend;
-use crate::decoding::decode_buffer::DecodeBuffer;
 use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
 use crate::decoding::errors::{DecodeBlockContentError, FrameDecoderError};
 use crate::decoding::flat_buf::FlatBuf;
@@ -224,16 +223,23 @@ impl DecoderScratchKind {
         Self::Ring(s)
     }
 
-    /// Construct a flat-backed scratch sized for a single-segment
-    /// frame. `frame_content_size` is the upcoming output size in
-    /// bytes (== `window_size` when the flag is set).
+    /// Construct a flat-backed scratch for a single-segment frame.
+    /// `frame_content_size` is the upcoming output size in bytes
+    /// (== `window_size` when the flag is set).
+    ///
+    /// Lazy buffer allocation (mirrors [`Self::new_ring`]): do NOT
+    /// pre-size the `FlatBuf`. The direct-decode path
+    /// (`run_direct_decode`) writes through `UserSliceBackend` and never
+    /// touches this buffer, so eagerly allocating a full FCS wastes one
+    /// whole content-size of peak memory on the common direct-eligible
+    /// single-segment frame. The non-direct fallback reserves it once via
+    /// `reserve_buffer(window_size)` at frame entry before any block
+    /// write (`FlatBuf::reserve` adds the `WILDCOPY_OVERLENGTH` slack),
+    /// and every inline-exec site (trait method and per-kernel macros)
+    /// now carries a tight-tail bounded copy, so a tight buffer can never
+    /// overshoot regardless of construction-time slack.
     fn new_flat(frame_content_size: usize) -> Self {
-        let flat = FlatBuf::with_capacity(frame_content_size);
-        // DecoderScratch's default ctor would discard the pre-sized
-        // FlatBuf — go through from_backend so the buffer carries the
-        // capacity the constructor wants.
-        let mut s = DecoderScratch::<FlatBuf>::new(frame_content_size);
-        s.buffer = DecodeBuffer::from_backend(flat, frame_content_size);
+        let s = DecoderScratch::<FlatBuf>::new(frame_content_size);
         Self::Flat(s)
     }
 
@@ -286,13 +292,11 @@ impl DecoderScratchKind {
     /// decodes don't pay repeated `reserve_amortized` grow steps
     /// (128 KiB → 256 KiB → ... → window) as blocks accumulate.
     ///
-    /// Direct-eligible ring-backed frames never call this and pay zero
-    /// ring allocation for the window. Flat-backed (single-segment)
-    /// frames eagerly size their `FlatBuf` to `frame_content_size` at
-    /// `new_flat` construction time, so a direct-eligible flat frame
-    /// already paid for that capacity before this helper is reachable;
-    /// the "zero buffer allocation" guarantee here applies to the
-    /// ring path only.
+    /// Direct-eligible frames never call this and pay zero backing-buffer
+    /// allocation for the window, on BOTH backends: `new_ring` and
+    /// `new_flat` are each lazy (no pre-reserve), so a direct-eligible
+    /// frame writes only through `UserSliceBackend` and leaves this
+    /// buffer empty.
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
         match self {
@@ -466,14 +470,12 @@ impl FrameDecoderState {
     /// from `source`. When `magicless` is `true`, the 4-byte magic
     /// number prefix is NOT consumed (donor `ZSTD_f_zstd1_magicless`).
     /// Crate-internal — reached only via `FrameDecoder::init` /
-    /// `FrameDecoder::init_with_dict_handle`. For multi-segment
-    /// (ring-backed) frames the decode buffer is allocated lazily —
+    /// `FrameDecoder::init_with_dict_handle`. The decode buffer is
+    /// allocated lazily on BOTH backends (`new_ring` and `new_flat`):
     /// direct-eligible frames pay zero buffer allocation, and the
     /// non-direct fallback reserves `window_size` once in
-    /// `decode_all_impl` via `reserve_buffer`. Single-segment
-    /// (flat-backed) frames eagerly size the backing `FlatBuf` to
-    /// `frame_content_size` because the flat path writes the entire
-    /// output into the same buffer and cannot defer that allocation.
+    /// `decode_all_impl` / `decode_blocks` via `reserve_buffer` before
+    /// any block write.
     pub(crate) fn new_with_format(
         source: impl Read,
         magicless: bool,
@@ -510,17 +512,13 @@ impl FrameDecoderState {
     /// only via `FrameDecoder::reset`.
     ///
     /// `DecodeBuffer::reset` no longer reserves window_size for either
-    /// backend — capacity decisions live one layer up. For ring-backed
-    /// scratch, direct-eligible frames pay zero allocation here and
-    /// the non-direct path is pre-reserved by `decode_all_impl` /
-    /// `decode_blocks` via `DecoderScratchKind::reserve_buffer(window_size)`
-    /// before any block writes. Flat-backed scratch is sized to
-    /// `frame_content_size` by `DecoderScratchKind::new_flat` at first
-    /// construction (and on Ring → Flat transition); a reused flat
-    /// scratch whose new frame fits within the prior FCS reuses the
-    /// existing capacity, and one whose new FCS is larger is also
-    /// pre-reserved by the same `reserve_buffer(window_size)` call at
-    /// frame entry (single-segment frames have window_size == FCS).
+    /// backend — capacity decisions live one layer up. Both backends are
+    /// lazy: direct-eligible frames pay zero backing-buffer allocation
+    /// here (they write through `UserSliceBackend`), and the non-direct
+    /// path is pre-reserved by `decode_all_impl` / `decode_blocks` via
+    /// `DecoderScratchKind::reserve_buffer(window_size)` before any block
+    /// write. A reused scratch whose new frame fits within prior capacity
+    /// reuses it; a larger one grows on that same `reserve_buffer` call.
     pub(crate) fn reset_with_format(
         &mut self,
         source: impl Read,
@@ -1661,7 +1659,6 @@ impl FrameDecoder {
         mut output: &mut [u8],
         mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
     ) -> Result<usize, FrameDecoderError> {
-        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut total_bytes_written = 0;
         while !input.is_empty() {
             match init_frame(self, &mut input) {
@@ -1697,7 +1694,15 @@ impl FrameDecoder {
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
-            let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
+            // Direct decode requires only that the caller slice holds the
+            // declared content; the inline sequence-exec path no longer
+            // needs `WILDCOPY_OVERLENGTH` trailing slack because the
+            // trailing sequence(s) take the bounded (non-overshooting)
+            // copy in `UserSliceBackend::exec_sequence_bounded`. This is
+            // the universal "decode into an FCS-sized buffer" case (a
+            // caller sizing `output` to exactly `frame_content_size`),
+            // so dropping the slack requirement halves its peak alloc.
+            //
             // Per-block checksums collected inside `run_direct_decode`
             // post-loop (over recorded (start, end) ranges of `output`)
             // so the direct path stays eligible AND keeps the
@@ -1706,7 +1711,7 @@ impl FrameDecoder {
             // validation. Path choice no longer alters checksum
             // semantics.
             let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
+                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -1775,7 +1780,6 @@ impl FrameDecoder {
         mut init_frame: impl FnMut(&mut Self, &mut &[u8]) -> Result<(), FrameDecoderError>,
         mut skippable_visitor: Option<&mut dyn FnMut(u8, &[u8])>,
     ) -> Result<usize, FrameDecoderError> {
-        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let mut total_bytes_written = 0;
         while !input.is_empty() {
             match init_frame(self, &mut input) {
@@ -1827,9 +1831,13 @@ impl FrameDecoder {
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
-            let needed = content_size.saturating_add(WILDCOPY_OVERLENGTH as u64);
+            // Only `cap >= frame_content_size` needed; the trailing
+            // sequence(s) take the bounded copy in
+            // `UserSliceBackend::exec_sequence_bounded`, so no
+            // `WILDCOPY_OVERLENGTH` trailing slack is required (see the
+            // no-lsm path above).
             let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= needed;
+                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -1897,36 +1905,25 @@ impl FrameDecoder {
     ///
     /// `input` must contain an exact number of frames.
     ///
-    /// `output` must have enough extra capacity to hold the decompressed data.
-    /// This function reserves an additional [`WILDCOPY_OVERLENGTH`]
-    /// bytes on top of the caller's capacity so the per-frame direct
-    /// decode path stays eligible — that may grow the vector by up
-    /// to that fixed amount via `Vec::reserve`. It will NOT grow
-    /// further to fit the decompressed payload itself; the caller's
-    /// pre-allocated capacity must already cover the data. If you
-    /// don't know how large the output will be, use
+    /// `output` must have enough spare capacity to hold the decompressed
+    /// data. This adds no extra slack: exact-fit output is now eligible
+    /// for the direct decode path, so a `Vec::with_capacity(fcs)` is
+    /// decoded straight into without a growth/reallocation. It will NOT
+    /// grow the vector to fit the decompressed payload itself; the
+    /// caller's pre-allocated capacity must already cover the data. If
+    /// you don't know how large the output will be, use
     /// [`FrameDecoder::decode_blocks`] instead.
     ///
     /// This calls [`FrameDecoder::init`], and all bytes currently in the decoder will be lost.
     ///
-    /// The length of the output vector is updated to include the decompressed data.
-    /// The length is not changed if an error occurs. The
-    /// `WILDCOPY_OVERLENGTH` slack is internal — `output.len()` on
-    /// return is the actual decompressed size, NOT the inflated
-    /// capacity. Callers who pre-sized the Vec with
-    /// `Vec::with_capacity(fcs)` see no functional change beyond
-    /// the small one-time capacity bump.
+    /// The length of the output vector is updated to include the
+    /// decompressed data. The length is not changed if an error occurs.
     pub fn decode_all_to_vec(
         &mut self,
         input: &[u8],
         output: &mut Vec<u8>,
     ) -> Result<(), FrameDecoderError> {
-        use super::buffer_backend::WILDCOPY_OVERLENGTH;
         let len = output.len();
-        // Reserve WILDCOPY slack on top of the caller's capacity so
-        // `decode_all` can land on the direct path even when the
-        // caller didn't pre-allocate slack themselves.
-        output.reserve(WILDCOPY_OVERLENGTH);
         let cap = output.capacity();
         output.resize(cap, 0);
         match self.decode_all(input, &mut output[len..]) {
@@ -1954,7 +1951,10 @@ impl FrameDecoder {
     /// - `content_size` matches `self.state.frame_header
     ///   .frame_content_size()` and is `> 0` (caller already passed
     ///   the eligibility gate).
-    /// - `output.len() >= content_size + WILDCOPY_OVERLENGTH`.
+    /// - `output.len() >= content_size`. No `WILDCOPY_OVERLENGTH`
+    ///   trailing slack is required: the trailing sequence(s) take the
+    ///   bounded (non-overshooting) copy in
+    ///   [`UserSliceBackend::exec_sequence_bounded`].
     /// - No active dictionary
     ///   (`self.state.using_dict.is_none()`).
     ///
@@ -2248,18 +2248,21 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
-    fn decode_all_legacy_drain_matches_direct_path_on_single_segment_frame() {
+    fn decode_all_tight_and_slack_outputs_match_on_single_segment_frame() {
         // Roundtrip a small payload through the encoder, then decode
         // it via `decode_all` on two output shapes that select
-        // different internal paths:
-        //   1. Tight output (no WILDCOPY_OVERLENGTH slack) → legacy
-        //      `decode_blocks` + `read()` drain path.
-        //   2. Output with WILDCOPY slack → direct
-        //      `run_direct_decode` + `UserSliceBackend` path.
-        // Both paths must produce identical output bytes — the only
-        // difference is the internal buffer/drain shape, not the
-        // decoded semantics. This is the regression gate for the
-        // direct-decode wiring.
+        // different internal sequence-exec paths within the direct
+        // decode:
+        //   1. Tight output (exactly `frame_content_size`, no
+        //      WILDCOPY_OVERLENGTH slack) → direct path whose trailing
+        //      sequence(s) take the bounded (non-overshooting) copy in
+        //      `UserSliceBackend::exec_sequence_bounded`.
+        //   2. Output with WILDCOPY slack → direct path whose
+        //      sequences all take the SIMD wildcopy fast path.
+        // Both must produce identical output bytes — the bounded tail
+        // copy must reconstruct the same data as the overshooting fast
+        // path. This is the regression gate for the relaxed
+        // direct-decode gate (`cap >= content_size`).
         let payload: Vec<u8> = (0..4096u32).map(|i| (i & 0xFF) as u8).collect();
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
         compressor.set_source(payload.as_slice());
@@ -2289,6 +2292,54 @@ mod tests {
             "direct decode produced wrong byte count"
         );
         assert_eq!(&out_b[..n_b], payload.as_slice());
+    }
+
+    #[test]
+    fn decode_all_tight_output_overlapping_tail_match_roundtrips() {
+        // The bounded tail copy must handle an OVERLAPPING match
+        // (offset < match_length) as the trailing sequence when the
+        // output slice is sized to exactly `frame_content_size`. A long
+        // run of a single byte at the end of the payload encodes as an
+        // offset-1 match whose length far exceeds the offset, so the
+        // bounded copy's overlapping (forward byte-by-byte) branch is
+        // exercised at the buffer tail where the SIMD overshoot would
+        // otherwise run past `cap`. Decoding into a tight buffer and
+        // matching the original payload byte-for-byte is the regression
+        // gate for the overlap branch of `exec_sequence_bounded`.
+        let mut payload: Vec<u8> = (0..256u32).map(|i| (i & 0xFF) as u8).collect();
+        payload.extend(core::iter::repeat_n(0xABu8, 8192));
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        // Anti-vacuous precondition: the 8 KiB trailing run of a single
+        // byte must compress to a Compressed block dominated by ONE long
+        // offset-1 (overlapping, offset < match_length) match — not a Raw
+        // block. If the encoder ever stopped emitting that overlapping
+        // tail match the test would pass without exercising
+        // `exec_sequence_bounded`'s overlapping forward-copy branch, so
+        // gate on the output being a tiny fraction of the input (a raw
+        // block would be ~`payload.len()`; an offset-1 run match is tens
+        // of bytes).
+        assert!(
+            compressed.len() < payload.len() / 8,
+            "expected an overlapping-tail match to dominate the frame \
+             (compressed={} payload={}); the bounded overlap branch would \
+             not be exercised otherwise",
+            compressed.len(),
+            payload.len(),
+        );
+
+        // Tight output: exactly content_size, no WILDCOPY slack.
+        let mut dec = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len()];
+        let n = dec
+            .decode_all(compressed.as_slice(), &mut out)
+            .expect("tight-output decode with overlapping tail match should succeed");
+        assert_eq!(n, payload.len());
+        assert_eq!(out, payload, "bounded overlap tail copy corrupted output");
     }
 
     #[test]
@@ -2598,13 +2649,15 @@ mod tests {
     }
 
     #[test]
-    fn decode_all_falls_back_when_output_too_small_for_wildcopy_slack() {
+    fn decode_all_exact_fit_output_decodes_correctly() {
         // Output sized exactly to frame_content_size (no
-        // WILDCOPY_OVERLENGTH slack) must NOT trigger the direct
-        // path — the burst's `extend_from_within_unchecked` writes
-        // past `tail` into the slack region. Direct dispatcher
-        // recognises this and falls back to the FlatBuf + drain
-        // path which still produces the right output.
+        // WILDCOPY_OVERLENGTH slack) is now eligible for the direct
+        // path: every output-write site is exact-fit-safe (sequence
+        // exec falls back to the bounded, non-overshooting copy on the
+        // trailing sequence(s), Raw/RLE blocks copy exactly). This must
+        // produce the same bytes as a slack-padded buffer. Exercised on
+        // x86 through the per-kernel AVX2/SSE2 inline-exec macros, which
+        // carry the same tight-tail branch.
         let payload: Vec<u8> = (0..2048u32)
             .map(|i| (i.wrapping_mul(31) & 0xFF) as u8)
             .collect();
@@ -2615,11 +2668,11 @@ mod tests {
         compressor.compress();
 
         let mut dec = FrameDecoder::new();
-        // Exactly payload.len(), no slack — direct path is gated out.
+        // Exactly payload.len(), no slack.
         let mut out = alloc::vec![0u8; payload.len()];
         let n = dec
             .decode_all(compressed.as_slice(), &mut out)
-            .expect("decode_all should still succeed via fallback");
+            .expect("exact-fit decode_all should succeed");
         assert_eq!(n, payload.len());
         assert_eq!(&out[..n], payload.as_slice());
     }
@@ -2651,9 +2704,18 @@ mod tests {
         wire.extend_from_slice(&[1u8, 2, 3, 4]);
 
         let mut dec = FrameDecoder::new();
-        // Size output exactly at declared FCS (no WILDCOPY slack)
-        // so the eligibility check gates the direct path out.
-        let mut out = alloc::vec![0u8; 20];
+        // Size output SMALLER than the declared FCS so direct-decode is
+        // gated out (`output.len() >= content_size` is false) and the
+        // frame takes the legacy fallback drain loop — the path this test
+        // guards. The corrupt frame only produces 4 bytes, so 19 is ample
+        // room; the point is `19 != declared FCS (20)`.
+        const DECLARED_FCS: usize = 20;
+        let mut out = alloc::vec![0u8; DECLARED_FCS - 1];
+        assert_ne!(
+            out.len(),
+            DECLARED_FCS,
+            "output must be smaller than FCS to exercise the fallback path",
+        );
         let err = dec
             .decode_all(wire.as_slice(), &mut out)
             .expect_err("fallback must reject corrupt FCS underflow");

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -230,13 +230,12 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         use super::exec_sequence_inline::x86::{
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_overlap_8byte_stride,
         };
-        // Fallible capacity check — covers the literal+match copies
-        // INCLUDING the wildcopy overshoot tail (up to 15 bytes past
-        // `tail + total`). On a well-formed frame the caller-side
-        // `WILDCOPY_OVERLENGTH = 32` slack on the user slice absorbs
-        // it; on a malformed frame whose sequences overproduce past
-        // `frame_content_size`, the check returns
-        // `ExecuteSequencesError::OutputBufferOverflow` so the
+        // Fallible capacity check for the literal+match copies, with
+        // `overshoot = 0` — the SIMD wildcopy's up-to-15-byte tail overshoot
+        // is NOT absorbed by caller-side slice slack (the slice carries none);
+        // it is handled by the tight-tail bounded branch below. On a malformed
+        // frame whose sequences overproduce past `frame_content_size`, the
+        // check returns `ExecuteSequencesError::OutputBufferOverflow` so the
         // safe public decode APIs (`decode_all`, `decode_all_to_vec`)
         // surface a structured `FrameDecoderError` rather than
         // panic on the unsafe write surface.
@@ -432,10 +431,10 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
     /// short-offset (`offset < 16`) match path also stay on the
     /// SSE2 helpers — they're capped by the caller-side
     /// `inline_path_safe` gate at 16-byte slack and changing them
-    /// would require re-tightening that gate. Match copy slack is
-    /// bounded by `UserSliceBackend`'s `WILDCOPY_OVERLENGTH = 32`
-    /// byte padding at the slice tail, which accommodates the
-    /// 31-byte AVX2 stride overshoot.
+    /// would require re-tightening that gate. The 31-byte AVX2 stride
+    /// overshoot is contained by the per-sequence `overshoot = 0`
+    /// capacity guard plus the tight-tail bounded copy (the slice
+    /// carries no trailing slack), not by slice-tail padding.
     ///
     /// # Safety
     /// Same preconditions as [`Self::exec_sequence_inline`] plus
@@ -458,11 +457,11 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             copy16, overlap_copy8, wildcopy_no_overlap, wildcopy_no_overlap_avx2,
             wildcopy_overlap_8byte_stride,
         };
-        // 31-byte tail overshoot bound: the AVX2 no-overlap match
-        // wildcopy may write up to 31 bytes past `tail + total`.
-        // UserSliceBackend's slice carries `WILDCOPY_OVERLENGTH = 32`
-        // slack at construction (see `from_slice`), which accommodates
-        // this overshoot for well-formed frames.
+        // 31-byte tail overshoot bound: the AVX2 no-overlap match wildcopy may
+        // write up to 31 bytes past `tail + total`. The slice carries NO
+        // trailing slack (`from_slice` takes the caller's exact buffer), so
+        // this overshoot is handled by the tight-tail bounded branch below
+        // rather than absorbed by slice capacity.
         const MAX_WILDCOPY_OVERSHOOT: usize = 31;
         let cap = self.slice.len();
         // `self.tail <= cap` holds on entry (`from_slice` starts at 0 and every

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -3,9 +3,8 @@
 //!
 //! Selected automatically by
 //! [`crate::decoding::FrameDecoder::decode_all`] (and
-//! [`crate::decoding::FrameDecoder::decode_all_to_vec`], which
-//! reserves the extra slack internally) when ALL of the following
-//! hold:
+//! [`crate::decoding::FrameDecoder::decode_all_to_vec`]) when ALL of
+//! the following hold:
 //! - `frame_content_size > 0` — the header-derived content size
 //!   is non-zero. This is the actual eligibility condition (NOT
 //!   "FCS present"): an empty frame with an explicit FCS=0
@@ -14,8 +13,11 @@
 //!   distinguish "FCS absent" from "FCS=0 explicit" elsewhere in
 //!   the decoder, use `FrameHeader::fcs_declared()` (e.g. the
 //!   fallback path's post-decode size check does).
-//! - `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH`
-//!   (room for the SIMD wildcopy overshoot slack).
+//! - `output.len() >= frame_content_size` — the slice holds the
+//!   declared content. No `WILDCOPY_OVERLENGTH` slack is required:
+//!   when a sequence's literal+match bytes fit but the SIMD wildcopy
+//!   overshoot would not, the trailing sequence(s) take the bounded
+//!   (non-overshooting) copy in [`UserSliceBackend::exec_sequence_bounded`].
 //! - No active dictionary (the persistent dict_content is not
 //!   carried into the stack-local DecodeBuffer this backend
 //!   builds; dict frames stay on the regular path).
@@ -84,10 +86,12 @@ use super::buffer_backend::{BufferBackend, WILDCOPY_OVERLENGTH};
 ///   past `tail` and expect meaningful decode output.
 ///
 /// The caller MUST size the output slice with at least
-/// `frame_content_size + WILDCOPY_OVERLENGTH` bytes so SIMD wildcopy
-/// overshoots from `extend_from_within_unchecked` stay inside the
-/// allocation. The dispatch site in [`crate::decoding::FrameDecoder`]
-/// validates this precondition.
+/// `frame_content_size` bytes. No `WILDCOPY_OVERLENGTH` slack is
+/// required: when the SIMD wildcopy overshoot would run past the slice
+/// end, the trailing sequence(s) fall back to the bounded
+/// (non-overshooting) copy in [`Self::exec_sequence_bounded`]. The
+/// dispatch site in [`crate::decoding::FrameDecoder`] validates this
+/// precondition.
 ///
 /// # Safety contract on malformed Compressed blocks
 ///
@@ -135,16 +139,66 @@ pub(crate) struct UserSliceBackend<'a> {
 }
 
 impl<'a> UserSliceBackend<'a> {
-    /// Construct a backend wrapping `slice`. The slice must have at
-    /// least `frame_content_size + WILDCOPY_OVERLENGTH` bytes of
-    /// length so SIMD wildcopy overshoots stay inside the allocation;
-    /// the dispatcher in `FrameDecoder` enforces this.
+    /// Construct a backend wrapping `slice`. The slice must hold at
+    /// least `frame_content_size` bytes; the dispatcher in
+    /// `FrameDecoder` enforces this. No `WILDCOPY_OVERLENGTH` trailing
+    /// slack is required: when a sequence's literal+match bytes fit but
+    /// the SIMD wildcopy overshoot would not, the inline exec paths fall
+    /// back to [`Self::exec_sequence_bounded`] (exact, non-overshooting
+    /// copies) for that trailing sequence.
     pub(crate) fn from_slice(slice: &'a mut [u8]) -> Self {
         Self {
             slice,
             head: 0,
             tail: 0,
         }
+    }
+
+    /// Exact, non-overshooting copy for the trailing sequence(s) when the
+    /// remaining slice capacity is too tight for the SIMD wildcopy
+    /// overshoot of the fast path. Lets the direct-decode gate require
+    /// only `cap >= frame_content_size` instead of
+    /// `cap >= frame_content_size + WILDCOPY_OVERLENGTH`, halving the
+    /// peak allocation on the universal decode-into-FCS-sized-buffer
+    /// case (caller no longer needs trailing slack).
+    ///
+    /// Portable on purpose: this is the slow tail path (a handful of
+    /// sequences per frame at most), so the byte-exact copies cost
+    /// nothing measurable while keeping one implementation across all
+    /// ISA arms.
+    ///
+    /// # Safety
+    /// - `self.tail + lit_length + match_length <= self.slice.len()`
+    ///   (caller asserts exact fit before dispatching here).
+    /// - `offset >= 1` and `offset <= (self.tail - self.head) +
+    ///   lit_length` (donor's `oLitEnd - offset` precondition), so the
+    ///   match source stays inside the already-written window.
+    /// - `lit_src` is valid for `lit_length` bytes (this path reads
+    ///   exactly `lit_length`, no 16-byte overshoot, so the parent
+    ///   literals buffer always covers it).
+    #[inline]
+    unsafe fn exec_sequence_bounded(
+        &mut self,
+        lit_src: *const u8,
+        lit_length: usize,
+        offset: usize,
+        match_length: usize,
+    ) {
+        // SAFETY: forwarded to the shared bounded-copy helper; the
+        // doc-comment preconditions match its contract one-for-one
+        // (`base[tail..]` writable for `lit+match`, `lit_src` readable for
+        // `lit_length`, `offset` inside the written region).
+        unsafe {
+            super::exec_sequence_inline::exec_sequence_bounded_copy(
+                self.slice.as_mut_ptr(),
+                self.tail,
+                lit_src,
+                lit_length,
+                offset,
+                match_length,
+            );
+        }
+        self.tail += lit_length + match_length;
     }
 }
 
@@ -196,13 +250,12 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         // `self.tail <= cap` holds on entry (`from_slice` starts at 0 and
         // every prior sequence advanced `tail` only after this same check),
         // satisfying the `tail <= cap` precondition; see `sequence_output_fits`.
-        let total = sequence_output_fits(
-            lit_length,
-            match_length,
-            self.tail,
-            cap,
-            MAX_WILDCOPY_OVERSHOOT,
-        )?;
+        // Hard guard with `overshoot = 0`: errors only on a genuine
+        // exact-fit overflow. The <=15-byte SIMD wildcopy slack is
+        // handled by the tight-tail branch below, so the caller slice
+        // no longer needs `WILDCOPY_OVERLENGTH` trailing slack for the
+        // direct-decode path — `cap >= frame_content_size` suffices.
+        let total = sequence_output_fits(lit_length, match_length, self.tail, cap, 0)?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
@@ -225,9 +278,25 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             self.tail,
         );
 
+        // Tight-tail: the literal+match bytes fit exactly but the
+        // <=15-byte wildcopy overshoot of the fast path would write
+        // past `cap`. Take the exact (non-overshooting) copy so the
+        // final sequence(s) near the buffer end stay in-bounds. Only
+        // the trailing sequence(s) of a tightly-sized output slice hit
+        // this; the bulk of the frame still takes the SIMD fast path.
+        if total + MAX_WILDCOPY_OVERSHOOT > cap - self.tail {
+            // SAFETY: `total <= cap - tail` (guard above), so the exact
+            // copies stay in-bounds; `offset <= tail + lit_length`
+            // keeps the match source valid; `lit_src` reads exactly
+            // `lit_length` bytes (no 16-byte overshoot), strictly
+            // within the parent literals buffer.
+            unsafe { self.exec_sequence_bounded(lit_src, lit_length, offset, match_length) };
+            return Ok(());
+        }
+
         // SAFETY: capacity asserted above; pointer arithmetic stays
-        // within `self.slice` for the writes (tail + total <=
-        // slice.len()) and reads (match src = tail + lit_length -
+        // within `self.slice` for the writes (tail + total + overshoot
+        // <= slice.len()) and reads (match src = tail + lit_length -
         // offset, bounded by `offset <= tail + lit_length`). Literal
         // reads use the caller-provided `lit_src` whose provenance
         // covers the parent literals buffer (NOT a sub-slice), so
@@ -290,14 +359,10 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         const MAX_WILDCOPY_OVERSHOOT: usize = 15;
         let cap = self.slice.len();
         // `self.tail <= cap` precondition holds as in the SSE2 arm; see
-        // `sequence_output_fits`.
-        let total = sequence_output_fits(
-            lit_length,
-            match_length,
-            self.tail,
-            cap,
-            MAX_WILDCOPY_OVERSHOOT,
-        )?;
+        // `sequence_output_fits`. Hard guard with `overshoot = 0`; the
+        // <=15-byte wildcopy slack is handled by the tight-tail branch
+        // below (see the x86 arm for the rationale).
+        let total = sequence_output_fits(lit_length, match_length, self.tail, cap, 0)?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
@@ -313,6 +378,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             self.head,
             self.tail,
         );
+
+        // Tight-tail bounded copy; see the x86 arm for the rationale.
+        if total + MAX_WILDCOPY_OVERSHOOT > cap - self.tail {
+            // SAFETY: `total <= cap - tail` (guard above) bounds the
+            // exact copies; `offset <= tail + lit_length` keeps the
+            // match source valid; `lit_src` reads exactly `lit_length`
+            // bytes within the parent literals buffer.
+            unsafe { self.exec_sequence_bounded(lit_src, lit_length, offset, match_length) };
+            return Ok(());
+        }
 
         // SAFETY: identical invariants to the x86 arm — the capacity
         // check bounds every write (plus the ≤ 15-byte wildcopy
@@ -392,14 +467,10 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
         let cap = self.slice.len();
         // `self.tail <= cap` holds on entry (`from_slice` starts at 0 and every
         // prior sequence advanced `tail` only after this same check), satisfying
-        // the `tail <= cap` precondition; see `sequence_output_fits`.
-        let total = sequence_output_fits(
-            lit_length,
-            match_length,
-            self.tail,
-            cap,
-            MAX_WILDCOPY_OVERSHOOT,
-        )?;
+        // the `tail <= cap` precondition; see `sequence_output_fits`. Hard guard
+        // with `overshoot = 0`; the <=31-byte AVX2 wildcopy slack is handled by
+        // the tight-tail branch below (see the SSE2 arm for the rationale).
+        let total = sequence_output_fits(lit_length, match_length, self.tail, cap, 0)?;
         let new_tail = self.tail + total;
         debug_assert!(offset >= 1);
         debug_assert!(match_length >= 1);
@@ -415,6 +486,16 @@ impl<'a> BufferBackend for UserSliceBackend<'a> {
             self.head,
             self.tail,
         );
+
+        // Tight-tail bounded copy; see the SSE2 arm for the rationale.
+        if total + MAX_WILDCOPY_OVERSHOOT > cap - self.tail {
+            // SAFETY: `total <= cap - tail` (guard above) bounds the
+            // exact copies; `offset <= tail + lit_length` keeps the
+            // match source valid; `lit_src` reads exactly `lit_length`
+            // bytes within the parent literals buffer.
+            unsafe { self.exec_sequence_bounded(lit_src, lit_length, offset, match_length) };
+            return Ok(());
+        }
 
         unsafe {
             let base_mut = self.slice.as_mut_ptr();

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -311,7 +311,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         .estimator_inner
         .take()
         .map(|b| *b)
-        .unwrap_or_else(super::CompressedBlockScratch::new);
+        .unwrap_or_default();
     let mut estimator = SplitEstimator {
         parts: &scratch.parts,
         prefix_sums: &scratch.prefix_sums,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -138,6 +138,14 @@ pub(crate) struct CompressedBlockScratch {
     compressed: Vec<u8>,
     estimator_sequences: Vec<crate::blocks::sequence_section::Sequence>,
     estimator_workspace: EstimatorWorkspace,
+    /// Reusable scratch for the block-split estimator's inner
+    /// `CompressState` — kept across frames so the estimator does not
+    /// re-allocate a whole `CompressedBlockScratch` (4×`Box<[u32;256]>`
+    /// count tables + Vecs) every frame in a reused compressor. `Box`
+    /// breaks the type recursion; `None` by default (lazily filled on
+    /// first block-split). The estimator uses `EntropyOnlyMatcher` and
+    /// never re-splits, so this nesting is one level deep.
+    estimator_inner: Option<Box<CompressedBlockScratch>>,
 }
 
 impl CompressedBlockScratch {
@@ -296,6 +304,14 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     scratch.partitions.clear();
     scratch.prefix_sums.rebuild(&scratch.parts.sequences);
     let mut workspace = core::mem::take(&mut scratch.estimator_workspace);
+    // Reuse the estimator's inner scratch across frames instead of
+    // allocating a fresh `CompressedBlockScratch` (count tables + Vecs)
+    // every block-split. Lazily created on the first split.
+    let inner_scratch = scratch
+        .estimator_inner
+        .take()
+        .map(|b| *b)
+        .unwrap_or_else(super::CompressedBlockScratch::new);
     let mut estimator = SplitEstimator {
         parts: &scratch.parts,
         prefix_sums: &scratch.prefix_sums,
@@ -310,7 +326,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
             matcher: EntropyOnlyMatcher,
             last_huff_table: state.last_huff_table.clone(),
             fse_tables: clone_fse_tables(&state.fse_tables),
-            block_scratch: super::CompressedBlockScratch::new(),
+            block_scratch: inner_scratch,
             offset_hist: state.offset_hist,
             strategy_tag: state.strategy_tag,
         },
@@ -320,6 +336,9 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     scratch.partitions.push(scratch.parts.sequences.len());
     workspace = estimator.workspace;
     scratch.estimator_workspace = workspace;
+    // Stash the inner scratch back for the next frame (its buffers stay
+    // allocated; the estimator clears them per use).
+    scratch.estimator_inner = Some(Box::new(estimator.scratch_state.block_scratch));
 
     scratch.compressed.clear();
     let mut seq_start = 0usize;

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -43,7 +43,11 @@ fn min_literals_to_compress(
         return 6;
     }
     let shift: u32 = match strategy {
-        StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy => 3,
+        StrategyTag::Fast
+        | StrategyTag::Dfast
+        | StrategyTag::Greedy
+        | StrategyTag::Lazy
+        | StrategyTag::Btlazy2 => 3,
         StrategyTag::BtOpt => 2,
         StrategyTag::BtUltra => 1,
         StrategyTag::BtUltra2 => 0,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -27,12 +27,12 @@ const MAX_NB_BLOCK_SPLITS: usize = 196;
 /// strategy 1..6 → 64 bytes, strategy 7 (btopt) → 32, strategy 8 (btultra)
 /// → 16, strategy 9 (btultra2) → 8.
 ///
-/// Our `StrategyTag` enum has seven variants (no separate lazy2/btlazy2 —
-/// the `Lazy` variant covers donor strategies 4..6). Within the
-/// fast..lazy2 band donor's shift table is flat: strategies 1..6 all
-/// pin `shift = MIN(9 - strat, 3) = 3`, so `Lazy → 64-byte floor`
-/// regardless of which donor index (4, 5, or 6) we'd nominally use.
-/// No aggressiveness gradient within this band to preserve.
+/// Our `StrategyTag` enum has eight variants: `Lazy` covers donor strategies
+/// 4..5 (greedy/lazy/lazy2) and `Btlazy2` is the separate donor strategy 6.
+/// Within the fast..btlazy2 band donor's shift table is flat: strategies 1..6
+/// all pin `shift = MIN(9 - strat, 3) = 3`, so both `Lazy` and `Btlazy2` land
+/// on the 64-byte floor. No aggressiveness gradient within this band to
+/// preserve (the gradient only starts at btopt).
 #[inline]
 fn min_literals_to_compress(
     strategy: crate::encoding::strategy::StrategyTag,

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -2294,6 +2294,7 @@ mod tests {
             StrategyTag::Dfast,
             StrategyTag::Greedy,
             StrategyTag::Lazy,
+            StrategyTag::Btlazy2,
         ] {
             assert_eq!(min_literals_to_compress(strat, false), 64);
             assert_eq!(min_literals_to_compress(strat, true), 6);
@@ -2314,6 +2315,7 @@ mod tests {
             StrategyTag::Dfast,
             StrategyTag::Greedy,
             StrategyTag::Lazy,
+            StrategyTag::Btlazy2,
             StrategyTag::BtOpt,
         ] {
             assert_eq!(min_gain(src, strat), (src >> 6) + 2);
@@ -2391,6 +2393,10 @@ mod tests {
                 "Lazy/{lit_len}"
             );
             assert!(
+                !prefer_repeat_eligible(StrategyTag::Btlazy2, lit_len),
+                "Btlazy2/{lit_len}"
+            );
+            assert!(
                 !prefer_repeat_eligible(StrategyTag::BtOpt, lit_len),
                 "BtOpt/{lit_len}"
             );
@@ -2410,6 +2416,7 @@ mod tests {
             assert!(!prefer_repeat_eligible(StrategyTag::Fast, lit_len));
             assert!(!prefer_repeat_eligible(StrategyTag::Dfast, lit_len));
             assert!(!prefer_repeat_eligible(StrategyTag::Greedy, lit_len));
+            assert!(!prefer_repeat_eligible(StrategyTag::Btlazy2, lit_len));
         }
     }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1620,365 +1620,6 @@ impl DfastMatchGenerator {
     }
 }
 
-#[cfg(test)]
-mod extend_with_repcode_tests {
-    //! Targeted regression coverage for `extend_with_repcode_after_match`.
-    //!
-    //! These tests intentionally bypass the higher-level
-    //! `compress_to_vec` roundtrip path used by `cross_validation` so
-    //! that a failure pinpoints the post-match rep helper rather than
-    //! firing somewhere downstream (block writer / huff0 / FSE / decode).
-    //! The capture closure records the exact sequence stream the matcher
-    //! emits, which is what the assertions check.
-    use alloc::vec;
-    use alloc::vec::Vec;
-
-    use super::*;
-
-    /// Capture every sequence the matcher emits into an owned record,
-    /// so the assertions can match on `lit_len` / `offset` / `match_len`
-    /// shape directly. `Sequence::Triple` carries borrowed literals; we
-    /// take their length and discard the bytes (the test only cares
-    /// about the structural shape, not the literal content).
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    enum CapturedSeq {
-        Triple {
-            lit_len: usize,
-            offset: usize,
-            match_len: usize,
-        },
-        Literals {
-            lit_len: usize,
-        },
-    }
-
-    fn record_seq<'a>(out: &'a mut Vec<CapturedSeq>) -> impl FnMut(Sequence<'_>) + 'a {
-        move |seq| match seq {
-            Sequence::Triple {
-                literals,
-                offset,
-                match_len,
-            } => out.push(CapturedSeq::Triple {
-                lit_len: literals.len(),
-                offset,
-                match_len,
-            }),
-            Sequence::Literals { literals } => out.push(CapturedSeq::Literals {
-                lit_len: literals.len(),
-            }),
-        }
-    }
-
-    fn build_dfast_with(data: &[u8]) -> DfastMatchGenerator {
-        // Window sized to the block so the matcher does not start
-        // trimming history mid-test.
-        let mut dfast = DfastMatchGenerator::new(data.len().next_power_of_two().max(64));
-        dfast.use_fast_loop = false; // exercise `start_matching_general`
-        dfast.ensure_hash_tables();
-        dfast.add_data(data.to_vec(), |_| {});
-        dfast
-    }
-
-    /// Direct call into [`DfastMatchGenerator::extend_with_repcode_after_match`]
-    /// with a hand-built post-primary-match state. Going through
-    /// `start_matching` is unreliable for this assertion because the
-    /// primary `best_match` greedily consumes a constant run in a
-    /// single `Triple` (offset 1, match_len = block - 1), leaving the
-    /// helper nothing to extend. Instead we set up the state the
-    /// helper expects after a primary emit and verify it chains
-    /// rep-0 sequences for as many bytes as the rep predicate
-    /// matches.
-    #[test]
-    fn dfast_repcode_extension_emits_zero_literal_rep_on_constant_run() {
-        let data: Vec<u8> = vec![b'A'; 64];
-        let mut dfast = build_dfast_with(&data);
-
-        // Post-primary-match state: pretend a previous sequence emitted
-        // with offset = 4 (`offset_hist[0]`). Under the donor swap the
-        // post-match rep probe consults `offset_hist[1]`, here set to
-        // 1 so every subsequent byte (constant 'A') matches its
-        // predecessor.
-        dfast.offset_hist = [4, 1, 8];
-        let current_abs_start = dfast.history_abs_start + dfast.window_size - data.len();
-        let current_len = data.len();
-        // Start the helper mid-block; the leading bytes are the
-        // "literals + match" the (simulated) primary would have
-        // covered. `literals_start == pos` is the post-emit invariant
-        // — `lit_len` for the next sequence is zero.
-        let pos = 10usize;
-        let mut literals_start = pos;
-
-        let mut seqs = Vec::new();
-        let new_pos = {
-            let mut rec = record_seq(&mut seqs);
-            dfast.extend_with_repcode_after_match(
-                current_abs_start,
-                current_len,
-                pos,
-                &mut literals_start,
-                &mut rec,
-            )
-        };
-
-        assert!(
-            new_pos > pos,
-            "helper must advance pos past at least one rep match \
-             (pos={pos}, new_pos={new_pos})"
-        );
-        assert_eq!(
-            literals_start, new_pos,
-            "helper must keep literals_start == new_pos so the caller's main \
-             loop sees zero pending literals after the rep chain"
-        );
-        assert!(!seqs.is_empty(), "helper must emit at least one Triple");
-        for seq in &seqs {
-            match seq {
-                CapturedSeq::Triple {
-                    lit_len,
-                    offset,
-                    match_len: _,
-                } => {
-                    assert_eq!(
-                        *lit_len, 0,
-                        "rep emission must be zero-literal (got {seq:?})"
-                    );
-                    assert_eq!(
-                        *offset, 1,
-                        "rep emission must use the swapped-in offset_hist[1] = 1 \
-                         (got {seq:?})"
-                    );
-                }
-                CapturedSeq::Literals { .. } => {
-                    panic!("rep extension must not emit a Literals tail: {seq:?}");
-                }
-            }
-        }
-    }
-
-    /// Cross-block / retained-history case: probe with `offset > pos`
-    /// (where `pos` is block-local) so the candidate lives in retained
-    /// history from a previously committed block. The
-    /// CodeRabbit-flagged `rep > pos` guard would have rejected
-    /// exactly this path — the current implementation only gates on
-    /// `cur_idx.checked_sub(rep)` so the helper accepts the cross-
-    /// block offset and emits the rep sequence.
-    #[test]
-    fn dfast_repcode_extension_walks_into_retained_history() {
-        let block_a: Vec<u8> = vec![b'C'; 64];
-        let block_b: Vec<u8> = vec![b'C'; 32];
-        let mut dfast = DfastMatchGenerator::new(256);
-        dfast.use_fast_loop = false;
-        dfast.ensure_hash_tables();
-        dfast.add_data(block_a, |_| {});
-        dfast.add_data(block_b.clone(), |_| {});
-
-        // Post-primary-match state targeting cross-block rep: probe
-        // offset = 40 (a candidate inside block A bytes), block-local
-        // cursor = 5 (so `rep > pos` under the rejected guard).
-        dfast.offset_hist = [4, 40, 8];
-        let current_len = block_b.len();
-        let current_abs_start = dfast.history_abs_start + dfast.window_size - current_len;
-        let pos = 5usize;
-        let mut literals_start = pos;
-
-        let mut seqs = Vec::new();
-        let new_pos = {
-            let mut rec = record_seq(&mut seqs);
-            dfast.extend_with_repcode_after_match(
-                current_abs_start,
-                current_len,
-                pos,
-                &mut literals_start,
-                &mut rec,
-            )
-        };
-
-        assert!(
-            new_pos > pos,
-            "rep with offset > block-local pos must still emit a match when the \
-             candidate lives in retained history (pos={pos}, new_pos={new_pos})"
-        );
-        assert_eq!(seqs.len(), 1, "expected one rep emit, got {seqs:?}");
-        match &seqs[0] {
-            CapturedSeq::Triple {
-                lit_len,
-                offset,
-                match_len: _,
-            } => {
-                assert_eq!(*lit_len, 0, "rep emit must be zero-literal");
-                assert_eq!(*offset, 40, "rep emit must use the cross-block offset 40");
-            }
-            other => panic!("expected Triple, got {other:?}"),
-        }
-    }
-
-    /// The helper accepts 4-byte rep extensions (donor `MINMATCH = 4`),
-    /// not the main-loop `DFAST_MIN_MATCH_LEN = 5` floor. A regression
-    /// back above 4 would still pass the constant-run / cross-block tests
-    /// above (their rep matches extend much further), so this fixture
-    /// is built so the rep matches EXACTLY 4 bytes before terminating:
-    /// the byte at `pos + 4` differs from the byte at `pos + 4 - rep`.
-    ///
-    /// Fixture (32 bytes, indices `0..=31`):
-    ///   `"ABCD????ABCD!??????????ABCDX????"`
-    ///    01234567890123456789012345678901     (ones digit)
-    ///              1111111111222222222233     (tens digit, aligned)
-    ///
-    /// Probe state:
-    ///   * `offset_hist[1] = 8` → rep probe reads `concat[pos - 8..]`.
-    ///   * `pos = 8` → `concat[8..12] = "ABCD"`, `concat[0..4] = "ABCD"`
-    ///     → 4 bytes match.
-    ///   * `concat[12] = '!'` vs `concat[4] = '?'` → 5th byte mismatch,
-    ///     so the rep extension stops at exactly 4 bytes.
-    #[test]
-    fn dfast_repcode_extension_accepts_exactly_four_byte_rep() {
-        // Block: "ABCD????" (8) + "ABCD!" (5) + "??????????" (10) +
-        //        "ABCDX" (5) + "????" (4) = 32 bytes total. The
-        //        important invariants are `concat[0..4] == "ABCD"`,
-        //        `concat[8..12] == "ABCD"`, and `concat[12] = '!'`
-        //        (so byte 12 ≠ byte 4 = '?', stopping the rep at
-        //        length 4). The trailing bytes are irrelevant — we
-        //        only iterate the helper at `pos = 8` and the rep
-        //        chain terminates after one 4-byte emit because the
-        //        next rep probe (post-swap) would need bytes at
-        //        `pos + 4` to match a different offset.
-        let data: Vec<u8> = b"ABCD????ABCD!??????????ABCDX????".to_vec();
-        assert_eq!(data.len(), 32, "fixture invariant: 32 bytes");
-        let mut dfast = DfastMatchGenerator::new(64);
-        dfast.use_fast_loop = false;
-        dfast.ensure_hash_tables();
-        dfast.add_data(data.clone(), |_| {});
-
-        dfast.offset_hist = [12, 8, 4];
-        let current_abs_start = dfast.history_abs_start + dfast.window_size - data.len();
-        let current_len = data.len();
-        let pos = 8usize;
-        let mut literals_start = pos;
-
-        let mut seqs = Vec::new();
-        let new_pos = {
-            let mut rec = record_seq(&mut seqs);
-            dfast.extend_with_repcode_after_match(
-                current_abs_start,
-                current_len,
-                pos,
-                &mut literals_start,
-                &mut rec,
-            )
-        };
-
-        // Helper must emit a single 4-byte rep, then stop because
-        // the 5th byte mismatches.
-        assert_eq!(seqs.len(), 1, "expected one 4-byte rep emit, got {seqs:?}");
-        match &seqs[0] {
-            CapturedSeq::Triple {
-                lit_len,
-                offset,
-                match_len,
-            } => {
-                assert_eq!(*lit_len, 0, "rep emit must be zero-literal");
-                assert_eq!(*offset, 8, "rep emit must use offset 8 (offset_hist[1])");
-                assert_eq!(
-                    *match_len, 4,
-                    "rep emit must be exactly 4 bytes (donor MINMATCH floor). \
-                     A regression back to DFAST_MIN_MATCH_LEN > 4 would skip \
-                     this emission entirely and the test would fail with 0 seqs."
-                );
-            }
-            other => panic!("expected Triple, got {other:?}"),
-        }
-        assert_eq!(new_pos, pos + 4, "pos must advance by exactly 4");
-        assert_eq!(literals_start, new_pos, "literals_start must follow pos");
-    }
-
-    /// Integration coverage for the **fast-loop** call sites of
-    /// `extend_with_repcode_after_match` inside
-    /// `start_matching_fast_loop`. The direct-call tests above pin
-    /// down the helper's contract; this test drives the full fast
-    /// loop end-to-end through the production `compress_to_vec`
-    /// pipeline on a fixture engineered to exercise the post-match
-    /// rep chain on the fast-loop path.
-    ///
-    /// `CompressionLevel::Default` is the production config that
-    /// enables `use_fast_loop = true` (see `Matcher::reset` in
-    /// `match_generator.rs`). The fixture alternates 60-byte runs of
-    /// `'A'` with single `'B'` break bytes and a short `'A'` tail
-    /// per cycle — the breaks terminate the fast loop's primary match
-    /// early, so subsequent iterations have runway for the helper to
-    /// chain additional reps. A regression that broke either fast-
-    /// loop helper call site surfaces as a roundtrip failure (decoded
-    /// != input) or a ratio explosion. Constructing
-    /// `DfastMatchGenerator` directly and asserting on captured
-    /// sequences was attempted but the fixture engineering is
-    /// brittle: the fast loop's primary match on simple constant
-    /// fixtures consumes the entire remaining block in a single
-    /// Triple, leaving no bytes for the helper to extend. The
-    /// high-level roundtrip sidesteps that fragility while still
-    /// routing through the same call site via the production driver.
-    ///
-    /// Gated on `feature = "std"`: the `Read::read_to_end` method
-    /// used to drain `StreamingDecoder` resolves to `std::io::Read`
-    /// only when std is enabled. Under no-std `StreamingDecoder`
-    /// implements the crate's `io_nostd::Read` alias instead, and
-    /// the call site has to be rewritten through that trait. The
-    /// fast-loop helper itself is exercised under both
-    /// configurations by the direct-call tests above plus the
-    /// `cross_validation` Default-level roundtrip — gating this one
-    /// integration test on std loses no coverage, only saves the
-    /// dual-trait rewrite.
-    #[cfg(feature = "std")]
-    #[test]
-    fn dfast_default_level_roundtrip_with_repetitive_breaks_exercises_fast_loop() {
-        // ~4 KiB of input: 64 cycles of [60 'A's, 1 'B', 3 'A's].
-        let mut data: Vec<u8> = Vec::with_capacity(64 * 64);
-        for _ in 0..64 {
-            data.extend_from_slice(&[b'A'; 60]);
-            data.push(b'B');
-            data.extend_from_slice(&[b'A'; 3]);
-        }
-        assert!(
-            data.len() > 4000,
-            "fixture invariant: long enough for fast loop"
-        );
-
-        let compressed = crate::encoding::compress_to_vec(
-            data.as_slice(),
-            crate::encoding::CompressionLevel::Default,
-        );
-
-        // Decompress and assert byte-for-byte parity. A regression
-        // that broke the fast-loop helper call would either produce
-        // invalid frames (decode error) or wrong bytes (mismatch).
-        let mut decoder = crate::decoding::StreamingDecoder::new(compressed.as_slice())
-            .expect("default-level frame must decode");
-        let mut decoded = Vec::with_capacity(data.len());
-        // Under `feature = "std"` (the gate above) `StreamingDecoder`
-        // implements `std::io::Read`, so `Read::read_to_end` resolves
-        // through the standard library's blanket implementation.
-        std::io::Read::read_to_end(&mut decoder, &mut decoded)
-            .expect("fast-loop output must round-trip cleanly");
-        assert_eq!(
-            decoded, data,
-            "Default-level (use_fast_loop = true) roundtrip must be \
-             byte-for-byte exact on the repetitive-breaks fixture"
-        );
-
-        // Ratio sanity: the post-match rep helper is what makes
-        // repetitive runs compress aggressively on the fast-loop
-        // path. A regression to a no-op helper would still produce
-        // some compression via the primary match, but the ratio
-        // would degrade. A 2:1 floor is conservative enough not to
-        // flake on small fixture changes while still catching
-        // structural failures of the fast loop.
-        assert!(
-            compressed.len() * 2 < data.len(),
-            "fast loop must compress repetitive runs to at least 2:1, \
-             got {} → {} bytes",
-            data.len(),
-            compressed.len()
-        );
-    }
-}
 
 /// Per-kernel body of the dfast fast match loop. Mirrors the BT/opt
 /// `*_body!` macros: the wrapper carries the `#[target_feature]` umbrella and
@@ -2862,5 +2503,365 @@ impl DfastMatchGenerator {
             handle_sequence,
             crate::encoding::fastpath::scalar::common_prefix_len_ptr
         )
+    }
+}
+
+#[cfg(test)]
+mod extend_with_repcode_tests {
+    //! Targeted regression coverage for `extend_with_repcode_after_match`.
+    //!
+    //! These tests intentionally bypass the higher-level
+    //! `compress_to_vec` roundtrip path used by `cross_validation` so
+    //! that a failure pinpoints the post-match rep helper rather than
+    //! firing somewhere downstream (block writer / huff0 / FSE / decode).
+    //! The capture closure records the exact sequence stream the matcher
+    //! emits, which is what the assertions check.
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    /// Capture every sequence the matcher emits into an owned record,
+    /// so the assertions can match on `lit_len` / `offset` / `match_len`
+    /// shape directly. `Sequence::Triple` carries borrowed literals; we
+    /// take their length and discard the bytes (the test only cares
+    /// about the structural shape, not the literal content).
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum CapturedSeq {
+        Triple {
+            lit_len: usize,
+            offset: usize,
+            match_len: usize,
+        },
+        Literals {
+            lit_len: usize,
+        },
+    }
+
+    fn record_seq<'a>(out: &'a mut Vec<CapturedSeq>) -> impl FnMut(Sequence<'_>) + 'a {
+        move |seq| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => out.push(CapturedSeq::Triple {
+                lit_len: literals.len(),
+                offset,
+                match_len,
+            }),
+            Sequence::Literals { literals } => out.push(CapturedSeq::Literals {
+                lit_len: literals.len(),
+            }),
+        }
+    }
+
+    fn build_dfast_with(data: &[u8]) -> DfastMatchGenerator {
+        // Window sized to the block so the matcher does not start
+        // trimming history mid-test.
+        let mut dfast = DfastMatchGenerator::new(data.len().next_power_of_two().max(64));
+        dfast.use_fast_loop = false; // exercise `start_matching_general`
+        dfast.ensure_hash_tables();
+        dfast.add_data(data.to_vec(), |_| {});
+        dfast
+    }
+
+    /// Direct call into [`DfastMatchGenerator::extend_with_repcode_after_match`]
+    /// with a hand-built post-primary-match state. Going through
+    /// `start_matching` is unreliable for this assertion because the
+    /// primary `best_match` greedily consumes a constant run in a
+    /// single `Triple` (offset 1, match_len = block - 1), leaving the
+    /// helper nothing to extend. Instead we set up the state the
+    /// helper expects after a primary emit and verify it chains
+    /// rep-0 sequences for as many bytes as the rep predicate
+    /// matches.
+    #[test]
+    fn dfast_repcode_extension_emits_zero_literal_rep_on_constant_run() {
+        let data: Vec<u8> = vec![b'A'; 64];
+        let mut dfast = build_dfast_with(&data);
+
+        // Post-primary-match state: pretend a previous sequence emitted
+        // with offset = 4 (`offset_hist[0]`). Under the donor swap the
+        // post-match rep probe consults `offset_hist[1]`, here set to
+        // 1 so every subsequent byte (constant 'A') matches its
+        // predecessor.
+        dfast.offset_hist = [4, 1, 8];
+        let current_abs_start = dfast.history_abs_start + dfast.window_size - data.len();
+        let current_len = data.len();
+        // Start the helper mid-block; the leading bytes are the
+        // "literals + match" the (simulated) primary would have
+        // covered. `literals_start == pos` is the post-emit invariant
+        // — `lit_len` for the next sequence is zero.
+        let pos = 10usize;
+        let mut literals_start = pos;
+
+        let mut seqs = Vec::new();
+        let new_pos = {
+            let mut rec = record_seq(&mut seqs);
+            dfast.extend_with_repcode_after_match(
+                current_abs_start,
+                current_len,
+                pos,
+                &mut literals_start,
+                &mut rec,
+            )
+        };
+
+        assert!(
+            new_pos > pos,
+            "helper must advance pos past at least one rep match \
+             (pos={pos}, new_pos={new_pos})"
+        );
+        assert_eq!(
+            literals_start, new_pos,
+            "helper must keep literals_start == new_pos so the caller's main \
+             loop sees zero pending literals after the rep chain"
+        );
+        assert!(!seqs.is_empty(), "helper must emit at least one Triple");
+        for seq in &seqs {
+            match seq {
+                CapturedSeq::Triple {
+                    lit_len,
+                    offset,
+                    match_len: _,
+                } => {
+                    assert_eq!(
+                        *lit_len, 0,
+                        "rep emission must be zero-literal (got {seq:?})"
+                    );
+                    assert_eq!(
+                        *offset, 1,
+                        "rep emission must use the swapped-in offset_hist[1] = 1 \
+                         (got {seq:?})"
+                    );
+                }
+                CapturedSeq::Literals { .. } => {
+                    panic!("rep extension must not emit a Literals tail: {seq:?}");
+                }
+            }
+        }
+    }
+
+    /// Cross-block / retained-history case: probe with `offset > pos`
+    /// (where `pos` is block-local) so the candidate lives in retained
+    /// history from a previously committed block. The
+    /// CodeRabbit-flagged `rep > pos` guard would have rejected
+    /// exactly this path — the current implementation only gates on
+    /// `cur_idx.checked_sub(rep)` so the helper accepts the cross-
+    /// block offset and emits the rep sequence.
+    #[test]
+    fn dfast_repcode_extension_walks_into_retained_history() {
+        let block_a: Vec<u8> = vec![b'C'; 64];
+        let block_b: Vec<u8> = vec![b'C'; 32];
+        let mut dfast = DfastMatchGenerator::new(256);
+        dfast.use_fast_loop = false;
+        dfast.ensure_hash_tables();
+        dfast.add_data(block_a, |_| {});
+        dfast.add_data(block_b.clone(), |_| {});
+
+        // Post-primary-match state targeting cross-block rep: probe
+        // offset = 40 (a candidate inside block A bytes), block-local
+        // cursor = 5 (so `rep > pos` under the rejected guard).
+        dfast.offset_hist = [4, 40, 8];
+        let current_len = block_b.len();
+        let current_abs_start = dfast.history_abs_start + dfast.window_size - current_len;
+        let pos = 5usize;
+        let mut literals_start = pos;
+
+        let mut seqs = Vec::new();
+        let new_pos = {
+            let mut rec = record_seq(&mut seqs);
+            dfast.extend_with_repcode_after_match(
+                current_abs_start,
+                current_len,
+                pos,
+                &mut literals_start,
+                &mut rec,
+            )
+        };
+
+        assert!(
+            new_pos > pos,
+            "rep with offset > block-local pos must still emit a match when the \
+             candidate lives in retained history (pos={pos}, new_pos={new_pos})"
+        );
+        assert_eq!(seqs.len(), 1, "expected one rep emit, got {seqs:?}");
+        match &seqs[0] {
+            CapturedSeq::Triple {
+                lit_len,
+                offset,
+                match_len: _,
+            } => {
+                assert_eq!(*lit_len, 0, "rep emit must be zero-literal");
+                assert_eq!(*offset, 40, "rep emit must use the cross-block offset 40");
+            }
+            other => panic!("expected Triple, got {other:?}"),
+        }
+    }
+
+    /// The helper accepts 4-byte rep extensions (donor `MINMATCH = 4`),
+    /// not the main-loop `DFAST_MIN_MATCH_LEN = 5` floor. A regression
+    /// back above 4 would still pass the constant-run / cross-block tests
+    /// above (their rep matches extend much further), so this fixture
+    /// is built so the rep matches EXACTLY 4 bytes before terminating:
+    /// the byte at `pos + 4` differs from the byte at `pos + 4 - rep`.
+    ///
+    /// Fixture (32 bytes, indices `0..=31`):
+    ///   `"ABCD????ABCD!??????????ABCDX????"`
+    ///    01234567890123456789012345678901     (ones digit)
+    ///              1111111111222222222233     (tens digit, aligned)
+    ///
+    /// Probe state:
+    ///   * `offset_hist[1] = 8` → rep probe reads `concat[pos - 8..]`.
+    ///   * `pos = 8` → `concat[8..12] = "ABCD"`, `concat[0..4] = "ABCD"`
+    ///     → 4 bytes match.
+    ///   * `concat[12] = '!'` vs `concat[4] = '?'` → 5th byte mismatch,
+    ///     so the rep extension stops at exactly 4 bytes.
+    #[test]
+    fn dfast_repcode_extension_accepts_exactly_four_byte_rep() {
+        // Block: "ABCD????" (8) + "ABCD!" (5) + "??????????" (10) +
+        //        "ABCDX" (5) + "????" (4) = 32 bytes total. The
+        //        important invariants are `concat[0..4] == "ABCD"`,
+        //        `concat[8..12] == "ABCD"`, and `concat[12] = '!'`
+        //        (so byte 12 ≠ byte 4 = '?', stopping the rep at
+        //        length 4). The trailing bytes are irrelevant — we
+        //        only iterate the helper at `pos = 8` and the rep
+        //        chain terminates after one 4-byte emit because the
+        //        next rep probe (post-swap) would need bytes at
+        //        `pos + 4` to match a different offset.
+        let data: Vec<u8> = b"ABCD????ABCD!??????????ABCDX????".to_vec();
+        assert_eq!(data.len(), 32, "fixture invariant: 32 bytes");
+        let mut dfast = DfastMatchGenerator::new(64);
+        dfast.use_fast_loop = false;
+        dfast.ensure_hash_tables();
+        dfast.add_data(data.clone(), |_| {});
+
+        dfast.offset_hist = [12, 8, 4];
+        let current_abs_start = dfast.history_abs_start + dfast.window_size - data.len();
+        let current_len = data.len();
+        let pos = 8usize;
+        let mut literals_start = pos;
+
+        let mut seqs = Vec::new();
+        let new_pos = {
+            let mut rec = record_seq(&mut seqs);
+            dfast.extend_with_repcode_after_match(
+                current_abs_start,
+                current_len,
+                pos,
+                &mut literals_start,
+                &mut rec,
+            )
+        };
+
+        // Helper must emit a single 4-byte rep, then stop because
+        // the 5th byte mismatches.
+        assert_eq!(seqs.len(), 1, "expected one 4-byte rep emit, got {seqs:?}");
+        match &seqs[0] {
+            CapturedSeq::Triple {
+                lit_len,
+                offset,
+                match_len,
+            } => {
+                assert_eq!(*lit_len, 0, "rep emit must be zero-literal");
+                assert_eq!(*offset, 8, "rep emit must use offset 8 (offset_hist[1])");
+                assert_eq!(
+                    *match_len, 4,
+                    "rep emit must be exactly 4 bytes (donor MINMATCH floor). \
+                     A regression back to DFAST_MIN_MATCH_LEN > 4 would skip \
+                     this emission entirely and the test would fail with 0 seqs."
+                );
+            }
+            other => panic!("expected Triple, got {other:?}"),
+        }
+        assert_eq!(new_pos, pos + 4, "pos must advance by exactly 4");
+        assert_eq!(literals_start, new_pos, "literals_start must follow pos");
+    }
+
+    /// Integration coverage for the **fast-loop** call sites of
+    /// `extend_with_repcode_after_match` inside
+    /// `start_matching_fast_loop`. The direct-call tests above pin
+    /// down the helper's contract; this test drives the full fast
+    /// loop end-to-end through the production `compress_to_vec`
+    /// pipeline on a fixture engineered to exercise the post-match
+    /// rep chain on the fast-loop path.
+    ///
+    /// `CompressionLevel::Default` is the production config that
+    /// enables `use_fast_loop = true` (see `Matcher::reset` in
+    /// `match_generator.rs`). The fixture alternates 60-byte runs of
+    /// `'A'` with single `'B'` break bytes and a short `'A'` tail
+    /// per cycle — the breaks terminate the fast loop's primary match
+    /// early, so subsequent iterations have runway for the helper to
+    /// chain additional reps. A regression that broke either fast-
+    /// loop helper call site surfaces as a roundtrip failure (decoded
+    /// != input) or a ratio explosion. Constructing
+    /// `DfastMatchGenerator` directly and asserting on captured
+    /// sequences was attempted but the fixture engineering is
+    /// brittle: the fast loop's primary match on simple constant
+    /// fixtures consumes the entire remaining block in a single
+    /// Triple, leaving no bytes for the helper to extend. The
+    /// high-level roundtrip sidesteps that fragility while still
+    /// routing through the same call site via the production driver.
+    ///
+    /// Gated on `feature = "std"`: the `Read::read_to_end` method
+    /// used to drain `StreamingDecoder` resolves to `std::io::Read`
+    /// only when std is enabled. Under no-std `StreamingDecoder`
+    /// implements the crate's `io_nostd::Read` alias instead, and
+    /// the call site has to be rewritten through that trait. The
+    /// fast-loop helper itself is exercised under both
+    /// configurations by the direct-call tests above plus the
+    /// `cross_validation` Default-level roundtrip — gating this one
+    /// integration test on std loses no coverage, only saves the
+    /// dual-trait rewrite.
+    #[cfg(feature = "std")]
+    #[test]
+    fn dfast_default_level_roundtrip_with_repetitive_breaks_exercises_fast_loop() {
+        // ~4 KiB of input: 64 cycles of [60 'A's, 1 'B', 3 'A's].
+        let mut data: Vec<u8> = Vec::with_capacity(64 * 64);
+        for _ in 0..64 {
+            data.extend_from_slice(&[b'A'; 60]);
+            data.push(b'B');
+            data.extend_from_slice(&[b'A'; 3]);
+        }
+        assert!(
+            data.len() > 4000,
+            "fixture invariant: long enough for fast loop"
+        );
+
+        let compressed = crate::encoding::compress_to_vec(
+            data.as_slice(),
+            crate::encoding::CompressionLevel::Default,
+        );
+
+        // Decompress and assert byte-for-byte parity. A regression
+        // that broke the fast-loop helper call would either produce
+        // invalid frames (decode error) or wrong bytes (mismatch).
+        let mut decoder = crate::decoding::StreamingDecoder::new(compressed.as_slice())
+            .expect("default-level frame must decode");
+        let mut decoded = Vec::with_capacity(data.len());
+        // Under `feature = "std"` (the gate above) `StreamingDecoder`
+        // implements `std::io::Read`, so `Read::read_to_end` resolves
+        // through the standard library's blanket implementation.
+        std::io::Read::read_to_end(&mut decoder, &mut decoded)
+            .expect("fast-loop output must round-trip cleanly");
+        assert_eq!(
+            decoded, data,
+            "Default-level (use_fast_loop = true) roundtrip must be \
+             byte-for-byte exact on the repetitive-breaks fixture"
+        );
+
+        // Ratio sanity: the post-match rep helper is what makes
+        // repetitive runs compress aggressively on the fast-loop
+        // path. A regression to a no-op helper would still produce
+        // some compression via the primary match, but the ratio
+        // would degrade. A 2:1 floor is conservative enough not to
+        // flake on small fixture changes while still catching
+        // structural failures of the fast loop.
+        assert!(
+            compressed.len() * 2 < data.len(),
+            "fast loop must compress repetitive runs to at least 2:1, \
+             got {} → {} bytes",
+            data.len(),
+            compressed.len()
+        );
     }
 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -612,7 +612,19 @@ impl DfastMatchGenerator {
         // has at most `bits` bits set, in-bounds for the `1 << bits` tables.
         // `pos + 1` fits u32: concat indices are bounded by the u32 history
         // gate upstream (`check_stream_abs_headroom`).
-        let mut pos = start_concat;
+        //
+        // Backfill the previous chunk's last 7/3 bytes (the seam), which only
+        // became hashable now that this chunk extended history — mirrors the
+        // dense priming paths' backfill so multi-chunk dictionary priming
+        // doesn't drop seam-spanning candidates.
+        //
+        // `saturating_sub` is a deliberate FLOOR clamp to concat position 0
+        // (the dict start), NOT overflow-masking: `start_concat` is a valid
+        // concat index, and the seam window `[start_concat - tail, start_concat)`
+        // is clamped at 0 because there are no dict bytes before the front.
+        // The first chunk (`start_concat == 0`) clamps to 0 → no seam, no-op.
+        let backfill_floor = start_concat.saturating_sub(Self::BOUNDARY_DENSE_TAIL_LEN);
+        let mut pos = backfill_floor;
         while pos < long_safe_end {
             unsafe {
                 let load_ptr = base.add(history_start + pos);
@@ -1588,6 +1600,16 @@ impl DfastMatchGenerator {
         // strictly cheaper than a full inner-loop iter.
         let idxl0 = unsafe { *self.long_hash.as_ptr().add(hl0_idx) };
         let idxs0 = unsafe { *self.short_hash.as_ptr().add(hs0_idx) };
+
+        // Live tables only — no attached-dict probe here, by design. This
+        // helper runs for exactly ONE position per block (the last hashable
+        // `ip0` when `ip1` has fallen off the tail), so a missed dict match
+        // costs at most one sequence per ~128 KiB block (negligible ratio).
+        // `seed_remaining_hashable_starts` inserts this position so it is
+        // dict-searchable in the next block; replicating the full dict
+        // long+short dual-probe here would duplicate ~40 lines for that single
+        // boundary position and defeat the helper's "strictly cheaper than a
+        // full inner-loop iter" purpose.
 
         // Long-hash probe first (upstream priority: an 8-byte hit
         // beats a 4-byte hit even before extension).

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -561,8 +561,20 @@ impl DfastMatchGenerator {
 
     /// Mark the dict tables fully built (CDict cache). The driver calls this
     /// after the final dictionary chunk so the next frame skips the re-hash.
+    ///
+    /// Only the fast-loop path builds the immutable dict tables; the
+    /// general-path levels (L1/L2/L4) prime the dict into the LIVE tables and
+    /// `invalidate()` the attach cache (see [`Self::skip_matching_for_dict_attach`]),
+    /// leaving `self.dict.table()` empty. Gate on `use_fast_loop` so a
+    /// general-path frame can never flip the primed flag, which would let a
+    /// later fast-loop frame short-circuit [`Self::prime_dict_tables_for_range`]
+    /// with no dict tables built. ([`DictAttach::mark_primed`] also self-guards
+    /// on `table.is_some()`, so this is belt-and-suspenders making the
+    /// precondition explicit at the call site.)
     pub(crate) fn mark_dict_primed(&mut self) {
-        self.dict.mark_primed();
+        if self.use_fast_loop {
+            self.dict.mark_primed();
+        }
     }
 
     /// Drop the cached dict tables (next frame carries no dict, or eviction /
@@ -759,7 +771,6 @@ impl DfastMatchGenerator {
         self.seed_remaining_hashable_starts(current_abs_start, current_len, pos);
         self.emit_trailing_literals(literals_start, handle_sequence);
     }
-
 
     /// Single-cursor probe at the last hashable position in the
     /// current block. Called from `start_matching_fast_loop` only when

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -760,767 +760,6 @@ impl DfastMatchGenerator {
         self.emit_trailing_literals(literals_start, handle_sequence);
     }
 
-    fn start_matching_fast_loop(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        // Behaviour change vs the pre-refactor `start_matching_general`:
-        // this fast loop deliberately drops the strict-incompressible
-        // early-skip path (the `block_looks_incompressible_strict` short
-        // circuit + `miss_run` / `DFAST_LOCAL_SKIP_TRIGGER` thresholding).
-        // The step ramp is now driven purely by distance traveled
-        // (`DFAST_SKIP_STEP_GROWTH_INTERVAL = 64`, donor parity except
-        // donor uses 256 — see "Donor-deviation audit" in the PR body),
-        // so blocks the strict gate used to bail out of early now scan
-        // through the standard ramp. `block_looks_incompressible_strict`
-        // is still used by `levels/fastest.rs` for the Fastest preset
-        // and by `incompressible.rs` unit tests, so the helper itself
-        // stays.
-        //
-        // Donor outer/inner structure (`zstd_double_fast.c:167-322`):
-        //   * outer `while(1)` runs once per match-found-and-stored;
-        //   * inner `do { ... } while (ip1 <= ilimit)` carries `hl0`,
-        //     `idxl0` between iterations, and precomputes `hl1` so the
-        //     next iter's long hash is reused (one long-hash compute per
-        //     two positions scanned, not per position).
-        // We mirror that here. Per-frame invariants are hoisted before
-        // the outer loop; mutable state (`position_base`, `history_abs_start`)
-        // is re-snapshotted inside the outer loop because `emit_candidate`
-        // → `insert_positions` → `ensure_room_for` can advance the rebase
-        // base mid-frame.
-        //
-        // Rebase BEFORE any inner-loop slot pack. The hot loop computes
-        // `packed_curr = (abs_ip0 - position_base) as u32 + 1` and writes
-        // it straight into the hash tables, bypassing `insert_position`
-        // (which is where `ensure_room_for` normally fires). On a long
-        // stream of all-miss / non-hashable blocks the matcher can advance
-        // `current_abs_start` arbitrarily far without any per-byte insert,
-        // so `position_base` may be stale by `> u32::MAX`. The first
-        // fast-loop block after that would silently truncate `packed_curr`
-        // and poison both hash tables. The guard band in `ensure_room_for`
-        // (`DFAST_REBASE_GUARD_BAND`) covers the entire current block's
-        // worth of positions, so a single call at function entry suffices.
-        //
-        // Raw-pointer aliasing invariant. The inner loop caches
-        // `short_hash_ptr = self.short_hash.as_mut_ptr()` and
-        // `long_hash_ptr = self.long_hash.as_mut_ptr()` (and a
-        // `history_base_ptr` for the byte-buffer reads), then over
-        // the rest of the function does:
-        //
-        //   * raw writes / reads via `*short_hash_ptr.add(...) =
-        //     packed_curr`, `*long_hash_ptr.add(...) = packed_curr`,
-        //     and `*long_hash_ptr.add(hl1_idx)`;
-        //   * `&self`-shared reads of `self.offset_hist[0]` for the
-        //     rep1 peek;
-        //   * `&self`-shared slice reads of `self.history` (`let
-        //     concat = &self.history[history_start_offset..]`) for
-        //     `extend_backwards_shared` invocations.
-        //
-        // This is sound under both Stacked Borrows and Tree Borrows
-        // because the three fields touched (`short_hash`, `long_hash`,
-        // `history`, `offset_hist`) are physically disjoint
-        // allocations — `Vec<u32>`/`Vec<u8>` each own their own heap
-        // buffer, and `offset_hist` is an inline `[u32; 3]` inside
-        // the struct. A raw pointer derived from one field's Vec data
-        // has provenance over that field only, so the subsequent
-        // `&self` reads of sibling fields don't reborrow through the
-        // raw pointer's provenance tree.
-        //
-        // CRITICAL: this invariant must be preserved by any future
-        // refactor that adds method calls inside the loop body. A
-        // call that takes `&mut self` (e.g.,
-        // `self.ensure_hash_tables()`, `self.insert_position(...)`)
-        // would reborrow the tables and invalidate the cached raw
-        // pointers — every such call must happen OUTSIDE the
-        // `'outer: loop` (as `ensure_room_for` does, hoisted to the
-        // function preamble above) or be followed by a fresh
-        // `as_mut_ptr()` reload of both `short_hash_ptr` /
-        // `long_hash_ptr`. The outer-loop body already re-snapshots
-        // `history_base_ptr` per iteration for exactly this reason
-        // (`emit_candidate` → `insert_positions` may grow `history`
-        // and trigger a realloc), so the same re-snapshot discipline
-        // applies to the hash-table pointers.
-        //
-        // `current_len > 0` is a precondition of this helper: every
-        // caller (`start_matching`, `skip_matching`, `skip_matching_dense`)
-        // returns early at `current_len == 0`. Encode it as a hard
-        // assert so a future caller that forgets the gate fails loudly
-        // in debug rather than wrap-underflowing the `- 1` below; the
-        // rebase is unconditional in release builds since the
-        // precondition holds.
-        debug_assert!(current_len > 0, "fast_loop precondition: current_len > 0");
-        self.ensure_room_for(current_abs_start + current_len - 1);
-        const PRIME: u64 = 0xCF1BBCDCB7A56463_u64;
-        let short_shift = 64 - self.short_hash_bits;
-        let long_shift = 64 - self.long_hash_bits;
-        let mut pos = 1usize;
-        let mut literals_start = 0usize;
-
-        // Dict dual-probe (donor `ZSTD_dictMatchState`): snapshot the immutable
-        // dict tables ONCE. Unlike the live tables (which `emit_candidate` may
-        // grow / rebase), the dict tables are never mutated during matching, so
-        // one snapshot before the outer loop stays valid every iteration. The
-        // raw pointers hold no borrow, so the per-iter `&self`/`&mut self`
-        // accesses below coexist. `use_dict` gates every probe so the no-dict
-        // hot path keeps its exact instruction shape. `dict_end` is the
-        // dict/input boundary as a CONCAT index (history_start-relative); the
-        // dict is invalidated on any history eviction, so concat indices stay
-        // valid for the snapshot's lifetime.
-        // `use_dict` MUST track table presence, NOT `is_attached()`:
-        // `prime_dict_tables_for_range` records the dict region (so
-        // `is_attached()` is true) but returns before allocating the
-        // tables when the hashable region is shorter than the short-hash
-        // lookahead. Gating on `table().is_some()` keeps the null dict
-        // pointers out of the probe below, which dereferences them before
-        // the `dict_end` bound is consulted.
-        let (use_dict, dict_long_ptr, dict_short_ptr, dict_end): (
-            bool,
-            *const u32,
-            *const u32,
-            usize,
-        ) = match self.dict.table() {
-            Some(d) => (
-                true,
-                d.long.as_ptr(),
-                d.short.as_ptr(),
-                self.dict.region_len(),
-            ),
-            None => (false, core::ptr::null(), core::ptr::null(), 0),
-        };
-
-        'outer: loop {
-            // Outer-iter precondition: at least `HASH_READ_SIZE = 8` bytes
-            // ahead of `pos` so the unconditional 8-byte `u64` load below
-            // is in-bounds for the live history buffer. `DFAST_MIN_MATCH_LEN
-            // = 5` is the match acceptance threshold and is NOT a safe
-            // load bound — using it here read up to 3 bytes past
-            // `history.len()` on tiny blocks (CI fuzz `interop` crash,
-            // 7-byte input).
-            // NOTE: when this guard fires on the very first outer-iter
-            // (tiny block, `current_len < 9`), we `break 'outer` BEFORE
-            // `tail_seed_anchor` is even declared. The post-loop
-            // `seed_remaining_hashable_starts(.., pos)` then runs with
-            // `pos` at its initial value (1 on first frame, or the
-            // post-match cursor from a previous outer iter); that's the
-            // correct tail seed for tiny blocks — `seed_pos = pos.min(
-            // current_len).min(boundary_tail_start)` plus the
-            // `seed_pos + DFAST_SHORT_HASH_LOOKAHEAD <= current_len`
-            // guard inside the seeder keeps every insert in-bounds.
-            if pos + HASH_READ_SIZE > current_len {
-                break 'outer;
-            }
-            let mut step = 1usize;
-            let mut next_step_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
-            let mut ip0 = pos;
-            let mut ip1 = ip0 + step;
-            // Same `HASH_READ_SIZE` rationale for `ip1`: the inner loop
-            // pre-loads 8 bytes at `concat_idx1` for the `hl1` precompute
-            // and the `_search_next_long` retry, so `ip1 + 8 <= current_len`
-            // must hold before we enter. If `ip0` is still hashable but
-            // `ip1` is not (boundary case `pos == current_len - 8`), we
-            // still want to probe `ip0` — skipping it would leave the
-            // last hashable position to `seed_remaining_hashable_starts`,
-            // which inserts but does NOT search, and that drops real
-            // matches in the tail window vs the upstream reference
-            // (whose single-cursor loop probes every position p with
-            // `p + HASH_READ_SIZE <= iend`). Handle the boundary inline
-            // before exiting: a single-cursor probe at `ip0` (rep peek
-            // and `_search_next_long` retry both depend on `ip1` so
-            // they're skipped — donor accepts that exact tradeoff at
-            // the iend boundary).
-            if ip1 + HASH_READ_SIZE > current_len {
-                if let Some(committed) =
-                    self.probe_tail_ip0_only(current_abs_start, current_len, ip0, literals_start)
-                {
-                    let start = self.emit_candidate(
-                        current_abs_start,
-                        &mut literals_start,
-                        committed,
-                        handle_sequence,
-                    );
-                    pos = start + committed.match_len;
-                    pos = self.extend_with_repcode_after_match(
-                        current_abs_start,
-                        current_len,
-                        pos,
-                        &mut literals_start,
-                        handle_sequence,
-                    );
-                    continue 'outer;
-                }
-                break 'outer;
-            }
-
-            // Re-read every per-frame-mutable cursor here — `emit_candidate`
-            // in the previous outer iteration may have triggered a rebase.
-            let history_abs_start = self.history_abs_start;
-            let position_base = self.position_base;
-            let history_start_offset = self.history_start;
-            let history_base_ptr = self.history.as_ptr();
-            let short_hash_ptr = self.short_hash.as_mut_ptr();
-            let long_hash_ptr = self.long_hash.as_mut_ptr();
-            let concat_len = self.history.len() - history_start_offset;
-
-            // Pre-compute long hash at ip0 ONCE per outer iter.
-            // `concat_idx = (current_abs_start + ip0) - history_abs_start`
-            // is the byte offset within `live_history`.
-            let mut hl0_idx;
-            let mut idxl0;
-            // SAFETY: `current_abs_start + ip0 >= history_abs_start`
-            // (`ip` is inside the current block, which is part of live
-            // history). The 8-byte unaligned load on
-            // `concat[concat_idx..]` is safe because the outer loop
-            // guards above enforce `ip0 + HASH_READ_SIZE <= current_len`,
-            // and `current_abs_start + current_len - history_abs_start
-            // <= concat_len` (live history contains the full current
-            // block plus any retained earlier blocks), giving
-            // `concat_idx + 8 <= concat_len`. The `debug_assert!` below
-            // makes that invariant explicit so a future refactor that
-            // touches eviction / `compact_history` / `trim_to_window`
-            // semantics catches a violation in tests instead of leaking
-            // through to ASan UB.
-            unsafe {
-                let concat_idx = (current_abs_start + ip0) - history_abs_start;
-                debug_assert!(
-                    concat_idx + HASH_READ_SIZE <= concat_len,
-                    "fast-loop 8-byte load OOB: concat_idx={} HASH_READ_SIZE={} concat_len={}",
-                    concat_idx,
-                    HASH_READ_SIZE,
-                    concat_len,
-                );
-                let v8 = (history_base_ptr.add(history_start_offset + concat_idx) as *const u64)
-                    .read_unaligned();
-                hl0_idx = (v8.wrapping_mul(PRIME) >> long_shift) as usize;
-                idxl0 = *long_hash_ptr.add(hl0_idx);
-            }
-
-            // Inner-loop exit shape. Every `break 'inner` produces a
-            // value of this type, so the type system enforces the
-            // previously implicit pairing between "did we commit a
-            // match?" and "where does the tail seeder pick up?":
-            //
-            //   * `Committed(c)` — rep1 / long / short(+next_long retry)
-            //     paths chose `c`; outer arm runs emit + rep-extension.
-            //   * `Tail(seed)` — inner ran out of safe scan room at
-            //     `seed = ip0` (first un-scanned position); outer arm
-            //     hands `seed` to `seed_remaining_hashable_starts` so
-            //     the tail seeder does not redundantly re-pack
-            //     positions the fast loop already wrote (which is what
-            //     restarting from outer-entry `pos` would do on a
-            //     miss-only block — throwing away the skip-step win on
-            //     incompressible data).
-            //
-            // Adding a new `break 'inner` variant now forces the
-            // author to pick a `InnerExit::…` variant explicitly; the
-            // previous `Option<MatchCandidate>` + sibling `usize`
-            // pairing relied on a comment-block to flag the coupling.
-            enum InnerExit {
-                Committed(MatchCandidate),
-                Tail(usize),
-            }
-
-            let inner_exit: InnerExit = 'inner: loop {
-                let abs_ip0 = current_abs_start + ip0;
-                let abs_ip1 = current_abs_start + ip1;
-                let lit_len_ip0 = ip0 - literals_start;
-                let lit_len_ip1 = ip1 - literals_start;
-                let packed_curr = ((abs_ip0 - position_base) as u32) + 1;
-
-                let concat_idx0 = abs_ip0 - history_abs_start;
-                let concat_idx1 = abs_ip1 - history_abs_start;
-
-                // Load 8 bytes at ip0 for both short (low 4) and long
-                // probe equality checks. We already used `v8_at_ip0` to
-                // compute hl0/idxl0 in the outer init / previous iter's
-                // carry; reload now (cheap unaligned read) so the
-                // `read_unaligned` is from the same offset the
-                // probe-eq below will use.
-                let v8_0 = unsafe {
-                    (history_base_ptr.add(history_start_offset + concat_idx0) as *const u64)
-                        .read_unaligned()
-                };
-                let v4_0 = v8_0 & 0xFFFF_FFFF;
-                let hs0_idx = (v4_0.wrapping_mul(PRIME) >> short_shift) as usize;
-                let idxs0 = unsafe { *short_hash_ptr.add(hs0_idx) };
-
-                // Donor parity (`zstd_double_fast.c:187`): update BOTH
-                // tables at curr BEFORE checking matches. The benefit is
-                // for hash-table consumers, NOT the rep peek (rep at ip+1
-                // reads `offset_hist[0]`, never the hash tables). The
-                // donor rationale is the long-hash retry path: the next
-                // inner iter's `idxl1` lookup (`hashLong[hl1_idx]`) can
-                // collide with this iter's `hl0_idx`, and writing curr
-                // first means a self-collision still resolves to a real
-                // match instead of the previous occupant. The short
-                // probe of the same iter and the `_search_next_long`
-                // retry at ip+1 are the other consumers that see the
-                // fresh write.
-                unsafe {
-                    *long_hash_ptr.add(hl0_idx) = packed_curr;
-                    *short_hash_ptr.add(hs0_idx) = packed_curr;
-                }
-
-                // Donor parity (`zstd_double_fast.c:190`): inline rep1
-                // peek at ip+1, 4-byte gate. Donor's hot path checks ONLY
-                // `offset_1` here (full 3-rep walk lives in lazy/btopt).
-                // Since the peek is at `ip+1` with `pos >= literals_start`,
-                // `lit_len_ip1 >= 1`, so `offset_hist[0]` is the donor's
-                // `offset_1`. The `repcode_candidate_shared` helper we used
-                // before walked all three offsets + did a full SIMD
-                // `common_prefix_len` per probe, paying ~3× the work for
-                // rep2/rep3 hits that the dfast fast path never benefits
-                // from (those wins live in the lazy/btopt strategies).
-                let rep1 = self.offset_hist[0] as usize;
-                if rep1 != 0 && rep1 <= abs_ip1 {
-                    let cand_pos_r = abs_ip1 - rep1;
-                    if cand_pos_r >= history_abs_start
-                        && cand_pos_r >= current_abs_start + literals_start
-                    {
-                        let cand_idx_r = cand_pos_r - history_abs_start;
-                        // 4-byte gate; full forward count only if it passes.
-                        let cand4 = unsafe {
-                            (history_base_ptr.add(history_start_offset + cand_idx_r) as *const u32)
-                                .read_unaligned()
-                        };
-                        let cur4 = unsafe {
-                            (history_base_ptr.add(history_start_offset + concat_idx1) as *const u32)
-                                .read_unaligned()
-                        };
-                        if cand4 == cur4 {
-                            let mut match_len = 4usize;
-                            let max_fwd = concat_len.saturating_sub(concat_idx1 + 4);
-                            unsafe {
-                                let lhs =
-                                    history_base_ptr.add(history_start_offset + cand_idx_r + 4);
-                                let rhs =
-                                    history_base_ptr.add(history_start_offset + concat_idx1 + 4);
-                                let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                    lhs, rhs, max_fwd,
-                                );
-                                match_len += ext;
-                            }
-                            // Rep extensions use the 4-byte
-                            // `DFAST_REP_MIN_MATCH_LEN` floor, NOT the
-                            // hash-search `DFAST_MIN_MATCH_LEN = 5`. Rep
-                            // coding has no on-wire offset cost, so the
-                            // upstream reference accepts 4-byte rep
-                            // hits; gating at 5 here would silently drop
-                            // every 4-byte rep1 the upstream encoder
-                            // produces, and leave the post-match
-                            // `extend_with_repcode_after_match` chain
-                            // (which uses 4) inconsistent with the peek.
-                            if match_len >= DFAST_REP_MIN_MATCH_LEN {
-                                let concat = &self.history[history_start_offset..];
-                                let rep_cand = extend_backwards_shared(
-                                    concat,
-                                    history_abs_start,
-                                    cand_pos_r,
-                                    abs_ip1,
-                                    match_len,
-                                    lit_len_ip1,
-                                );
-                                break 'inner InnerExit::Committed(rep_cand);
-                            }
-                        }
-                    }
-                }
-
-                // Precompute hl1 (donor `_search_next_long` carry, line 197).
-                let v8_1 = unsafe {
-                    (history_base_ptr.add(history_start_offset + concat_idx1) as *const u64)
-                        .read_unaligned()
-                };
-                let hl1_idx = (v8_1.wrapping_mul(PRIME) >> long_shift) as usize;
-
-                // Long match check at ip0 with idxl0. 8-byte equality
-                // gate (`MEM_read64`) — if it passes, candidate is real.
-                if idxl0 != DFAST_EMPTY_SLOT {
-                    let cand_pos = position_base + (idxl0 as usize) - 1;
-                    if cand_pos >= history_abs_start && cand_pos < abs_ip0 {
-                        let cand_idx = cand_pos - history_abs_start;
-                        // SAFETY: same buffer/length bounds as v8_0 above.
-                        let cand_v8 = unsafe {
-                            (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
-                                .read_unaligned()
-                        };
-                        if cand_v8 == v8_0 {
-                            // 8 bytes match; count forward + extend back.
-                            let mut match_len = 8usize;
-                            let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
-                            // SAFETY: both ptrs at the same buffer; offsets
-                            // verified above. `max_fwd` caps the scan to
-                            // the live region.
-                            unsafe {
-                                let lhs = history_base_ptr.add(history_start_offset + cand_idx + 8);
-                                let rhs =
-                                    history_base_ptr.add(history_start_offset + concat_idx0 + 8);
-                                let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                    lhs, rhs, max_fwd,
-                                );
-                                match_len += ext;
-                            }
-                            let concat = &self.history[history_start_offset..];
-                            let cand = extend_backwards_shared(
-                                concat,
-                                history_abs_start,
-                                cand_pos,
-                                abs_ip0,
-                                match_len,
-                                lit_len_ip0,
-                            );
-                            break 'inner InnerExit::Committed(cand);
-                        }
-                    }
-                }
-
-                // Dict long fallback (donor `dictMatchState`): the live long
-                // missed (empty / out-of-window / 8-byte mismatch). Probe the
-                // immutable dict long table at the SAME `hl0_idx`. Flat model:
-                // the dict sits in the contiguous history before the input, so
-                // a dict match is `offset = abs_ip0 - dict_abs` and the forward
-                // count crosses the dict→input boundary like any in-window
-                // match (no `dictBase`/`count_2segments`).
-                if use_dict {
-                    // SAFETY: when `use_dict`, `dict_long_ptr` is non-null and
-                    // sized `1 << long_hash_bits`; `hl0_idx < 1 << long_hash_bits`.
-                    let dl = unsafe { *dict_long_ptr.add(hl0_idx) };
-                    if dl != DFAST_EMPTY_SLOT {
-                        let dp = (dl as usize) - 1;
-                        // Dict long slots were only written for positions with
-                        // 8-byte lookahead, so `dp + 8 <= dict_len <= concat_len`;
-                        // `dp < dict_end` keeps the match inside the dict region.
-                        if dp < dict_end {
-                            debug_assert!(
-                                dp + HASH_READ_SIZE <= concat_len,
-                                "dict long load OOB: dp={dp} concat_len={concat_len}",
-                            );
-                            // SAFETY: `dp + 8 <= concat_len` (above) ⇒ the 8-byte
-                            // load at concat `dp` is in-bounds for live history.
-                            let dcand_v8 = unsafe {
-                                (history_base_ptr.add(history_start_offset + dp) as *const u64)
-                                    .read_unaligned()
-                            };
-                            if dcand_v8 == v8_0 {
-                                let mut match_len = 8usize;
-                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
-                                // SAFETY: both ptrs in the same buffer; `max_fwd`
-                                // caps the scan to the live region.
-                                unsafe {
-                                    let lhs = history_base_ptr.add(history_start_offset + dp + 8);
-                                    let rhs = history_base_ptr
-                                        .add(history_start_offset + concat_idx0 + 8);
-                                    let ext =
-                                        crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                            lhs, rhs, max_fwd,
-                                        );
-                                    match_len += ext;
-                                }
-                                let cand_pos = history_abs_start + dp;
-                                let concat = &self.history[history_start_offset..];
-                                let cand = extend_backwards_shared(
-                                    concat,
-                                    history_abs_start,
-                                    cand_pos,
-                                    abs_ip0,
-                                    match_len,
-                                    lit_len_ip0,
-                                );
-                                break 'inner InnerExit::Committed(cand);
-                            }
-                        }
-                    }
-                }
-
-                let idxl1 = unsafe { *long_hash_ptr.add(hl1_idx) };
-
-                // Short match check at ip0 with idxs0 — 4-byte gate
-                // ONLY (donor `zstd_double_fast.c:220`). Forward count
-                // and `_search_next_long` retry happen ONLY on hit.
-                if idxs0 != DFAST_EMPTY_SLOT {
-                    let cand_pos_s = position_base + (idxs0 as usize) - 1;
-                    if cand_pos_s >= history_abs_start && cand_pos_s < abs_ip0 {
-                        let cand_idx_s = cand_pos_s - history_abs_start;
-                        let cand4 = unsafe {
-                            (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
-                                .read_unaligned()
-                        };
-                        if cand4 == v4_0 as u32 {
-                            // Short hit: count forward from byte 4 onwards.
-                            let mut s_match_len = 4usize;
-                            let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
-                            unsafe {
-                                let lhs =
-                                    history_base_ptr.add(history_start_offset + cand_idx_s + 4);
-                                let rhs =
-                                    history_base_ptr.add(history_start_offset + concat_idx0 + 4);
-                                let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                    lhs, rhs, max_fwd,
-                                );
-                                s_match_len += ext;
-                            }
-                            let concat = &self.history[history_start_offset..];
-                            let short_cand = extend_backwards_shared(
-                                concat,
-                                history_abs_start,
-                                cand_pos_s,
-                                abs_ip0,
-                                s_match_len,
-                                lit_len_ip0,
-                            );
-
-                            // Enforce the hash-search floor BEFORE
-                            // committing this short hit. The 4-byte
-                            // equality gate plus forward-count extension
-                            // can produce `short_cand.match_len < 5`
-                            // (the literal 4-byte hit, no extension).
-                            // `probe_slot_match` rejects below-floor
-                            // long-hash hits at the same gate; the
-                            // short-hash path must do the same so the
-                            // fast loop never emits a sub-floor non-rep
-                            // match. The retry below can still upgrade
-                            // to a long hit (which has its own 8-byte
-                            // floor, comfortably above `DFAST_MIN_MATCH_LEN`).
-                            let short_hit_valid = short_cand.match_len >= DFAST_MIN_MATCH_LEN;
-
-                            // Donor `_search_next_long` retry (line 260):
-                            // try long match at ip1 with precomputed idxl1.
-                            // If it produces a strictly longer match, use it.
-                            let mut chosen = short_cand;
-                            let mut retry_upgraded = false;
-                            let mut live_l1_hit = false;
-                            if idxl1 != DFAST_EMPTY_SLOT {
-                                let cand_pos_l1 = position_base + (idxl1 as usize) - 1;
-                                if cand_pos_l1 >= history_abs_start && cand_pos_l1 < abs_ip1 {
-                                    let cand_idx_l1 = cand_pos_l1 - history_abs_start;
-                                    let cand_v8_l1 = unsafe {
-                                        (history_base_ptr.add(history_start_offset + cand_idx_l1)
-                                            as *const u64)
-                                            .read_unaligned()
-                                    };
-                                    if cand_v8_l1 == v8_1 {
-                                        live_l1_hit = true;
-                                        let mut l1_match_len = 8usize;
-                                        let max_fwd_l1 = concat_len.saturating_sub(concat_idx1 + 8);
-                                        unsafe {
-                                            let lhs = history_base_ptr
-                                                .add(history_start_offset + cand_idx_l1 + 8);
-                                            let rhs = history_base_ptr
-                                                .add(history_start_offset + concat_idx1 + 8);
-                                            let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                                lhs, rhs, max_fwd_l1,
-                                            );
-                                            l1_match_len += ext;
-                                        }
-                                        if l1_match_len > short_cand.match_len {
-                                            let concat = &self.history[history_start_offset..];
-                                            chosen = extend_backwards_shared(
-                                                concat,
-                                                history_abs_start,
-                                                cand_pos_l1,
-                                                abs_ip1,
-                                                l1_match_len,
-                                                lit_len_ip1,
-                                            );
-                                            // Long-hash hits start at 8
-                                            // bytes (`MEM_read64` gate
-                                            // above), well above
-                                            // `DFAST_MIN_MATCH_LEN = 5`,
-                                            // so the retry upgrade is
-                                            // always valid even when
-                                            // the raw short hit was
-                                            // below the floor.
-                                            retry_upgraded = true;
-                                        }
-                                    }
-                                }
-                            }
-                            // Dict long match at ip1 (donor `_search_next_long`
-                            // dict arm, zstd_double_fast.c:472-483): probed ONLY
-                            // when the live long+1 missed, mirroring donor's
-                            // `else if dictTagsMatchL3`. Attach-mode keeps the
-                            // dict in a SEPARATE table, so the live long+1 probe
-                            // above never sees dict positions; without this the
-                            // dict-long upgrade the old dense-reprime path got
-                            // for free (dict positions lived in the live table)
-                            // is lost and the loop emits the shorter short match.
-                            if !live_l1_hit && use_dict {
-                                // SAFETY: `use_dict` ⇒ `dict_long_ptr` non-null,
-                                // sized `1 << long_hash_bits`; `hl1_idx` is in range.
-                                let dl1 = unsafe { *dict_long_ptr.add(hl1_idx) };
-                                if dl1 != DFAST_EMPTY_SLOT {
-                                    let dp1 = (dl1 as usize) - 1;
-                                    if dp1 < dict_end {
-                                        debug_assert!(
-                                            dp1 + HASH_READ_SIZE <= concat_len,
-                                            "dict long+1 load OOB: dp1={dp1} concat_len={concat_len}",
-                                        );
-                                        // SAFETY: `dp1 + 8 <= concat_len` ⇒ the
-                                        // 8-byte load at concat `dp1` is in-bounds.
-                                        let dcand_v8_l1 = unsafe {
-                                            (history_base_ptr.add(history_start_offset + dp1)
-                                                as *const u64)
-                                                .read_unaligned()
-                                        };
-                                        if dcand_v8_l1 == v8_1 {
-                                            let mut dl1_match_len = 8usize;
-                                            let max_fwd =
-                                                concat_len.saturating_sub(concat_idx1 + 8);
-                                            // SAFETY: same buffer; `max_fwd` caps
-                                            // the scan to the live region.
-                                            unsafe {
-                                                let lhs = history_base_ptr
-                                                    .add(history_start_offset + dp1 + 8);
-                                                let rhs = history_base_ptr
-                                                    .add(history_start_offset + concat_idx1 + 8);
-                                                let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                                    lhs, rhs, max_fwd,
-                                                );
-                                                dl1_match_len += ext;
-                                            }
-                                            if dl1_match_len > short_cand.match_len {
-                                                let cand_pos = history_abs_start + dp1;
-                                                let concat = &self.history[history_start_offset..];
-                                                chosen = extend_backwards_shared(
-                                                    concat,
-                                                    history_abs_start,
-                                                    cand_pos,
-                                                    abs_ip1,
-                                                    dl1_match_len,
-                                                    lit_len_ip1,
-                                                );
-                                                retry_upgraded = true;
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                            if short_hit_valid || retry_upgraded {
-                                break 'inner InnerExit::Committed(chosen);
-                            }
-                            // Below-floor short hit with no retry
-                            // upgrade — fall through to the step bump
-                            // and keep scanning. Discarding here is
-                            // correctness-relevant: emitting a 4-byte
-                            // non-rep match would mint an offset on
-                            // wire that costs more than the 4-byte
-                            // payload buys (offsets at level 2/3 dfast
-                            // are 13–17 bits depending on offset class
-                            // and prior offset_hist state — strictly
-                            // worse than emitting the 4 bytes as
-                            // literals).
-                        }
-                    }
-                }
-
-                // Dict short fallback (donor `dictMatchState`): the live short
-                // missed / was below floor. Probe the immutable dict short
-                // table at the SAME `hs0_idx`, 4-byte gate, forward count, then
-                // enforce the same `DFAST_MIN_MATCH_LEN` floor the live short
-                // path uses (a sub-floor non-rep match mints a wire offset that
-                // costs more than emitting the bytes as literals). No
-                // `_search_next_long` retry: the dict long fallback already
-                // covers the long-upgrade case at `ip0`.
-                if use_dict {
-                    // SAFETY: `use_dict` ⇒ `dict_short_ptr` non-null, sized
-                    // `1 << short_hash_bits`; `hs0_idx < 1 << short_hash_bits`.
-                    let ds = unsafe { *dict_short_ptr.add(hs0_idx) };
-                    if ds != DFAST_EMPTY_SLOT {
-                        let dp = (ds as usize) - 1;
-                        if dp < dict_end {
-                            debug_assert!(
-                                dp + 4 <= concat_len,
-                                "dict short load OOB: dp={dp} concat_len={concat_len}",
-                            );
-                            // SAFETY: short slots were only written with 4 bytes
-                            // of lookahead ⇒ `dp + 4 <= dict_len <= concat_len`.
-                            let dcand4 = unsafe {
-                                (history_base_ptr.add(history_start_offset + dp) as *const u32)
-                                    .read_unaligned()
-                            };
-                            if dcand4 == v4_0 as u32 {
-                                let mut s_match_len = 4usize;
-                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
-                                unsafe {
-                                    let lhs = history_base_ptr.add(history_start_offset + dp + 4);
-                                    let rhs = history_base_ptr
-                                        .add(history_start_offset + concat_idx0 + 4);
-                                    let ext =
-                                        crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
-                                            lhs, rhs, max_fwd,
-                                        );
-                                    s_match_len += ext;
-                                }
-                                let cand_pos = history_abs_start + dp;
-                                let concat = &self.history[history_start_offset..];
-                                let dcand = extend_backwards_shared(
-                                    concat,
-                                    history_abs_start,
-                                    cand_pos,
-                                    abs_ip0,
-                                    s_match_len,
-                                    lit_len_ip0,
-                                );
-                                if dcand.match_len >= DFAST_MIN_MATCH_LEN {
-                                    break 'inner InnerExit::Committed(dcand);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Step bump on distance (donor `zstd_double_fast.c:224-228`).
-                if ip1 >= next_step_pos {
-                    step = (step + 1).min(DFAST_MAX_SKIP_STEP);
-                    next_step_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
-                }
-
-                // Advance: ip0 = ip1; ip1 += step; carry hl1 → hl0 / idxl1 → idxl0.
-                ip0 = ip1;
-                ip1 += step;
-                hl0_idx = hl1_idx;
-                idxl0 = idxl1;
-                if ip1 + HASH_READ_SIZE > current_len {
-                    // First position the fast loop did NOT pack into the
-                    // hash tables. `seed_remaining_hashable_starts` will
-                    // pick up from `ip0` instead of restarting at the
-                    // outer-entry `pos`.
-                    break 'inner InnerExit::Tail(ip0);
-                }
-            };
-
-            match inner_exit {
-                InnerExit::Committed(candidate) => {
-                    let start = self.emit_candidate(
-                        current_abs_start,
-                        &mut literals_start,
-                        candidate,
-                        handle_sequence,
-                    );
-                    pos = start + candidate.match_len;
-                    pos = self.extend_with_repcode_after_match(
-                        current_abs_start,
-                        current_len,
-                        pos,
-                        &mut literals_start,
-                        handle_sequence,
-                    );
-                }
-                InnerExit::Tail(seed) => {
-                    // Inner loop ran out of safe scan room without
-                    // committing. Hand the tail seeder the first
-                    // un-scanned position so it does not redundantly
-                    // re-pack everything the fast loop already wrote.
-                    pos = seed;
-                    break 'outer;
-                }
-            }
-        }
-
-        self.seed_remaining_hashable_starts(current_abs_start, current_len, pos);
-        self.emit_trailing_literals(literals_start, handle_sequence);
-    }
 
     /// Single-cursor probe at the last hashable position in the
     /// current block. Called from `start_matching_fast_loop` only when
@@ -2727,5 +1966,890 @@ mod extend_with_repcode_tests {
             data.len(),
             compressed.len()
         );
+    }
+}
+
+/// Per-kernel body of the dfast fast match loop. Mirrors the BT/opt
+/// `*_body!` macros: the wrapper carries the `#[target_feature]` umbrella and
+/// passes its tier `common_prefix_len_ptr` as `$cpl`, so the 7 match-extension
+/// cpl calls inline under one umbrella and `select_kernel()` is resolved ONCE
+/// per block in the bare dispatcher, never per cpl call.
+macro_rules! start_matching_fast_loop_body {
+    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident, $cpl:path) => {{
+        // Behaviour change vs the pre-refactor `start_matching_general`:
+        // this fast loop deliberately drops the strict-incompressible
+        // early-skip path (the `block_looks_incompressible_strict` short
+        // circuit + `miss_run` / `DFAST_LOCAL_SKIP_TRIGGER` thresholding).
+        // The step ramp is now driven purely by distance traveled
+        // (`DFAST_SKIP_STEP_GROWTH_INTERVAL = 64`, donor parity except
+        // donor uses 256 — see "Donor-deviation audit" in the PR body),
+        // so blocks the strict gate used to bail out of early now scan
+        // through the standard ramp. `block_looks_incompressible_strict`
+        // is still used by `levels/fastest.rs` for the Fastest preset
+        // and by `incompressible.rs` unit tests, so the helper itself
+        // stays.
+        //
+        // Donor outer/inner structure (`zstd_double_fast.c:167-322`):
+        //   * outer `while(1)` runs once per match-found-and-stored;
+        //   * inner `do { ... } while (ip1 <= ilimit)` carries `hl0`,
+        //     `idxl0` between iterations, and precomputes `hl1` so the
+        //     next iter's long hash is reused (one long-hash compute per
+        //     two positions scanned, not per position).
+        // We mirror that here. Per-frame invariants are hoisted before
+        // the outer loop; mutable state (`position_base`, `history_abs_start`)
+        // is re-snapshotted inside the outer loop because `emit_candidate`
+        // → `insert_positions` → `ensure_room_for` can advance the rebase
+        // base mid-frame.
+        //
+        // Rebase BEFORE any inner-loop slot pack. The hot loop computes
+        // `packed_curr = (abs_ip0 - position_base) as u32 + 1` and writes
+        // it straight into the hash tables, bypassing `insert_position`
+        // (which is where `ensure_room_for` normally fires). On a long
+        // stream of all-miss / non-hashable blocks the matcher can advance
+        // `$current_abs_start` arbitrarily far without any per-byte insert,
+        // so `position_base` may be stale by `> u32::MAX`. The first
+        // fast-loop block after that would silently truncate `packed_curr`
+        // and poison both hash tables. The guard band in `ensure_room_for`
+        // (`DFAST_REBASE_GUARD_BAND`) covers the entire current block's
+        // worth of positions, so a single call at function entry suffices.
+        //
+        // Raw-pointer aliasing invariant. The inner loop caches
+        // `short_hash_ptr = $self.short_hash.as_mut_ptr()` and
+        // `long_hash_ptr = $self.long_hash.as_mut_ptr()` (and a
+        // `history_base_ptr` for the byte-buffer reads), then over
+        // the rest of the function does:
+        //
+        //   * raw writes / reads via `*short_hash_ptr.add(...) =
+        //     packed_curr`, `*long_hash_ptr.add(...) = packed_curr`,
+        //     and `*long_hash_ptr.add(hl1_idx)`;
+        //   * `&$self`-shared reads of `$self.offset_hist[0]` for the
+        //     rep1 peek;
+        //   * `&$self`-shared slice reads of `$self.history` (`let
+        //     concat = &$self.history[history_start_offset..]`) for
+        //     `extend_backwards_shared` invocations.
+        //
+        // This is sound under both Stacked Borrows and Tree Borrows
+        // because the three fields touched (`short_hash`, `long_hash`,
+        // `history`, `offset_hist`) are physically disjoint
+        // allocations — `Vec<u32>`/`Vec<u8>` each own their own heap
+        // buffer, and `offset_hist` is an inline `[u32; 3]` inside
+        // the struct. A raw pointer derived from one field's Vec data
+        // has provenance over that field only, so the subsequent
+        // `&$self` reads of sibling fields don't reborrow through the
+        // raw pointer's provenance tree.
+        //
+        // CRITICAL: this invariant must be preserved by any future
+        // refactor that adds method calls inside the loop body. A
+        // call that takes `&mut $self` (e.g.,
+        // `$self.ensure_hash_tables()`, `$self.insert_position(...)`)
+        // would reborrow the tables and invalidate the cached raw
+        // pointers — every such call must happen OUTSIDE the
+        // `'outer: loop` (as `ensure_room_for` does, hoisted to the
+        // function preamble above) or be followed by a fresh
+        // `as_mut_ptr()` reload of both `short_hash_ptr` /
+        // `long_hash_ptr`. The outer-loop body already re-snapshots
+        // `history_base_ptr` per iteration for exactly this reason
+        // (`emit_candidate` → `insert_positions` may grow `history`
+        // and trigger a realloc), so the same re-snapshot discipline
+        // applies to the hash-table pointers.
+        //
+        // `$current_len > 0` is a precondition of this helper: every
+        // caller (`start_matching`, `skip_matching`, `skip_matching_dense`)
+        // returns early at `$current_len == 0`. Encode it as a hard
+        // assert so a future caller that forgets the gate fails loudly
+        // in debug rather than wrap-underflowing the `- 1` below; the
+        // rebase is unconditional in release builds since the
+        // precondition holds.
+        debug_assert!($current_len > 0, "fast_loop precondition: $current_len > 0");
+        $self.ensure_room_for($current_abs_start + $current_len - 1);
+        const PRIME: u64 = 0xCF1BBCDCB7A56463_u64;
+        let short_shift = 64 - $self.short_hash_bits;
+        let long_shift = 64 - $self.long_hash_bits;
+        let mut pos = 1usize;
+        let mut literals_start = 0usize;
+
+        // Dict dual-probe (donor `ZSTD_dictMatchState`): snapshot the immutable
+        // dict tables ONCE. Unlike the live tables (which `emit_candidate` may
+        // grow / rebase), the dict tables are never mutated during matching, so
+        // one snapshot before the outer loop stays valid every iteration. The
+        // raw pointers hold no borrow, so the per-iter `&$self`/`&mut $self`
+        // accesses below coexist. `use_dict` gates every probe so the no-dict
+        // hot path keeps its exact instruction shape. `dict_end` is the
+        // dict/input boundary as a CONCAT index (history_start-relative); the
+        // dict is invalidated on any history eviction, so concat indices stay
+        // valid for the snapshot's lifetime.
+        // `use_dict` MUST track table presence, NOT `is_attached()`:
+        // `prime_dict_tables_for_range` records the dict region (so
+        // `is_attached()` is true) but returns before allocating the
+        // tables when the hashable region is shorter than the short-hash
+        // lookahead. Gating on `table().is_some()` keeps the null dict
+        // pointers out of the probe below, which dereferences them before
+        // the `dict_end` bound is consulted.
+        let (use_dict, dict_long_ptr, dict_short_ptr, dict_end): (
+            bool,
+            *const u32,
+            *const u32,
+            usize,
+        ) = match $self.dict.table() {
+            Some(d) => (
+                true,
+                d.long.as_ptr(),
+                d.short.as_ptr(),
+                $self.dict.region_len(),
+            ),
+            None => (false, core::ptr::null(), core::ptr::null(), 0),
+        };
+
+        'outer: loop {
+            // Outer-iter precondition: at least `HASH_READ_SIZE = 8` bytes
+            // ahead of `pos` so the unconditional 8-byte `u64` load below
+            // is in-bounds for the live history buffer. `DFAST_MIN_MATCH_LEN
+            // = 5` is the match acceptance threshold and is NOT a safe
+            // load bound — using it here read up to 3 bytes past
+            // `history.len()` on tiny blocks (CI fuzz `interop` crash,
+            // 7-byte input).
+            // NOTE: when this guard fires on the very first outer-iter
+            // (tiny block, `$current_len < 9`), we `break 'outer` BEFORE
+            // `tail_seed_anchor` is even declared. The post-loop
+            // `seed_remaining_hashable_starts(.., pos)` then runs with
+            // `pos` at its initial value (1 on first frame, or the
+            // post-match cursor from a previous outer iter); that's the
+            // correct tail seed for tiny blocks — `seed_pos = pos.min(
+            // $current_len).min(boundary_tail_start)` plus the
+            // `seed_pos + DFAST_SHORT_HASH_LOOKAHEAD <= $current_len`
+            // guard inside the seeder keeps every insert in-bounds.
+            if pos + HASH_READ_SIZE > $current_len {
+                break 'outer;
+            }
+            let mut step = 1usize;
+            let mut next_step_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
+            let mut ip0 = pos;
+            let mut ip1 = ip0 + step;
+            // Same `HASH_READ_SIZE` rationale for `ip1`: the inner loop
+            // pre-loads 8 bytes at `concat_idx1` for the `hl1` precompute
+            // and the `_search_next_long` retry, so `ip1 + 8 <= $current_len`
+            // must hold before we enter. If `ip0` is still hashable but
+            // `ip1` is not (boundary case `pos == $current_len - 8`), we
+            // still want to probe `ip0` — skipping it would leave the
+            // last hashable position to `seed_remaining_hashable_starts`,
+            // which inserts but does NOT search, and that drops real
+            // matches in the tail window vs the upstream reference
+            // (whose single-cursor loop probes every position p with
+            // `p + HASH_READ_SIZE <= iend`). Handle the boundary inline
+            // before exiting: a single-cursor probe at `ip0` (rep peek
+            // and `_search_next_long` retry both depend on `ip1` so
+            // they're skipped — donor accepts that exact tradeoff at
+            // the iend boundary).
+            if ip1 + HASH_READ_SIZE > $current_len {
+                if let Some(committed) =
+                    $self.probe_tail_ip0_only($current_abs_start, $current_len, ip0, literals_start)
+                {
+                    let start = $self.emit_candidate(
+                        $current_abs_start,
+                        &mut literals_start,
+                        committed,
+                        $handle_sequence,
+                    );
+                    pos = start + committed.match_len;
+                    pos = $self.extend_with_repcode_after_match(
+                        $current_abs_start,
+                        $current_len,
+                        pos,
+                        &mut literals_start,
+                        $handle_sequence,
+                    );
+                    continue 'outer;
+                }
+                break 'outer;
+            }
+
+            // Re-read every per-frame-mutable cursor here — `emit_candidate`
+            // in the previous outer iteration may have triggered a rebase.
+            let history_abs_start = $self.history_abs_start;
+            let position_base = $self.position_base;
+            let history_start_offset = $self.history_start;
+            let history_base_ptr = $self.history.as_ptr();
+            let short_hash_ptr = $self.short_hash.as_mut_ptr();
+            let long_hash_ptr = $self.long_hash.as_mut_ptr();
+            let concat_len = $self.history.len() - history_start_offset;
+
+            // Pre-compute long hash at ip0 ONCE per outer iter.
+            // `concat_idx = ($current_abs_start + ip0) - history_abs_start`
+            // is the byte offset within `live_history`.
+            let mut hl0_idx;
+            let mut idxl0;
+            // SAFETY: `$current_abs_start + ip0 >= history_abs_start`
+            // (`ip` is inside the current block, which is part of live
+            // history). The 8-byte unaligned load on
+            // `concat[concat_idx..]` is safe because the outer loop
+            // guards above enforce `ip0 + HASH_READ_SIZE <= $current_len`,
+            // and `$current_abs_start + $current_len - history_abs_start
+            // <= concat_len` (live history contains the full current
+            // block plus any retained earlier blocks), giving
+            // `concat_idx + 8 <= concat_len`. The `debug_assert!` below
+            // makes that invariant explicit so a future refactor that
+            // touches eviction / `compact_history` / `trim_to_window`
+            // semantics catches a violation in tests instead of leaking
+            // through to ASan UB.
+            unsafe {
+                let concat_idx = ($current_abs_start + ip0) - history_abs_start;
+                debug_assert!(
+                    concat_idx + HASH_READ_SIZE <= concat_len,
+                    "fast-loop 8-byte load OOB: concat_idx={} HASH_READ_SIZE={} concat_len={}",
+                    concat_idx,
+                    HASH_READ_SIZE,
+                    concat_len,
+                );
+                let v8 = (history_base_ptr.add(history_start_offset + concat_idx) as *const u64)
+                    .read_unaligned();
+                hl0_idx = (v8.wrapping_mul(PRIME) >> long_shift) as usize;
+                idxl0 = *long_hash_ptr.add(hl0_idx);
+            }
+
+            // Inner-loop exit shape. Every `break 'inner` produces a
+            // value of this type, so the type system enforces the
+            // previously implicit pairing between "did we commit a
+            // match?" and "where does the tail seeder pick up?":
+            //
+            //   * `Committed(c)` — rep1 / long / short(+next_long retry)
+            //     paths chose `c`; outer arm runs emit + rep-extension.
+            //   * `Tail(seed)` — inner ran out of safe scan room at
+            //     `seed = ip0` (first un-scanned position); outer arm
+            //     hands `seed` to `seed_remaining_hashable_starts` so
+            //     the tail seeder does not redundantly re-pack
+            //     positions the fast loop already wrote (which is what
+            //     restarting from outer-entry `pos` would do on a
+            //     miss-only block — throwing away the skip-step win on
+            //     incompressible data).
+            //
+            // Adding a new `break 'inner` variant now forces the
+            // author to pick a `InnerExit::…` variant explicitly; the
+            // previous `Option<MatchCandidate>` + sibling `usize`
+            // pairing relied on a comment-block to flag the coupling.
+            enum InnerExit {
+                Committed(MatchCandidate),
+                Tail(usize),
+            }
+
+            let inner_exit: InnerExit = 'inner: loop {
+                let abs_ip0 = $current_abs_start + ip0;
+                let abs_ip1 = $current_abs_start + ip1;
+                let lit_len_ip0 = ip0 - literals_start;
+                let lit_len_ip1 = ip1 - literals_start;
+                let packed_curr = ((abs_ip0 - position_base) as u32) + 1;
+
+                let concat_idx0 = abs_ip0 - history_abs_start;
+                let concat_idx1 = abs_ip1 - history_abs_start;
+
+                // Load 8 bytes at ip0 for both short (low 4) and long
+                // probe equality checks. We already used `v8_at_ip0` to
+                // compute hl0/idxl0 in the outer init / previous iter's
+                // carry; reload now (cheap unaligned read) so the
+                // `read_unaligned` is from the same offset the
+                // probe-eq below will use.
+                let v8_0 = unsafe {
+                    (history_base_ptr.add(history_start_offset + concat_idx0) as *const u64)
+                        .read_unaligned()
+                };
+                let v4_0 = v8_0 & 0xFFFF_FFFF;
+                let hs0_idx = (v4_0.wrapping_mul(PRIME) >> short_shift) as usize;
+                let idxs0 = unsafe { *short_hash_ptr.add(hs0_idx) };
+
+                // Donor parity (`zstd_double_fast.c:187`): update BOTH
+                // tables at curr BEFORE checking matches. The benefit is
+                // for hash-table consumers, NOT the rep peek (rep at ip+1
+                // reads `offset_hist[0]`, never the hash tables). The
+                // donor rationale is the long-hash retry path: the next
+                // inner iter's `idxl1` lookup (`hashLong[hl1_idx]`) can
+                // collide with this iter's `hl0_idx`, and writing curr
+                // first means a $self-collision still resolves to a real
+                // match instead of the previous occupant. The short
+                // probe of the same iter and the `_search_next_long`
+                // retry at ip+1 are the other consumers that see the
+                // fresh write.
+                unsafe {
+                    *long_hash_ptr.add(hl0_idx) = packed_curr;
+                    *short_hash_ptr.add(hs0_idx) = packed_curr;
+                }
+
+                // Donor parity (`zstd_double_fast.c:190`): inline rep1
+                // peek at ip+1, 4-byte gate. Donor's hot path checks ONLY
+                // `offset_1` here (full 3-rep walk lives in lazy/btopt).
+                // Since the peek is at `ip+1` with `pos >= literals_start`,
+                // `lit_len_ip1 >= 1`, so `offset_hist[0]` is the donor's
+                // `offset_1`. The `repcode_candidate_shared` helper we used
+                // before walked all three offsets + did a full SIMD
+                // `common_prefix_len` per probe, paying ~3× the work for
+                // rep2/rep3 hits that the dfast fast path never benefits
+                // from (those wins live in the lazy/btopt strategies).
+                let rep1 = $self.offset_hist[0] as usize;
+                if rep1 != 0 && rep1 <= abs_ip1 {
+                    let cand_pos_r = abs_ip1 - rep1;
+                    if cand_pos_r >= history_abs_start
+                        && cand_pos_r >= $current_abs_start + literals_start
+                    {
+                        let cand_idx_r = cand_pos_r - history_abs_start;
+                        // 4-byte gate; full forward count only if it passes.
+                        let cand4 = unsafe {
+                            (history_base_ptr.add(history_start_offset + cand_idx_r) as *const u32)
+                                .read_unaligned()
+                        };
+                        let cur4 = unsafe {
+                            (history_base_ptr.add(history_start_offset + concat_idx1) as *const u32)
+                                .read_unaligned()
+                        };
+                        if cand4 == cur4 {
+                            let mut match_len = 4usize;
+                            let max_fwd = concat_len.saturating_sub(concat_idx1 + 4);
+                            unsafe {
+                                let lhs =
+                                    history_base_ptr.add(history_start_offset + cand_idx_r + 4);
+                                let rhs =
+                                    history_base_ptr.add(history_start_offset + concat_idx1 + 4);
+                                let ext = $cpl(
+                                    lhs, rhs, max_fwd,
+                                );
+                                match_len += ext;
+                            }
+                            // Rep extensions use the 4-byte
+                            // `DFAST_REP_MIN_MATCH_LEN` floor, NOT the
+                            // hash-search `DFAST_MIN_MATCH_LEN = 5`. Rep
+                            // coding has no on-wire offset cost, so the
+                            // upstream reference accepts 4-byte rep
+                            // hits; gating at 5 here would silently drop
+                            // every 4-byte rep1 the upstream encoder
+                            // produces, and leave the post-match
+                            // `extend_with_repcode_after_match` chain
+                            // (which uses 4) inconsistent with the peek.
+                            if match_len >= DFAST_REP_MIN_MATCH_LEN {
+                                let concat = &$self.history[history_start_offset..];
+                                let rep_cand = extend_backwards_shared(
+                                    concat,
+                                    history_abs_start,
+                                    cand_pos_r,
+                                    abs_ip1,
+                                    match_len,
+                                    lit_len_ip1,
+                                );
+                                break 'inner InnerExit::Committed(rep_cand);
+                            }
+                        }
+                    }
+                }
+
+                // Precompute hl1 (donor `_search_next_long` carry, line 197).
+                let v8_1 = unsafe {
+                    (history_base_ptr.add(history_start_offset + concat_idx1) as *const u64)
+                        .read_unaligned()
+                };
+                let hl1_idx = (v8_1.wrapping_mul(PRIME) >> long_shift) as usize;
+
+                // Long match check at ip0 with idxl0. 8-byte equality
+                // gate (`MEM_read64`) — if it passes, candidate is real.
+                if idxl0 != DFAST_EMPTY_SLOT {
+                    let cand_pos = position_base + (idxl0 as usize) - 1;
+                    if cand_pos >= history_abs_start && cand_pos < abs_ip0 {
+                        let cand_idx = cand_pos - history_abs_start;
+                        // SAFETY: same buffer/length bounds as v8_0 above.
+                        let cand_v8 = unsafe {
+                            (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
+                                .read_unaligned()
+                        };
+                        if cand_v8 == v8_0 {
+                            // 8 bytes match; count forward + extend back.
+                            let mut match_len = 8usize;
+                            let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
+                            // SAFETY: both ptrs at the same buffer; offsets
+                            // verified above. `max_fwd` caps the scan to
+                            // the live region.
+                            unsafe {
+                                let lhs = history_base_ptr.add(history_start_offset + cand_idx + 8);
+                                let rhs =
+                                    history_base_ptr.add(history_start_offset + concat_idx0 + 8);
+                                let ext = $cpl(
+                                    lhs, rhs, max_fwd,
+                                );
+                                match_len += ext;
+                            }
+                            let concat = &$self.history[history_start_offset..];
+                            let cand = extend_backwards_shared(
+                                concat,
+                                history_abs_start,
+                                cand_pos,
+                                abs_ip0,
+                                match_len,
+                                lit_len_ip0,
+                            );
+                            break 'inner InnerExit::Committed(cand);
+                        }
+                    }
+                }
+
+                // Dict long fallback (donor `dictMatchState`): the live long
+                // missed (empty / out-of-window / 8-byte mismatch). Probe the
+                // immutable dict long table at the SAME `hl0_idx`. Flat model:
+                // the dict sits in the contiguous history before the input, so
+                // a dict match is `offset = abs_ip0 - dict_abs` and the forward
+                // count crosses the dict→input boundary like any in-window
+                // match (no `dictBase`/`count_2segments`).
+                if use_dict {
+                    // SAFETY: when `use_dict`, `dict_long_ptr` is non-null and
+                    // sized `1 << long_hash_bits`; `hl0_idx < 1 << long_hash_bits`.
+                    let dl = unsafe { *dict_long_ptr.add(hl0_idx) };
+                    if dl != DFAST_EMPTY_SLOT {
+                        let dp = (dl as usize) - 1;
+                        // Dict long slots were only written for positions with
+                        // 8-byte lookahead, so `dp + 8 <= dict_len <= concat_len`;
+                        // `dp < dict_end` keeps the match inside the dict region.
+                        if dp < dict_end {
+                            debug_assert!(
+                                dp + HASH_READ_SIZE <= concat_len,
+                                "dict long load OOB: dp={dp} concat_len={concat_len}",
+                            );
+                            // SAFETY: `dp + 8 <= concat_len` (above) ⇒ the 8-byte
+                            // load at concat `dp` is in-bounds for live history.
+                            let dcand_v8 = unsafe {
+                                (history_base_ptr.add(history_start_offset + dp) as *const u64)
+                                    .read_unaligned()
+                            };
+                            if dcand_v8 == v8_0 {
+                                let mut match_len = 8usize;
+                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
+                                // SAFETY: both ptrs in the same buffer; `max_fwd`
+                                // caps the scan to the live region.
+                                unsafe {
+                                    let lhs = history_base_ptr.add(history_start_offset + dp + 8);
+                                    let rhs = history_base_ptr
+                                        .add(history_start_offset + concat_idx0 + 8);
+                                    let ext =
+                                        $cpl(
+                                            lhs, rhs, max_fwd,
+                                        );
+                                    match_len += ext;
+                                }
+                                let cand_pos = history_abs_start + dp;
+                                let concat = &$self.history[history_start_offset..];
+                                let cand = extend_backwards_shared(
+                                    concat,
+                                    history_abs_start,
+                                    cand_pos,
+                                    abs_ip0,
+                                    match_len,
+                                    lit_len_ip0,
+                                );
+                                break 'inner InnerExit::Committed(cand);
+                            }
+                        }
+                    }
+                }
+
+                let idxl1 = unsafe { *long_hash_ptr.add(hl1_idx) };
+
+                // Short match check at ip0 with idxs0 — 4-byte gate
+                // ONLY (donor `zstd_double_fast.c:220`). Forward count
+                // and `_search_next_long` retry happen ONLY on hit.
+                if idxs0 != DFAST_EMPTY_SLOT {
+                    let cand_pos_s = position_base + (idxs0 as usize) - 1;
+                    if cand_pos_s >= history_abs_start && cand_pos_s < abs_ip0 {
+                        let cand_idx_s = cand_pos_s - history_abs_start;
+                        let cand4 = unsafe {
+                            (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
+                                .read_unaligned()
+                        };
+                        if cand4 == v4_0 as u32 {
+                            // Short hit: count forward from byte 4 onwards.
+                            let mut s_match_len = 4usize;
+                            let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
+                            unsafe {
+                                let lhs =
+                                    history_base_ptr.add(history_start_offset + cand_idx_s + 4);
+                                let rhs =
+                                    history_base_ptr.add(history_start_offset + concat_idx0 + 4);
+                                let ext = $cpl(
+                                    lhs, rhs, max_fwd,
+                                );
+                                s_match_len += ext;
+                            }
+                            let concat = &$self.history[history_start_offset..];
+                            let short_cand = extend_backwards_shared(
+                                concat,
+                                history_abs_start,
+                                cand_pos_s,
+                                abs_ip0,
+                                s_match_len,
+                                lit_len_ip0,
+                            );
+
+                            // Enforce the hash-search floor BEFORE
+                            // committing this short hit. The 4-byte
+                            // equality gate plus forward-count extension
+                            // can produce `short_cand.match_len < 5`
+                            // (the literal 4-byte hit, no extension).
+                            // `probe_slot_match` rejects below-floor
+                            // long-hash hits at the same gate; the
+                            // short-hash path must do the same so the
+                            // fast loop never emits a sub-floor non-rep
+                            // match. The retry below can still upgrade
+                            // to a long hit (which has its own 8-byte
+                            // floor, comfortably above `DFAST_MIN_MATCH_LEN`).
+                            let short_hit_valid = short_cand.match_len >= DFAST_MIN_MATCH_LEN;
+
+                            // Donor `_search_next_long` retry (line 260):
+                            // try long match at ip1 with precomputed idxl1.
+                            // If it produces a strictly longer match, use it.
+                            let mut chosen = short_cand;
+                            let mut retry_upgraded = false;
+                            let mut live_l1_hit = false;
+                            if idxl1 != DFAST_EMPTY_SLOT {
+                                let cand_pos_l1 = position_base + (idxl1 as usize) - 1;
+                                if cand_pos_l1 >= history_abs_start && cand_pos_l1 < abs_ip1 {
+                                    let cand_idx_l1 = cand_pos_l1 - history_abs_start;
+                                    let cand_v8_l1 = unsafe {
+                                        (history_base_ptr.add(history_start_offset + cand_idx_l1)
+                                            as *const u64)
+                                            .read_unaligned()
+                                    };
+                                    if cand_v8_l1 == v8_1 {
+                                        live_l1_hit = true;
+                                        let mut l1_match_len = 8usize;
+                                        let max_fwd_l1 = concat_len.saturating_sub(concat_idx1 + 8);
+                                        unsafe {
+                                            let lhs = history_base_ptr
+                                                .add(history_start_offset + cand_idx_l1 + 8);
+                                            let rhs = history_base_ptr
+                                                .add(history_start_offset + concat_idx1 + 8);
+                                            let ext = $cpl(
+                                                lhs, rhs, max_fwd_l1,
+                                            );
+                                            l1_match_len += ext;
+                                        }
+                                        if l1_match_len > short_cand.match_len {
+                                            let concat = &$self.history[history_start_offset..];
+                                            chosen = extend_backwards_shared(
+                                                concat,
+                                                history_abs_start,
+                                                cand_pos_l1,
+                                                abs_ip1,
+                                                l1_match_len,
+                                                lit_len_ip1,
+                                            );
+                                            // Long-hash hits start at 8
+                                            // bytes (`MEM_read64` gate
+                                            // above), well above
+                                            // `DFAST_MIN_MATCH_LEN = 5`,
+                                            // so the retry upgrade is
+                                            // always valid even when
+                                            // the raw short hit was
+                                            // below the floor.
+                                            retry_upgraded = true;
+                                        }
+                                    }
+                                }
+                            }
+                            // Dict long match at ip1 (donor `_search_next_long`
+                            // dict arm, zstd_double_fast.c:472-483): probed ONLY
+                            // when the live long+1 missed, mirroring donor's
+                            // `else if dictTagsMatchL3`. Attach-mode keeps the
+                            // dict in a SEPARATE table, so the live long+1 probe
+                            // above never sees dict positions; without this the
+                            // dict-long upgrade the old dense-reprime path got
+                            // for free (dict positions lived in the live table)
+                            // is lost and the loop emits the shorter short match.
+                            if !live_l1_hit && use_dict {
+                                // SAFETY: `use_dict` ⇒ `dict_long_ptr` non-null,
+                                // sized `1 << long_hash_bits`; `hl1_idx` is in range.
+                                let dl1 = unsafe { *dict_long_ptr.add(hl1_idx) };
+                                if dl1 != DFAST_EMPTY_SLOT {
+                                    let dp1 = (dl1 as usize) - 1;
+                                    if dp1 < dict_end {
+                                        debug_assert!(
+                                            dp1 + HASH_READ_SIZE <= concat_len,
+                                            "dict long+1 load OOB: dp1={dp1} concat_len={concat_len}",
+                                        );
+                                        // SAFETY: `dp1 + 8 <= concat_len` ⇒ the
+                                        // 8-byte load at concat `dp1` is in-bounds.
+                                        let dcand_v8_l1 = unsafe {
+                                            (history_base_ptr.add(history_start_offset + dp1)
+                                                as *const u64)
+                                                .read_unaligned()
+                                        };
+                                        if dcand_v8_l1 == v8_1 {
+                                            let mut dl1_match_len = 8usize;
+                                            let max_fwd =
+                                                concat_len.saturating_sub(concat_idx1 + 8);
+                                            // SAFETY: same buffer; `max_fwd` caps
+                                            // the scan to the live region.
+                                            unsafe {
+                                                let lhs = history_base_ptr
+                                                    .add(history_start_offset + dp1 + 8);
+                                                let rhs = history_base_ptr
+                                                    .add(history_start_offset + concat_idx1 + 8);
+                                                let ext = $cpl(
+                                                    lhs, rhs, max_fwd,
+                                                );
+                                                dl1_match_len += ext;
+                                            }
+                                            if dl1_match_len > short_cand.match_len {
+                                                let cand_pos = history_abs_start + dp1;
+                                                let concat = &$self.history[history_start_offset..];
+                                                chosen = extend_backwards_shared(
+                                                    concat,
+                                                    history_abs_start,
+                                                    cand_pos,
+                                                    abs_ip1,
+                                                    dl1_match_len,
+                                                    lit_len_ip1,
+                                                );
+                                                retry_upgraded = true;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            if short_hit_valid || retry_upgraded {
+                                break 'inner InnerExit::Committed(chosen);
+                            }
+                            // Below-floor short hit with no retry
+                            // upgrade — fall through to the step bump
+                            // and keep scanning. Discarding here is
+                            // correctness-relevant: emitting a 4-byte
+                            // non-rep match would mint an offset on
+                            // wire that costs more than the 4-byte
+                            // payload buys (offsets at level 2/3 dfast
+                            // are 13–17 bits depending on offset class
+                            // and prior offset_hist state — strictly
+                            // worse than emitting the 4 bytes as
+                            // literals).
+                        }
+                    }
+                }
+
+                // Dict short fallback (donor `dictMatchState`): the live short
+                // missed / was below floor. Probe the immutable dict short
+                // table at the SAME `hs0_idx`, 4-byte gate, forward count, then
+                // enforce the same `DFAST_MIN_MATCH_LEN` floor the live short
+                // path uses (a sub-floor non-rep match mints a wire offset that
+                // costs more than emitting the bytes as literals). No
+                // `_search_next_long` retry: the dict long fallback already
+                // covers the long-upgrade case at `ip0`.
+                if use_dict {
+                    // SAFETY: `use_dict` ⇒ `dict_short_ptr` non-null, sized
+                    // `1 << short_hash_bits`; `hs0_idx < 1 << short_hash_bits`.
+                    let ds = unsafe { *dict_short_ptr.add(hs0_idx) };
+                    if ds != DFAST_EMPTY_SLOT {
+                        let dp = (ds as usize) - 1;
+                        if dp < dict_end {
+                            debug_assert!(
+                                dp + 4 <= concat_len,
+                                "dict short load OOB: dp={dp} concat_len={concat_len}",
+                            );
+                            // SAFETY: short slots were only written with 4 bytes
+                            // of lookahead ⇒ `dp + 4 <= dict_len <= concat_len`.
+                            let dcand4 = unsafe {
+                                (history_base_ptr.add(history_start_offset + dp) as *const u32)
+                                    .read_unaligned()
+                            };
+                            if dcand4 == v4_0 as u32 {
+                                let mut s_match_len = 4usize;
+                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
+                                unsafe {
+                                    let lhs = history_base_ptr.add(history_start_offset + dp + 4);
+                                    let rhs = history_base_ptr
+                                        .add(history_start_offset + concat_idx0 + 4);
+                                    let ext =
+                                        $cpl(
+                                            lhs, rhs, max_fwd,
+                                        );
+                                    s_match_len += ext;
+                                }
+                                let cand_pos = history_abs_start + dp;
+                                let concat = &$self.history[history_start_offset..];
+                                let dcand = extend_backwards_shared(
+                                    concat,
+                                    history_abs_start,
+                                    cand_pos,
+                                    abs_ip0,
+                                    s_match_len,
+                                    lit_len_ip0,
+                                );
+                                if dcand.match_len >= DFAST_MIN_MATCH_LEN {
+                                    break 'inner InnerExit::Committed(dcand);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Step bump on distance (donor `zstd_double_fast.c:224-228`).
+                if ip1 >= next_step_pos {
+                    step = (step + 1).min(DFAST_MAX_SKIP_STEP);
+                    next_step_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
+                }
+
+                // Advance: ip0 = ip1; ip1 += step; carry hl1 → hl0 / idxl1 → idxl0.
+                ip0 = ip1;
+                ip1 += step;
+                hl0_idx = hl1_idx;
+                idxl0 = idxl1;
+                if ip1 + HASH_READ_SIZE > $current_len {
+                    // First position the fast loop did NOT pack into the
+                    // hash tables. `seed_remaining_hashable_starts` will
+                    // pick up from `ip0` instead of restarting at the
+                    // outer-entry `pos`.
+                    break 'inner InnerExit::Tail(ip0);
+                }
+            };
+
+            match inner_exit {
+                InnerExit::Committed(candidate) => {
+                    let start = $self.emit_candidate(
+                        $current_abs_start,
+                        &mut literals_start,
+                        candidate,
+                        $handle_sequence,
+                    );
+                    pos = start + candidate.match_len;
+                    pos = $self.extend_with_repcode_after_match(
+                        $current_abs_start,
+                        $current_len,
+                        pos,
+                        &mut literals_start,
+                        $handle_sequence,
+                    );
+                }
+                InnerExit::Tail(seed) => {
+                    // Inner loop ran out of safe scan room without
+                    // committing. Hand the tail seeder the first
+                    // un-scanned position so it does not redundantly
+                    // re-pack everything the fast loop already wrote.
+                    pos = seed;
+                    break 'outer;
+                }
+            }
+        }
+
+        $self.seed_remaining_hashable_starts($current_abs_start, $current_len, pos);
+        $self.emit_trailing_literals(literals_start, $handle_sequence);
+    }};
+}
+
+impl DfastMatchGenerator {
+    /// Dispatcher for the per-kernel dfast fast loop: resolve the tier ONCE
+    /// per block via `select_kernel()` and call the matching
+    /// `start_matching_fast_loop_<kernel>` wrapper, so every per-position
+    /// `common_prefix_len_ptr` inlines under one `#[target_feature]` umbrella
+    /// (mirrors `build_optimal_plan_impl`). Replaces the prior per-cpl
+    /// `dispatch_common_prefix_len_ptr` runtime dispatch.
+    fn start_matching_fast_loop(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        unsafe {
+            self.start_matching_fast_loop_neon(current_abs_start, current_len, handle_sequence)
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
+            match select_kernel() {
+                FastpathKernel::Avx2Bmi2 => unsafe {
+                    self.start_matching_fast_loop_avx2_bmi2(
+                        current_abs_start,
+                        current_len,
+                        handle_sequence,
+                    )
+                },
+                FastpathKernel::Sse42 => unsafe {
+                    self.start_matching_fast_loop_sse42(
+                        current_abs_start,
+                        current_len,
+                        handle_sequence,
+                    )
+                },
+                FastpathKernel::Scalar => self.start_matching_fast_loop_scalar(
+                    current_abs_start,
+                    current_len,
+                    handle_sequence,
+                ),
+            }
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            self.start_matching_fast_loop_scalar(current_abs_start, current_len, handle_sequence)
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    unsafe fn start_matching_fast_loop_neon(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_fast_loop_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            crate::encoding::fastpath::neon::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn start_matching_fast_loop_sse42(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_fast_loop_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            crate::encoding::fastpath::sse42::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    unsafe fn start_matching_fast_loop_avx2_bmi2(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_fast_loop_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+    #[allow(unused_unsafe)]
+    fn start_matching_fast_loop_scalar(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_fast_loop_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            crate::encoding::fastpath::scalar::common_prefix_len_ptr
+        )
     }
 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -16,6 +16,7 @@ use core::convert::TryInto;
 
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
+use super::dict_attach::DictAttach;
 use super::incompressible::block_looks_incompressible;
 use super::match_generator::{
     DFAST_EMPTY_SLOT, DFAST_HASH_BITS, DFAST_INCOMPRESSIBLE_SKIP_STEP, DFAST_LOCAL_SKIP_TRIGGER,
@@ -26,7 +27,7 @@ use super::match_table::helpers::{
     LazyMatchConfig, best_len_offset_candidate, common_prefix_len, extend_backwards_shared,
     pick_lazy_match_shared, repcode_candidate_shared,
 };
-use super::match_table::storage::check_stream_abs_headroom;
+use super::match_table::storage::{REBASE_RESET_FLOOR_CEILING, check_stream_abs_headroom};
 use super::opt::types::MatchCandidate;
 
 /// Donor `HASH_READ_SIZE` (`zstd_compress_internal.h`): the largest probe
@@ -109,6 +110,32 @@ pub(crate) struct DfastMatchGenerator {
     pub(crate) use_fast_loop: bool,
     // Lazy match lookahead depth (internal tuning parameter).
     pub(crate) lazy_depth: u8,
+    /// Immutable dictionary long+short hash tables (donor `dictMatchState`)
+    /// plus the CDict cache lifecycle, via the shared [`DictAttach`] level-1
+    /// scaffolding. Built once over the dictionary region at the front of the
+    /// contiguous history (flat `[dict][input]` model like the Fast backend:
+    /// a dict match is `offset = ip - dict_pos` and counts cross the
+    /// dict→input boundary, no `dictBase`/`dictIndexDelta`). Slots store the
+    /// dict position as a +1-biased CONCAT index (offset into
+    /// `history[history_start..]`), NOT the live tables' `position_base`-packed
+    /// encoding — the dict table is never rebased, so it keys off the stable
+    /// concat coordinate and is invalidated on any history eviction (which
+    /// would slide the dict out of the concat) so positions never go stale.
+    /// `is_attached()` activates the dual-probe kernel; `region_len()` is the
+    /// dict/input boundary (`dict_end`, a concat index).
+    pub(crate) dict: DictAttach<DfastDictTables>,
+}
+
+/// The dfast backend's immutable dictionary tables — a long+short pair mirroring
+/// the live [`DfastMatchGenerator::long_hash`] / [`DfastMatchGenerator::short_hash`]
+/// shapes, sized to the same `(long_hash_bits, short_hash_bits)`. Held by the
+/// shared [`DictAttach`] level-1 lifecycle; the per-tier dual-probe LOOKUP is
+/// level-2 in this backend's kernel. Slots hold a +1-biased concat index
+/// (`DFAST_EMPTY_SLOT = 0` is "no entry").
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DfastDictTables {
+    pub(crate) long: alloc::vec::Vec<u32>,
+    pub(crate) short: alloc::vec::Vec<u32>,
 }
 
 impl DfastMatchGenerator {
@@ -136,6 +163,7 @@ impl DfastMatchGenerator {
             short_hash_bits: DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA,
             use_fast_loop: false,
             lazy_depth: 1,
+            dict: DictAttach::new(),
         }
     }
 
@@ -148,6 +176,7 @@ impl DfastMatchGenerator {
         let min_bits = MIN_WINDOW_LOG as usize;
         let long_clamped = long_bits.max(min_bits);
         let short_clamped = short_bits.max(min_bits);
+        let resized = self.long_hash_bits != long_clamped || self.short_hash_bits != short_clamped;
         if self.long_hash_bits != long_clamped {
             self.long_hash_bits = long_clamped;
             self.long_hash = Vec::new();
@@ -155,6 +184,12 @@ impl DfastMatchGenerator {
         if self.short_hash_bits != short_clamped {
             self.short_hash_bits = short_clamped;
             self.short_hash = Vec::new();
+        }
+        if resized {
+            // A table-size change makes the cached dict tables (sized to the old
+            // bits) and their hash indices invalid — drop the attach so the next
+            // prime rebuilds at the new shape.
+            self.dict.invalidate();
         }
     }
 
@@ -227,15 +262,41 @@ impl DfastMatchGenerator {
     }
 
     pub(crate) fn reset(&mut self) {
+        // Floor-advance reset (issue #337 technique, completing it for the
+        // dfast backend — `MatchTable` already does this). Instead of
+        // zeroing the long/short tables every frame (a memset proportional
+        // to table size, ~25% of a small reused-context dfast frame),
+        // advance the absolute-position floor past the previous frame's
+        // end. Every slot-decode site rejects a candidate whose absolute
+        // position is below `history_abs_start` before it dereferences a
+        // history byte (audited: fast-loop long/short/long+1/repcode,
+        // `probe_tail_ip0_only`, `probe_slot_match`), so the previous
+        // frame's entries become unreachable without being cleared.
+        // `position_base` is left untouched so stale slots still decode to
+        // their (now sub-floor) absolute positions; `ensure_room_for` /
+        // `reduce` keep the `u32` packing bounded as the cursor climbs.
+        let next_floor = self.history_abs_start + (self.history.len() - self.history_start);
         self.window_size = 0;
         self.history.clear();
         self.history_start = 0;
-        self.history_abs_start = 0;
-        self.position_base = 0;
         self.offset_hist = [1, 4, 8];
-        if !self.short_hash.is_empty() {
-            self.short_hash.fill(DFAST_EMPTY_SLOT);
-            self.long_hash.fill(DFAST_EMPTY_SLOT);
+        if next_floor <= REBASE_RESET_FLOOR_CEILING {
+            // Fast path: advance the floor; tables keep their contents (a
+            // later `ensure_tables`/level change still reallocs them clean
+            // if the dimensions changed). The dict tables key off stable
+            // concat indices and are untouched here.
+            self.history_abs_start = next_floor;
+        } else {
+            // Bounded fallback: rewind the cursor and zero the tables so
+            // `history_abs_start` cannot climb toward `usize::MAX` (keeps
+            // `check_stream_abs_headroom` satisfiable on 32-bit targets;
+            // fires ~once per 2 GiB cumulative input there).
+            self.history_abs_start = 0;
+            self.position_base = 0;
+            if !self.short_hash.is_empty() {
+                self.short_hash.fill(DFAST_EMPTY_SLOT);
+                self.long_hash.fill(DFAST_EMPTY_SLOT);
+            }
         }
         // No Vec<u8> blocks to recycle: `add_data` returns each input
         // Vec to the caller eagerly via its own `reuse_space`, and the
@@ -313,6 +374,13 @@ impl DfastMatchGenerator {
             reuse_space(data);
             return;
         }
+        if self.window_size + data.len() > self.max_window_size {
+            // Eviction advances `history_start`, so the dict tables' concat
+            // indices (primed at `history_start == 0`) no longer address the
+            // dict bytes — drop the attach (dict ratio benefit lost once the
+            // dict slides out of the window, like the Fast backend).
+            self.dict.invalidate();
+        }
         while self.window_size + data.len() > self.max_window_size {
             let removed_len = self.window_blocks.pop_front().unwrap();
             self.window_size -= removed_len;
@@ -375,6 +443,11 @@ impl DfastMatchGenerator {
     /// other lifecycle calls) so adding one more per-backend arm is
     /// free.
     pub(crate) fn trim_to_window(&mut self) {
+        if self.window_size > self.max_window_size || self.history_start != 0 {
+            // Any history shift slides the dictionary out of (or within) the
+            // concat, staling the dict tables' concat indices — drop the attach.
+            self.dict.invalidate();
+        }
         while self.window_size > self.max_window_size {
             let removed_len = self.window_blocks.pop_front().unwrap();
             self.window_size -= removed_len;
@@ -454,6 +527,114 @@ impl DfastMatchGenerator {
             self.insert_positions(backfill_start, current_abs_start);
         }
         self.insert_positions(current_abs_start, current_abs_end);
+    }
+
+    /// Donor `ZSTD_dictMatchState` attach (dfast): hash the dictionary block at
+    /// the front of history into the SEPARATE immutable [`Self::dict`] tables
+    /// (long+short), once, instead of re-priming the live tables every frame
+    /// (`skip_matching_dense`). The dual-probe kernel then searches live + dict
+    /// without per-frame dict cost. Cached via the `DictAttach` primed flag.
+    pub(crate) fn skip_matching_for_dict_attach(&mut self) {
+        self.ensure_hash_tables();
+        // The dual-probe lives only in `start_matching_fast_loop`. The general
+        // path (L1/L2/L4) has no dict probe, so for those levels prime the dict
+        // into the LIVE tables (`skip_matching_dense`), where the dense scan
+        // finds it — keeping the attach win to the fast-loop levels (L3 /
+        // Default / L0) without regressing general-path dict ratio.
+        if !self.use_fast_loop {
+            self.dict.invalidate();
+            self.skip_matching_dense();
+            return;
+        }
+        let current_len = self.window_blocks.back().copied().unwrap_or(0);
+        if current_len == 0 {
+            return;
+        }
+        let current_abs_start = self.history_abs_start + self.window_size - current_len;
+        let current_abs_end = current_abs_start + current_len;
+        // Convert absolute → concat (history-relative) coordinates: the dict
+        // table keys off the stable concat index, not `position_base`.
+        let start_concat = current_abs_start - self.history_abs_start;
+        let end_concat = current_abs_end - self.history_abs_start;
+        self.prime_dict_tables_for_range(start_concat, end_concat);
+    }
+
+    /// Mark the dict tables fully built (CDict cache). The driver calls this
+    /// after the final dictionary chunk so the next frame skips the re-hash.
+    pub(crate) fn mark_dict_primed(&mut self) {
+        self.dict.mark_primed();
+    }
+
+    /// Drop the cached dict tables (next frame carries no dict, or eviction /
+    /// param change staled the concat positions).
+    pub(crate) fn invalidate_dict_cache(&mut self) {
+        self.dict.invalidate();
+    }
+
+    /// Build the immutable dict long+short tables over the contiguous-history
+    /// concat range `[start_concat, end_concat)` (the dictionary bytes at the
+    /// front of history). Mirrors [`Self::insert_positions`]' hash + lookahead
+    /// gating, but writes a +1-biased CONCAT index (`idx + 1`, stable across
+    /// `position_base` rebases) into `self.dict` rather than the live,
+    /// `position_base`-packed tables. `DFAST_EMPTY_SLOT = 0` means "no entry".
+    /// Skips the rehash when the CDict cache is already primed.
+    fn prime_dict_tables_for_range(&mut self, start_concat: usize, end_concat: usize) {
+        const PRIME: u64 = 0xCF1BBCDCB7A56463_u64;
+        // Record the dict/input boundary (concat index) regardless of whether
+        // any position is hashable (a sub-min-match dict still bounds dict_end).
+        self.dict.set_region_len(end_concat);
+        if self.dict.is_primed() {
+            return;
+        }
+        let history_start = self.history_start;
+        let concat_len = self.history.len() - history_start;
+        let long_bits = self.long_hash_bits;
+        let short_bits = self.short_hash_bits;
+        // Lookahead-safe cutoffs within the concat: long needs 8 readable
+        // bytes, short needs 4 (donor parity with `insert_positions`).
+        let long_safe_end = concat_len.saturating_sub(7).min(end_concat);
+        let short_safe_end = concat_len.saturating_sub(3).min(end_concat);
+        if start_concat >= short_safe_end {
+            return;
+        }
+        let dict = self.dict.table_mut_or_init(|| DfastDictTables {
+            long: alloc::vec![DFAST_EMPTY_SLOT; 1usize << long_bits],
+            short: alloc::vec![DFAST_EMPTY_SLOT; 1usize << short_bits],
+        });
+        let short_shift = 64 - short_bits;
+        let long_shift = 64 - long_bits;
+        let base = self.history.as_ptr();
+        let long_ptr = dict.long.as_mut_ptr();
+        let short_ptr = dict.short.as_mut_ptr();
+        // SAFETY: `base.add(history_start + pos)` is in-bounds for
+        // `pos + 8 <= concat_len` (long) / `pos + 4 <= concat_len` (short),
+        // enforced by the `*_safe_end` cutoffs. `*_idx = mixed >> (64 - bits)`
+        // has at most `bits` bits set, in-bounds for the `1 << bits` tables.
+        // `pos + 1` fits u32: concat indices are bounded by the u32 history
+        // gate upstream (`check_stream_abs_headroom`).
+        let mut pos = start_concat;
+        while pos < long_safe_end {
+            unsafe {
+                let load_ptr = base.add(history_start + pos);
+                let v8 = (load_ptr as *const u64).read_unaligned();
+                let v4 = v8 & 0xFFFF_FFFF;
+                let short_idx = (v4.wrapping_mul(PRIME) >> short_shift) as usize;
+                let long_idx = (v8.wrapping_mul(PRIME) >> long_shift) as usize;
+                let packed = (pos as u32) + 1;
+                *short_ptr.add(short_idx) = packed;
+                *long_ptr.add(long_idx) = packed;
+            }
+            pos += 1;
+        }
+        while pos < short_safe_end {
+            unsafe {
+                let load_ptr = base.add(history_start + pos);
+                let v4 = (load_ptr as *const u32).read_unaligned() as u64;
+                let short_idx = (v4.wrapping_mul(PRIME) >> short_shift) as usize;
+                *short_ptr.add(short_idx) = (pos as u32) + 1;
+            }
+            pos += 1;
+        }
     }
 
     pub(crate) fn start_matching(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
@@ -664,6 +845,38 @@ impl DfastMatchGenerator {
         let long_shift = 64 - self.long_hash_bits;
         let mut pos = 1usize;
         let mut literals_start = 0usize;
+
+        // Dict dual-probe (donor `ZSTD_dictMatchState`): snapshot the immutable
+        // dict tables ONCE. Unlike the live tables (which `emit_candidate` may
+        // grow / rebase), the dict tables are never mutated during matching, so
+        // one snapshot before the outer loop stays valid every iteration. The
+        // raw pointers hold no borrow, so the per-iter `&self`/`&mut self`
+        // accesses below coexist. `use_dict` gates every probe so the no-dict
+        // hot path keeps its exact instruction shape. `dict_end` is the
+        // dict/input boundary as a CONCAT index (history_start-relative); the
+        // dict is invalidated on any history eviction, so concat indices stay
+        // valid for the snapshot's lifetime.
+        // `use_dict` MUST track table presence, NOT `is_attached()`:
+        // `prime_dict_tables_for_range` records the dict region (so
+        // `is_attached()` is true) but returns before allocating the
+        // tables when the hashable region is shorter than the short-hash
+        // lookahead. Gating on `table().is_some()` keeps the null dict
+        // pointers out of the probe below, which dereferences them before
+        // the `dict_end` bound is consulted.
+        let (use_dict, dict_long_ptr, dict_short_ptr, dict_end): (
+            bool,
+            *const u32,
+            *const u32,
+            usize,
+        ) = match self.dict.table() {
+            Some(d) => (
+                true,
+                d.long.as_ptr(),
+                d.short.as_ptr(),
+                self.dict.region_len(),
+            ),
+            None => (false, core::ptr::null(), core::ptr::null(), 0),
+        };
 
         'outer: loop {
             // Outer-iter precondition: at least `HASH_READ_SIZE = 8` bytes
@@ -950,6 +1163,64 @@ impl DfastMatchGenerator {
                     }
                 }
 
+                // Dict long fallback (donor `dictMatchState`): the live long
+                // missed (empty / out-of-window / 8-byte mismatch). Probe the
+                // immutable dict long table at the SAME `hl0_idx`. Flat model:
+                // the dict sits in the contiguous history before the input, so
+                // a dict match is `offset = abs_ip0 - dict_abs` and the forward
+                // count crosses the dict→input boundary like any in-window
+                // match (no `dictBase`/`count_2segments`).
+                if use_dict {
+                    // SAFETY: when `use_dict`, `dict_long_ptr` is non-null and
+                    // sized `1 << long_hash_bits`; `hl0_idx < 1 << long_hash_bits`.
+                    let dl = unsafe { *dict_long_ptr.add(hl0_idx) };
+                    if dl != DFAST_EMPTY_SLOT {
+                        let dp = (dl as usize) - 1;
+                        // Dict long slots were only written for positions with
+                        // 8-byte lookahead, so `dp + 8 <= dict_len <= concat_len`;
+                        // `dp < dict_end` keeps the match inside the dict region.
+                        if dp < dict_end {
+                            debug_assert!(
+                                dp + HASH_READ_SIZE <= concat_len,
+                                "dict long load OOB: dp={dp} concat_len={concat_len}",
+                            );
+                            // SAFETY: `dp + 8 <= concat_len` (above) ⇒ the 8-byte
+                            // load at concat `dp` is in-bounds for live history.
+                            let dcand_v8 = unsafe {
+                                (history_base_ptr.add(history_start_offset + dp) as *const u64)
+                                    .read_unaligned()
+                            };
+                            if dcand_v8 == v8_0 {
+                                let mut match_len = 8usize;
+                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
+                                // SAFETY: both ptrs in the same buffer; `max_fwd`
+                                // caps the scan to the live region.
+                                unsafe {
+                                    let lhs = history_base_ptr.add(history_start_offset + dp + 8);
+                                    let rhs = history_base_ptr
+                                        .add(history_start_offset + concat_idx0 + 8);
+                                    let ext =
+                                        crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
+                                            lhs, rhs, max_fwd,
+                                        );
+                                    match_len += ext;
+                                }
+                                let cand_pos = history_abs_start + dp;
+                                let concat = &self.history[history_start_offset..];
+                                let cand = extend_backwards_shared(
+                                    concat,
+                                    history_abs_start,
+                                    cand_pos,
+                                    abs_ip0,
+                                    match_len,
+                                    lit_len_ip0,
+                                );
+                                break 'inner InnerExit::Committed(cand);
+                            }
+                        }
+                    }
+                }
+
                 let idxl1 = unsafe { *long_hash_ptr.add(hl1_idx) };
 
                 // Short match check at ip0 with idxs0 — 4-byte gate
@@ -1006,6 +1277,7 @@ impl DfastMatchGenerator {
                             // If it produces a strictly longer match, use it.
                             let mut chosen = short_cand;
                             let mut retry_upgraded = false;
+                            let mut live_l1_hit = false;
                             if idxl1 != DFAST_EMPTY_SLOT {
                                 let cand_pos_l1 = position_base + (idxl1 as usize) - 1;
                                 if cand_pos_l1 >= history_abs_start && cand_pos_l1 < abs_ip1 {
@@ -1016,6 +1288,7 @@ impl DfastMatchGenerator {
                                             .read_unaligned()
                                     };
                                     if cand_v8_l1 == v8_1 {
+                                        live_l1_hit = true;
                                         let mut l1_match_len = 8usize;
                                         let max_fwd_l1 = concat_len.saturating_sub(concat_idx1 + 8);
                                         unsafe {
@@ -1051,6 +1324,66 @@ impl DfastMatchGenerator {
                                     }
                                 }
                             }
+                            // Dict long match at ip1 (donor `_search_next_long`
+                            // dict arm, zstd_double_fast.c:472-483): probed ONLY
+                            // when the live long+1 missed, mirroring donor's
+                            // `else if dictTagsMatchL3`. Attach-mode keeps the
+                            // dict in a SEPARATE table, so the live long+1 probe
+                            // above never sees dict positions; without this the
+                            // dict-long upgrade the old dense-reprime path got
+                            // for free (dict positions lived in the live table)
+                            // is lost and the loop emits the shorter short match.
+                            if !live_l1_hit && use_dict {
+                                // SAFETY: `use_dict` ⇒ `dict_long_ptr` non-null,
+                                // sized `1 << long_hash_bits`; `hl1_idx` is in range.
+                                let dl1 = unsafe { *dict_long_ptr.add(hl1_idx) };
+                                if dl1 != DFAST_EMPTY_SLOT {
+                                    let dp1 = (dl1 as usize) - 1;
+                                    if dp1 < dict_end {
+                                        debug_assert!(
+                                            dp1 + HASH_READ_SIZE <= concat_len,
+                                            "dict long+1 load OOB: dp1={dp1} concat_len={concat_len}",
+                                        );
+                                        // SAFETY: `dp1 + 8 <= concat_len` ⇒ the
+                                        // 8-byte load at concat `dp1` is in-bounds.
+                                        let dcand_v8_l1 = unsafe {
+                                            (history_base_ptr.add(history_start_offset + dp1)
+                                                as *const u64)
+                                                .read_unaligned()
+                                        };
+                                        if dcand_v8_l1 == v8_1 {
+                                            let mut dl1_match_len = 8usize;
+                                            let max_fwd =
+                                                concat_len.saturating_sub(concat_idx1 + 8);
+                                            // SAFETY: same buffer; `max_fwd` caps
+                                            // the scan to the live region.
+                                            unsafe {
+                                                let lhs = history_base_ptr
+                                                    .add(history_start_offset + dp1 + 8);
+                                                let rhs = history_base_ptr
+                                                    .add(history_start_offset + concat_idx1 + 8);
+                                                let ext = crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
+                                                    lhs, rhs, max_fwd,
+                                                );
+                                                dl1_match_len += ext;
+                                            }
+                                            if dl1_match_len > short_cand.match_len {
+                                                let cand_pos = history_abs_start + dp1;
+                                                let concat = &self.history[history_start_offset..];
+                                                chosen = extend_backwards_shared(
+                                                    concat,
+                                                    history_abs_start,
+                                                    cand_pos,
+                                                    abs_ip1,
+                                                    dl1_match_len,
+                                                    lit_len_ip1,
+                                                );
+                                                retry_upgraded = true;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
                             if short_hit_valid || retry_upgraded {
                                 break 'inner InnerExit::Committed(chosen);
                             }
@@ -1065,6 +1398,62 @@ impl DfastMatchGenerator {
                             // and prior offset_hist state — strictly
                             // worse than emitting the 4 bytes as
                             // literals).
+                        }
+                    }
+                }
+
+                // Dict short fallback (donor `dictMatchState`): the live short
+                // missed / was below floor. Probe the immutable dict short
+                // table at the SAME `hs0_idx`, 4-byte gate, forward count, then
+                // enforce the same `DFAST_MIN_MATCH_LEN` floor the live short
+                // path uses (a sub-floor non-rep match mints a wire offset that
+                // costs more than emitting the bytes as literals). No
+                // `_search_next_long` retry: the dict long fallback already
+                // covers the long-upgrade case at `ip0`.
+                if use_dict {
+                    // SAFETY: `use_dict` ⇒ `dict_short_ptr` non-null, sized
+                    // `1 << short_hash_bits`; `hs0_idx < 1 << short_hash_bits`.
+                    let ds = unsafe { *dict_short_ptr.add(hs0_idx) };
+                    if ds != DFAST_EMPTY_SLOT {
+                        let dp = (ds as usize) - 1;
+                        if dp < dict_end {
+                            debug_assert!(
+                                dp + 4 <= concat_len,
+                                "dict short load OOB: dp={dp} concat_len={concat_len}",
+                            );
+                            // SAFETY: short slots were only written with 4 bytes
+                            // of lookahead ⇒ `dp + 4 <= dict_len <= concat_len`.
+                            let dcand4 = unsafe {
+                                (history_base_ptr.add(history_start_offset + dp) as *const u32)
+                                    .read_unaligned()
+                            };
+                            if dcand4 == v4_0 as u32 {
+                                let mut s_match_len = 4usize;
+                                let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
+                                unsafe {
+                                    let lhs = history_base_ptr.add(history_start_offset + dp + 4);
+                                    let rhs = history_base_ptr
+                                        .add(history_start_offset + concat_idx0 + 4);
+                                    let ext =
+                                        crate::encoding::fastpath::dispatch_common_prefix_len_ptr(
+                                            lhs, rhs, max_fwd,
+                                        );
+                                    s_match_len += ext;
+                                }
+                                let cand_pos = history_abs_start + dp;
+                                let concat = &self.history[history_start_offset..];
+                                let dcand = extend_backwards_shared(
+                                    concat,
+                                    history_abs_start,
+                                    cand_pos,
+                                    abs_ip0,
+                                    s_match_len,
+                                    lit_len_ip0,
+                                );
+                                if dcand.match_len >= DFAST_MIN_MATCH_LEN {
+                                    break 'inner InnerExit::Committed(dcand);
+                                }
+                            }
                         }
                     }
                 }
@@ -1430,10 +1819,33 @@ impl DfastMatchGenerator {
         candidate: MatchCandidate,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) -> usize {
-        self.insert_positions(
-            current_abs_start + *literals_start,
-            candidate.start + candidate.match_len,
-        );
+        // Insert the LITERAL region densely, the MATCH INTERIOR sparsely
+        // (upstream `zstd_double_fast.c` parity). The literal positions
+        // `[literals_start, match_start)` are load-bearing: the producer
+        // loop starts at `pos = 1` and only hashes positions it actually
+        // probes, so the block anchor (position 0) and any stepped-over
+        // literal byte is hashed ONLY here — dropping it loses real match
+        // sources for later positions (and later blocks). The match
+        // interior, by contrast, is never re-probed within the block;
+        // upstream fills only `curr+2` and `ip-2` there, so inserting the
+        // full `[match_start, match_end)` span was ~match_len wasted
+        // single-slot overwrites — the dominant self-time on
+        // dict-heavy / highly-matchable blocks. Mirror the rep-extension
+        // path's audited 3-target set (`curr+2`, `ip-2`, `ip-1`), each
+        // clamped to the open match interval.
+        let match_start = candidate.start;
+        let post_match_end = candidate.start + candidate.match_len;
+        self.insert_positions(current_abs_start + *literals_start, match_start);
+        let insert_targets = [
+            match_start + 2,                  // curr + 2
+            post_match_end.saturating_sub(2), // ip - 2 (post-match cursor)
+            post_match_end.saturating_sub(1), // ip - 1
+        ];
+        for &target in &insert_targets {
+            if target > match_start && target < post_match_end {
+                self.insert_position(target);
+            }
+        }
         // Inline the trailing-block slice rather than calling
         // `get_last_space()` so this matches the gate pattern used by
         // `skip_matching` / `start_matching` (read `window_blocks.back()`

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1620,7 +1620,6 @@ impl DfastMatchGenerator {
     }
 }
 
-
 /// Per-kernel body of the dfast fast match loop. Mirrors the BT/opt
 /// `*_body!` macros: the wrapper carries the `#[target_feature]` umbrella and
 /// passes its tier `common_prefix_len_ptr` as `$cpl`, so the 7 match-extension

--- a/zstd/src/encoding/dict_attach.rs
+++ b/zstd/src/encoding/dict_attach.rs
@@ -1,0 +1,146 @@
+//! Shared CDict-style dictionary-attach lifecycle, parameterized by the
+//! matcher's immutable dictionary table type `T`.
+//!
+//! This is the level-1 scaffolding common to every match-finder backend that
+//! supports donor `ZSTD_dictMatchState` attach-by-reference: instead of
+//! re-priming the whole dictionary into the live hash table(s) on every frame
+//! (O(dict) per frame, the dominant cost on small-payload `compress-dict`), the
+//! dictionary is hashed ONCE into a SEPARATE immutable table `T` held here, and
+//! the kernel dual-probes the live table(s) plus this dict table. A reused
+//! compressor keeps `T` across the per-frame `reset` (the dict re-commits to the
+//! same absolute history positions) via the `primed` cache flag — mirroring
+//! C copying / referencing `cdict->matchState` rather than rebuilding it.
+//!
+//! `T` is backend-specific (Fast = single `FastHashTable`; Dfast = a long+short
+//! pair; Row/HC/BT = their own structures); the per-backend BUILD of `T` and the
+//! per-kernel dual-probe LOOKUP are level-2 (kept in each backend, expanded per
+//! SIMD tier). This type only owns the shared lifecycle: presence, the
+//! dict/input boundary, the build-once cache flag, and invalidation.
+
+/// Lifecycle holder for an attached, immutable dictionary table of type `T`.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct DictAttach<T> {
+    /// The immutable dictionary table, built once over the dictionary region.
+    /// `Some` activates the backend's dual-probe kernel; `None` means no dict
+    /// is attached (or it was invalidated, e.g. on history eviction that would
+    /// stale the absolute dict positions) and the plain kernel runs.
+    table: Option<T>,
+    /// Number of dictionary bytes at the front of history — one past the last
+    /// valid dict position. The boundary the dual-probe kernel uses to separate
+    /// live-table (input) matches from dict-table matches. `0` when unattached.
+    region_len: usize,
+    /// CDict-equivalent cache flag: `true` once `table` is fully built for the
+    /// attached dictionary. A reused compressor keeps the built table across
+    /// per-frame `reset` and skips the re-hash. Cleared on parameter change,
+    /// history eviction, or dictionary attach/clear via [`Self::invalidate`].
+    primed: bool,
+}
+
+impl<T> DictAttach<T> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            table: None,
+            region_len: 0,
+            primed: false,
+        }
+    }
+
+    /// Whether a dict table is attached (drives the dual-probe dispatch).
+    #[inline]
+    pub(crate) fn is_attached(&self) -> bool {
+        self.table.is_some()
+    }
+
+    /// Shared reference to the dict table, if attached.
+    #[inline]
+    pub(crate) fn table(&self) -> Option<&T> {
+        self.table.as_ref()
+    }
+
+    /// The dict/input boundary (`dict_end`) for kernel bounds checks.
+    #[inline]
+    pub(crate) fn region_len(&self) -> usize {
+        self.region_len
+    }
+
+    /// Record the dict/input boundary. Set every prime call regardless of
+    /// whether any position was hashable (a sub-min-match dict still bounds the
+    /// input floor).
+    #[inline]
+    pub(crate) fn set_region_len(&mut self, region_len: usize) {
+        self.region_len = region_len;
+    }
+
+    /// CDict cache flag: `true` once the table is fully built. The prime path
+    /// checks this to skip the re-hash on reused frames.
+    #[inline]
+    pub(crate) fn is_primed(&self) -> bool {
+        self.primed
+    }
+
+    /// Mark the table fully built (CDict cache). Only marks when a table
+    /// actually exists — a sub-min-match dict builds no table and must re-run
+    /// the (cheap, no-op) prime path each frame.
+    #[inline]
+    pub(crate) fn mark_primed(&mut self) {
+        if self.table.is_some() {
+            self.primed = true;
+        }
+    }
+
+    /// Get the table for building, initializing it with `init` if absent.
+    /// Backends call this lazily inside their per-backend prime once they know
+    /// at least one position is hashable.
+    #[inline]
+    pub(crate) fn table_mut_or_init(&mut self, init: impl FnOnce() -> T) -> &mut T {
+        self.table.get_or_insert_with(init)
+    }
+
+    /// Mutable reference to the table, if attached (for the build/fill pass).
+    #[inline]
+    pub(crate) fn table_mut(&mut self) -> Option<&mut T> {
+        self.table.as_mut()
+    }
+
+    /// Drop the cached dict table, boundary, and primed flag. Called when the
+    /// next frame carries no dictionary (or on eviction/param change) so the
+    /// kernel never probes a stale dict region.
+    #[inline]
+    pub(crate) fn invalidate(&mut self) {
+        self.table = None;
+        self.region_len = 0;
+        self.primed = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::{vec, vec::Vec};
+
+    #[test]
+    fn lifecycle_attach_prime_invalidate() {
+        let mut da: DictAttach<Vec<u32>> = DictAttach::new();
+        assert!(!da.is_attached());
+        assert!(!da.is_primed());
+        assert_eq!(da.region_len(), 0);
+
+        da.set_region_len(128);
+        // mark_primed is a no-op while no table exists.
+        da.mark_primed();
+        assert!(!da.is_primed());
+
+        da.table_mut_or_init(|| vec![0u32; 16]).fill(7);
+        assert!(da.is_attached());
+        assert_eq!(da.table().unwrap()[0], 7);
+
+        da.mark_primed();
+        assert!(da.is_primed());
+        assert_eq!(da.region_len(), 128);
+
+        da.invalidate();
+        assert!(!da.is_attached());
+        assert!(!da.is_primed());
+        assert_eq!(da.region_len(), 0);
+    }
+}

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2848,6 +2848,158 @@ mod tests {
     }
 
     #[test]
+    fn default_level_tiny_raw_dict_compresses_cleanly() {
+        // Coverage for the dfast dict-attach fast path with a
+        // sub-min-match raw-content dictionary: the dict-table probe in
+        // `start_matching_fast_loop` is gated on the dict table actually
+        // existing (`table().is_some()`), not merely on `is_attached()`,
+        // so a dictionary whose hashable region is shorter than the
+        // short-hash lookahead (where `prime_dict_tables_for_range`
+        // returns before allocating the tables) never dereferences a
+        // null dict pointer. Compressing at the default (dfast) level
+        // with such a dict must succeed.
+        let dict_id = 0xABCD_0009;
+        let dict = crate::decoding::Dictionary::from_raw_content(dict_id, b"abc".to_vec())
+            .expect("raw dictionary should be valid");
+        let payload = b"the quick brown fox jumps over the lazy dog, repeatedly and at length";
+        let mut output = Vec::new();
+        let mut compressor = FrameCompressor::new(super::CompressionLevel::Default);
+        compressor
+            .set_dictionary(dict)
+            .expect("tiny raw dictionary should attach");
+        compressor.set_source(payload.as_slice());
+        compressor.set_drain(&mut output);
+        compressor.compress();
+        assert!(!output.is_empty(), "compression should produce a frame");
+
+        // Full roundtrip: decode the dict-compressed frame with the SAME
+        // dictionary attached and confirm byte-exact recovery — proves the
+        // tiny-dict fast path produces a correct frame, not just a non-empty
+        // one.
+        let decode_dict = crate::decoding::Dictionary::from_raw_content(dict_id, b"abc".to_vec())
+            .expect("raw dictionary should be valid");
+        let mut decoder = FrameDecoder::new();
+        decoder
+            .add_dict(decode_dict)
+            .expect("decoder dict should attach");
+        let mut decoded = Vec::with_capacity(payload.len());
+        decoder
+            .decode_all_to_vec(&output, &mut decoded)
+            .expect("dict roundtrip should decode");
+        assert_eq!(decoded, payload, "tiny-dict roundtrip mismatch");
+    }
+
+    /// Exercises the dictionary dual-probe (live + immutable dict tables)
+    /// in the Fast / dfast / Row match finders with a dict whose content
+    /// the payload actually reuses, so each backend's dict long/short
+    /// probe (and the dfast `ip+1` dict-long retry) is reached and the
+    /// dict-compressed frame round-trips through a decoder primed with the
+    /// same dict. The 3-byte-dict test above only proves the null-table
+    /// guard; this proves the full attach path produces correct frames.
+    #[test]
+    fn dict_attach_roundtrips_across_backends_with_matching_payload() {
+        let dict_id = 0xD1C7_0001;
+        const LINE: &[u8] =
+            b"ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n";
+        let mut dict_content = Vec::new();
+        for _ in 0..24 {
+            dict_content.extend_from_slice(LINE);
+        }
+        let mut payload = Vec::new();
+        for i in 0..256u32 {
+            payload.extend_from_slice(LINE);
+            payload.extend_from_slice(alloc::format!("seq={i}\n").as_bytes());
+        }
+
+        for level in [
+            super::CompressionLevel::Level(-5), // Fast (negative)
+            super::CompressionLevel::Level(1),  // Fast
+            super::CompressionLevel::Default,   // dfast (L3)
+            super::CompressionLevel::Level(8),  // Row-backed lazy2
+        ] {
+            let dict = crate::decoding::Dictionary::from_raw_content(dict_id, dict_content.clone())
+                .expect("raw dictionary should be valid");
+            let mut compressor = FrameCompressor::new(level);
+            compressor
+                .set_dictionary(dict)
+                .expect("dictionary should attach");
+            let mut out = Vec::new();
+            compressor.set_source(payload.as_slice());
+            compressor.set_drain(&mut out);
+            compressor.compress();
+            assert!(
+                out.len() < payload.len() / 2,
+                "level {level:?}: dict-primed compress should be effective (out={}, payload={})",
+                out.len(),
+                payload.len(),
+            );
+
+            let ddict =
+                crate::decoding::Dictionary::from_raw_content(dict_id, dict_content.clone())
+                    .expect("raw dictionary should be valid");
+            let mut decoder = FrameDecoder::new();
+            decoder.add_dict(ddict).expect("decoder dict should attach");
+            let mut decoded = Vec::with_capacity(payload.len());
+            decoder
+                .decode_all_to_vec(&out, &mut decoded)
+                .unwrap_or_else(|e| panic!("level {level:?}: dict roundtrip decode failed: {e:?}"));
+            assert_eq!(decoded, payload, "level {level:?}: dict roundtrip mismatch");
+        }
+    }
+
+    /// Reusing one compressor across independent frames with DIFFERENT
+    /// dictionaries must drop the per-backend dict cache on each swap
+    /// (Simple/Dfast/Row keep the attach index across frames). Without the
+    /// invalidation a later frame would reuse the previous dict's rows.
+    /// Each frame round-trips through a decoder primed with its own dict.
+    #[test]
+    fn dict_swap_across_reused_compressor_roundtrips() {
+        const LINE_A: &[u8] = b"alpha tenant=demo table=orders region=eu-west op=put status=ok\n";
+        const LINE_B: &[u8] = b"bravo customer=acme bucket=logs shard=7 op=get status=miss\n";
+        let mk = |line: &[u8], reps: usize| {
+            let mut v = Vec::new();
+            for _ in 0..reps {
+                v.extend_from_slice(line);
+            }
+            v
+        };
+        let dict_a = mk(LINE_A, 24);
+        let dict_b = mk(LINE_B, 24);
+        let payload_a = mk(LINE_A, 200);
+        let payload_b = mk(LINE_B, 200);
+
+        for level in [
+            super::CompressionLevel::Default,
+            super::CompressionLevel::Level(8),
+        ] {
+            let mut compressor: FrameCompressor = FrameCompressor::new(level);
+            for (dict_bytes, payload) in [(&dict_a, &payload_a), (&dict_b, &payload_b)] {
+                let dict =
+                    crate::decoding::Dictionary::from_raw_content(0xD1C7_0002, dict_bytes.clone())
+                        .expect("raw dictionary should be valid");
+                compressor
+                    .set_dictionary(dict)
+                    .expect("dictionary should attach");
+                let out = compressor.compress_independent_frame(payload.as_slice());
+
+                let ddict =
+                    crate::decoding::Dictionary::from_raw_content(0xD1C7_0002, dict_bytes.clone())
+                        .expect("raw dictionary should be valid");
+                let mut decoder = FrameDecoder::new();
+                decoder.add_dict(ddict).expect("decoder dict should attach");
+                let mut decoded = Vec::with_capacity(payload.len());
+                decoder
+                    .decode_all_to_vec(&out, &mut decoded)
+                    .unwrap_or_else(|e| panic!("level {level:?}: dict-swap decode failed: {e:?}"));
+                assert_eq!(
+                    decoded, *payload,
+                    "level {level:?}: dict-swap roundtrip mismatch"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn dictionary_roundtrip_stays_valid_after_output_exceeds_window() {
         use crate::encoding::match_generator::MatchGeneratorDriver;
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2873,6 +2873,17 @@ mod tests {
         compressor.compress();
         assert!(!output.is_empty(), "compression should produce a frame");
 
+        // The emitted frame must advertise the attached dictionary id, proving
+        // the tiny-dict path stayed active (the payload round-trips either way,
+        // so without this the test would also pass on a silent no-dict frame).
+        let (frame_header, _) = crate::decoding::frame::read_frame_header(output.as_slice())
+            .expect("encoded frame should have a readable header");
+        assert_eq!(
+            frame_header.dictionary_id(),
+            Some(dict_id),
+            "tiny raw dict frame should still advertise its dictionary id",
+        );
+
         // Full roundtrip: decode the dict-compressed frame with the SAME
         // dictionary attached and confirm byte-exact recovery — proves the
         // tiny-dict fast path produces a correct frame, not just a non-empty

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -3812,13 +3812,69 @@ mod tests {
         assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(1)); // dfast
         assert_eq!(level_pre_split(CompressionLevel::Level(5)), Some(2)); // greedy
         assert_eq!(level_pre_split(CompressionLevel::Level(7)), Some(2)); // lazy (depth 1)
-        assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(3)); // lazy2 lower bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(3)); // lazy2 (depth 2)
-        assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(3)); // lazy2 upper bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(3)); // btlazy2 lower bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(3)); // btlazy2 (depth 2)
+        // lazy2 / btlazy2 use the rate-1 full-scan splitter (4), not the
+        // rate-5 sampler (3): the sampler phantom-splits homogeneous periodic
+        // input (see `pre_split` comment + `periodic_stream_not_oversplit`).
+        assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(4)); // lazy2 lower bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(4)); // lazy2 (depth 2)
+        assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(4)); // lazy2 upper bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(4)); // btlazy2 lower bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(4)); // btlazy2 (depth 2)
         assert_eq!(level_pre_split(CompressionLevel::Level(16)), Some(4)); // btopt
         assert_eq!(level_pre_split(CompressionLevel::Level(22)), Some(4)); // btultra2
+    }
+
+    /// Regression: a homogeneous but periodic multi-block stream must not be
+    /// pre-split into tiny blocks at the lazy2 / btlazy2 levels. The rate-5
+    /// chunk sampler used to phantom-split such input at every 8 KB chunk,
+    /// cascading a large stream into hundreds of tiny blocks whose per-block
+    /// headers ballooned the output (~5x vs the lazy level next door). With
+    /// the rate-1 full-scan splitter the periodic stream is seen as uniform
+    /// and stays a few full blocks. We assert the lazy2 (L8) and btlazy2 (L15)
+    /// outputs stay within 2x of the lazy (L7) output on the same input, and
+    /// that every output round-trips.
+    #[test]
+    fn periodic_stream_not_oversplit() {
+        use crate::encoding::{CompressionLevel, compress_slice_to_vec};
+        const LINES: &[&str] = &[
+            "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+            "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+            "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+            "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+        ];
+        // 512 KB = 4 donor blocks, enough for the cascade to manifest.
+        let target = 512 * 1024usize;
+        let mut data = Vec::with_capacity(target);
+        let mut i = 0;
+        while data.len() < target {
+            let line = LINES[i % LINES.len()].as_bytes();
+            let take = line.len().min(target - data.len());
+            data.extend_from_slice(&line[..take]);
+            i += 1;
+        }
+        let l7 = compress_slice_to_vec(&data, CompressionLevel::Level(7)); // lazy depth1
+        let l8 = compress_slice_to_vec(&data, CompressionLevel::Level(8)); // lazy2
+        let l15 = compress_slice_to_vec(&data, CompressionLevel::Level(15)); // btlazy2
+        assert!(
+            l8.len() < l7.len() * 2,
+            "lazy2 over-split periodic stream: l7={} l8={}",
+            l7.len(),
+            l8.len()
+        );
+        assert!(
+            l15.len() < l7.len() * 2,
+            "btlazy2 over-split periodic stream: l7={} l15={}",
+            l7.len(),
+            l15.len()
+        );
+        for out in [&l7, &l8, &l15] {
+            let mut decoder = FrameDecoder::new();
+            let mut round = Vec::with_capacity(data.len());
+            decoder
+                .decode_all_to_vec(out, &mut round)
+                .expect("decode periodic stream");
+            assert_eq!(round, data, "periodic stream roundtrip mismatch");
+        }
     }
 
     /// End-to-end: a 256 KB payload whose SECOND 128 KB donor block carries

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2900,17 +2900,49 @@ mod tests {
     #[test]
     fn dict_attach_roundtrips_across_backends_with_matching_payload() {
         let dict_id = 0xD1C7_0001;
-        const LINE: &[u8] =
-            b"ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n";
+        // Distinct lines so the payload does NOT self-compress: each line
+        // appears exactly once in the payload, so without the dictionary there
+        // are no in-frame back-references to exploit. The dictionary holds the
+        // SAME lines, so the only way the output shrinks is if the dict probe
+        // actually fires. A no-dict baseline below pins that the dict path ran
+        // (self-compressible payloads would round-trip + stay small via
+        // in-frame matches alone, proving nothing).
+        let line = |i: u32| {
+            alloc::format!(
+                "ts=2026-03-26T21:{:02}:{:02}Z level=INFO msg=\"event {i:05}\" tenant=t{i} region=eu\n",
+                i / 60 % 60,
+                i % 60,
+            )
+            .into_bytes()
+        };
         let mut dict_content = Vec::new();
-        for _ in 0..24 {
-            dict_content.extend_from_slice(LINE);
-        }
-        let mut payload = Vec::new();
         for i in 0..256u32 {
-            payload.extend_from_slice(LINE);
-            payload.extend_from_slice(alloc::format!("seq={i}\n").as_bytes());
+            dict_content.extend_from_slice(&line(i));
         }
+        // Payload = the same distinct lines in a different (stride) order, each
+        // once → no self-repeats, every line is a dictionary match.
+        let mut payload = Vec::new();
+        let mut i = 0u32;
+        for _ in 0..256u32 {
+            payload.extend_from_slice(&line(i));
+            i = (i + 97) % 256; // coprime stride → permutation, no adjacency
+        }
+
+        let compress_at = |level, dict: Option<Vec<u8>>| -> Vec<u8> {
+            let mut compressor = FrameCompressor::new(level);
+            if let Some(bytes) = dict {
+                let d = crate::decoding::Dictionary::from_raw_content(dict_id, bytes)
+                    .expect("raw dictionary should be valid");
+                compressor
+                    .set_dictionary(d)
+                    .expect("dictionary should attach");
+            }
+            let mut out = Vec::new();
+            compressor.set_source(payload.as_slice());
+            compressor.set_drain(&mut out);
+            compressor.compress();
+            out
+        };
 
         for level in [
             super::CompressionLevel::Level(-5), // Fast (negative)
@@ -2918,21 +2950,16 @@ mod tests {
             super::CompressionLevel::Default,   // dfast (L3)
             super::CompressionLevel::Level(8),  // Row-backed lazy2
         ] {
-            let dict = crate::decoding::Dictionary::from_raw_content(dict_id, dict_content.clone())
-                .expect("raw dictionary should be valid");
-            let mut compressor = FrameCompressor::new(level);
-            compressor
-                .set_dictionary(dict)
-                .expect("dictionary should attach");
-            let mut out = Vec::new();
-            compressor.set_source(payload.as_slice());
-            compressor.set_drain(&mut out);
-            compressor.compress();
+            let out = compress_at(level, Some(dict_content.clone()));
+            let no_dict = compress_at(level, None);
+            // The dict path MUST measurably beat no-dict on this
+            // non-self-compressible payload — otherwise the dict probe never
+            // fired and the roundtrip below would prove nothing.
             assert!(
-                out.len() < payload.len() / 2,
-                "level {level:?}: dict-primed compress should be effective (out={}, payload={})",
+                out.len() < no_dict.len(),
+                "level {level:?}: dict-primed output ({}) must beat no-dict ({}) — dict probe did not fire",
                 out.len(),
-                payload.len(),
+                no_dict.len(),
             );
 
             let ddict =
@@ -2955,26 +2982,47 @@ mod tests {
     /// Each frame round-trips through a decoder primed with its own dict.
     #[test]
     fn dict_swap_across_reused_compressor_roundtrips() {
-        const LINE_A: &[u8] = b"alpha tenant=demo table=orders region=eu-west op=put status=ok\n";
-        const LINE_B: &[u8] = b"bravo customer=acme bucket=logs shard=7 op=get status=miss\n";
-        let mk = |line: &[u8], reps: usize| {
-            let mut v = Vec::new();
-            for _ in 0..reps {
-                v.extend_from_slice(line);
+        // Distinct lines per dict (not a single repeated line) so payloads do
+        // NOT self-compress: each line appears once, so a frame only shrinks if
+        // the dict probe fires, and — crucially for the invalidation check — if
+        // frame B reused dict A's stale rows it would emit offsets into A's
+        // distinct content, which decode under dict B reconstructs as WRONG
+        // bytes (caught by the roundtrip). A single repeated line would hide
+        // pollution behind in-frame matches.
+        let lines = |tag: &str| -> (Vec<u8>, Vec<u8>) {
+            let line =
+                |i: u32| alloc::format!("{tag} record {i:05} field=value{i} end\n").into_bytes();
+            let mut dict = Vec::new();
+            for i in 0..256u32 {
+                dict.extend_from_slice(&line(i));
             }
-            v
+            let mut payload = Vec::new();
+            let mut i = 0u32;
+            for _ in 0..256u32 {
+                payload.extend_from_slice(&line(i));
+                i = (i + 97) % 256;
+            }
+            (dict, payload)
         };
-        let dict_a = mk(LINE_A, 24);
-        let dict_b = mk(LINE_B, 24);
-        let payload_a = mk(LINE_A, 200);
-        let payload_b = mk(LINE_B, 200);
+        let (dict_a, payload_a) = lines("alpha");
+        let (dict_b, payload_b) = lines("bravo");
 
         for level in [
             super::CompressionLevel::Default,
             super::CompressionLevel::Level(8),
         ] {
+            let no_dict = |payload: &[u8]| -> usize {
+                let mut c: FrameCompressor = FrameCompressor::new(level);
+                c.compress_independent_frame(payload).len()
+            };
+            let no_dict_a = no_dict(&payload_a);
+            let no_dict_b = no_dict(&payload_b);
+
             let mut compressor: FrameCompressor = FrameCompressor::new(level);
-            for (dict_bytes, payload) in [(&dict_a, &payload_a), (&dict_b, &payload_b)] {
+            for (dict_bytes, payload, no_dict_len) in [
+                (&dict_a, &payload_a, no_dict_a),
+                (&dict_b, &payload_b, no_dict_b),
+            ] {
                 let dict =
                     crate::decoding::Dictionary::from_raw_content(0xD1C7_0002, dict_bytes.clone())
                         .expect("raw dictionary should be valid");
@@ -2982,6 +3030,12 @@ mod tests {
                     .set_dictionary(dict)
                     .expect("dictionary should attach");
                 let out = compressor.compress_independent_frame(payload.as_slice());
+                assert!(
+                    out.len() < no_dict_len,
+                    "level {level:?}: dict frame ({}) must beat no-dict ({}) — dict probe did not fire",
+                    out.len(),
+                    no_dict_len,
+                );
 
                 let ddict =
                     crate::decoding::Dictionary::from_raw_content(0xD1C7_0002, dict_bytes.clone())
@@ -2994,7 +3048,7 @@ mod tests {
                     .unwrap_or_else(|e| panic!("level {level:?}: dict-swap decode failed: {e:?}"));
                 assert_eq!(
                     decoded, *payload,
-                    "level {level:?}: dict-swap roundtrip mismatch"
+                    "level {level:?}: dict-swap roundtrip mismatch (stale dict rows?)"
                 );
             }
         }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1051,6 +1051,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 crate::encoding::strategy::StrategyTag::Dfast => 14,
                 crate::encoding::strategy::StrategyTag::Greedy
                 | crate::encoding::strategy::StrategyTag::Lazy
+                | crate::encoding::strategy::StrategyTag::Btlazy2
                 | crate::encoding::strategy::StrategyTag::BtOpt => 15,
             };
             let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| {

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2723,6 +2723,81 @@ mod tests {
     }
 
     #[test]
+    fn dict_primed_btlazy2_reused_across_attach_and_copy_boundary_is_byte_identical() {
+        // Btlazy2 (Level 15) uses the 32 KiB dict attach/copy cutoff in
+        // prepare_frame. Exercise BOTH sides of that boundary on a reused
+        // compressor: a sub-cutoff payload (re-prime/attach path) and an
+        // over-cutoff payload (copy-snapshot restore path). In each case the
+        // warm-cache second frame must reproduce the cold-cache first frame
+        // byte-for-byte (the dict cache is a timing optimization, never a
+        // content change), and every frame must round-trip.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let dict_id = super::EncoderDictionary::from_bytes(dict_raw)
+            .expect("dict bytes should parse")
+            .id();
+        // Distinct lines so the payload does not trivially self-compress; the
+        // BT finder + dict dual-probe both get exercised.
+        let make_payload = |target: usize| {
+            let mut p = Vec::with_capacity(target);
+            let mut i = 0u64;
+            while p.len() < target {
+                p.extend_from_slice(
+                    format!(
+                        "tenant=demo op=put key={i} value=aaaaabbbbbcccccddddd-{}\n",
+                        i % 97
+                    )
+                    .as_bytes(),
+                );
+                i += 1;
+            }
+            p
+        };
+        // Below the 32 KiB cutoff (attach/re-prime) and above it (copy-snapshot).
+        for target in [16 * 1024usize, 64 * 1024usize] {
+            let payload = make_payload(target);
+            let mut warm: FrameCompressor =
+                FrameCompressor::new(super::CompressionLevel::Level(15));
+            warm.set_encoder_dictionary(
+                super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+            )
+            .expect("dict attach");
+            // Frame 1 builds + marks the dict tables; frame 2 reuses them.
+            let frame1 = warm.compress_independent_frame(payload.as_slice());
+            let frame2 = warm.compress_independent_frame(payload.as_slice());
+            assert_eq!(
+                frame1, frame2,
+                "reused dict cache must reproduce the freshly-primed frame byte-for-byte \
+                 (Level 15, target={target})"
+            );
+            // Cold-cache compressor: must match the warm-cache bytes.
+            let mut cold: FrameCompressor =
+                FrameCompressor::new(super::CompressionLevel::Level(15));
+            cold.set_encoder_dictionary(
+                super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+            )
+            .expect("dict attach");
+            let cold_frame = cold.compress_independent_frame(payload.as_slice());
+            assert_eq!(
+                cold_frame, frame1,
+                "cold-cache compressor must match warm-cache frame (Level 15, target={target})"
+            );
+            // Round-trip through a decoder primed with the same dict.
+            for frame in [&frame1, &frame2] {
+                let (hdr, _) = crate::decoding::frame::read_frame_header(frame.as_slice())
+                    .expect("frame header");
+                assert_eq!(hdr.dictionary_id(), Some(dict_id));
+                let mut decoder = FrameDecoder::new();
+                decoder
+                    .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
+                    .unwrap();
+                let mut decoded = Vec::with_capacity(payload.len());
+                decoder.decode_all_to_vec(frame, &mut decoded).unwrap();
+                assert_eq!(decoded.as_slice(), payload.as_slice());
+            }
+        }
+    }
+
+    #[test]
     fn set_dictionary_from_bytes_matches_full_decode_byte_for_byte() {
         // The encoder-only dict parse (`decode_dict_for_encoding`, used by
         // `set_dictionary_from_bytes`) skips the FSE/HUF decoder-table build and

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -454,7 +454,19 @@ fn apply_param_overrides(params: &mut LevelParams, ov: &super::parameters::Param
             params.row.get_or_insert(ROW_L5);
         }
         SearchMethod::HashChain | SearchMethod::BinaryTree => {
-            params.hc.get_or_insert(HC_OVERRIDE_DEFAULT);
+            // A `Btlazy2` strategy override moved off a non-HC row needs the
+            // BT 5-byte finder hash (donor minMatch 5); other synthesized HC
+            // rows keep the 4-byte default. An explicit `min_match` override
+            // below refines this further.
+            params.hc.get_or_insert(HcConfig {
+                search_mls: if matches!(params.strategy_tag, super::strategy::StrategyTag::Btlazy2)
+                {
+                    5
+                } else {
+                    HC_OVERRIDE_DEFAULT.search_mls
+                },
+                ..HC_OVERRIDE_DEFAULT
+            });
         }
     }
 
@@ -527,6 +539,13 @@ fn apply_param_overrides(params: &mut LevelParams, ov: &super::parameters::Param
                 }
                 if let Some(target_length) = ov.target_length {
                     hc.target_len = target_length as usize;
+                }
+                if let Some(min_match) = ov.min_match {
+                    // Donor `mls = BOUNDED(4, cParams.minMatch, 6)`: a BT
+                    // min_match override maps into the finder hash width. Only
+                    // the BT body reads `search_mls`; HC/lazy keep 4-byte
+                    // hashing regardless, so this is a no-op for them.
+                    hc.search_mls = (min_match as usize).clamp(4, 6);
                 }
             }
         }
@@ -2679,9 +2698,25 @@ pub(crate) use bt_insert_step_no_rebase_body;
 /// repeat-offset match always out-gains an explicit-offset one
 /// (`zstd_lazy.c` `ZSTD_storeSeq` offBase convention).
 #[inline]
-fn btlazy2_offbase(offset: usize, reps: [u32; 3]) -> u32 {
+fn btlazy2_offbase(offset: usize, reps: [u32; 3], ll0: bool) -> u32 {
     let o = offset as u32;
-    if o == reps[0] {
+    // Donor repcode mapping shifts by `ll0` (zero-literal position): the cheap
+    // codes become rep1 / rep2 / (rep0 - 1) instead of rep0 / rep1 / rep2,
+    // because at ll0 an offset equal to rep0 is the special rep0-1 case, not
+    // repcode 1. Scoring offsets against the wrong code at ll0 over-rewards a
+    // rep0-distance match that does not actually encode as the cheapest code.
+    if ll0 {
+        if o == reps[1] {
+            1
+        } else if o == reps[2] {
+            2
+        } else if reps[0] > 1 && o == reps[0] - 1 {
+            3
+        } else {
+            // Offsets are < window (<= 2^27), so `+ 3` never overflows u32.
+            o + 3
+        }
+    } else if o == reps[0] {
         1
     } else if o == reps[1] {
         2
@@ -2697,8 +2732,8 @@ fn btlazy2_offbase(offset: usize, reps: [u32; 3]) -> u32 {
 /// selection metric that lets a shorter repeat-offset match beat a longer
 /// explicit-offset one. `offBase >= 1`, so `highbit` is well-defined.
 #[inline]
-fn btlazy2_gain(match_len: usize, offset: usize, reps: [u32; 3]) -> i64 {
-    let offbase = btlazy2_offbase(offset, reps);
+fn btlazy2_gain(match_len: usize, offset: usize, reps: [u32; 3], ll0: bool) -> i64 {
+    let offbase = btlazy2_offbase(offset, reps, ll0);
     (match_len as i64) * 4 - (31 - offbase.leading_zeros()) as i64
 }
 
@@ -2755,6 +2790,9 @@ macro_rules! start_matching_btlazy2_body {
         macro_rules! bt_select {
             ($p:expr) => {{
                 let sel_pos: usize = $p;
+                // `ll0` (donor): zero literals pending before this position, so
+                // the repcode set is shifted (see `btlazy2_offbase`).
+                let ll0 = sel_pos == literals_start;
                 let sel_abs = current_abs_start + sel_pos;
                 candidates.clear();
                 let query = HcCandidateQuery {
@@ -2784,7 +2822,7 @@ macro_rules! start_matching_btlazy2_body {
                     if ml < HC_OPT_MIN_MATCH_LEN {
                         continue;
                     }
-                    let g = btlazy2_gain(ml, c.offset, reps);
+                    let g = btlazy2_gain(ml, c.offset, reps, ll0);
                     if g > sel_gain {
                         sel_gain = g;
                         sel_ml = ml;
@@ -2792,17 +2830,26 @@ macro_rules! start_matching_btlazy2_body {
                     }
                 }
                 let sel_idx = sel_abs - history_abs_start;
-                let rep0 = reps[0] as usize;
-                if rep0 != 0 && sel_idx >= rep0 {
+                // Donor probes `rep[0 + ll0]` directly (the length-sorted ladder
+                // drops short cheap reps): rep0 normally, rep1 at a zero-literal
+                // position where rep0 is not the cheapest code.
+                let probe_rep = if ll0 {
+                    reps[1] as usize
+                } else {
+                    reps[0] as usize
+                };
+                if probe_rep != 0 && sel_idx >= probe_rep {
                     let tail = current_len - sel_pos;
-                    // SAFETY: `sel_idx - rep0 < sel_idx`, `sel_idx + tail <=
+                    // SAFETY: `sel_idx - probe_rep < sel_idx`, `sel_idx + tail <=
                     // concat_full.len()`; same overshoot slack the collector
                     // relies on for this block.
-                    let rep_ml = unsafe { $cmf(concat_full, sel_idx, sel_idx - rep0, tail, 0) };
-                    if rep_ml >= HC_OPT_MIN_MATCH_LEN && btlazy2_gain(rep_ml, rep0, reps) > sel_gain
+                    let rep_ml =
+                        unsafe { $cmf(concat_full, sel_idx, sel_idx - probe_rep, tail, 0) };
+                    if rep_ml >= HC_OPT_MIN_MATCH_LEN
+                        && btlazy2_gain(rep_ml, probe_rep, reps, ll0) > sel_gain
                     {
                         sel_ml = rep_ml;
-                        sel_off = rep0;
+                        sel_off = probe_rep;
                     }
                 }
                 (sel_ml, sel_off)
@@ -2829,8 +2876,10 @@ macro_rules! start_matching_btlazy2_body {
                 }
                 let reps = $self.table.offset_hist;
                 let margin = if d == 0 { 4 } else { 7 };
-                let gain1 = btlazy2_gain(best_ml, best_off, reps) + margin;
-                let gain2 = btlazy2_gain(ml2, off2, reps);
+                // `best` sits at `start` (ll0 iff no literals precede it); the
+                // lookahead match at `start + 1` always has a pending literal.
+                let gain1 = btlazy2_gain(best_ml, best_off, reps, start == literals_start) + margin;
+                let gain2 = btlazy2_gain(ml2, off2, reps, false);
                 if gain2 > gain1 {
                     best_ml = ml2;
                     best_off = off2;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -265,22 +265,6 @@ const ROW_L5: RowConfig = RowConfig {
     mls: ROW_MIN_MATCH_LEN,
 };
 
-// Level-8 lazy2 routed to the Row finder (donor `useRowMatchFinder`: the row
-// finder is enabled by default for greedy/lazy/lazy2 whenever windowLog > 14,
-// which holds for every lazy level here). Donor `clevels.h` L8 (srcSize > 256
-// KB) is searchLog=4, targetLength=16, minMatch=5, from which the row matcher
-// derives rowLog = clamp(searchLog, 4, 6) = 4, search_depth = 1 << min(searchLog,
-// rowLog) = 16, target_len = 16. Replaces the legacy HashChain config so the
-// bounded row dual-probe (and its dict attach) runs instead of the unbounded
-// hash-chain dict walk.
-const ROW_L8: RowConfig = RowConfig {
-    hash_bits: ROW_HASH_BITS,
-    row_log: 4,
-    search_depth: 16,
-    target_len: 16,
-    mls: ROW_MIN_MATCH_LEN,
-};
-
 /// Per-level Double-Fast hash sizing, mirroring the donor `clevels.h` columns
 /// (config-driven, not a hardcoded constant): `long_hash_log` =
 /// `cParams.hashLog` (the long 8-byte hash table), `short_hash_log` =
@@ -402,6 +386,8 @@ impl LevelParams {
                     Some(2)
                 }
             }
+            // btlazy2 rides the same lazy2 split code (3).
+            super::strategy::StrategyTag::Btlazy2 => Some(3),
             super::strategy::StrategyTag::BtOpt
             | super::strategy::StrategyTag::BtUltra
             | super::strategy::StrategyTag::BtUltra2 => Some(4),
@@ -536,6 +522,8 @@ fn ldm_strategy_ordinal(tag: super::strategy::StrategyTag, lazy_depth: u8) -> u3
                 4
             }
         }
+        // Donor `ZSTD_btlazy2` ordinal.
+        StrategyTag::Btlazy2 => 6,
         StrategyTag::BtOpt => 7,
         StrategyTag::BtUltra => 8,
         StrategyTag::BtUltra2 => 9,
@@ -633,7 +621,7 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, search: super::strategy::SearchMethod::RowHash, window_log: 21, lazy_depth: 0, fast: None, dfast: None, hc: None, row: Some(ROW_L5) },
     /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }), row: None },
     /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }), row: None },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::RowHash, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: None, row: Some(ROW_L8) },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 16 }), row: None },
     /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 21, chain_log: 20, search_depth: 16, target_len: 16 }), row: None },
     /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 16 }), row: None },
     /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 64, target_len: 16 }), row: None },
@@ -646,9 +634,9 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // smaller searchLog find longer matches (and re-establish a strict ratio
     // ladder above L12) is tracked separately; until it lands these levels sit
     // close to L12 on hash-chain inputs by design.
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }), row: None },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }), row: None },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }), row: None },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }), row: None },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }), row: None },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }), row: None },
     /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 48 }), row: None },
     /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 32, target_len: 64 }), row: None },
     /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 64, target_len: 64 }), row: None },
@@ -2323,6 +2311,9 @@ impl Matcher for MatchGeneratorDriver {
                     .start_matching_lazy(&mut handle_sequence);
             }
             SearchMethod::BinaryTree => match self.strategy_tag {
+                StrategyTag::Btlazy2 => self
+                    .hc_matcher_mut()
+                    .start_matching_btlazy2(&mut handle_sequence),
                 StrategyTag::BtOpt => self.compress_block::<strategy::BtOpt>(&mut handle_sequence),
                 StrategyTag::BtUltra => {
                     self.compress_block::<strategy::BtUltra>(&mut handle_sequence)
@@ -2331,7 +2322,7 @@ impl Matcher for MatchGeneratorDriver {
                     self.compress_block::<strategy::BtUltra2>(&mut handle_sequence)
                 }
                 _ => unreachable!(
-                    "SearchMethod::BinaryTree requires an opt strategy tag (BtOpt/BtUltra/BtUltra2)"
+                    "SearchMethod::BinaryTree requires a BT strategy tag (Btlazy2/BtOpt/BtUltra/BtUltra2)"
                 ),
             },
         }
@@ -2631,6 +2622,94 @@ pub(crate) use bt_insert_step_no_rebase_body;
 /// (`ACCURATE_PRICE`, `FAVOR_SMALL_OFFSETS`) come from the wrapper's
 /// generic parameter list and are referenced as bare identifiers; macro
 /// hygiene resolves them at the expansion site.
+/// Per-kernel body of the `btlazy2` (levels 13-15) greedy/lazy parse over
+/// the binary-tree match finder. Mirrors `build_optimal_plan_impl_body!`'s
+/// kernel-dispatch discipline: the wrapper carries the `#[target_feature]`
+/// umbrella and passes its tier-specific `collect_optimal_candidates_initialized_<kernel>`
+/// as `$collect`, so the per-position BT collect (and its inlined cpl)
+/// stays under one umbrella — the runtime `select_kernel()` dispatch happens
+/// ONCE per block in the bare `start_matching_btlazy2`, never per position.
+macro_rules! start_matching_btlazy2_body {
+    ($self:ident, $handle_sequence:ident, $collect:ident $(,)?) => {{
+        $self.table.ensure_tables();
+        let current_len = *$self.table.chunk_lens.back().unwrap();
+        if current_len == 0 {
+            return;
+        }
+        let current_ptr = $self.table.get_last_space().as_ptr();
+        // Mutates tables but never reallocates `history`, so this tail slice
+        // stays valid for the routine's duration (same as the other parsers).
+        let current: &[u8] = unsafe { core::slice::from_raw_parts(current_ptr, current_len) };
+        let current_abs_start =
+            $self.table.history_abs_start + $self.table.window_size - current_len;
+        let current_abs_end = current_abs_start + current_len;
+        $self
+            .table
+            .apply_limited_update_after_long_match(current_abs_start);
+        $self
+            .table
+            .backfill_boundary_positions(current_abs_start, current_abs_end);
+
+        let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtOpt>();
+        let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
+
+        let mut pos = 0usize;
+        let mut literals_start = 0usize;
+        while pos + HC_OPT_MIN_MATCH_LEN <= current_len {
+            let abs_pos = current_abs_start + pos;
+            let lit_len = pos - literals_start;
+            candidates.clear();
+            let query = HcCandidateQuery {
+                reps: $self.table.offset_hist,
+                lit_len,
+                ldm_candidate: None,
+            };
+            // SAFETY: called inside the wrapper's `#[target_feature]` umbrella
+            // (the scalar wrapper's `$collect` is a safe fn — `unused_unsafe`
+            // is allowed on the wrapper).
+            unsafe {
+                $self.$collect::<super::strategy::BtOpt, true>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    &mut candidates,
+                );
+            }
+            // Greedy commit: the ladder is increasing in length, so the last
+            // entry is the longest match found at this position (donor btlazy2
+            // commits the best/longest match).
+            if let Some(best) = candidates.last().copied() {
+                let match_len = best.match_len.min(current_len - pos);
+                if match_len >= HC_OPT_MIN_MATCH_LEN {
+                    let literals = &current[literals_start..pos];
+                    $handle_sequence(Sequence::Triple {
+                        literals,
+                        offset: best.offset,
+                        match_len,
+                    });
+                    let _ = encode_offset_with_history(
+                        best.offset as u32,
+                        lit_len as u32,
+                        &mut $self.table.offset_hist,
+                    );
+                    pos += match_len;
+                    literals_start = pos;
+                    continue;
+                }
+            }
+            pos += 1;
+        }
+
+        if literals_start < current_len {
+            $handle_sequence(Sequence::Literals {
+                literals: &current[literals_start..],
+            });
+        }
+        $self.backend.bt_mut().opt_candidates_scratch = candidates;
+    }};
+}
+
 macro_rules! build_optimal_plan_impl_body {
     (
         $self:expr,
@@ -4005,7 +4084,10 @@ impl HcMatchGenerator {
         let is_btultra2 = tag == StrategyTag::BtUltra2;
         let uses_bt = matches!(
             tag,
-            StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2
+            StrategyTag::Btlazy2
+                | StrategyTag::BtOpt
+                | StrategyTag::BtUltra
+                | StrategyTag::BtUltra2
         );
         // btultra and btultra2 both run the mls=3 hash3 short-match probe
         // (clevels.h minMatch 3). The `is_btultra2` flag below stays
@@ -4108,6 +4190,7 @@ impl HcMatchGenerator {
             StrategyTag::Fast | StrategyTag::Dfast | StrategyTag::Greedy | StrategyTag::Lazy => {
                 self.start_matching_lazy(&mut handle_sequence)
             }
+            StrategyTag::Btlazy2 => self.start_matching_btlazy2(&mut handle_sequence),
             StrategyTag::BtOpt => {
                 self.start_matching_optimal::<strategy::BtOpt>(&mut handle_sequence)
             }
@@ -4211,6 +4294,97 @@ impl HcMatchGenerator {
                 literals: &current[literals_start..],
             });
         }
+    }
+
+    /// Donor `ZSTD_btlazy2` (levels 13-15): binary-tree match finder with a
+    /// greedy/lazy parse. Bare dispatcher — resolves the runtime tier ONCE
+    /// per block via `select_kernel()` and calls the matching
+    /// `start_matching_btlazy2_<kernel>` wrapper, so the per-position BT
+    /// collect runs under a single `#[target_feature]` umbrella (mirrors
+    /// `build_optimal_plan_impl`). See `start_matching_btlazy2_body!` for the
+    /// shared loop.
+    fn start_matching_btlazy2(&mut self, mut handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        unsafe {
+            self.start_matching_btlazy2_neon(&mut handle_sequence)
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
+            match select_kernel() {
+                FastpathKernel::Avx2Bmi2 => unsafe {
+                    self.start_matching_btlazy2_avx2_bmi2(&mut handle_sequence)
+                },
+                FastpathKernel::Sse42 => unsafe {
+                    self.start_matching_btlazy2_sse42(&mut handle_sequence)
+                },
+                FastpathKernel::Scalar => self.start_matching_btlazy2_scalar(&mut handle_sequence),
+            }
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64"
+        )))]
+        {
+            self.start_matching_btlazy2_scalar(&mut handle_sequence)
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    unsafe fn start_matching_btlazy2_neon(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_btlazy2_body!(
+            self,
+            handle_sequence,
+            collect_optimal_candidates_initialized_neon
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn start_matching_btlazy2_sse42(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_btlazy2_body!(
+            self,
+            handle_sequence,
+            collect_optimal_candidates_initialized_sse42
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    unsafe fn start_matching_btlazy2_avx2_bmi2(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_btlazy2_body!(
+            self,
+            handle_sequence,
+            collect_optimal_candidates_initialized_avx2_bmi2
+        )
+    }
+
+    // Scalar wrapper: no `#[target_feature]`; `$collect` (the scalar collect)
+    // is a safe fn, so the body macro's `unsafe` block is inert here. Same cfg
+    // as `collect_optimal_candidates_initialized_scalar` (absent on
+    // aarch64-little, where NEON is the baseline tier).
+    #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+    #[allow(unused_unsafe)]
+    fn start_matching_btlazy2_scalar(
+        &mut self,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_btlazy2_body!(
+            self,
+            handle_sequence,
+            collect_optimal_candidates_initialized_scalar
+        )
     }
 
     fn start_matching_optimal<S: super::strategy::Strategy>(
@@ -4687,7 +4861,7 @@ impl HcMatchGenerator {
                     query,
                     out,
                 ),
-            StrategyTag::BtOpt => self
+            StrategyTag::Btlazy2 | StrategyTag::BtOpt => self
                 .collect_optimal_candidates_initialized::<strategy::BtOpt, true>(
                     abs_pos,
                     current_abs_end,
@@ -5771,7 +5945,10 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
     check(CompressionLevel::Level(4), StrategyTag::Dfast);
     check(CompressionLevel::Level(5), StrategyTag::Greedy);
     check(CompressionLevel::Level(7), StrategyTag::Lazy);
-    check(CompressionLevel::Level(15), StrategyTag::Lazy);
+    check(CompressionLevel::Level(12), StrategyTag::Lazy);
+    check(CompressionLevel::Level(13), StrategyTag::Btlazy2);
+    check(CompressionLevel::Level(14), StrategyTag::Btlazy2);
+    check(CompressionLevel::Level(15), StrategyTag::Btlazy2);
     check(CompressionLevel::Level(16), StrategyTag::BtOpt);
     check(CompressionLevel::Level(18), StrategyTag::BtUltra);
     check(CompressionLevel::Level(22), StrategyTag::BtUltra2);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1497,7 +1497,16 @@ impl MatchGeneratorDriver {
                 }
             }
             super::strategy::BackendTag::HashChain => {
-                self.hc_matcher_mut().skip_matching(Some(false))
+                let table = &mut self.hc_matcher_mut().table;
+                if table.uses_bt {
+                    // BT / optimal levels: keep the dict in history for the dms
+                    // but do NOT insert it into the live tree (donor separate
+                    // dictMatchState). Lazy-HC levels still index the dict into
+                    // the live chain (they have no dms).
+                    table.skip_matching_dict_bt();
+                } else {
+                    self.hc_matcher_mut().skip_matching(Some(false));
+                }
             }
         }
     }
@@ -2016,9 +2025,14 @@ impl Matcher for MatchGeneratorDriver {
                 .saturating_add(granted_retained_budget);
         }
         if self.active_backend() == super::strategy::BackendTag::HashChain {
-            self.hc_matcher_mut()
-                .table
-                .set_dictionary_limit_from_primed_bytes(committed_dict_budget);
+            let table = &mut self.hc_matcher_mut().table;
+            table.set_dictionary_limit_from_primed_bytes(committed_dict_budget);
+            // Build the dictMatchState chain for BT/optimal levels so the
+            // collect dual-probes the dictionary with its own compare budget
+            // (the dict bytes were just committed to the front of history).
+            if table.uses_bt {
+                table.prime_dms_chain(committed_dict_budget);
+            }
         }
         // CDict-equivalent: now that every dict chunk is indexed, mark the
         // Fast-backend dict table primed so the next frame's re-prime reuses
@@ -4033,6 +4047,71 @@ macro_rules! bt_insert_and_collect_matches_body {
         if larger_slot != usize::MAX {
             $table.chain_table[larger_slot] = $crate::encoding::match_table::storage::HC_EMPTY;
         }
+
+        // Dict dual-probe (donor `ZSTD_dictMatchState`, zstd_opt.c:776-812):
+        // after the live tree, walk the immutable dictionary chain with its
+        // OWN compare budget and push any dict match longer than the live best
+        // into the ladder. Dict positions are dictionary-relative concat
+        // indices in `[0, region)`, pinned at the front of history, so a dict
+        // candidate at `dict_idx` sits at offset `idx - dict_idx`. The optimal
+        // parser prices these (its DP lookahead values the repcode chain a dict
+        // match seeds), unlike the greedy/lazy parsers.
+        if let Some(dms) = $table.dms.table() {
+            let region = $table.dms.region_len();
+            let dh = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
+                concat,
+                idx,
+                dms.hash_log,
+                dms.mls,
+            );
+            let mut dcur = dms.hash_table[dh];
+            let mut dms_compares = $profile.max_chain_depth.min($search_depth);
+            while dms_compares > 0 {
+                if dcur == $crate::encoding::match_table::storage::HC_EMPTY {
+                    break;
+                }
+                let dict_idx = (dcur - 1) as usize;
+                dms_compares -= 1;
+                let dnext = dms.chain_table[dict_idx];
+                let dms_self_loop = dnext == dcur;
+                if dict_idx < region && dict_idx < idx {
+                    // SAFETY: `dict_idx < idx` and `idx + tail_limit <=
+                    // concat.len()` (checked at entry); same umbrella as the
+                    // live walk's `$cmf`.
+                    let match_len = unsafe { $cmf(concat, idx, dict_idx, tail_limit, 0) };
+                    if match_len > best_len {
+                        let offset = idx - dict_idx;
+                        let accepted = $crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                            $out,
+                            $best_len_for_skip,
+                            $crate::encoding::opt::types::MatchCandidate {
+                                start: $abs_pos,
+                                offset,
+                                match_len,
+                            },
+                            $min_match_len,
+                        );
+                        if accepted {
+                            best_len = match_len;
+                            let candidate_end = $abs_pos + match_len;
+                            if candidate_end > match_end_abs {
+                                match_end_abs = candidate_end;
+                            }
+                            if match_len >= tail_limit
+                                || match_len > $crate::encoding::cost_model::HC_OPT_NUM
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if dms_self_loop {
+                    break;
+                }
+                dcur = dnext;
+            }
+        }
+
         // `match_end_abs >= abs_pos + 9 >= 9` (initialized and monotonic),
         // so `match_end_abs - 8 >= 1` cannot underflow.
         $table.skip_insert_until_abs = match_end_abs - 8;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2485,7 +2485,7 @@ macro_rules! bt_insert_step_no_rebase_body {
             concat,
             idx,
             $table.hash_log,
-            $crate::encoding::bt::BtMatcher::HASH_MLS,
+            $table.search_mls,
         );
         let Some(relative_pos) = $table.relative_position($abs_pos) else {
             return 1;
@@ -3902,7 +3902,7 @@ macro_rules! bt_insert_and_collect_matches_body {
             concat,
             idx,
             $table.hash_log,
-            $crate::encoding::bt::BtMatcher::HASH_MLS,
+            $table.search_mls,
         );
         let Some(relative_pos) = $table.relative_position($abs_pos) else {
             return;
@@ -4117,6 +4117,19 @@ impl HcMatchGenerator {
         self.table.search_depth = self.hc.search_depth;
         self.table.is_btultra2 = is_btultra2;
         self.table.uses_bt = uses_bt;
+        // BT finder hash width, donor `mls = BOUNDED(4, cParams.minMatch, 6)`.
+        // clevels.h (srcSize > 256 KiB tier): btlazy2 L13-15 and btopt L16 are
+        // minMatch=5; btopt L17 is minMatch=4; btultra/btultra2 are minMatch=3
+        // (4-byte main hash + the hash3 short-match probe). The 5-byte hash
+        // shortens the BT walk vs our prior 4-byte everywhere (speed). Only the
+        // BT body reads `search_mls`. `window_log` here is source-clamped (so it
+        // can't tell L16 from L17 on a small source); `config.target_len` is the
+        // level's own value (L16=48, L17=64) and distinguishes them reliably.
+        self.table.search_mls = match tag {
+            StrategyTag::Btlazy2 => 5,
+            StrategyTag::BtOpt if config.target_len <= 48 => 5,
+            _ => 4,
+        };
         // Stage D: promote the backend discriminator. HC modes drop the
         // BT scratch buffers entirely; switching back into a BT mode
         // allocates a fresh `BtMatcher` on demand.

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1795,7 +1795,8 @@ impl Matcher for MatchGeneratorDriver {
                     let wlog = hc_hash_bits_for_window(table_window_size);
                     let uses_bt = matches!(
                         strategy_tag,
-                        super::strategy::StrategyTag::BtOpt
+                        super::strategy::StrategyTag::Btlazy2
+                            | super::strategy::StrategyTag::BtOpt
                             | super::strategy::StrategyTag::BtUltra
                             | super::strategy::StrategyTag::BtUltra2
                     );
@@ -2672,7 +2673,7 @@ macro_rules! start_matching_btlazy2_body {
             .table
             .backfill_boundary_positions(current_abs_start, current_abs_end);
 
-        let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::BtOpt>();
+        let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::Btlazy2>();
         let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
 
         let mut pos = 0usize;
@@ -2684,13 +2685,16 @@ macro_rules! start_matching_btlazy2_body {
             let query = HcCandidateQuery {
                 reps: $self.table.offset_hist,
                 lit_len,
+                // No LDM seed: L13-15 run at windowLog 22, below donor's
+                // LDM auto-enable threshold (windowLog >= 27), so long-
+                // distance matching is off for this strategy by default.
                 ldm_candidate: None,
             };
             // SAFETY: called inside the wrapper's `#[target_feature]` umbrella
             // (the scalar wrapper's `$collect` is a safe fn — `unused_unsafe`
             // is allowed on the wrapper).
             unsafe {
-                $self.$collect::<super::strategy::BtOpt, true>(
+                $self.$collect::<super::strategy::Btlazy2, true>(
                     abs_pos,
                     current_abs_end,
                     profile,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2060,7 +2060,7 @@ impl Matcher for MatchGeneratorDriver {
             // collect dual-probes the dictionary with its own compare budget
             // (the dict bytes were just committed to the front of history).
             if table.uses_bt {
-                table.prime_dms_chain(committed_dict_budget);
+                table.prime_dms_bt(committed_dict_budget);
             }
         }
         // CDict-equivalent: now that every dict chunk is indexed, mark the
@@ -4080,14 +4080,18 @@ macro_rules! bt_insert_and_collect_matches_body {
             $table.chain_table[larger_slot] = $crate::encoding::match_table::storage::HC_EMPTY;
         }
 
-        // Dict dual-probe (donor `ZSTD_dictMatchState`, zstd_opt.c:776-812):
-        // after the live tree, walk the immutable dictionary chain with its
-        // OWN compare budget and push any dict match longer than the live best
-        // into the ladder. Dict positions are dictionary-relative concat
-        // indices in `[0, region)`, pinned at the front of history, so a dict
-        // candidate at `dict_idx` sits at offset `idx - dict_idx`. The optimal
-        // parser prices these (its DP lookahead values the repcode chain a dict
-        // match seeds), unlike the greedy/lazy parsers.
+        // Dict dual-probe (donor `ZSTD_dictMatchState`, zstd_opt.c:777-813):
+        // after the live tree, descend the immutable dictionary BINARY TREE
+        // (built in `prime_dms_bt`) with its OWN compare budget and push any
+        // dict match longer than the live best into the ladder. The DUBT
+        // descent reaches the longest dict match efficiently (a hash-chain
+        // surfaced only the few same-bucket candidates and left most of the
+        // dict savings unrealised at btlazy2 / btopt). Dict positions are
+        // dictionary-relative concat indices in `[0, region)`, pinned at the
+        // front of history, so a dict candidate at `dict_idx` sits at offset
+        // `idx - dict_idx` (no donor `dmsIndexDelta`). The optimal parser
+        // prices these (its DP lookahead values the repcode chain a dict match
+        // seeds); the greedy/lazy parser commits the longest.
         if let Some(dms) = $table.dms.table() {
             let region = $table.dms.region_len();
             let dh = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
@@ -4097,50 +4101,62 @@ macro_rules! bt_insert_and_collect_matches_body {
                 dms.mls,
             );
             let mut dcur = dms.hash_table[dh];
+            // DUBT seed lengths: bytes already known common on each side, so
+            // `$cmf` resumes from there (donor commonLengthSmaller/Larger).
+            let mut common_smaller = 0usize;
+            let mut common_larger = 0usize;
             let mut dms_compares = $profile.max_chain_depth.min($search_depth);
-            while dms_compares > 0 {
-                if dcur == $crate::encoding::match_table::storage::HC_EMPTY {
+            while dms_compares > 0 && dcur != $crate::encoding::match_table::storage::HC_EMPTY {
+                let dict_idx = (dcur - 1) as usize;
+                // The dict tree holds only dict positions (`< region <= idx`).
+                if dict_idx >= region || dict_idx >= idx {
                     break;
                 }
-                let dict_idx = (dcur - 1) as usize;
                 dms_compares -= 1;
-                let dnext = dms.chain_table[dict_idx];
-                let dms_self_loop = dnext == dcur;
-                if dict_idx < region && dict_idx < idx {
-                    // SAFETY: `dict_idx < idx` and `idx + tail_limit <=
-                    // concat.len()` (checked at entry); same umbrella as the
-                    // live walk's `$cmf`.
-                    let match_len = unsafe { $cmf(concat, idx, dict_idx, tail_limit, 0) };
-                    if match_len > best_len {
-                        let offset = idx - dict_idx;
-                        let accepted = $crate::encoding::bt::BtMatcher::push_candidate_ladder(
-                            $out,
-                            $best_len_for_skip,
-                            $crate::encoding::opt::types::MatchCandidate {
-                                start: $abs_pos,
-                                offset,
-                                match_len,
-                            },
-                            $min_match_len,
-                        );
-                        if accepted {
-                            best_len = match_len;
-                            let candidate_end = $abs_pos + match_len;
-                            if candidate_end > match_end_abs {
-                                match_end_abs = candidate_end;
-                            }
-                            if match_len >= tail_limit
-                                || match_len > $crate::encoding::cost_model::HC_OPT_NUM
-                            {
-                                break;
-                            }
+                let pair = 2 * dict_idx;
+                let seed = common_smaller.min(common_larger);
+                // SAFETY: `dict_idx < idx` and `idx + tail_limit <=
+                // concat.len()` (checked at entry); same umbrella as the live
+                // walk's `$cmf`. `seed <= prior match_len <= tail_limit`.
+                let match_len = unsafe { $cmf(concat, idx, dict_idx, tail_limit, seed) };
+                if match_len > best_len {
+                    let offset = idx - dict_idx;
+                    let accepted = $crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                        $out,
+                        $best_len_for_skip,
+                        $crate::encoding::opt::types::MatchCandidate {
+                            start: $abs_pos,
+                            offset,
+                            match_len,
+                        },
+                        $min_match_len,
+                    );
+                    if accepted {
+                        best_len = match_len;
+                        let candidate_end = $abs_pos + match_len;
+                        if candidate_end > match_end_abs {
+                            match_end_abs = candidate_end;
+                        }
+                        if match_len > $crate::encoding::cost_model::HC_OPT_NUM {
+                            break;
                         }
                     }
                 }
-                if dms_self_loop {
+                // Match reached the block tail: can't order the pair (donor
+                // `ip+matchLength == iLimit`), and indexing `concat[idx +
+                // match_len]` below would step past the searchable region.
+                if match_len >= tail_limit {
                     break;
                 }
-                dcur = dnext;
+                // Descend the DUBT (donor zstd_opt.c:806-811): dict candidate
+                // smaller than input → its larger child is closer to `idx`.
+                if concat[dict_idx + match_len] < concat[idx + match_len] {
+                    common_smaller = match_len;
+                    dcur = dms.chain_table[pair + 1];
+                } else {
+                    common_larger = match_len;
+                    dcur = dms.chain_table[pair];
+                }
             }
         }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -377,17 +377,31 @@ impl LevelParams {
             super::strategy::StrategyTag::Fast => Some(0),
             super::strategy::StrategyTag::Dfast => Some(1),
             super::strategy::StrategyTag::Greedy => Some(2),
-            // lazy=2, lazy2/btlazy2=3; both lazy2 and btlazy2 ride the Lazy
-            // tag at lazy_depth 2 in the level table.
+            // The lazy2 / btlazy2 band (Lazy at lazy_depth >= 2, and Btlazy2)
+            // uses the rate-1 full-scan chunk splitter (4), NOT the rate-5
+            // sampler (3). The rate-5 sampler combined with the larger
+            // hash_log is sensitive enough to register a phantom statistical
+            // transition on perfectly homogeneous but periodic input (e.g. a
+            // repeating log-line stream whose period does not divide the 8 KB
+            // chunk size): the sampled bytes land on a different phase in each
+            // chunk, so two identical-distribution chunks look different and
+            // the block is split at 8 KB, then re-split on every window,
+            // cascading a large stream into hundreds of tiny blocks whose
+            // per-block headers dwarf the payload. The rate-1 scan reads every
+            // byte, so it sees periodic data as uniform and declines to split,
+            // while still finding genuine content boundaries (measured better
+            // ratio on the real decode corpus, and no longer expands a
+            // periodic stream vs a single full block). lazy/greedy keep the
+            // coarse samplers (lower hash_log => not sensitive enough to
+            // alias here).
             super::strategy::StrategyTag::Lazy => {
                 if self.lazy_depth >= 2 {
-                    Some(3)
+                    Some(4)
                 } else {
                     Some(2)
                 }
             }
-            // btlazy2 rides the same lazy2 split code (3).
-            super::strategy::StrategyTag::Btlazy2 => Some(3),
+            super::strategy::StrategyTag::Btlazy2 => Some(4),
             super::strategy::StrategyTag::BtOpt
             | super::strategy::StrategyTag::BtUltra
             | super::strategy::StrategyTag::BtUltra2 => Some(4),

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2673,6 +2673,35 @@ pub(crate) use bt_insert_step_no_rebase_body;
 /// (`ACCURATE_PRICE`, `FAVOR_SMALL_OFFSETS`) come from the wrapper's
 /// generic parameter list and are referenced as bare identifiers; macro
 /// hygiene resolves them at the expansion site.
+/// Donor `offBase` for the btlazy2 lazy gain heuristic: a match whose offset
+/// equals one of the three active repeat offsets prices as the cheap repcode
+/// code (1/2/3); any other offset prices as `offset + 3`. So an equal-length
+/// repeat-offset match always out-gains an explicit-offset one
+/// (`zstd_lazy.c` `ZSTD_storeSeq` offBase convention).
+#[inline]
+fn btlazy2_offbase(offset: usize, reps: [u32; 3]) -> u32 {
+    let o = offset as u32;
+    if o == reps[0] {
+        1
+    } else if o == reps[1] {
+        2
+    } else if o == reps[2] {
+        3
+    } else {
+        // Offsets are < window (<= 2^27), so `+ 3` never overflows u32.
+        o + 3
+    }
+}
+
+/// Donor lazy match gain (`matchLength * 4 - ZSTD_highbit32(offBase)`): the
+/// selection metric that lets a shorter repeat-offset match beat a longer
+/// explicit-offset one. `offBase >= 1`, so `highbit` is well-defined.
+#[inline]
+fn btlazy2_gain(match_len: usize, offset: usize, reps: [u32; 3]) -> i64 {
+    let offbase = btlazy2_offbase(offset, reps);
+    (match_len as i64) * 4 - (31 - offbase.leading_zeros()) as i64
+}
+
 /// Per-kernel body of the `btlazy2` (levels 13-15) greedy/lazy parse over
 /// the binary-tree match finder. Mirrors `build_optimal_plan_impl_body!`'s
 /// kernel-dispatch discipline: the wrapper carries the `#[target_feature]`
@@ -2681,7 +2710,7 @@ pub(crate) use bt_insert_step_no_rebase_body;
 /// stays under one umbrella — the runtime `select_kernel()` dispatch happens
 /// ONCE per block in the bare `start_matching_btlazy2`, never per position.
 macro_rules! start_matching_btlazy2_body {
-    ($self:ident, $handle_sequence:ident, $collect:ident $(,)?) => {{
+    ($self:ident, $handle_sequence:ident, $collect:ident, $cmf:path $(,)?) => {{
         $self.table.ensure_tables();
         let current_len = *$self.table.chunk_lens.back().unwrap();
         if current_len == 0 {
@@ -2691,6 +2720,16 @@ macro_rules! start_matching_btlazy2_body {
         // Mutates tables but never reallocates `history`, so this tail slice
         // stays valid for the routine's duration (same as the other parsers).
         let current: &[u8] = unsafe { core::slice::from_raw_parts(current_ptr, current_len) };
+        // Full contiguous history (dict + prior blocks + current block) as a
+        // raw slice, for the explicit repcode probe: a rep offset can point
+        // before the current block, which `current` can't reach. Same
+        // no-realloc validity contract as `current`; holds no borrow, so it
+        // coexists with the `&mut self` collector calls below.
+        let history_abs_start = $self.table.history_abs_start;
+        let concat_full: &[u8] = unsafe {
+            let base = $self.table.history.as_ptr().add($self.table.history_start);
+            core::slice::from_raw_parts(base, $self.table.history.len() - $self.table.history_start)
+        };
         let current_abs_start =
             $self.table.history_abs_start + $self.table.window_size - current_len;
         let current_abs_end = current_abs_start + current_len;
@@ -2704,55 +2743,120 @@ macro_rules! start_matching_btlazy2_body {
         let profile = HcOptimalCostProfile::const_for_strategy::<super::strategy::Btlazy2>();
         let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
 
+        let depth = $self.hc.lazy_depth as usize;
         let mut pos = 0usize;
         let mut literals_start = 0usize;
-        while pos + HC_OPT_MIN_MATCH_LEN <= current_len {
-            let abs_pos = current_abs_start + pos;
-            let lit_len = pos - literals_start;
-            candidates.clear();
-            let query = HcCandidateQuery {
-                reps: $self.table.offset_hist,
-                lit_len,
-                // No LDM seed: L13-15 run at windowLog 22, below donor's
-                // LDM auto-enable threshold (windowLog >= 27), so long-
-                // distance matching is off for this strategy by default.
-                ldm_candidate: None,
-            };
-            // SAFETY: called inside the wrapper's `#[target_feature]` umbrella
-            // (the scalar wrapper's `$collect` is a safe fn — `unused_unsafe`
-            // is allowed on the wrapper).
-            unsafe {
-                $self.$collect::<super::strategy::Btlazy2, true>(
-                    abs_pos,
-                    current_abs_end,
-                    profile,
-                    query,
-                    &mut candidates,
-                );
-            }
-            // Greedy commit: the ladder is increasing in length, so the last
-            // entry is the longest match found at this position (donor btlazy2
-            // commits the best/longest match).
-            if let Some(best) = candidates.last().copied() {
-                let match_len = best.match_len.min(current_len - pos);
-                if match_len >= HC_OPT_MIN_MATCH_LEN {
-                    let literals = &current[literals_start..pos];
-                    $handle_sequence(Sequence::Triple {
-                        literals,
-                        offset: best.offset,
-                        match_len,
-                    });
-                    let _ = encode_offset_with_history(
-                        best.offset as u32,
-                        lit_len as u32,
-                        &mut $self.table.offset_hist,
+
+        // Collect + select the highest-GAIN match at a position (donor
+        // `ZSTD_searchMax` plus the explicit offset_1 repcode check): scan the
+        // length-sorted BT/dms ladder by gain, then probe rep0 directly since
+        // the ladder's strictly-increasing-length filter drops short cheap
+        // reps. Expands to `(match_len, offset)`; `match_len == 0` = no match.
+        macro_rules! bt_select {
+            ($p:expr) => {{
+                let sel_pos: usize = $p;
+                let sel_abs = current_abs_start + sel_pos;
+                candidates.clear();
+                let query = HcCandidateQuery {
+                    reps: $self.table.offset_hist,
+                    lit_len: sel_pos - literals_start,
+                    // No LDM seed: L13-15 run at windowLog 22, below donor's
+                    // LDM auto-enable threshold (windowLog >= 27).
+                    ldm_candidate: None,
+                };
+                // SAFETY: called inside the wrapper's `#[target_feature]`
+                // umbrella (the scalar wrapper's `$collect` is a safe fn).
+                unsafe {
+                    $self.$collect::<super::strategy::Btlazy2, true>(
+                        sel_abs,
+                        current_abs_end,
+                        profile,
+                        query,
+                        &mut candidates,
                     );
-                    pos += match_len;
-                    literals_start = pos;
-                    continue;
+                }
+                let reps = $self.table.offset_hist;
+                let mut sel_ml = 0usize;
+                let mut sel_off = 0usize;
+                let mut sel_gain = i64::MIN;
+                for c in candidates.iter() {
+                    let ml = c.match_len.min(current_len - sel_pos);
+                    if ml < HC_OPT_MIN_MATCH_LEN {
+                        continue;
+                    }
+                    let g = btlazy2_gain(ml, c.offset, reps);
+                    if g > sel_gain {
+                        sel_gain = g;
+                        sel_ml = ml;
+                        sel_off = c.offset;
+                    }
+                }
+                let sel_idx = sel_abs - history_abs_start;
+                let rep0 = reps[0] as usize;
+                if rep0 != 0 && sel_idx >= rep0 {
+                    let tail = current_len - sel_pos;
+                    // SAFETY: `sel_idx - rep0 < sel_idx`, `sel_idx + tail <=
+                    // concat_full.len()`; same overshoot slack the collector
+                    // relies on for this block.
+                    let rep_ml = unsafe { $cmf(concat_full, sel_idx, sel_idx - rep0, tail, 0) };
+                    if rep_ml >= HC_OPT_MIN_MATCH_LEN && btlazy2_gain(rep_ml, rep0, reps) > sel_gain
+                    {
+                        sel_ml = rep_ml;
+                        sel_off = rep0;
+                    }
+                }
+                (sel_ml, sel_off)
+            }};
+        }
+
+        while pos + HC_OPT_MIN_MATCH_LEN <= current_len {
+            let (mut best_ml, mut best_off) = bt_select!(pos);
+            if best_ml < HC_OPT_MIN_MATCH_LEN {
+                pos += 1;
+                continue;
+            }
+            // Lazy lookahead (donor depth 1/2): advance one byte and accept the
+            // later match only if it out-gains the current one by the donor
+            // margin (deferring costs an extra literal — `+4` at depth 1, `+7`
+            // at depth 2). `start` tracks where the chosen match begins.
+            let mut start = pos;
+            let mut d = 0usize;
+            while d < depth && start + 1 + HC_OPT_MIN_MATCH_LEN <= current_len {
+                let look = start + 1;
+                let (ml2, off2) = bt_select!(look);
+                if ml2 < HC_OPT_MIN_MATCH_LEN {
+                    break;
+                }
+                let reps = $self.table.offset_hist;
+                let margin = if d == 0 { 4 } else { 7 };
+                let gain1 = btlazy2_gain(best_ml, best_off, reps) + margin;
+                let gain2 = btlazy2_gain(ml2, off2, reps);
+                if gain2 > gain1 {
+                    best_ml = ml2;
+                    best_off = off2;
+                    start = look;
+                    d += 1;
+                } else {
+                    break;
                 }
             }
-            pos += 1;
+            // Commit the chosen match at `start`; [literals_start, start) is
+            // emitted as literals. `best_ml` was bounded to `current_len -
+            // start` at selection, so `start + best_ml <= current_len`.
+            let lit_len = start - literals_start;
+            let literals = &current[literals_start..start];
+            $handle_sequence(Sequence::Triple {
+                literals,
+                offset: best_off,
+                match_len: best_ml,
+            });
+            let _ = encode_offset_with_history(
+                best_off as u32,
+                lit_len as u32,
+                &mut $self.table.offset_hist,
+            );
+            pos = start + best_ml;
+            literals_start = pos;
         }
 
         if literals_start < current_len {
@@ -4483,7 +4587,8 @@ impl HcMatchGenerator {
         start_matching_btlazy2_body!(
             self,
             handle_sequence,
-            collect_optimal_candidates_initialized_neon
+            collect_optimal_candidates_initialized_neon,
+            crate::encoding::fastpath::neon::count_match_from_indices
         )
     }
 
@@ -4496,7 +4601,8 @@ impl HcMatchGenerator {
         start_matching_btlazy2_body!(
             self,
             handle_sequence,
-            collect_optimal_candidates_initialized_sse42
+            collect_optimal_candidates_initialized_sse42,
+            crate::encoding::fastpath::sse42::count_match_from_indices
         )
     }
 
@@ -4509,7 +4615,8 @@ impl HcMatchGenerator {
         start_matching_btlazy2_body!(
             self,
             handle_sequence,
-            collect_optimal_candidates_initialized_avx2_bmi2
+            collect_optimal_candidates_initialized_avx2_bmi2,
+            crate::encoding::fastpath::avx2_bmi2::count_match_from_indices
         )
     }
 
@@ -4526,7 +4633,8 @@ impl HcMatchGenerator {
         start_matching_btlazy2_body!(
             self,
             handle_sequence,
-            collect_optimal_candidates_initialized_scalar
+            collect_optimal_candidates_initialized_scalar,
+            crate::encoding::fastpath::scalar::count_match_from_indices
         )
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4988,7 +4988,15 @@ impl HcMatchGenerator {
                     query,
                     out,
                 ),
-            StrategyTag::Btlazy2 | StrategyTag::BtOpt => self
+            StrategyTag::Btlazy2 => self
+                .collect_optimal_candidates_initialized::<strategy::Btlazy2, true>(
+                    abs_pos,
+                    current_abs_end,
+                    profile,
+                    query,
+                    out,
+                ),
+            StrategyTag::BtOpt => self
                 .collect_optimal_candidates_initialized::<strategy::BtOpt, true>(
                     abs_pos,
                     current_abs_end,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1752,9 +1752,17 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::Row(row) => {
                 row.max_window_size = max_window_size;
                 row.lazy_depth = params.lazy_depth;
-                row.configure(params.row.expect("Row level row carries a RowConfig"));
+                let row_cfg = params.row.expect("Row level row carries a RowConfig");
+                row.configure(row_cfg);
                 if hinted {
-                    resolved_table_bits = row_hash_bits_for_window(table_window_size);
+                    // Clamp the configured hash width by the hinted window
+                    // (donor `ZSTD_adjustCParams` caps hashLog by windowLog) —
+                    // `min`, not replace, so an explicit `hash_log` param
+                    // override (`row_cfg.hash_bits`) survives the hinted path
+                    // instead of being overwritten by the window value.
+                    resolved_table_bits = row_cfg
+                        .hash_bits
+                        .min(row_hash_bits_for_window(table_window_size));
                     row.set_hash_bits(resolved_table_bits);
                 }
                 row.reset();

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -159,6 +159,13 @@ struct HcConfig {
     chain_log: usize,
     search_depth: usize,
     target_len: usize,
+    /// Binary-tree finder hash width (donor `mls = BOUNDED(4, minMatch, 6)`),
+    /// carried explicitly per level so it is NOT inferred from `target_len`
+    /// (a `target_length` override must not silently flip the finder between
+    /// 5- and 4-byte hashing). Only the BT body reads it; HC/lazy levels keep
+    /// it at 4 (their `hash_position` is always 4-byte). 5 for the
+    /// minMatch=5 BT levels (btlazy2 + btopt L16), 4 elsewhere.
+    search_mls: usize,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -184,6 +191,7 @@ const HC_CONFIG: HcConfig = HcConfig {
     chain_log: HC_CHAIN_LOG,
     search_depth: HC_SEARCH_DEPTH,
     target_len: HC_TARGET_LEN,
+    search_mls: 4,
 };
 
 /// Base HashChain config synthesized when a public-parameter strategy
@@ -196,6 +204,7 @@ const HC_OVERRIDE_DEFAULT: HcConfig = HcConfig {
     chain_log: super::match_table::storage::HC_CHAIN_LOG,
     search_depth: HC_SEARCH_DEPTH,
     target_len: HC_TARGET_LEN,
+    search_mls: 4,
 };
 
 const BTULTRA2_HC_CONFIG: HcConfig = HcConfig {
@@ -203,6 +212,7 @@ const BTULTRA2_HC_CONFIG: HcConfig = HcConfig {
     chain_log: 24,
     search_depth: 512,
     target_len: 256,
+    search_mls: 4,
 };
 
 const BTULTRA2_HC_CONFIG_L22: HcConfig = HcConfig {
@@ -210,6 +220,7 @@ const BTULTRA2_HC_CONFIG_L22: HcConfig = HcConfig {
     chain_log: 27,
     search_depth: 512,
     target_len: 999,
+    search_mls: 4,
 };
 
 const BTULTRA2_HC_CONFIG_L22_256K: HcConfig = HcConfig {
@@ -217,6 +228,7 @@ const BTULTRA2_HC_CONFIG_L22_256K: HcConfig = HcConfig {
     chain_log: 19,
     search_depth: 1 << 13,
     target_len: 999,
+    search_mls: 4,
 };
 
 const BTULTRA2_HC_CONFIG_L22_128K: HcConfig = HcConfig {
@@ -224,6 +236,7 @@ const BTULTRA2_HC_CONFIG_L22_128K: HcConfig = HcConfig {
     chain_log: 18,
     search_depth: 1 << 11,
     target_len: 999,
+    search_mls: 4,
 };
 
 const BTULTRA2_HC_CONFIG_L22_16K: HcConfig = HcConfig {
@@ -231,6 +244,7 @@ const BTULTRA2_HC_CONFIG_L22_16K: HcConfig = HcConfig {
     chain_log: 15,
     search_depth: 1 << 10,
     target_len: 999,
+    search_mls: 4,
 };
 
 // Default Row config: only used by tests and the test-only parse×search
@@ -633,13 +647,13 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // long-enough match — the dominant cost in the L5..=L15 speed
     // regression vs FFI (see lazy_band_target_len_matches_donor_default_table).
     /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, search: super::strategy::SearchMethod::RowHash, window_log: 21, lazy_depth: 0, fast: None, dfast: None, hc: None, row: Some(ROW_L5) },
-    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }), row: None },
-    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }), row: None },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 16 }), row: None },
-    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 21, chain_log: 20, search_depth: 16, target_len: 16 }), row: None },
-    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 16 }), row: None },
-    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 64, target_len: 16 }), row: None },
-    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 64, target_len: 32 }), row: None },
+    /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4, search_mls: 4 }), row: None },
+    /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8, search_mls: 4 }), row: None },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 16, search_mls: 4 }), row: None },
+    /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 21, chain_log: 20, search_depth: 16, target_len: 16, search_mls: 4 }), row: None },
+    /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 16, search_mls: 4 }), row: None },
+    /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 64, target_len: 16, search_mls: 4 }), row: None },
+    /*12 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 64, target_len: 32, search_mls: 4 }), row: None },
     // L13-15: reference uses btlazy2 (binary-tree finder) with searchLog 4/5/6
     // (search_depth 16/32/64) and targetLength 32. We run the hash-chain Lazy
     // parser here, so we mirror the reference search budget rather than inflate
@@ -648,14 +662,14 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     // smaller searchLog find longer matches (and re-establish a strict ratio
     // ladder above L12) is tracked separately; until it lands these levels sit
     // close to L12 on hash-chain inputs by design.
-    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32 }), row: None },
-    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32 }), row: None },
-    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32 }), row: None },
-    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 48 }), row: None },
-    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 32, target_len: 64 }), row: None },
-    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 64, target_len: 64 }), row: None },
-    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 24, search_depth: 128, target_len: 256 }), row: None },
-    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 25, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 25, search_depth: 128, target_len: 256 }), row: None },
+    /*13 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 16, target_len: 32, search_mls: 5 }), row: None },
+    /*14 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 22, search_depth: 32, target_len: 32, search_mls: 5 }), row: None },
+    /*15 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Btlazy2, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 23, search_depth: 64, target_len: 32, search_mls: 5 }), row: None },
+    /*16 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 22, search_depth: 32, target_len: 48, search_mls: 5 }), row: None },
+    /*17 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtOpt, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 32, target_len: 64, search_mls: 4 }), row: None },
+    /*18 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 23, search_depth: 64, target_len: 64, search_mls: 4 }), row: None },
+    /*19 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 23, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 24, search_depth: 128, target_len: 256, search_mls: 4 }), row: None },
+    /*20 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 25, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 23, chain_log: 25, search_depth: 128, target_len: 256, search_mls: 4 }), row: None },
     /*21 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 26, lazy_depth: 2, fast: None, dfast: None, hc: Some(BTULTRA2_HC_CONFIG), row: None },
     /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 27, lazy_depth: 2, fast: None, dfast: None, hc: Some(BTULTRA2_HC_CONFIG_L22), row: None },
 ];
@@ -4222,19 +4236,14 @@ impl HcMatchGenerator {
         self.table.search_depth = self.hc.search_depth;
         self.table.is_btultra2 = is_btultra2;
         self.table.uses_bt = uses_bt;
-        // BT finder hash width, donor `mls = BOUNDED(4, cParams.minMatch, 6)`.
-        // clevels.h (srcSize > 256 KiB tier): btlazy2 L13-15 and btopt L16 are
-        // minMatch=5; btopt L17 is minMatch=4; btultra/btultra2 are minMatch=3
-        // (4-byte main hash + the hash3 short-match probe). The 5-byte hash
-        // shortens the BT walk vs our prior 4-byte everywhere (speed). Only the
-        // BT body reads `search_mls`. `window_log` here is source-clamped (so it
-        // can't tell L16 from L17 on a small source); `config.target_len` is the
-        // level's own value (L16=48, L17=64) and distinguishes them reliably.
-        self.table.search_mls = match tag {
-            StrategyTag::Btlazy2 => 5,
-            StrategyTag::BtOpt if config.target_len <= 48 => 5,
-            _ => 4,
-        };
+        // BT finder hash width, donor `mls = BOUNDED(4, cParams.minMatch, 6)`,
+        // carried explicitly in the level config so a `target_length` override
+        // cannot silently flip the finder between 5- and 4-byte hashing. Only
+        // the BT body reads it; HC/lazy levels leave it at 4. clevels.h
+        // (srcSize > 256 KiB tier): btlazy2 L13-15 + btopt L16 are minMatch=5,
+        // btopt L17 is minMatch=4, btultra/btultra2 are minMatch=3 (4-byte main
+        // hash + the hash3 short-match probe).
+        self.table.search_mls = config.search_mls;
         // Stage D: promote the backend discriminator. HC modes drop the
         // BT scratch buffers entirely; switching back into a BT mode
         // allocates a fresh `BtMatcher` on demand.
@@ -6949,6 +6958,7 @@ fn btultra_and_btultra2_both_keep_dictionary_candidates() {
         chain_log: 22,
         search_depth: 32,
         target_len: 256,
+        search_mls: 4,
     };
     let window_log = 20u8;
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -265,6 +265,22 @@ const ROW_L5: RowConfig = RowConfig {
     mls: ROW_MIN_MATCH_LEN,
 };
 
+// Level-8 lazy2 routed to the Row finder (donor `useRowMatchFinder`: the row
+// finder is enabled by default for greedy/lazy/lazy2 whenever windowLog > 14,
+// which holds for every lazy level here). Donor `clevels.h` L8 (srcSize > 256
+// KB) is searchLog=4, targetLength=16, minMatch=5, from which the row matcher
+// derives rowLog = clamp(searchLog, 4, 6) = 4, search_depth = 1 << min(searchLog,
+// rowLog) = 16, target_len = 16. Replaces the legacy HashChain config so the
+// bounded row dual-probe (and its dict attach) runs instead of the unbounded
+// hash-chain dict walk.
+const ROW_L8: RowConfig = RowConfig {
+    hash_bits: ROW_HASH_BITS,
+    row_log: 4,
+    search_depth: 16,
+    target_len: 16,
+    mls: ROW_MIN_MATCH_LEN,
+};
+
 /// Per-level Double-Fast hash sizing, mirroring the donor `clevels.h` columns
 /// (config-driven, not a hardcoded constant): `long_hash_log` =
 /// `cParams.hashLog` (the long 8-byte hash table), `short_hash_log` =
@@ -462,6 +478,13 @@ fn apply_param_overrides(params: &mut LevelParams, ov: &super::parameters::Param
         }
         SearchMethod::RowHash => {
             if let Some(row) = params.row.as_mut() {
+                // Row hash-table width override (mirrors dfast `long_hash_log`
+                // / hc `hash_log`). Row has no separate chain table — the
+                // per-row depth comes from `search_log` below — so only
+                // `hash_log` maps here; `chain_log` has no Row analogue.
+                if let Some(hash_log) = ov.hash_log {
+                    row.hash_bits = hash_log as usize;
+                }
                 if let Some(search_log) = ov.search_log {
                     // Donor: rowLog = clamp(searchLog, 4, 6);
                     //        nbAttempts = 1 << min(searchLog, rowLog).
@@ -544,6 +567,22 @@ pub(crate) fn source_size_ceil_log(size: u64) -> u8 {
 /// the primed-snapshot key) and `prime_with_dictionary` (which acts on it).
 const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 13;
 
+/// Dfast counterpart of [`FAST_ATTACH_DICT_CUTOFF_LOG`]: donor
+/// `ZSTD_dictMatchState` attach cutoff for the double-fast strategy is 16 KiB
+/// (`2^14`), so small / unknown-size inputs ATTACH (separate immutable dict
+/// long+short tables + dual-probe in `start_matching_fast_loop`) and larger
+/// known-size inputs COPY (re-prime the dict into the live tables, where the
+/// dense scan matches it as window history). The attach build also self-gates
+/// on `use_fast_loop` inside `skip_matching_for_dict_attach` — only the
+/// fast-loop levels (L3 / Default / L0) carry the dual-probe.
+const DFAST_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
+
+/// `ZSTD_dictMatchState` attach cutoff for the Row (greedy/lazy) strategy is
+/// 32 KiB (`2^15`, donor `attachDictSizeCutoffs`): small / unknown-size inputs
+/// ATTACH the dict into the separate immutable row index (bounded dual-probe in
+/// `row_candidate_rl`), larger known-size inputs dense-COPY into the live rows.
+const ROW_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
+
 // Source-size cap for the dfast hash bits when a size hint is present: a tiny
 // input needs no larger hash than its window. The donor `cParams.hashLog` /
 // `chainLog` (from `DfastConfig`) caps it from above at the call site.
@@ -555,6 +594,15 @@ fn dfast_hash_bits_for_window(max_window_size: usize) -> usize {
 fn row_hash_bits_for_window(max_window_size: usize) -> usize {
     let window_log = (usize::BITS - 1 - max_window_size.leading_zeros()) as usize;
     window_log.clamp(MIN_WINDOW_LOG as usize, ROW_HASH_BITS)
+}
+
+/// `floor(log2(window))` for the HashChain table-log cap (donor
+/// `ZSTD_adjustCParams_internal`). The caller clamps the level's `hash_log` /
+/// `chain_log` from above with this so a small hinted input doesn't allocate the
+/// full level's tables.
+fn hc_hash_bits_for_window(max_window_size: usize) -> usize {
+    let window_log = (usize::BITS - 1 - max_window_size.leading_zeros()) as usize;
+    window_log.max(MIN_WINDOW_LOG as usize)
 }
 
 /// Parameter table for numeric compression levels 1–22.
@@ -585,7 +633,7 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /* 5 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Greedy, search: super::strategy::SearchMethod::RowHash, window_log: 21, lazy_depth: 0, fast: None, dfast: None, hc: None, row: Some(ROW_L5) },
     /* 6 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 19, chain_log: 18, search_depth: 8,  target_len: 4 }), row: None },
     /* 7 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 1, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 8 }), row: None },
-    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 20, chain_log: 19, search_depth: 16, target_len: 16 }), row: None },
+    /* 8 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::RowHash, window_log: 21, lazy_depth: 2, fast: None, dfast: None, hc: None, row: Some(ROW_L8) },
     /* 9 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 21, chain_log: 20, search_depth: 16, target_len: 16 }), row: None },
     /*10 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 32, target_len: 16 }), row: None },
     /*11 */ LevelParams { strategy_tag: super::strategy::StrategyTag::Lazy, search: super::strategy::SearchMethod::HashChain, window_log: 22, lazy_depth: 2, fast: None, dfast: None, hc: Some(HcConfig { hash_log: 22, chain_log: 21, search_depth: 64, target_len: 16 }), row: None },
@@ -1422,9 +1470,43 @@ impl MatchGeneratorDriver {
                 }
                 self.recycle_simple_space();
             }
-            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().skip_matching_dense(),
+            super::strategy::BackendTag::Dfast => {
+                // Donor `ZSTD_dictMatchState` mode selection for dfast (cutoff
+                // 16 KiB): small / unknown-size inputs ATTACH (build the
+                // separate immutable dict long+short tables; the dual-probe
+                // `start_matching_fast_loop` searches live + dict, the path that
+                // avoids the per-frame dict re-prime that dominates small
+                // `compress-dict`). Larger known-size inputs COPY (re-prime the
+                // dict into the live tables via `skip_matching_dense`, where the
+                // dense scan matches it as window history). `skip_matching_for_dict_attach`
+                // self-gates on `use_fast_loop` (only fast-loop levels carry the
+                // dual-probe; general-path levels fall back to the dense copy).
+                let attach = self
+                    .reset_size_log
+                    .is_none_or(|log| log <= DFAST_ATTACH_DICT_CUTOFF_LOG);
+                if attach {
+                    self.dfast_matcher_mut().skip_matching_for_dict_attach();
+                } else {
+                    self.dfast_matcher_mut().invalidate_dict_cache();
+                    self.dfast_matcher_mut().skip_matching_dense();
+                }
+            }
             super::strategy::BackendTag::Row => {
-                self.row_matcher_mut().skip_matching_with_hint(Some(false))
+                // Donor `ZSTD_RowFindBestMatch` `dictMatchState`: small /
+                // unknown-size inputs ATTACH (build the separate immutable dict
+                // row index; the bounded dual-probe in `row_candidate_rl`
+                // searches live + dict, avoiding the per-frame dict re-index),
+                // larger known-size inputs COPY (dense re-prime into the live
+                // rows).
+                let attach = self
+                    .reset_size_log
+                    .is_none_or(|log| log <= ROW_ATTACH_DICT_CUTOFF_LOG);
+                if attach {
+                    self.row_matcher_mut().prime_dict_attach_current_block();
+                } else {
+                    self.row_matcher_mut().invalidate_dict_cache();
+                    self.row_matcher_mut().skip_matching_with_hint(Some(false));
+                }
             }
             super::strategy::BackendTag::HashChain => {
                 self.hc_matcher_mut().skip_matching(Some(false))
@@ -1692,11 +1774,30 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::HashChain(hc) => {
                 hc.table.max_window_size = max_window_size;
                 hc.hc.lazy_depth = params.lazy_depth;
-                hc.configure(
-                    params.hc.expect("HashChain level row carries an HcConfig"),
-                    strategy_tag,
-                    params.window_log,
-                );
+                let mut hc_cfg = params.hc.expect("HashChain level row carries an HcConfig");
+                // Cap the hash / chain table logs by the hinted window so a small
+                // input doesn't allocate the full level's tables (the donor
+                // `ZSTD_adjustCParams_internal` clamp: `hashLog <= windowLog + 1`,
+                // and `cycleLog <= windowLog` — `cycleLog == chainLog` for the HC
+                // finder, `chainLog - 1` for the BT pair table, so `chainLog <=
+                // windowLog` (+1 for BT)). Ratio-neutral: a hinted window of
+                // `2^wlog` bytes holds at most `2^wlog` positions, so the slots
+                // beyond that are never populated — capping only sheds unused
+                // allocation. Was the source of L10-lazy peak-alloc ~2.15x the
+                // donor on a 1 MiB input. Only applied when hinted; an
+                // unknown-size stream keeps the full level tables.
+                if hinted {
+                    let wlog = hc_hash_bits_for_window(table_window_size);
+                    let uses_bt = matches!(
+                        strategy_tag,
+                        super::strategy::StrategyTag::BtOpt
+                            | super::strategy::StrategyTag::BtUltra
+                            | super::strategy::StrategyTag::BtUltra2
+                    );
+                    hc_cfg.hash_log = hc_cfg.hash_log.min(wlog + 1);
+                    hc_cfg.chain_log = hc_cfg.chain_log.min(if uses_bt { wlog + 1 } else { wlog });
+                }
+                hc.configure(hc_cfg, strategy_tag, params.window_log);
                 let vec_pool = &mut self.vec_pool;
                 hc.reset(|mut data| {
                     data.resize(data.capacity(), 0);
@@ -1928,8 +2029,11 @@ impl Matcher for MatchGeneratorDriver {
         // it (skips the re-hash) while still re-committing the dict bytes to
         // history. No-op when the attach path built no table (copy mode or a
         // sub-8-byte dict) — `mark_dict_primed` self-guards on table presence.
-        if self.active_backend() == super::strategy::BackendTag::Simple {
-            self.simple_mut().mark_dict_primed();
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => self.simple_mut().mark_dict_primed(),
+            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().mark_dict_primed(),
+            super::strategy::BackendTag::Row => self.row_matcher_mut().mark_dict_primed(),
+            _ => {}
         }
     }
 
@@ -1987,8 +2091,15 @@ impl Matcher for MatchGeneratorDriver {
         // to the dictionary being removed / replaced. Left in place, the next
         // same-params `reset` would retain it and the kernel would probe a
         // dict region whose bytes are no longer re-committed to history.
-        if self.active_backend() == super::strategy::BackendTag::Simple {
-            self.simple_mut().invalidate_dict_cache();
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => self.simple_mut().invalidate_dict_cache(),
+            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().invalidate_dict_cache(),
+            // Row keeps its attach index across frames (like Simple/Dfast),
+            // so a dictionary swap must drop its cached dict rows too;
+            // otherwise the next small/unknown-size frame reuses stale
+            // attach state through `prime_dict_attach_current_block`.
+            super::strategy::BackendTag::Row => self.row_matcher_mut().invalidate_dict_cache(),
+            _ => {}
         }
     }
 
@@ -4067,7 +4178,7 @@ impl HcMatchGenerator {
             let best = self.hc.find_best_match(&self.table, abs_pos, lit_len);
             if let Some(candidate) = self.hc.pick_lazy_match(&self.table, abs_pos, lit_len, best) {
                 self.table
-                    .insert_positions(abs_pos, candidate.start + candidate.match_len);
+                    .insert_match_span(abs_pos, candidate.start + candidate.match_len);
                 let start = candidate.start - current_abs_start;
                 let literals = &current[literals_start..start];
                 handle_sequence(Sequence::Triple {

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -21,6 +21,7 @@ use alloc::vec::Vec;
 use super::super::Sequence;
 use super::super::blocks::encode_offset_with_history;
 use super::super::cost_model::{HC_OPT_NUM, HcOptimalCostProfile};
+use super::super::dict_attach::DictAttach;
 use super::super::hc::HC_MIN_MATCH_LEN;
 use super::super::opt::types::{HcOptimalSequence, MatchCandidate};
 use super::helpers::INCOMPRESSIBLE_SKIP_STEP;
@@ -215,6 +216,27 @@ pub(crate) const HC_CHAIN_LOG: usize = 19;
 pub(crate) const HC3_HASH_LOG: usize = 17;
 
 /// Shared storage backing every match finder. Holds the contiguous
+/// Immutable dictionary match structure (donor `ZSTD_dictMatchState`) for
+/// the binary-tree / optimal path. A hash + single-link chain over the
+/// dictionary content concat range, searched in addition to the live BT
+/// with its OWN compare budget so dictionary candidates are reachable even
+/// when the live tree's budget is spent on recent positions. Slots store
+/// `dict_rel + 1` (dictionary-relative concat index); `0` is empty.
+#[derive(Clone, Default)]
+pub(crate) struct DmsDictTables {
+    /// Head-of-chain per hash bucket (`1 << hash_log` entries).
+    pub(crate) hash_table: Vec<u32>,
+    /// Per-dictionary-position next link (`region_len` entries).
+    pub(crate) chain_table: Vec<u32>,
+    /// Hash width (bits) the dict chain was built at, so probe hashing
+    /// reproduces the same buckets.
+    pub(crate) hash_log: usize,
+    /// Match-length search width (`mls`) the dict chain was built/probed at —
+    /// the live cParams `minMatch` (donor `ZSTD_dictMatchState` uses the same
+    /// `mls` as the live search), so probe hashing matches the build.
+    pub(crate) mls: usize,
+}
+
 /// history buffer, the rolling window, and the hash / chain / hash3
 /// tables. Methods on this struct contain only logic that's identical
 /// between HC and BT modes — backend-specific table interpretation
@@ -268,6 +290,10 @@ pub(crate) struct MatchTable {
     /// guarantee 8 readable bytes); the HC `hash_position` stays 4-byte.
     /// Defaults to `4`.
     pub(crate) search_mls: usize,
+    /// Immutable dictionary match chain (donor `ZSTD_dictMatchState`),
+    /// searched by the BT/optimal collect alongside the live tree. `Some`
+    /// once primed from a non-empty dictionary on a BT level.
+    pub(crate) dms: DictAttach<DmsDictTables>,
 }
 
 impl MatchTable {
@@ -297,6 +323,7 @@ impl MatchTable {
             is_btultra2: false,
             uses_bt: false,
             search_mls: 4,
+            dms: DictAttach::new(),
         }
     }
 
@@ -534,6 +561,48 @@ impl MatchTable {
         } else {
             Some(self.history_abs_start.saturating_add(primed_len))
         };
+    }
+
+    /// Build the immutable dictionary match chain (donor `ZSTD_dictMatchState`)
+    /// over the first `region_len` bytes of the live history (the dictionary
+    /// content at the front). Hashed at the BT `search_mls` width into a
+    /// dict-sized hash log, so the BT/optimal collect can dual-probe it with
+    /// its own compare budget. `dict_rel + 1` packing, `0` sentinel. Called on
+    /// BT levels (`uses_bt`); cached across frames via `DictAttach::is_primed`.
+    pub(crate) fn prime_dms_chain(&mut self, region_len: usize) {
+        // Donor `ZSTD_dictMatchState` searches the dict at the live cParams
+        // `minMatch` (= our `search_mls`), NOT a fixed 3 — a fixed 3 surfaces
+        // huge-offset ml=3 dict matches that the greedy btlazy2 parser commits
+        // at a loss. The dms's value is being a SEPARATE structure (the dict is
+        // not in the live tree), not a lower minMatch.
+        let mls = self.search_mls;
+        let read = if mls >= 5 { 8 } else { 4 };
+        let concat = self.live_history();
+        let region = region_len.min(concat.len());
+        if region < read {
+            self.dms.invalidate();
+            return;
+        }
+        // Dict-sized hash log: ceil-log2(region) clamped to [10, hash_log].
+        let dms_hash_log =
+            (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
+        let mut hash_table = alloc::vec![0u32; 1usize << dms_hash_log];
+        let mut chain_table = alloc::vec![0u32; region];
+        let mut p = 0usize;
+        while p + read <= region {
+            let h = Self::hash_position_at(concat, p, dms_hash_log, mls);
+            chain_table[p] = hash_table[h];
+            hash_table[h] = (p + 1) as u32;
+            p += 1;
+        }
+        // `concat`'s borrow of `self` ends above; now mutate `self.dms`.
+        let tables = self.dms.table_mut_or_init(DmsDictTables::default);
+        tables.hash_table = hash_table;
+        tables.chain_table = chain_table;
+        tables.hash_log = dms_hash_log;
+        tables.mls = mls;
+        self.dms.set_region_len(region);
+        self.dms.mark_primed();
     }
 
     /// Append a freshly committed buffer to the rolling window. Drops
@@ -1559,6 +1628,21 @@ impl MatchTable {
     /// `skip_matching` body — backfill the slice boundary and then walk
     /// the current slice in either dense or sparse mode (driven by the
     /// `incompressible_hint`). BT and HC modes branch via `uses_bt`.
+    /// Dict-priming for BT / optimal levels (donor `ZSTD_dictMatchState`):
+    /// the dictionary content stays in `history` (so the dms chain can read it
+    /// and offsets are computed across the dict→input boundary) but is NOT
+    /// inserted into the LIVE binary tree — the donor keeps the dictionary in a
+    /// SEPARATE matchState, so the live tree searches only the input. Advancing
+    /// the BT (`skip_insert_until_abs`) and hash3 cursors past the committed
+    /// dict block makes the first input block's tree update start after it,
+    /// leaving the live tree input-only (the dms is the sole dict source).
+    pub(crate) fn skip_matching_dict_bt(&mut self) {
+        self.ensure_tables();
+        let committed_end = self.history_abs_start + self.window_size;
+        self.skip_insert_until_abs = self.skip_insert_until_abs.max(committed_end);
+        self.next_to_update3 = self.next_to_update3.max(committed_end);
+    }
+
     pub(crate) fn skip_matching(&mut self, incompressible_hint: Option<bool>) {
         self.ensure_tables();
         let current_len = *self.chunk_lens.back().unwrap();

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -224,9 +224,12 @@ pub(crate) const HC3_HASH_LOG: usize = 17;
 /// `dict_rel + 1` (dictionary-relative concat index); `0` is empty.
 #[derive(Clone, Default)]
 pub(crate) struct DmsDictTables {
-    /// Head-of-chain per hash bucket (`1 << hash_log` entries).
+    /// Per-hash-bucket binary-tree root (`1 << hash_log` entries), packed
+    /// `dict_rel + 1` (`0` = empty).
     pub(crate) hash_table: Vec<u32>,
-    /// Per-dictionary-position next link (`region_len` entries).
+    /// Binary-tree children, 2 per dict position (`2 * region_len` entries):
+    /// `[2*p] = smaller child, [2*p+1] = larger child` of dict position `p`,
+    /// packed `dict_rel + 1` (`0` = empty). An unsorted-DUBT (donor dms-BT).
     pub(crate) chain_table: Vec<u32>,
     /// Hash width (bits) the dict chain was built at, so probe hashing
     /// reproduces the same buckets.
@@ -563,13 +566,21 @@ impl MatchTable {
         };
     }
 
-    /// Build the immutable dictionary match chain (donor `ZSTD_dictMatchState`)
-    /// over the first `region_len` bytes of the live history (the dictionary
-    /// content at the front). Hashed at the BT `search_mls` width into a
-    /// dict-sized hash log, so the BT/optimal collect can dual-probe it with
-    /// its own compare budget. `dict_rel + 1` packing, `0` sentinel. Called on
-    /// BT levels (`uses_bt`); cached across frames via `DictAttach::is_primed`.
-    pub(crate) fn prime_dms_chain(&mut self, region_len: usize) {
+    /// Build the immutable dictionary match **binary tree** (donor
+    /// `ZSTD_dictMatchState`, the dms-BT walked in `ZSTD_insertBtAndGetAllMatches`
+    /// `zstd_opt.c:777-813`) over the first `region_len` bytes of the live
+    /// history (the dictionary content at the front). A hash-chain dms surfaces
+    /// only the few candidates that share a hash bucket; a DUBT descends to the
+    /// LONGEST dict match efficiently, which is where the donor extracts the
+    /// bulk of its dict-match value at btlazy2 / btopt (a chain there left
+    /// 80-90% of the dict savings on the table). Hashed at the BT `search_mls`
+    /// width into a dict-sized hash log; `chain_table` holds 2 entries per dict
+    /// position (`[smaller_child, larger_child]`), `hash_table` the per-bucket
+    /// tree roots. `dict_rel + 1` packing, `0` sentinel. Dict positions are
+    /// concat indices at the front of the shared buffer, so the walk's offset is
+    /// `idx - dict_idx` directly (no donor `dmsIndexDelta`). Called on BT levels
+    /// (`uses_bt`); cached across frames via `DictAttach::is_primed`.
+    pub(crate) fn prime_dms_bt(&mut self, region_len: usize) {
         // Donor `ZSTD_dictMatchState` searches the dict at the live cParams
         // `minMatch` (= our `search_mls`), NOT a fixed 3 — a fixed 3 surfaces
         // huge-offset ml=3 dict matches that the greedy btlazy2 parser commits
@@ -586,14 +597,61 @@ impl MatchTable {
         // Dict-sized hash log: ceil-log2(region) clamped to [10, hash_log].
         let dms_hash_log =
             (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
+        // Build-pass compare budget: the dict is bounded (<= window), so a
+        // generous fixed depth keeps the tree well-ordered without the live
+        // searchLog cap. Mirrors donor `ZSTD_insertBt1` nbCompares.
+        const DMS_BUILD_DEPTH: usize = 1 << 9;
         let mut hash_table = alloc::vec![0u32; 1usize << dms_hash_log];
-        let mut chain_table = alloc::vec![0u32; region];
-        let mut p = 0usize;
-        while p + read <= region {
-            let h = Self::hash_position_at(concat, p, dms_hash_log, mls);
-            chain_table[p] = hash_table[h];
-            hash_table[h] = (p + 1) as u32;
-            p += 1;
+        // 2 children per dict position: [smaller, larger].
+        let mut chain_table = alloc::vec![0u32; 2 * region];
+        let mut current = 0usize;
+        while current + read <= region {
+            let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
+            // Insert `current` as the new root; splay the old tree into
+            // `current`'s smaller/larger subtrees (donor `ZSTD_insertBt1`).
+            let mut match_packed = hash_table[h];
+            hash_table[h] = (current + 1) as u32;
+            let mut smaller_slot = 2 * current;
+            let mut larger_slot = 2 * current + 1;
+            let mut common_smaller = 0usize;
+            let mut common_larger = 0usize;
+            let mut compares = DMS_BUILD_DEPTH;
+            while compares > 0 && match_packed != 0 {
+                let cand = (match_packed - 1) as usize;
+                // Tree holds only earlier positions; `cand < current` always.
+                if cand >= current {
+                    break;
+                }
+                compares -= 1;
+                let next_pair = 2 * cand;
+                let mut ml = common_smaller.min(common_larger);
+                // Common prefix bounded by the dict tail from `current`
+                // (`cand < current`, so `current` is the binding limit).
+                let limit = region - current;
+                while ml < limit && concat[cand + ml] == concat[current + ml] {
+                    ml += 1;
+                }
+                if current + ml >= region {
+                    // Reached the dict end: can't order this pair, stop (donor
+                    // `ip+matchLength == iend` break).
+                    break;
+                }
+                if concat[cand + ml] < concat[current + ml] {
+                    // `cand` (and its smaller subtree) sorts below `current`.
+                    chain_table[smaller_slot] = match_packed;
+                    common_smaller = ml;
+                    smaller_slot = next_pair + 1;
+                    match_packed = chain_table[next_pair + 1];
+                } else {
+                    chain_table[larger_slot] = match_packed;
+                    common_larger = ml;
+                    larger_slot = next_pair;
+                    match_packed = chain_table[next_pair];
+                }
+            }
+            chain_table[smaller_slot] = 0;
+            chain_table[larger_slot] = 0;
+            current += 1;
         }
         // `concat`'s borrow of `self` ends above; now mutate `self.dms`.
         let tables = self.dms.table_mut_or_init(DmsDictTables::default);

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1323,6 +1323,35 @@ impl MatchTable {
         self.next_to_update3 = self.next_to_update3.max(end);
     }
 
+    /// Index a just-emitted match span with the donor skip-threshold cap
+    /// (`ZSTD_row_update_internal`, `zstd_lazy.c:922-940`): when the span
+    /// exceeds `SKIP_THRESHOLD` positions only the first `MAX_START` and last
+    /// `MAX_END` are chained, the interior is skipped. Indexing every interior
+    /// byte of a long match is O(matchlen) and dominates HashChain (lazy)
+    /// encode time on periodic inputs where one match can span a whole block;
+    /// donor's hash-chain finder chains nothing in the interior at all, so the
+    /// 96 + 32 cap is a conservative (ratio-preserving) mirror that still keeps
+    /// boundary anchors for the following search.
+    pub(crate) fn insert_match_span(&mut self, start: usize, end: usize) {
+        const SKIP_THRESHOLD: usize = 384;
+        const MAX_START: usize = 96;
+        const MAX_END: usize = 32;
+        if end.saturating_sub(start) > SKIP_THRESHOLD {
+            // Raw arithmetic is correct by design here, NOT masked with
+            // `saturating_*`. `start` / `end` are absolute stream
+            // positions, and `check_stream_abs_headroom` guarantees
+            // `abs_pos + STREAM_ABS_HEADROOM (= 4112) <= usize::MAX` for
+            // every position in the frame, so `start + MAX_START` (96)
+            // cannot overflow even on a 32-bit target. In this branch
+            // `end - start > SKIP_THRESHOLD (384)`, so `end > 384 >
+            // MAX_END (32)` and `end - MAX_END` cannot underflow.
+            self.insert_positions(start, start + MAX_START);
+            self.insert_positions(end - MAX_END, end);
+        } else {
+            self.insert_positions(start, end);
+        }
+    }
+
     /// Tight hash/chain fill for `[start, end)` when the caller has already
     /// proven every position is `(rel + 1)`-representable (so no rebase and
     /// no `rel == 0` skip can occur). Equivalent to looping

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -179,6 +179,11 @@ mod stream_abs_headroom_tests {
 pub(crate) const HC_PRIME3BYTES: u32 = 506_832_829;
 /// Knuth-style 4-byte hash multiplier. Donor parity: `ZSTD_HASHPRIME`.
 pub(crate) const HC_PRIME4BYTES: u32 = 2_654_435_761;
+/// 5-byte hash multiplier. Donor parity: `prime5bytes` in
+/// `lib/compress/zstd_compress_internal.h`.
+pub(crate) const HC_PRIME5BYTES: u64 = 889_523_592_379;
+/// 6-byte hash multiplier. Donor parity: `prime6bytes`.
+pub(crate) const HC_PRIME6BYTES: u64 = 227_718_039_650_203;
 
 /// Hash / chain / hash3 sentinel marking an empty slot.
 ///
@@ -255,6 +260,14 @@ pub(crate) struct MatchTable {
     /// `btultra`, `btultra2`). Mirrored from the active strategy for
     /// the same reason as `is_btultra2`.
     pub(crate) uses_bt: bool,
+    /// Binary-tree finder hash width (`mls`), donor `ZSTD_hashPtr` mls =
+    /// `BOUNDED(4, cParams.minMatch, 6)`. clevels.h gives the btlazy2 / btopt
+    /// band (levels 13-16) `minMatch = 5` → a 5-byte (8-byte read) hash that
+    /// shortens the chains the BT walks (speed), so it is set per level in
+    /// `configure`. Only the BT body reads it (the BT hash sites already
+    /// guarantee 8 readable bytes); the HC `hash_position` stays 4-byte.
+    /// Defaults to `4`.
+    pub(crate) search_mls: usize,
 }
 
 impl MatchTable {
@@ -283,6 +296,7 @@ impl MatchTable {
             search_depth: 0,
             is_btultra2: false,
             uses_bt: false,
+            search_mls: 4,
         }
     }
 
@@ -428,6 +442,17 @@ impl MatchTable {
         unsafe { u32::from_le(core::ptr::read_unaligned(ptr as *const u32)) }
     }
 
+    /// 8-byte little-endian read for the `mls` 5/6 hash. Donor parity:
+    /// `MEM_readLE64`.
+    ///
+    /// # Safety
+    /// `ptr` must be valid for a `u64` read (caller guarantees 8 in-bounds
+    /// bytes — every `mls >= 5` hash site gates on `idx + 8 <= len`).
+    #[inline(always)]
+    pub(crate) unsafe fn read_le_u64_ptr(ptr: *const u8) -> u64 {
+        unsafe { u64::from_le(core::ptr::read_unaligned(ptr as *const u64)) }
+    }
+
     /// MLS-parameterised hash of a 32-bit value into a `hash_log`-bit
     /// index. Donor parity: the `mls`-switch in `ZSTD_hashPtr`.
     #[inline(always)]
@@ -438,9 +463,28 @@ impl MatchTable {
         }
     }
 
+    /// 8-byte (`mls` 5/6) hash of a 64-bit value into a `hash_log`-bit index.
+    /// Donor parity: `ZSTD_hash5` / `ZSTD_hash6` in
+    /// `lib/compress/zstd_compress_internal.h` (`(readLE64 << (64 - 8*mls)) *
+    /// primeNbytes >> (64 - hBits)`). Used by the `minMatch = 5` lazy / BT
+    /// band (clevels.h levels 6-16).
+    #[inline(always)]
+    pub(crate) fn hash_value8_with_mls(value: u64, hash_log: usize, mls: usize) -> usize {
+        match mls {
+            6 => (((value << 16).wrapping_mul(HC_PRIME6BYTES)) >> (64 - hash_log)) as usize,
+            // mls == 5 (and any other 8-byte caller defaults here).
+            _ => (((value << 24).wrapping_mul(HC_PRIME5BYTES)) >> (64 - hash_log)) as usize,
+        }
+    }
+
     /// Hash a 4-byte window at the head of `data`.
     #[inline(always)]
     pub(crate) fn hash_position_with_mls(data: &[u8], hash_log: usize, mls: usize) -> usize {
+        if mls >= 5 {
+            debug_assert!(data.len() >= 8);
+            let value = unsafe { Self::read_le_u64_ptr(data.as_ptr()) };
+            return Self::hash_value8_with_mls(value, hash_log, mls);
+        }
         let value = Self::read_le_u32(data);
         Self::hash_value_with_mls(value, hash_log, mls)
     }
@@ -450,6 +494,12 @@ impl MatchTable {
     /// path.
     #[inline(always)]
     pub(crate) fn hash_position_at(data: &[u8], idx: usize, hash_log: usize, mls: usize) -> usize {
+        if mls >= 5 {
+            // 8-byte (mls 5/6) hash. Caller guarantees `idx + 8 <= len`.
+            debug_assert!(idx + 8 <= data.len());
+            let value = unsafe { Self::read_le_u64_ptr(data.as_ptr().add(idx)) };
+            return Self::hash_value8_with_mls(value, hash_log, mls);
+        }
         debug_assert!(idx + 4 <= data.len());
         let value = unsafe { Self::read_le_u32_ptr(data.as_ptr().add(idx)) };
         Self::hash_value_with_mls(value, hash_log, mls)

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -40,6 +40,7 @@
 
 pub(crate) mod block_header;
 pub(crate) mod blocks;
+pub(crate) mod dict_attach;
 pub(crate) mod fastpath;
 pub(crate) mod frame_header;
 pub(crate) mod incompressible;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1647,8 +1647,13 @@ impl RowMatchGenerator {
         // is u32-bounded upstream).
         for concat in start_concat..safe_end {
             unsafe {
+                // Little-endian load to match the live probe's
+                // `u32::from_le_bytes` hash (`hash_and_row`); a native-endian
+                // load would bucket dict rows differently on big-endian targets
+                // and lose every attached-dict match there.
                 let value =
-                    (base.add(history_start + concat) as *const u32).read_unaligned() as u64;
+                    u32::from_le((base.add(history_start + concat) as *const u32).read_unaligned())
+                        as u64;
                 let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(hash_kernel, value);
                 let combined = hash >> (u64::BITS as usize - total_bits);
                 let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -17,108 +17,37 @@ use core::convert::TryInto;
 
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
+use super::dict_attach::DictAttach;
 use super::match_generator::{
     ROW_EMPTY_SLOT, ROW_HASH_BITS, ROW_HASH_KEY_LEN, ROW_LOG, ROW_MIN_MATCH_LEN, ROW_SEARCH_DEPTH,
     ROW_TAG_BITS, ROW_TARGET_LEN, RowConfig,
 };
+
+/// Immutable row-hash dictionary index (donor `ZSTD_RowFindBestMatch`'s
+/// `dictMatchState` probe). Built once over the dictionary region and probed as
+/// ONE fixed-width row (`<= row_entries` tag-matched candidates) AFTER the live
+/// row, so the dict search is bounded (unlike a hash-chain walk) and never
+/// re-indexed per frame. `positions` store CONCAT indices (history_start-
+/// relative, floor-rebase-invariant); `ROW_EMPTY_SLOT = u32::MAX` marks empty.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct RowDictTables {
+    pub(crate) heads: Vec<u8>,
+    pub(crate) positions: Vec<u32>,
+    pub(crate) tags: Vec<u8>,
+}
 use super::match_table::helpers::{
-    INCOMPRESSIBLE_SKIP_STEP, LazyMatchConfig, best_len_offset_candidate, common_prefix_len,
-    extend_backwards_shared, pick_lazy_match_shared, repcode_candidate_shared,
+    INCOMPRESSIBLE_SKIP_STEP, LazyMatchConfig, best_len_offset_candidate, extend_backwards_shared,
+    pick_lazy_match_shared, repcode_candidate_shared,
 };
 use super::opt::types::MatchCandidate;
 
-/// Which kernel computes the row tag-match mask. Resolved once per
-/// `RowMatchGenerator` (CPU features don't change mid-process) and stored
-/// so the per-position `row_candidate` hot path avoids a repeated runtime
-/// feature query. `Sse2` covers the SSE2 baseline (always present on
-/// x86_64); `Avx2` is used when the CPU has AVX2; everything else (other
-/// architectures, x86 without SSE2) uses the scalar reference.
-#[derive(Copy, Clone, Eq, PartialEq)]
-enum RowTagKernel {
-    Scalar,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    Sse2,
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    Avx2,
-    // Little-endian only: the movemask packing reinterprets the lanes
-    // through u16/u32/u64, which groups bytes by native order — correct only
-    // on little-endian. Big-endian aarch64 falls back to the scalar kernel.
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    Neon,
-    // WebAssembly fixed-128-bit SIMD. Compile-time only (wasm has no runtime
-    // CPUID): present only when the build enables `simd128`.
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    Simd128,
-}
-
-impl RowTagKernel {
-    /// Resolve the best available tag-match kernel for this build/CPU.
-    fn detect() -> Self {
-        #[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
-        {
-            use std::arch::is_x86_feature_detected;
-            if is_x86_feature_detected!("avx2") {
-                return RowTagKernel::Avx2;
-            }
-            if is_x86_feature_detected!("sse2") {
-                return RowTagKernel::Sse2;
-            }
-        }
-        // no_std: resolve from compile-time `target_feature` flags. Use
-        // `if cfg!(...)` (not `#[cfg]`-gated `return` blocks) so the trailing
-        // `RowTagKernel::Scalar` stays reachable and every variant is
-        // "constructed" — `target_feature = "sse2"` / `"neon"` are baseline on
-        // x86_64 / aarch64, so a `#[cfg]`-gated unconditional `return` there
-        // makes the scalar fallback `unreachable_code` and leaves `Avx2`
-        // dead-code under `-D warnings`. `cfg!` const-folds to the same
-        // codegen while keeping every variant constructed; the
-        // `#[allow(unreachable_code)]` on the fallback below guards the case
-        // where `cfg!` folds the baseline-feature `if` to an unconditional
-        // `return` (mirrors `cpu_kernel::detect_cpu_kernel`).
-        #[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64")))]
-        {
-            if cfg!(target_feature = "avx2") {
-                return RowTagKernel::Avx2;
-            }
-            if cfg!(target_feature = "sse2") {
-                return RowTagKernel::Sse2;
-            }
-        }
-        #[cfg(all(feature = "std", target_arch = "aarch64", target_endian = "little"))]
-        {
-            if std::arch::is_aarch64_feature_detected!("neon") {
-                return RowTagKernel::Neon;
-            }
-        }
-        #[cfg(all(
-            not(feature = "std"),
-            target_arch = "aarch64",
-            target_endian = "little"
-        ))]
-        {
-            if cfg!(target_feature = "neon") {
-                return RowTagKernel::Neon;
-            }
-        }
-        // wasm32: no runtime CPUID. Resolve purely from the compile-time
-        // `simd128` target feature, baked into the build (the variant only
-        // exists under that cfg). Mirrors the no_std `cfg!` arms above.
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        ))]
-        {
-            return RowTagKernel::Simd128;
-        }
-        #[allow(unreachable_code)]
-        RowTagKernel::Scalar
-    }
-}
+// The row probe reuses the shared `fastpath::FastpathKernel` selection so each
+// per-tier `#[target_feature]` probe can inline BOTH the tag-match mask AND the
+// matching `fastpath::<tier>::common_prefix_len_ptr` (the tiers must share a
+// feature set for the cpl to inline — `Sse42` is a superset of the SSE2 mask
+// intrinsics, `Avx2Bmi2` of the AVX2 mask). `select_kernel()` does the runtime
+// detect once per process via a `OnceLock`.
+use super::fastpath::FastpathKernel;
 
 /// Compile-time row tag-match kernel. Each ZST monomorphises the per-row
 /// tag compare so the search hot loop drops the runtime `RowTagKernel`
@@ -129,54 +58,80 @@ impl RowTagKernel {
 /// supports its ISA — the same contract `RowTagKernel::detect` upholds for
 /// the enum's `unsafe` SIMD calls.
 pub(crate) trait RowTags: Copy {
-    /// `true` for SIMD tiers: precompute a full match bitmask once, then
-    /// test one bit per probed slot. `false` for scalar: on-the-fly
-    /// per-slot byte compare (cheaper when `search_depth < row_entries`).
-    const USE_MASK: bool;
-    /// Bitmask of slots whose tag byte equals `tag` (bit `j` ⇔ `tags[j]
-    /// == tag`). Only called when `USE_MASK`. `tags.len()` is the row
-    /// width (16 / 32 / 64).
-    fn mask(tags: &[u8], tag: u8) -> u64;
+    /// Run the row match probe (live row + dict dual-probe) for this kernel.
+    /// Forwards to the matcher's per-tier `#[target_feature]` probe method whose
+    /// body expands the tier's `row_tag_mask_*!` SIMD inline (no function call),
+    /// so the vector tag-match inlines straight-line under the kernel's feature
+    /// umbrella instead of crossing the `#[target_feature]` ABI boundary on every
+    /// probe (which it does even for baseline NEON/SSE2 — see `fastpath` module
+    /// docs). Runtime kernel selection happens once at the `dispatch_tag_kernel!`
+    /// site, never inside the per-position hot loop.
+    ///
+    /// # Safety
+    /// The caller (via `dispatch_tag_kernel!`) only selects a kernel whose ISA
+    /// `RowTagKernel::detect` confirmed present, upholding the per-tier
+    /// `#[target_feature]` contract.
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate>;
 }
 
+// On wasm32+simd128 the row tier is the compile-time `Simd128Tags`, so the
+// scalar fallback ZST is never constructed there (it stays the fallback on
+// every other target, and on scalar-only wasm builds).
+#[cfg_attr(
+    all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ),
+    allow(dead_code)
+)]
 #[derive(Copy, Clone)]
 struct ScalarTags;
 impl RowTags for ScalarTags {
-    const USE_MASK: bool = false;
-    // `USE_MASK == false` const-folds the mask branch away, so this is never
-    // invoked on the hot path; it delegates to the scalar reference for
-    // completeness (and to keep the reference fn live outside `cfg(test)`).
     #[inline]
-    fn mask(tags: &[u8], tag: u8) -> u64 {
-        row_tag_match_mask_scalar(tags, tag)
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        // Scalar has no target feature; the probe body runs as-is.
+        unsafe { matcher.row_probe_scalar::<ROW_LOG>(abs_pos, lit_len) }
     }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[derive(Copy, Clone)]
-struct Sse2Tags;
+struct Sse42Tags;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl RowTags for Sse2Tags {
-    const USE_MASK: bool = true;
+impl RowTags for Sse42Tags {
     #[inline]
-    fn mask(tags: &[u8], tag: u8) -> u64 {
-        // SAFETY: only dispatched-to when `tag_kernel == Sse2` (SSE2 is
-        // baseline on x86_64 and confirmed by `detect()` on x86).
-        unsafe { row_tag_match_mask_sse2(tags, tag) }
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        // SAFETY: dispatched only when `tag_kernel == Sse42` (SSE4.2 confirmed).
+        unsafe { matcher.row_probe_sse42::<ROW_LOG>(abs_pos, lit_len) }
     }
 }
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[derive(Copy, Clone)]
-struct Avx2Tags;
+struct Avx2Bmi2Tags;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-impl RowTags for Avx2Tags {
-    const USE_MASK: bool = true;
+impl RowTags for Avx2Bmi2Tags {
     #[inline]
-    fn mask(tags: &[u8], tag: u8) -> u64 {
-        // SAFETY: only dispatched-to when `tag_kernel == Avx2`, set by
-        // `detect()` after confirming AVX2.
-        unsafe { row_tag_match_mask_avx2(tags, tag) }
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        // SAFETY: dispatched only when `tag_kernel == Avx2Bmi2` (AVX2+BMI2 confirmed).
+        unsafe { matcher.row_probe_avx2bmi2::<ROW_LOG>(abs_pos, lit_len) }
     }
 }
 
@@ -185,15 +140,21 @@ impl RowTags for Avx2Tags {
 struct NeonTags;
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
 impl RowTags for NeonTags {
-    const USE_MASK: bool = true;
     #[inline]
-    fn mask(tags: &[u8], tag: u8) -> u64 {
-        // SAFETY: only dispatched-to when `tag_kernel == Neon` (baseline
-        // on little-endian aarch64, confirmed by `detect()`).
-        unsafe { row_tag_match_mask_neon(tags, tag) }
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        // SAFETY: dispatched only when `tag_kernel == Neon` (NEON confirmed).
+        unsafe { matcher.row_probe_neon::<ROW_LOG>(abs_pos, lit_len) }
     }
 }
 
+// WebAssembly fixed-128-bit SIMD tier. wasm has no runtime CPUID, so this is
+// compile-time only: present (and dispatched-to) exactly when the build enables
+// `simd128`, selected directly in `dispatch_tag_kernel!` rather than via the
+// runtime `FastpathKernel` (which carries no wasm tier).
 #[cfg(all(
     target_arch = "wasm32",
     target_feature = "simd128",
@@ -207,35 +168,52 @@ struct Simd128Tags;
     feature = "kernel_simd128"
 ))]
 impl RowTags for Simd128Tags {
-    const USE_MASK: bool = true;
     #[inline]
-    fn mask(tags: &[u8], tag: u8) -> u64 {
-        row_tag_match_mask_simd128(tags, tag)
+    unsafe fn probe<const ROW_LOG: usize>(
+        matcher: &RowMatchGenerator,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        // wasm simd128 is compile-time; `row_probe_simd128` needs no
+        // `#[target_feature]` and the intrinsics inline directly.
+        unsafe { matcher.row_probe_simd128::<ROW_LOG>(abs_pos, lit_len) }
     }
 }
 
-/// Resolve the runtime `tag_kernel` to a `RowTags` ZST once, then call a
-/// `*_k::<K>` method that binds the `row_log` const. The kernel branch
-/// runs once per block (cold), so the per-position hot loop is fully
+/// Resolve the runtime `tag_kernel` (`FastpathKernel`) to a `RowTags` ZST once,
+/// then call a `*_k::<K>` method that binds the `row_log` const. The kernel
+/// branch runs once per block (cold), so the per-position hot loop is fully
 /// monomorphised over the selected tier — no runtime kernel enum inside.
 macro_rules! dispatch_tag_kernel {
-    ($self:ident . $k_method:ident ( $($arg:expr),* )) => {
-        match $self.tag_kernel {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            RowTagKernel::Avx2 => $self.$k_method::<Avx2Tags>($($arg),*),
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            RowTagKernel::Sse2 => $self.$k_method::<Sse2Tags>($($arg),*),
-            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-            RowTagKernel::Neon => $self.$k_method::<NeonTags>($($arg),*),
-            #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-            RowTagKernel::Simd128 => $self.$k_method::<Simd128Tags>($($arg),*),
-            RowTagKernel::Scalar => $self.$k_method::<ScalarTags>($($arg),*),
+    ($self:ident . $k_method:ident ( $($arg:expr),* )) => {{
+        // wasm32 has no runtime CPUID: when the build enables `simd128`, the
+        // tier is resolved at compile time straight to `Simd128Tags`, so the
+        // runtime `FastpathKernel` match (native-only) is cfg'd out entirely.
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        {
+            $self.$k_method::<Simd128Tags>($($arg),*)
         }
-    };
+        #[cfg(not(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )))]
+        {
+            match $self.tag_kernel {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Avx2Bmi2 => $self.$k_method::<Avx2Bmi2Tags>($($arg),*),
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Sse42 => $self.$k_method::<Sse42Tags>($($arg),*),
+                #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+                FastpathKernel::Neon => $self.$k_method::<NeonTags>($($arg),*),
+                FastpathKernel::Scalar => $self.$k_method::<ScalarTags>($($arg),*),
+            }
+        }
+    }};
 }
 
 /// Bind the runtime `row_log` (clamped 4..=6) to the const `ROW_LOG` of a
@@ -252,162 +230,381 @@ macro_rules! dispatch_row_log {
     };
 }
 
-/// Scalar reference: one byte compare per slot. SIMD kernels below compute
-/// the identical mask with a vector compare + movemask (donor
-/// `ZSTD_row_getMatchMask` shape).
-#[inline]
-fn row_tag_match_mask_scalar(tags: &[u8], tag: u8) -> u64 {
-    let mut mask = 0u64;
-    for (j, &t) in tags.iter().enumerate() {
-        if t == tag {
-            mask |= 1u64 << j;
+/// Row tag-match mask kernels as `macro_rules!` bodies (donor
+/// `ZSTD_row_getMatchMask`). Per the SW-Rust SIMD rule, the SIMD body is a macro
+/// expanded at the call site inside each per-kernel `#[target_feature]` probe so
+/// the vector compare + movemask inline straight-line — `#[inline(always)]` +
+/// `#[target_feature]` on a function is forbidden (rust-lang/rust#145574), so a
+/// function call would otherwise cross the feature ABI boundary on every probe.
+/// Each expands to a `u64` bitmask: bit `j` set iff `tags[j] == tag`. The
+/// `row_tag_match_mask_*` wrapper fns below reuse these macros so the
+/// bit-identity tests exercise the exact same code the hot path runs.
+macro_rules! row_tag_mask_scalar {
+    ($tags:expr, $tag:expr) => {{
+        let tags: &[u8] = $tags;
+        let tag: u8 = $tag;
+        let mut mask = 0u64;
+        for (j, &t) in tags.iter().enumerate() {
+            if t == tag {
+                mask |= 1u64 << j;
+            }
         }
-    }
-    mask
+        mask
+    }};
 }
 
-/// SSE2 tag-match mask: `_mm_cmpeq_epi8` + `_mm_movemask_epi8` over each
-/// 16-byte chunk of the row. `tags.len()` is a multiple of 16, so no scalar
-/// tail is needed.
-///
-/// # Safety
-/// Caller must ensure SSE2 is available (always true on x86_64; checked by
-/// `RowTagKernel::detect`).
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[target_feature(enable = "sse2")]
-unsafe fn row_tag_match_mask_sse2(tags: &[u8], tag: u8) -> u64 {
-    #[cfg(target_arch = "x86")]
-    use core::arch::x86::{_mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8};
-    #[cfg(target_arch = "x86_64")]
-    use core::arch::x86_64::{_mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8};
-
-    let needle = _mm_set1_epi8(tag as i8);
-    let mut mask = 0u64;
-    let mut off = 0;
-    while off + 16 <= tags.len() {
-        // SAFETY: `off + 16 <= tags.len()`, so the 16-byte unaligned load is
-        // in bounds.
-        let v = unsafe { _mm_loadu_si128(tags.as_ptr().add(off) as *const _) };
-        let eq = _mm_cmpeq_epi8(v, needle);
-        let bits = _mm_movemask_epi8(eq) as u16 as u64;
-        mask |= bits << off;
-        off += 16;
-    }
-    mask
+macro_rules! row_tag_mask_sse2 {
+    ($tags:expr, $tag:expr) => {{
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::{_mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8};
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::{
+            _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8,
+        };
+        let tags: &[u8] = $tags;
+        let needle = _mm_set1_epi8($tag as i8);
+        let mut mask = 0u64;
+        let mut off = 0;
+        while off + 16 <= tags.len() {
+            // SAFETY: `off + 16 <= tags.len()`, so the 16-byte load is in bounds;
+            // the enclosing fn carries `#[target_feature(enable = "sse2")]`.
+            let v = unsafe { _mm_loadu_si128(tags.as_ptr().add(off) as *const _) };
+            let eq = _mm_cmpeq_epi8(v, needle);
+            mask |= (_mm_movemask_epi8(eq) as u16 as u64) << off;
+            off += 16;
+        }
+        mask
+    }};
 }
 
-/// AVX2 tag-match mask: `_mm256_cmpeq_epi8` + `_mm256_movemask_epi8` over
-/// each 32-byte chunk, falling back to a 16-byte SSE2 chunk for a 16-wide
-/// row. `tags.len()` is 16 / 32 / 64.
-///
-/// # Safety
-/// Caller must ensure AVX2 is available (checked by `RowTagKernel::detect`).
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[target_feature(enable = "avx2")]
-unsafe fn row_tag_match_mask_avx2(tags: &[u8], tag: u8) -> u64 {
-    #[cfg(target_arch = "x86")]
-    use core::arch::x86::{
-        _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8, _mm256_cmpeq_epi8,
-        _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
-    };
-    #[cfg(target_arch = "x86_64")]
-    use core::arch::x86_64::{
-        _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8, _mm256_cmpeq_epi8,
-        _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
-    };
-
-    let needle = _mm256_set1_epi8(tag as i8);
-    let mut mask = 0u64;
-    let mut off = 0;
-    while off + 32 <= tags.len() {
-        // SAFETY: `off + 32 <= tags.len()`, so the 32-byte load is in bounds.
-        let v = unsafe { _mm256_loadu_si256(tags.as_ptr().add(off) as *const _) };
-        let eq = _mm256_cmpeq_epi8(v, needle);
-        let bits = _mm256_movemask_epi8(eq) as u32 as u64;
-        mask |= bits << off;
-        off += 32;
-    }
-    if off + 16 <= tags.len() {
-        let needle16 = _mm_set1_epi8(tag as i8);
-        // SAFETY: `off + 16 <= tags.len()`, so the 16-byte load is in bounds.
-        let v = unsafe { _mm_loadu_si128(tags.as_ptr().add(off) as *const _) };
-        let eq = _mm_cmpeq_epi8(v, needle16);
-        let bits = _mm_movemask_epi8(eq) as u16 as u64;
-        mask |= bits << off;
-    }
-    mask
+macro_rules! row_tag_mask_avx2 {
+    ($tags:expr, $tag:expr) => {{
+        #[cfg(target_arch = "x86")]
+        use core::arch::x86::{
+            _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8, _mm256_cmpeq_epi8,
+            _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+        };
+        #[cfg(target_arch = "x86_64")]
+        use core::arch::x86_64::{
+            _mm_cmpeq_epi8, _mm_loadu_si128, _mm_movemask_epi8, _mm_set1_epi8, _mm256_cmpeq_epi8,
+            _mm256_loadu_si256, _mm256_movemask_epi8, _mm256_set1_epi8,
+        };
+        let tags: &[u8] = $tags;
+        let tag = $tag;
+        let needle = _mm256_set1_epi8(tag as i8);
+        let mut mask = 0u64;
+        let mut off = 0;
+        while off + 32 <= tags.len() {
+            // SAFETY: `off + 32 <= tags.len()`; enclosing fn is `target_feature(avx2)`.
+            let v = unsafe { _mm256_loadu_si256(tags.as_ptr().add(off) as *const _) };
+            let eq = _mm256_cmpeq_epi8(v, needle);
+            mask |= (_mm256_movemask_epi8(eq) as u32 as u64) << off;
+            off += 32;
+        }
+        if off + 16 <= tags.len() {
+            let needle16 = _mm_set1_epi8(tag as i8);
+            // SAFETY: `off + 16 <= tags.len()`; enclosing fn is `target_feature(avx2)`.
+            let v = unsafe { _mm_loadu_si128(tags.as_ptr().add(off) as *const _) };
+            let eq = _mm_cmpeq_epi8(v, needle16);
+            mask |= (_mm_movemask_epi8(eq) as u16 as u64) << off;
+        }
+        mask
+    }};
 }
 
-/// NEON tag-match mask: `vceqq_u8` against the broadcast tag, then a
-/// 16-byte-to-16-bit movemask (NEON has no direct equivalent, so pack the
-/// per-lane high bits with the progressive shift-right-accumulate sequence).
-/// `tags.len()` is a multiple of 16.
-///
-/// # Safety
-/// Caller must ensure NEON is available (baseline on aarch64; checked by
-/// `RowTagKernel::detect`).
 #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-#[target_feature(enable = "neon")]
-unsafe fn row_tag_match_mask_neon(tags: &[u8], tag: u8) -> u64 {
-    use core::arch::aarch64::{
-        vceqq_u8, vdupq_n_u8, vgetq_lane_u8, vld1q_u8, vreinterpretq_u8_u64, vreinterpretq_u16_u8,
-        vreinterpretq_u32_u16, vreinterpretq_u64_u32, vshrq_n_u8, vsraq_n_u16, vsraq_n_u32,
-        vsraq_n_u64,
-    };
-
-    let needle = vdupq_n_u8(tag);
-    let mut mask = 0u64;
-    let mut off = 0;
-    while off + 16 <= tags.len() {
-        // SAFETY: `off + 16 <= tags.len()`, so the 16-byte load is in bounds.
-        let v = unsafe { vld1q_u8(tags.as_ptr().add(off)) };
-        let eq = vceqq_u8(v, needle); // 0xFF per lane where equal, else 0x00.
-        // Collapse the 16 lanes' high bits into a 16-bit movemask, matching
-        // `_mm_movemask_epi8` lane order. Each `vsra` shifts a lane right and
-        // adds it into its neighbour, halving the live-lane count each step.
-        let high = vshrq_n_u8(eq, 7); // lane -> 1 if matched, else 0.
-        let paired16 = vreinterpretq_u32_u16(vsraq_n_u16(
-            vreinterpretq_u16_u8(high),
-            vreinterpretq_u16_u8(high),
-            7,
-        ));
-        let paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
-        let paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
-        let bits = (vgetq_lane_u8(paired64, 0) as u64) | ((vgetq_lane_u8(paired64, 8) as u64) << 8);
-        mask |= bits << off;
-        off += 16;
-    }
-    mask
+macro_rules! row_tag_mask_neon {
+    ($tags:expr, $tag:expr) => {{
+        use core::arch::aarch64::{
+            vceqq_u8, vdupq_n_u8, vgetq_lane_u8, vld1q_u8, vreinterpretq_u8_u64,
+            vreinterpretq_u16_u8, vreinterpretq_u32_u16, vreinterpretq_u64_u32, vshrq_n_u8,
+            vsraq_n_u16, vsraq_n_u32, vsraq_n_u64,
+        };
+        let tags: &[u8] = $tags;
+        let needle = vdupq_n_u8($tag);
+        let mut mask = 0u64;
+        let mut off = 0;
+        while off + 16 <= tags.len() {
+            // SAFETY: `off + 16 <= tags.len()`; enclosing fn is `target_feature(neon)`.
+            let v = unsafe { vld1q_u8(tags.as_ptr().add(off)) };
+            let eq = vceqq_u8(v, needle);
+            let high = vshrq_n_u8(eq, 7);
+            let paired16 = vreinterpretq_u32_u16(vsraq_n_u16(
+                vreinterpretq_u16_u8(high),
+                vreinterpretq_u16_u8(high),
+                7,
+            ));
+            let paired32 = vreinterpretq_u64_u32(vsraq_n_u32(paired16, paired16, 14));
+            let paired64 = vreinterpretq_u8_u64(vsraq_n_u64(paired32, paired32, 28));
+            let bits =
+                (vgetq_lane_u8(paired64, 0) as u64) | ((vgetq_lane_u8(paired64, 8) as u64) << 8);
+            mask |= bits << off;
+            off += 16;
+        }
+        mask
+    }};
 }
 
-/// WebAssembly `simd128` tag-match mask: `i8x16_eq` against the broadcast
-/// tag, then `i8x16_bitmask` (the direct 16-lane-to-16-bit movemask wasm
-/// provides) over each 16-byte chunk. Shape mirrors the SSE2 kernel exactly.
-/// `tags.len()` is a multiple of 16, so no scalar tail is needed. Compiled
-/// only under `target_feature = "simd128"`, so the intrinsics are available
-/// without a separate `#[target_feature]` attribute (no runtime detection on
-/// wasm); only `v128_load` is `unsafe` (a raw pointer load).
+// WebAssembly `simd128` tag-match mask: `i8x16_eq` against the broadcast tag,
+// then `i8x16_bitmask` (wasm's direct 16-lane-to-16-bit movemask) over each
+// 16-byte chunk. Shape mirrors the SSE2 kernel; `tags.len()` is a multiple of
+// 16 so no scalar tail is needed. Compiled only under `target_feature =
+// "simd128"`, so the intrinsics are available without a `#[target_feature]`
+// attribute (no runtime detection on wasm); only `v128_load` is `unsafe`.
 #[cfg(all(
     target_arch = "wasm32",
     target_feature = "simd128",
     feature = "kernel_simd128"
 ))]
-fn row_tag_match_mask_simd128(tags: &[u8], tag: u8) -> u64 {
-    use core::arch::wasm32::{i8x16_bitmask, i8x16_eq, i8x16_splat, v128_load};
+macro_rules! row_tag_mask_simd128 {
+    ($tags:expr, $tag:expr) => {{
+        use core::arch::wasm32::{i8x16_bitmask, i8x16_eq, i8x16_splat, v128_load};
+        let tags: &[u8] = $tags;
+        let needle = i8x16_splat($tag as i8);
+        let mut mask = 0u64;
+        let mut off = 0;
+        while off + 16 <= tags.len() {
+            // SAFETY: `off + 16 <= tags.len()`, so the 16-byte unaligned load is
+            // in bounds.
+            let v = unsafe { v128_load(tags.as_ptr().add(off) as *const _) };
+            let eq = i8x16_eq(v, needle);
+            mask |= (i8x16_bitmask(eq) as u64) << off;
+            off += 16;
+        }
+        mask
+    }};
+}
 
-    let needle = i8x16_splat(tag as i8);
-    let mut mask = 0u64;
-    let mut off = 0;
-    while off + 16 <= tags.len() {
-        // SAFETY: `off + 16 <= tags.len()`, so the 16-byte unaligned load is
-        // in bounds.
-        let v = unsafe { v128_load(tags.as_ptr().add(off) as *const _) };
-        let eq = i8x16_eq(v, needle);
-        let bits = i8x16_bitmask(eq) as u64;
-        mask |= bits << off;
-        off += 16;
-    }
-    mask
+/// Emit a per-kernel row match probe method on `RowMatchGenerator`. The body is
+/// written ONCE here and stamped per tier under that tier's `#[target_feature]`
+/// umbrella; the tag-match SIMD is expanded inline via the `$maskmac` macro (not
+/// a function call), so the vector compare inlines straight-line — no
+/// `#[target_feature]` ABI boundary on the per-probe hot path. Runtime kernel
+/// selection happens once at the `dispatch_tag_kernel!` site; this method is the
+/// per-tier monomorphised hot loop with no kernel branch inside it.
+///
+/// `$use_mask` is the compile-time bitmask-vs-byte-compare choice; `$maskmac` is
+/// the tier's `row_tag_mask_*!`; the optional `$tf` is the `target_feature`.
+/// Mirrors the former generic `row_candidate_rl`: live row probe, dict
+/// dual-probe, speculative tail gate.
+macro_rules! gen_row_probe {
+    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+        $(#[target_feature(enable = $tf)])?
+        #[allow(unused_unsafe)]
+        // wasm32+simd128 selects `row_probe_simd128` at compile time, leaving
+        // `row_probe_scalar` (the only other tier compiled on wasm) unused.
+        #[cfg_attr(
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ),
+            allow(dead_code)
+        )]
+        unsafe fn $name<const ROW_LOG: usize>(
+            &self,
+            abs_pos: usize,
+            lit_len: usize,
+        ) -> Option<MatchCandidate> {
+            debug_assert_eq!(ROW_LOG, self.row_log);
+            let mls = self.mls;
+            let concat = self.live_history();
+            let current_idx = abs_pos - self.history_abs_start;
+            if current_idx + mls > concat.len() {
+                return None;
+            }
+
+            let (row, tag) = self.hash_and_row(abs_pos)?;
+            let row_entries = 1usize << ROW_LOG;
+            let row_mask = row_entries - 1;
+            let row_base = row << ROW_LOG;
+            let head = self.row_heads[row] as usize;
+            let max_walk = self.search_depth.min(row_entries);
+
+            // SIMD tiers precompute the full bitmask once (the tag-match
+            // intrinsic inlines under this method's `#[target_feature]`); the
+            // scalar tier (`USE_MASK == false`) const-folds this away and does
+            // an on-the-fly per-slot byte compare in the loop.
+            let tag_match = if $use_mask {
+                $maskmac!(&self.row_tags[row_base..row_base + row_entries], tag)
+            } else {
+                0
+            };
+
+            let mut best: Option<MatchCandidate> = None;
+            for i in 0..max_walk {
+                let slot = (head + i) & row_mask;
+                let idx = row_base + slot;
+                let matched = if $use_mask {
+                    (tag_match >> slot) & 1 != 0
+                } else {
+                    self.row_tags[idx] == tag
+                };
+                if !matched {
+                    continue;
+                }
+                let raw_pos = self.row_positions[idx];
+                if raw_pos == ROW_EMPTY_SLOT {
+                    continue;
+                }
+                let candidate_pos = raw_pos as usize;
+                if candidate_pos < self.history_abs_start || candidate_pos >= abs_pos {
+                    continue;
+                }
+                let candidate_idx = candidate_pos - self.history_abs_start;
+                // Speculative tail gate (HC `hash_chain_candidate` parity):
+                // a 4-byte compare at the length the candidate must reach to
+                // outgrow `best` proves whether the full `common_prefix_len`
+                // can pay off. Gated on offset-monotonicity since the row walk
+                // is not offset-ordered. Ratio-neutral.
+                if let Some(b) = best {
+                    let new_offset = abs_pos - candidate_pos;
+                    if new_offset >= b.offset
+                        && let Some(tail_off) = b.match_len.checked_sub(lit_len + 3)
+                    {
+                        let m_end = candidate_idx + tail_off + 4;
+                        let i_end = current_idx + tail_off + 4;
+                        if i_end > concat.len()
+                            || m_end > concat.len()
+                            || concat[candidate_idx + tail_off..m_end]
+                                != concat[current_idx + tail_off..i_end]
+                        {
+                            continue;
+                        }
+                    }
+                }
+                // Per-tier `common_prefix_len_ptr` expanded inline (same feature
+                // umbrella as this probe) — no `dispatch_common_prefix_len_ptr`
+                // runtime match + `#[target_feature]` call per candidate. `max =
+                // concat.len() - current_idx` since `candidate_idx < current_idx`.
+                let match_len = unsafe {
+                    $cpl(
+                        concat.as_ptr().add(candidate_idx),
+                        concat.as_ptr().add(current_idx),
+                        concat.len() - current_idx,
+                    )
+                };
+                if match_len >= mls {
+                    let candidate =
+                        self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len);
+                    best = best_len_offset_candidate(best, Some(candidate));
+                    if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
+                        return best;
+                    }
+                }
+            }
+
+            // Dict dual-probe (donor `ZSTD_RowFindBestMatch` `dictMatchState`):
+            // one bounded immutable dict row (concat-indexed positions).
+            if let Some(dict) = self.dict.table() {
+                let dict_end = self.dict.region_len();
+                let drow_base = row << ROW_LOG;
+                let dhead = dict.heads[row] as usize;
+                let dtag_match = if $use_mask {
+                    $maskmac!(&dict.tags[drow_base..drow_base + row_entries], tag)
+                } else {
+                    0
+                };
+                for i in 0..max_walk {
+                    let slot = (dhead + i) & row_mask;
+                    let didx = drow_base + slot;
+                    let matched = if $use_mask {
+                        (dtag_match >> slot) & 1 != 0
+                    } else {
+                        dict.tags[didx] == tag
+                    };
+                    if !matched {
+                        continue;
+                    }
+                    let dp = dict.positions[didx];
+                    if dp == ROW_EMPTY_SLOT {
+                        continue;
+                    }
+                    let dp = dp as usize;
+                    if dp >= dict_end || dp + mls > concat.len() {
+                        continue;
+                    }
+                    let cand_abs = self.history_abs_start + dp;
+                    if let Some(b) = best {
+                        let new_offset = abs_pos - cand_abs;
+                        if new_offset >= b.offset
+                            && let Some(tail_off) = b.match_len.checked_sub(lit_len + 3)
+                        {
+                            let m_end = dp + tail_off + 4;
+                            let i_end = current_idx + tail_off + 4;
+                            if i_end > concat.len()
+                                || m_end > concat.len()
+                                || concat[dp + tail_off..m_end]
+                                    != concat[current_idx + tail_off..i_end]
+                            {
+                                continue;
+                            }
+                        }
+                    }
+                    let match_len = unsafe {
+                        $cpl(
+                            concat.as_ptr().add(dp),
+                            concat.as_ptr().add(current_idx),
+                            concat.len() - current_idx,
+                        )
+                    };
+                    if match_len >= mls {
+                        let candidate = self.extend_backwards(cand_abs, abs_pos, match_len, lit_len);
+                        best = best_len_offset_candidate(best, Some(candidate));
+                        if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
+                            return best;
+                        }
+                    }
+                }
+            }
+            best
+        }
+    };
+}
+
+// Reference mask wrappers for the bit-identity tests (`tag_mask_tests`). The
+// `row_tag_mask_*!` macros are the production source of truth (expanded inline
+// in the per-kernel `row_probe_*` methods); these fns just give the tests a
+// callable handle to assert SIMD == scalar. Gated to the same cfg as the test
+// module so they carry no weight in production builds.
+#[cfg(test)]
+fn row_tag_match_mask_scalar(tags: &[u8], tag: u8) -> u64 {
+    row_tag_mask_scalar!(tags, tag)
+}
+
+/// # Safety
+/// Caller must ensure SSE2 is available (checked by `RowTagKernel::detect`).
+#[cfg(all(
+    test,
+    feature = "std",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+#[target_feature(enable = "sse2")]
+unsafe fn row_tag_match_mask_sse2(tags: &[u8], tag: u8) -> u64 {
+    row_tag_mask_sse2!(tags, tag)
+}
+
+/// # Safety
+/// Caller must ensure AVX2 is available (checked by `RowTagKernel::detect`).
+#[cfg(all(
+    test,
+    feature = "std",
+    any(target_arch = "x86", target_arch = "x86_64")
+))]
+#[target_feature(enable = "avx2")]
+unsafe fn row_tag_match_mask_avx2(tags: &[u8], tag: u8) -> u64 {
+    row_tag_mask_avx2!(tags, tag)
+}
+
+/// # Safety
+/// Caller must ensure NEON is available (baseline on aarch64; checked by
+/// `RowTagKernel::detect`).
+#[cfg(all(test, target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+unsafe fn row_tag_match_mask_neon(tags: &[u8], tag: u8) -> u64 {
+    row_tag_mask_neon!(tags, tag)
 }
 
 #[derive(Clone)]
@@ -451,8 +648,22 @@ pub(crate) struct RowMatchGenerator {
     pub(crate) row_positions: Vec<u32>,
     pub(crate) row_tags: Vec<u8>,
     /// Cached tag-match SIMD kernel; CPU features are fixed per process, so
-    /// resolve once instead of querying per `row_candidate` call.
-    tag_kernel: RowTagKernel,
+    /// resolve once instead of querying per `row_candidate` call. On
+    /// wasm32+simd128 the tier is compile-time (`dispatch_tag_kernel!` selects
+    /// `Simd128Tags` directly), so the field is unread there.
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ),
+        allow(dead_code)
+    )]
+    tag_kernel: FastpathKernel,
+    /// Attached immutable dictionary row index (donor `dictMatchState`). `Some`
+    /// activates the bounded dict probe in `row_candidate_rl`; built once and
+    /// cached across frames via `DictAttach`, invalidated on eviction / resize.
+    pub(crate) dict: DictAttach<RowDictTables>,
 }
 
 impl RowMatchGenerator {
@@ -475,7 +686,8 @@ impl RowMatchGenerator {
             row_heads: Vec::new(),
             row_positions: Vec::new(),
             row_tags: Vec::new(),
-            tag_kernel: RowTagKernel::detect(),
+            tag_kernel: crate::encoding::fastpath::select_kernel(),
+            dict: DictAttach::new(),
         }
     }
 
@@ -487,6 +699,15 @@ impl RowMatchGenerator {
             self.row_heads.clear();
             self.row_positions.clear();
             self.row_tags.clear();
+            // NOTE: do NOT invalidate the dict here. `set_hash_bits` is called
+            // twice per frame during level setup (once from `configure` with
+            // the level's `hash_bits`, once with the hint-resolved table bits),
+            // so `row_hash_log` oscillates every frame even when the level is
+            // unchanged. Invalidating here would drop the CDict cache on every
+            // frame. The dict is rebuilt by `prime_dict_rows` AFTER setup (final
+            // shape), and `prime_dict_rows` self-invalidates a cached index whose
+            // shape no longer matches — so a genuine level change is handled
+            // there, while the per-frame oscillation is ignored.
         }
     }
 
@@ -538,6 +759,11 @@ impl RowMatchGenerator {
         if self.history_abs_start + self.window_size + data.len() >= u32::MAX as usize - 1 {
             self.rebase_positions();
         }
+        if self.window_size + data.len() > self.max_window_size {
+            // Eviction advances `history_start`, staling the dict row index's
+            // concat positions — drop the attach (dict slid within/out window).
+            self.dict.invalidate();
+        }
         while self.window_size + data.len() > self.max_window_size {
             let removed_len = self.chunk_lens.pop_front().unwrap();
             self.window_size -= removed_len;
@@ -555,6 +781,9 @@ impl RowMatchGenerator {
     }
 
     pub(crate) fn trim_to_window(&mut self) {
+        if self.window_size > self.max_window_size {
+            self.dict.invalidate();
+        }
         while self.window_size > self.max_window_size {
             let removed_len = self.chunk_lens.pop_front().unwrap();
             self.window_size -= removed_len;
@@ -896,7 +1125,9 @@ impl RowMatchGenerator {
             // indexes the committed span.
             let chosen = match rep_match {
                 Some(rep) => Some(rep),
-                None => self.row_candidate_rl::<K, ROW_LOG>(abs_pos, lit_len),
+                // SAFETY: `K` selected by `dispatch_tag_kernel!` after `detect`
+                // confirmed its ISA; `K::probe` upholds the feature contract.
+                None => unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len) },
             };
 
             let Some(candidate) = chosen else {
@@ -1041,7 +1272,9 @@ impl RowMatchGenerator {
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         let rep = self.repcode_candidate(abs_pos, lit_len);
-        let row = self.row_candidate_rl::<K, ROW_LOG>(abs_pos, lit_len);
+        // SAFETY: `K` selected by `dispatch_tag_kernel!` after `detect` confirmed
+        // its ISA; `K::probe` upholds the per-tier feature contract.
+        let row = unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len) };
         best_len_offset_candidate(rep, row)
     }
 
@@ -1143,6 +1376,10 @@ impl RowMatchGenerator {
         dispatch_row_log!(self.pick_lazy_match_rl::<K>(abs_pos, lit_len, best))
     }
 
+    // Per-kernel row match probe. Runtime kernel selection happens ONCE via
+    // `dispatch_tag_kernel!`; the selected tier's `row_probe_*` method is the
+    // monomorphised per-position hot loop with the SIMD tag-match inlined under
+    // its `#[target_feature]` umbrella (no dispatcher branch inside the loop).
     #[allow(dead_code)]
     pub(crate) fn row_candidate(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
         dispatch_tag_kernel!(self.row_candidate_k(abs_pos, lit_len))
@@ -1152,83 +1389,66 @@ impl RowMatchGenerator {
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
-        dispatch_row_log!(self.row_candidate_rl::<K>(abs_pos, lit_len))
+        // SAFETY: `dispatch_tag_kernel!` only selects a `K` whose ISA `detect`
+        // confirmed present, upholding `K::probe`'s per-tier feature contract.
+        match self.row_log {
+            4 => unsafe { K::probe::<4>(self, abs_pos, lit_len) },
+            5 => unsafe { K::probe::<5>(self, abs_pos, lit_len) },
+            6 => unsafe { K::probe::<6>(self, abs_pos, lit_len) },
+            _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
+        }
     }
 
-    pub(crate) fn row_candidate_rl<K: RowTags, const ROW_LOG: usize>(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        debug_assert_eq!(ROW_LOG, self.row_log);
-        let mls = self.mls;
-        let concat = self.live_history();
-        let current_idx = abs_pos - self.history_abs_start;
-        if current_idx + mls > concat.len() {
-            return None;
-        }
-
-        let (row, tag) = self.hash_and_row(abs_pos)?;
-        let row_entries = 1usize << ROW_LOG;
-        let row_mask = row_entries - 1;
-        let row_base = row << ROW_LOG;
-        let head = self.row_heads[row] as usize;
-        let max_walk = self.search_depth.min(row_entries);
-
-        // `K::USE_MASK` is a compile-time const per tag kernel, so this whole
-        // branch const-folds: SIMD tiers precompute the full bitmask once and
-        // test one bit per probed slot; the scalar tier drops the mask and
-        // does an on-the-fly byte compare (cheaper when
-        // `search_depth < row_entries`). No runtime kernel enum on the hot
-        // path. `row_entries <= 64` (ROW_LOG 4..=6) so the mask fits a `u64`.
-        let tag_match = if K::USE_MASK {
-            K::mask(&self.row_tags[row_base..row_base + row_entries], tag)
-        } else {
-            0
-        };
-
-        let mut best = None;
-        for i in 0..max_walk {
-            let slot = (head + i) & row_mask;
-            let idx = row_base + slot;
-            let matched = if K::USE_MASK {
-                (tag_match >> slot) & 1 != 0
-            } else {
-                self.row_tags[idx] == tag
-            };
-            if !matched {
-                continue;
-            }
-            let raw_pos = self.row_positions[idx];
-            if raw_pos == ROW_EMPTY_SLOT {
-                continue;
-            }
-            // Stored positions are absolute (`< u32::MAX`, capped per frame in
-            // `add_data`); widen to `usize` for the window-bound checks.
-            let candidate_pos = raw_pos as usize;
-            if candidate_pos < self.history_abs_start || candidate_pos >= abs_pos {
-                continue;
-            }
-            let candidate_idx = candidate_pos - self.history_abs_start;
-            let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
-            if match_len >= mls {
-                let candidate = self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len);
-                best = best_len_offset_candidate(best, Some(candidate));
-                // Donor `ZSTD_RowFindBestMatch` walks every probed slot and
-                // keeps the longest; its only early break is "best possible"
-                // (the match already reaches the block end, so no later slot
-                // can beat it). cParams.targetLength is the LAZY outer loop's
-                // nice-match threshold, NOT a row-search cutoff — gating the
-                // row walk on it (target_len=2 at level 5) returned the first
-                // most-recent slot instead of the longest, inflating sequence
-                // count and losing ratio. Keep only the best-possible break.
-                if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
-                    return best;
-                }
-            }
-        }
-        best
-    }
+    // Each tier pairs its tag-match mask macro with the matching
+    // `fastpath::<tier>::common_prefix_len_ptr` so BOTH inline under the tier's
+    // `#[target_feature]` umbrella (the cpl features must be a subset of the
+    // probe's: SSE4.2 ⊇ the SSE2 mask intrinsics, AVX2+BMI2 ⊇ the AVX2 mask).
+    // Scalar uses the on-the-fly per-slot byte compare (`use_mask = false`).
+    gen_row_probe!(
+        row_probe_scalar,
+        false,
+        row_tag_mask_scalar,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_row_probe!(
+        row_probe_sse42,
+        true,
+        row_tag_mask_sse2,
+        crate::encoding::fastpath::sse42::common_prefix_len_ptr,
+        "sse4.2"
+    );
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_row_probe!(
+        row_probe_avx2bmi2,
+        true,
+        row_tag_mask_avx2,
+        crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
+        "avx2,bmi2"
+    );
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    gen_row_probe!(
+        row_probe_neon,
+        true,
+        row_tag_mask_neon,
+        crate::encoding::fastpath::neon::common_prefix_len_ptr,
+        "neon"
+    );
+    // wasm simd128 tag-match mask + scalar (portable) cpl. wasm simd128 is
+    // compile-time, so no `#[target_feature]` umbrella is passed; mirrors the
+    // wasm tier's behavior of vectorising only the tag scan, with the portable
+    // prefix-length kernel.
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    gen_row_probe!(
+        row_probe_simd128,
+        true,
+        row_tag_mask_simd128,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
 
     fn extend_backwards(
         &self,
@@ -1326,6 +1546,120 @@ impl RowMatchGenerator {
             // absolute cursor below `u32::MAX`, so the cast is lossless and
             // never collides with the `ROW_EMPTY_SLOT == u32::MAX` sentinel.
             *self.row_positions.get_unchecked_mut(row_base + next) = abs_pos as u32;
+        }
+    }
+
+    /// Mark the attached dict row index fully built (CDict cache).
+    pub(crate) fn mark_dict_primed(&mut self) {
+        self.dict.mark_primed();
+    }
+
+    /// Drop the cached dict row index (next frame carries no dict, or eviction /
+    /// resize staled the concat positions).
+    pub(crate) fn invalidate_dict_cache(&mut self) {
+        self.dict.invalidate();
+    }
+
+    /// Donor `ZSTD_RowFindBestMatch` `dictMatchState` attach: index the
+    /// just-committed dictionary block (current `chunk_lens` tail) into the
+    /// SEPARATE immutable dict row tables instead of the live ones, so the live
+    /// rows carry only input and the dict is never re-indexed per frame. The
+    /// dual-probe in `row_candidate_rl` searches live + dict (one bounded row
+    /// each).
+    pub(crate) fn prime_dict_attach_current_block(&mut self) {
+        self.ensure_tables();
+        let current_len = self.chunk_lens.back().copied().unwrap_or(0);
+        if current_len == 0 {
+            return;
+        }
+        let current_abs_start = self.history_abs_start + self.window_size - current_len;
+        let current_abs_end = current_abs_start + current_len;
+        let start_concat = current_abs_start - self.history_abs_start;
+        let end_concat = current_abs_end - self.history_abs_start;
+        // Backfill the `ROW_HASH_KEY_LEN - 1` bytes immediately before the
+        // block, mirroring the live insert path's `backfill_start`: those
+        // starts only become hashable once this block supplies the
+        // trailing key bytes, so without the backfill seam-spanning row
+        // candidates are dropped from the dict index permanently.
+        let prime_start = start_concat.saturating_sub(ROW_HASH_KEY_LEN - 1);
+        self.prime_dict_rows(prime_start, end_concat);
+    }
+
+    /// Build the immutable dictionary row index over the contiguous-history
+    /// concat range `[start_concat, end_concat)`. Mirrors [`Self::insert_position`]'s
+    /// row-hash + head-decrement slot write, but writes a CONCAT index (stable
+    /// across rebases) into the SEPARATE [`Self::dict`] tables. `ROW_EMPTY_SLOT`
+    /// marks empty. Skips the rehash when the CDict cache is already primed.
+    fn prime_dict_rows(&mut self, start_concat: usize, end_concat: usize) {
+        let row_count = 1usize << self.row_hash_log;
+        let row_entries = 1usize << self.row_log;
+        let total = row_count * row_entries;
+        // Drop a cached dict index built for a different table shape (a genuine
+        // level change resizes `row_hash_log`/`row_log`). `set_hash_bits`'s
+        // per-frame oscillation does NOT reach here — this runs after setup with
+        // the final shape — so a same-level reused frame keeps the cache.
+        // Key on the FULL shape, not just `heads.len()`: a level change that
+        // keeps `row_hash_log` but changes `row_log` leaves `heads.len()`
+        // equal while `positions`/`tags` are sized for the old `row_log`,
+        // and the probe path then indexes `row << row_log` slots that the
+        // cached table doesn't have (OOB / wrong slots).
+        if self.dict.table().is_some_and(|d| {
+            d.heads.len() != row_count || d.positions.len() != total || d.tags.len() != total
+        }) {
+            self.dict.invalidate();
+        }
+        self.dict.set_region_len(end_concat);
+        if self.dict.is_primed() {
+            return;
+        }
+        let row_log = self.row_log;
+        let row_hash_log = self.row_hash_log;
+        let hash_kernel = self.hash_kernel;
+        let history_start = self.history_start;
+        let concat_len = self.history.len() - history_start;
+        // Row hash needs `ROW_HASH_KEY_LEN` readable bytes of lookahead.
+        let safe_end = concat_len
+            .saturating_sub(ROW_HASH_KEY_LEN - 1)
+            .min(end_concat);
+        if start_concat >= safe_end {
+            return;
+        }
+        // `row_count` / `row_entries` / `total` were computed above for the
+        // shape-mismatch check and carry the same values here.
+        let row_mask = row_entries - 1;
+        let row_count_mask = row_count - 1;
+        // Raw history base taken before the mutable dict borrow (disjoint
+        // fields; the raw ptr holds no borrow).
+        let base = self.history.as_ptr();
+        let dict = self.dict.table_mut_or_init(|| RowDictTables {
+            heads: alloc::vec![0u8; row_count],
+            positions: alloc::vec![ROW_EMPTY_SLOT; total],
+            tags: alloc::vec![0u8; total],
+        });
+        let heads = dict.heads.as_mut_ptr();
+        let positions = dict.positions.as_mut_ptr();
+        let tags = dict.tags.as_mut_ptr();
+        let total_bits = row_hash_log + ROW_TAG_BITS;
+        // SAFETY: `base.add(history_start + concat)` is in-bounds for
+        // `concat + ROW_HASH_KEY_LEN <= concat_len` (enforced by `safe_end`).
+        // `row <= row_count_mask < row_count` (= heads.len()); `row_base + next
+        // < total` (= positions.len() = tags.len()). `concat` fits u32 (history
+        // is u32-bounded upstream).
+        for concat in start_concat..safe_end {
+            unsafe {
+                let value =
+                    (base.add(history_start + concat) as *const u32).read_unaligned() as u64;
+                let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(hash_kernel, value);
+                let combined = hash >> (u64::BITS as usize - total_bits);
+                let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;
+                let tag = combined as u8;
+                let row_base = row << row_log;
+                let head = *heads.add(row) as usize;
+                let next = head.wrapping_sub(1) & row_mask;
+                *heads.add(row) = next as u8;
+                *tags.add(row_base + next) = tag;
+                *positions.add(row_base + next) = concat as u32;
+            }
         }
     }
 }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -55,6 +55,7 @@
 use alloc::vec::Vec;
 
 use crate::encoding::Sequence;
+use crate::encoding::dict_attach::DictAttach;
 
 use super::fast_kernel::hash_table::FastHashTable;
 use super::fast_kernel::kernel::compress_block_fast;
@@ -232,32 +233,19 @@ pub(crate) struct FastKernelMatcher {
     /// (`borrowed[start..end]`, zero-copy) for the emit path — the
     /// borrowed analogue of `last_block_start` on the owned path.
     last_borrowed_block: Option<(usize, usize)>,
-    /// Immutable dictionary hash table for the donor `dictMatchState`
-    /// Fast path. Built once during `prime_with_dictionary` over the
-    /// dictionary region at the front of `history` (positions
-    /// `[1, dict_region_len)`), using the same `(hash_log, mls)` as
-    /// [`Self::hash_table`] so a single hash keys both tables. `Some`
-    /// activates the dual-probe [`compress_block_fast_dict`] kernel;
-    /// invalidated to `None` on any history eviction (the absolute dict
-    /// positions would otherwise go stale) so the no-dict kernel takes
-    /// over — correctness-safe, only the dict ratio benefit is lost on
-    /// inputs large enough to slide the dictionary out of the window.
-    dict_table: Option<FastHashTable>,
-    /// Number of dictionary bytes at the front of `history` (one past the
-    /// last valid dict position). The boundary between the dict region and
-    /// the frame input; doubles as the `input_floor` / `dict_end` the
-    /// dict kernel uses to separate main-table (input) from dict-table
-    /// matches. `0` when no dictionary is primed.
-    dict_region_len: usize,
-    /// CDict-equivalent cache flag: `true` once [`Self::dict_table`] has been
-    /// fully built for the attached dictionary. A reused compressor keeps the
-    /// built `dict_table` across the per-frame `reset` (the dictionary
-    /// re-commits to the same absolute history positions, so the hashed
-    /// positions stay valid) and skips re-hashing it — the donor copies /
-    /// references the precomputed `cdict->matchState` rather than rebuilding
-    /// it per frame. Cleared on parameter change, history eviction, or
-    /// dictionary attach/clear (see `invalidate_dict_cache`).
-    dict_primed: bool,
+    /// Immutable dictionary hash table (donor `dictMatchState` Fast path) plus
+    /// its CDict cache lifecycle, via the shared [`DictAttach`] level-1
+    /// scaffolding. The table is built once during `prime_with_dictionary` over
+    /// the dictionary region at the front of `history` (positions
+    /// `[1, region_len)`), using the same `(hash_log, mls)` as
+    /// [`Self::hash_table`] so a single hash keys both. Attached
+    /// (`is_attached()`) activates the dual-probe [`compress_block_fast_dict`]
+    /// kernel; invalidated on any history eviction (absolute dict positions
+    /// would otherwise go stale) so the no-dict kernel takes over —
+    /// correctness-safe, only the dict ratio benefit is lost when the input is
+    /// large enough to slide the dictionary out of the window. `region_len()`
+    /// is the dict/input boundary (`dict_end`).
+    dict: DictAttach<FastHashTable>,
 }
 
 impl FastKernelMatcher {
@@ -345,9 +333,7 @@ impl FastKernelMatcher {
             pending: None,
             borrowed: None,
             last_borrowed_block: None,
-            dict_table: None,
-            dict_region_len: 0,
-            dict_primed: false,
+            dict: DictAttach::new(),
         }
     }
 
@@ -375,9 +361,7 @@ impl FastKernelMatcher {
             // invalidates the cached dict table: its absolute positions
             // index a table whose shape no longer matches.
             self.hash_table = FastHashTable::new(hash_log, mls);
-            self.dict_table = None;
-            self.dict_region_len = 0;
-            self.dict_primed = false;
+            self.dict.invalidate();
         } else {
             // Same shape — keep the allocation, zero the entries via
             // `memset` (ZSTD_window_clear cadence). A primed dict table
@@ -641,9 +625,7 @@ impl FastKernelMatcher {
         // cost is the dict ratio benefit on inputs large enough to evict
         // the dictionary, which is exactly when the dict is no longer
         // reachable anyway.
-        self.dict_table = None;
-        self.dict_region_len = 0;
-        self.dict_primed = false;
+        self.dict.invalidate();
         self.hash_table.clear();
         self.last_block_start = self.last_block_start.saturating_sub(drop_n);
         // Skip position 0 — `prefix_start_index = 1` means the kernel
@@ -784,19 +766,19 @@ impl FastKernelMatcher {
         // additionally requires `pos >= window_low` and `pos < dict_end` so
         // emitted offsets (`ip0 - pos`) stay within the advertised window,
         // including the pre-drain 1x..2x-window band where `window_low > 0`.
-        let use_dict = self.dict_table.is_some();
+        let use_dict = self.dict.is_attached();
         let history: &[u8] = &self.history;
         let rep_out = if use_dict {
             use super::fast_kernel::kernel::PrefixBounds;
-            let dict_end = self.dict_region_len as u32;
+            let dict_end = self.dict.region_len() as u32;
             let bounds = PrefixBounds {
                 prefix_start_index,
                 window_low,
             };
             let main_table = &mut self.hash_table;
             let dict_table = self
-                .dict_table
-                .as_ref()
+                .dict
+                .table()
                 .expect("use_dict implies dict_table is Some");
             run_fast_kernel_block_dict(
                 history,
@@ -1177,18 +1159,14 @@ impl FastKernelMatcher {
     /// table actually exists — a sub-8-byte dict builds no table and must
     /// re-run the (cheap, no-op) prime path each frame.
     pub(crate) fn mark_dict_primed(&mut self) {
-        if self.dict_table.is_some() {
-            self.dict_primed = true;
-        }
+        self.dict.mark_primed();
     }
 
     /// Drop the cached dict table and its primed flag. Called by the driver
     /// when the next frame carries no dictionary, so the kernel never probes
     /// a stale dict region whose bytes are no longer re-committed.
     pub(crate) fn invalidate_dict_cache(&mut self) {
-        self.dict_table = None;
-        self.dict_region_len = 0;
-        self.dict_primed = false;
+        self.dict.invalidate();
     }
 
     /// Build (or extend) [`Self::dict_table`] over `history[range_start..]`,
@@ -1199,8 +1177,8 @@ impl FastKernelMatcher {
         let history_len = self.history.len();
         // Record the dict/input boundary regardless of whether any position
         // is hashable (a sub-8-byte dict still bounds the input floor).
-        self.dict_region_len = history_len;
-        if self.dict_primed {
+        self.dict.set_region_len(history_len);
+        if self.dict.is_primed() {
             // CDict-equivalent fast path: `dict_table` was built over the
             // identical dictionary bytes on a prior frame, and those bytes
             // sit at the same absolute history positions now (the dict is
@@ -1219,11 +1197,10 @@ impl FastKernelMatcher {
         if backfill_start > last_hashable {
             return;
         }
-        if self.dict_table.is_none() {
-            let hash_log = self.hash_table.hash_log();
-            let mls = self.hash_table.mls();
-            self.dict_table = Some(FastHashTable::new(hash_log, mls));
-        }
+        let hash_log = self.hash_table.hash_log();
+        let mls = self.hash_table.mls();
+        self.dict
+            .table_mut_or_init(|| FastHashTable::new(hash_log, mls));
         let base = self.history.as_ptr();
         match self.hash_table.mls() {
             4 => self.prime_dict_table_impl::<4>(base, backfill_start, last_hashable),
@@ -1245,8 +1222,8 @@ impl FastKernelMatcher {
         last_hashable: usize,
     ) {
         let dict_table = self
-            .dict_table
-            .as_mut()
+            .dict
+            .table_mut()
             .expect("prime_dict_table_for_range creates the table before this call");
         for pos in range_start..=last_hashable {
             // SAFETY: pos <= last_hashable = history_len - 8, so `base.add(pos)`
@@ -2066,7 +2043,7 @@ mod tests {
         // A position in the (HASH_READ_SIZE - 1)-byte gap just below the
         // seam: its 8-byte hash read straddles the chunk boundary.
         let p = seam - 4;
-        let dt = m.dict_table.as_ref().expect("dict table primed");
+        let dt = m.dict.table().expect("dict table primed");
         let h = unsafe { dt.hash_ptr::<4>(m.history.as_ptr().add(p)) };
         assert_eq!(
             unsafe { dt.get(h) },

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -387,9 +387,10 @@ impl StrategyTag {
     /// * 1-2 → `Fast`
     /// * 3-4 → `Dfast`
     /// * 5 → `Greedy`
-    /// * 6-15 → `Lazy` (donor splits 6/7=lazy, 8-12=lazy2,
-    ///   13-15=btlazy2; we collapse all three onto our `Lazy` tag and
-    ///   carry the lazy_depth variance via `LevelParams.lazy_depth`)
+    /// * 6-12 → `Lazy` (donor 6/7=lazy, 8-12=lazy2; we collapse lazy and
+    ///   lazy2 onto our `Lazy` tag and carry the lazy/lazy2 split via
+    ///   `LevelParams.lazy_depth` — 1 for lazy, 2 for lazy2)
+    /// * 13-15 → `Btlazy2` (donor btlazy2: BinaryTree finder + lazy parse)
     /// * 16-17 → `BtOpt`
     /// * 18 → `BtUltra`
     /// * 19-22 → `BtUltra2`

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -570,6 +570,7 @@ mod tests {
         assert!(!Dfast::USE_BT);
         assert!(!Greedy::USE_BT);
         assert!(!Lazy::USE_BT);
+        assert!(Btlazy2::USE_BT);
         assert!(BtOpt::USE_BT);
         assert!(BtUltra::USE_BT);
         assert!(BtUltra2::USE_BT);
@@ -583,6 +584,8 @@ mod tests {
         assert!(!Dfast::USE_HASH3);
         assert!(!Greedy::USE_HASH3);
         assert!(!Lazy::USE_HASH3);
+        assert!(!Btlazy2::USE_HASH3);
+        assert!(!Btlazy2::TWO_PASS_SEED);
         assert!(!BtOpt::USE_HASH3);
         assert!(BtUltra::USE_HASH3);
         assert!(BtUltra2::USE_HASH3);
@@ -597,9 +600,14 @@ mod tests {
     // silently.
     const _COST_MODEL_LAYOUT: () = {
         assert!(!Lazy::ACCURATE_PRICE && Lazy::FAVOR_SMALL_OFFSETS);
+        assert!(!Btlazy2::ACCURATE_PRICE && Btlazy2::FAVOR_SMALL_OFFSETS);
         assert!(!BtOpt::ACCURATE_PRICE && BtOpt::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra::ACCURATE_PRICE && !BtUltra::FAVOR_SMALL_OFFSETS);
         assert!(BtUltra2::ACCURATE_PRICE && !BtUltra2::FAVOR_SMALL_OFFSETS);
+        // btlazy2 runs the full BT find (no early bail) and a search depth
+        // that lets L15's configured search_depth=64 govern; see `Btlazy2`.
+        assert!(Btlazy2::MAX_CHAIN_DEPTH == 64);
+        assert!(Btlazy2::SUFFICIENT_MATCH_LEN == usize::MAX);
         assert!(BtOpt::MAX_CHAIN_DEPTH == 32);
         // 1 << searchLog for clevels.h level 18 (searchLog = 6).
         assert!(BtUltra::MAX_CHAIN_DEPTH == 64);

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -340,6 +340,10 @@ pub(crate) enum StrategyTag {
     Dfast,
     Greedy,
     Lazy,
+    /// Donor `ZSTD_btlazy2` (levels 13-15): binary-tree match finder with a
+    /// lazy parse (not the optimal DP). Shares the BT table layout / finder
+    /// with the opt strategies (`uses_bt`) but selects greedily/lazily.
+    Btlazy2,
     BtOpt,
     BtUltra,
     BtUltra2,
@@ -409,7 +413,9 @@ impl StrategyTag {
             Self::Fast => BackendTag::Simple,
             Self::Dfast => BackendTag::Dfast,
             Self::Greedy => BackendTag::Row,
-            Self::Lazy | Self::BtOpt | Self::BtUltra | Self::BtUltra2 => BackendTag::HashChain,
+            Self::Lazy | Self::Btlazy2 | Self::BtOpt | Self::BtUltra | Self::BtUltra2 => {
+                BackendTag::HashChain
+            }
         }
     }
 
@@ -423,7 +429,9 @@ impl StrategyTag {
             Self::Dfast => SearchMethod::DoubleFast,
             Self::Greedy => SearchMethod::RowHash,
             Self::Lazy => SearchMethod::HashChain,
-            Self::BtOpt | Self::BtUltra | Self::BtUltra2 => SearchMethod::BinaryTree,
+            Self::Btlazy2 | Self::BtOpt | Self::BtUltra | Self::BtUltra2 => {
+                SearchMethod::BinaryTree
+            }
         }
     }
 
@@ -433,7 +441,7 @@ impl StrategyTag {
     pub(crate) const fn parse_mode(self) -> ParseMode {
         match self {
             Self::Fast | Self::Dfast | Self::Greedy => ParseMode::Greedy,
-            Self::Lazy => ParseMode::Lazy,
+            Self::Lazy | Self::Btlazy2 => ParseMode::Lazy,
             Self::BtOpt | Self::BtUltra | Self::BtUltra2 => ParseMode::Optimal,
         }
     }

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -270,6 +270,33 @@ impl Strategy for Lazy {
     const SUFFICIENT_MATCH_LEN: usize = 32;
 }
 
+/// Levels 13-15 — donor `ZSTD_btlazy2`. Binary-tree match finder driving
+/// a greedy/lazy parse (NOT the optimal DP). Reuses the BT candidate
+/// collector to surface the longest match per position, then commits it
+/// greedily. minMatch = 5 (`search_mls`); the BT find runs to full depth
+/// (no `sufficient_match_len` early bail — donor `ZSTD_BtFindBestMatch`
+/// does not cap by `targetLength`), so `MAX_CHAIN_DEPTH` must be large
+/// enough that the runtime `HcConfig::search_depth` (16/32/64 for
+/// L13/14/15) governs the BT walk, not this const.
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) struct Btlazy2;
+
+impl Strategy for Btlazy2 {
+    const BACKEND: BackendTag = BackendTag::HashChain;
+    const MIN_MATCH: usize = 5;
+    const ACCURATE_PRICE: bool = false;
+    const FAVOR_SMALL_OFFSETS: bool = true;
+    const USE_HASH3: bool = false;
+    const USE_BT: bool = true;
+    const OPT_LEVEL: u8 = 0;
+    // L15 configures search_depth = 64; keep the cap at 64 so
+    // `max_chain_depth.min(search_depth)` lets the level's search_depth
+    // govern (BtOpt's 32 would silently halve L15's BT walk).
+    const MAX_CHAIN_DEPTH: usize = 64;
+    // Full BT find, no early bail (donor `ZSTD_BtFindBestMatch`).
+    const SUFFICIENT_MATCH_LEN: usize = usize::MAX;
+}
+
 /// Levels 16-17 — donor `ZSTD_btopt`. BT + opt without the ultra
 /// price-table refinements.
 #[derive(Copy, Clone, Debug, Default)]
@@ -461,9 +488,23 @@ mod tests {
         assert_strategy_matches_tag::<Dfast>(StrategyTag::Dfast);
         assert_strategy_matches_tag::<Greedy>(StrategyTag::Greedy);
         assert_strategy_matches_tag::<Lazy>(StrategyTag::Lazy);
+        assert_strategy_matches_tag::<Btlazy2>(StrategyTag::Btlazy2);
         assert_strategy_matches_tag::<BtOpt>(StrategyTag::BtOpt);
         assert_strategy_matches_tag::<BtUltra>(StrategyTag::BtUltra);
         assert_strategy_matches_tag::<BtUltra2>(StrategyTag::BtUltra2);
+    }
+
+    /// Pin the `Btlazy2` tag's full bridge: it runs the BinaryTree finder on
+    /// the HashChain backend with a Lazy parse (donor `ZSTD_btlazy2`).
+    #[test]
+    fn btlazy2_tag_bridge_contract() {
+        assert_eq!(StrategyTag::Btlazy2.backend(), BackendTag::HashChain);
+        assert_eq!(StrategyTag::Btlazy2.search(), SearchMethod::BinaryTree);
+        assert_eq!(StrategyTag::Btlazy2.parse_mode(), ParseMode::Lazy);
+        // The BT walk cap must let L15's search_depth = 64 govern (BtOpt's
+        // 32 would silently halve it); full find, no early bail.
+        assert_eq!(Btlazy2::MAX_CHAIN_DEPTH, 64);
+        assert_eq!(Btlazy2::SUFFICIENT_MATCH_LEN, usize::MAX);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two related donor-parity tracks on the encode and decode hot paths.

### Encode — dictionary attach + per-kernel row probe
- Extract a shared `DictAttach<T>` lifecycle and migrate the Fast finder onto it.
- Attach the dictionary by reference (bounded dual-probe, no per-frame dense re-prime) for the dfast (long+short) and Row finders, instead of re-priming dense tables every compress.
- Donor-sparse dfast match-interior insertion; cap HashChain lazy match-span insertion to the reference 96/32/384 bounds.
- Route L8 lazy2 to the Row finder (matches the reference `useRowMatchFinder` resolution) and persist the Row dict-attach cache across frames.
- Make the row tag-match SIMD per-kernel: a level-1 macro picks the table-type, level-2 macros inline the mask + common-prefix-len per ISA tier (Scalar / SSE4.2 / AVX2+BMI2 / NEON), selected once at invoke (no dispatcher in the hot loop). This makes the no-std (musl) baselines use their narrowest correct kernel instead of a single AVX2-global path.
- Cap HashChain table logs by the source-size hint (reference `ZSTD_adjustCParams` clamp): fixes an L10-lazy peak-alloc regression (2.15x -> 1.14x of the C donor), ratio-neutral.

### Decode — direct-path peak allocation
The direct-decode path (writing into the caller's slice) required `output.len() >= frame_content_size + WILDCOPY_OVERLENGTH` and eagerly allocated an unused `FlatBuf` sized to the full content. A caller sizing the output to exactly the content size (the universal "decode into an FCS-sized buffer" case) therefore paid for ~3x the content size at peak.

- Add `UserSliceBackend::exec_sequence_bounded`: an exact, non-overshooting literal+match copy (overlap handled by a forward byte loop) taken only by the trailing sequence(s) whose data fits but whose SIMD wildcopy overshoot would run past the slice end. All three inline arms (SSE2 / portable / AVX2) route the tight tail through it. The bulk of the frame still takes the SIMD fast path.
- Relax the direct-decode gate to `output.len() >= frame_content_size` on both dispatch sites.
- Make `new_flat` lazy (mirroring `new_ring`): direct-eligible single-segment frames now allocate no backing buffer; the non-direct fallback reserves once via `reserve_buffer`.

## Impact (i9-9900K, deterministic TrackingAllocator)

Decode peak alloc, `low-entropy-1m` level 10 lazy, decode into an exactly-sized buffer:
`3.15 MB -> 1.05 MB` rust vs `1.14 MB` C (now below the donor). Worst decode-peak ratio across all scenarios/levels is 1.05x, most are 1.00x.

## Testing
- 717 unit tests + 1000x roundtrip + cross-validation green.
- Same suites pass under AddressSanitizer (the bounded tail helper and the relaxed gate are arch-independent; the x86 SIMD arms share the portable `exec_sequence_bounded`).
- New regression test decoding into an exactly-sized buffer with an overlapping (offset < match_length) trailing match.
- clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Btlazy2 encoder strategy (higher-level option) and attachable immutable dictionary caches across matchers.

* **Improvements**
  * Direct/decode and in-place decode now accept exact-fit outputs without extra slack.
  * Safer tight-tail SIMD handling with a bounded fallback to avoid overshoot.
  * Finer per-level match-search tuning, improved dict priming/reuse, and richer matcher fallbacks.

* **Tests & Tooling**
  * Expanded dictionary-focused tests/benches, optional dict dumping in benchmarks, CI/manual dispatch refinement, and coverage reporting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->