### PR TITLE
feat(encode): configurable compression parameters API

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ All standard compression levels are wired and produce valid Zstandard frames dec
 
 - **Named presets:** `Fastest` (≈1), `Default` (≈3), `Better` (≈7), `Best` (≈11)
 - **Numeric levels:** `0..=22` and negative ultra-fast levels via `CompressionLevel::from_level(n)` — C zstd-compatible numbering
+- **Fine-grained parameters:** override individual knobs (`windowLog`, `hashLog`, `chainLog`, `searchLog`, `minMatch`, `targetLength`, `strategy`) and activate **long-distance matching** via `CompressionParameters::builder(...)`, the drop-in equivalent of C zstd's `ZSTD_CCtx_setParameter` surface
 - **Streaming encoder** via `std::io::Write`
 - **Dictionary compression** with the same dictionary format C zstd consumes
 - **Frame Content Size** — `FrameCompressor` writes FCS automatically; `StreamingEncoder` requires `set_pledged_content_size()` before the first write
@@ -123,6 +124,33 @@ encoder.write_all(b"world")?;
 encoder.finish()?;
 # Ok::<(), std::io::Error>(())
 ```
+
+#### Fine-grained parameters
+
+Override individual compression knobs (the drop-in equivalent of C zstd's
+`ZSTD_CCtx_setParameter`). Every knob left unset inherits the base level's
+default, so a parameter set that overrides nothing reproduces plain
+level-based compression. Long-distance matching is off at every level preset
+and is activated only here:
+
+```rust
+use structured_zstd::encoding::{
+    compress_with_parameters, CompressionLevel, CompressionParameters, Strategy,
+};
+
+let data: &[u8] = b"hello world";
+let params = CompressionParameters::builder(CompressionLevel::Level(19))
+    .window_log(22)
+    .strategy(Strategy::Btultra2)
+    .enable_long_distance_matching(true)
+    .build()
+    .expect("parameters within bounds");
+
+let compressed = compress_with_parameters(data, &params);
+```
+
+Each parameter's valid range is queryable via `CParameter::bounds()` (the
+analogue of `ZSTD_cParam_getBounds`); the builder validates every set knob.
 
 ### Decompression
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1654,13 +1654,22 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         match_generator
     }
 
-    /// Before calling [FrameCompressor::compress] you can replace the compression level
+    /// Before calling [FrameCompressor::compress] you can replace the compression level.
+    ///
+    /// This also clears any fine-grained parameter overrides installed via
+    /// [`set_parameters`](Self::set_parameters): reverting to a bare level
+    /// means plain level-based tuning, not the previous frame's customized
+    /// strategy / LDM / log overrides. To keep overriding, call
+    /// [`set_parameters`](Self::set_parameters) again with the new base level.
     pub fn set_compression_level(
         &mut self,
         compression_level: CompressionLevel,
     ) -> CompressionLevel {
         let old = self.compression_level;
         self.compression_level = compression_level;
+        // Drop sticky overrides so the level switch yields plain geometry.
+        self.strategy_override = None;
+        self.state.matcher.clear_param_overrides();
         old
     }
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -130,6 +130,13 @@ pub struct FrameCompressor<
     /// the per-block sizes. Cleared and refilled per frame.
     #[cfg(feature = "lsm")]
     block_decompressed_sizes: alloc::vec::Vec<u32>,
+    /// Effective strategy tag when a public-parameter
+    /// [`Strategy`](crate::encoding::Strategy) override (#27) is active.
+    /// `Some` overrides the level-derived `state.strategy_tag` so the
+    /// literal-compression gates and dict-attach cutoff see the strategy
+    /// the matcher actually runs, not the base level's. `None` keeps the
+    /// level-derived tag.
+    strategy_override: Option<crate::encoding::strategy::StrategyTag>,
 }
 
 #[derive(Clone, Default)]
@@ -602,7 +609,43 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             block_checksums: None,
             #[cfg(feature = "lsm")]
             block_decompressed_sizes: alloc::vec::Vec::new(),
+            strategy_override: None,
         }
+    }
+
+    /// Configure fine-grained compression parameters (#27).
+    ///
+    /// Resets the base [`CompressionLevel`](crate::encoding::CompressionLevel)
+    /// to the parameters' level and installs the per-knob overrides
+    /// (window/hash/chain/search logs, strategy, LDM) applied at the next
+    /// frame. Pass `None`-equivalent (a builder that overrides nothing)
+    /// to fall back to plain level-based compression.
+    ///
+    /// ```rust
+    /// use structured_zstd::encoding::{
+    ///     CompressionLevel, CompressionParameters, FrameCompressor, Strategy,
+    /// };
+    /// let params = CompressionParameters::builder(CompressionLevel::Level(19))
+    ///     .strategy(Strategy::Btultra2)
+    ///     .enable_long_distance_matching(true)
+    ///     .build()
+    ///     .unwrap();
+    /// let mut compressor: FrameCompressor = FrameCompressor::new(CompressionLevel::Default);
+    /// compressor.set_parameters(&params);
+    /// let compressed = compressor.compress_independent_frame(b"some data to compress");
+    /// assert!(!compressed.is_empty());
+    /// ```
+    pub fn set_parameters(&mut self, params: &crate::encoding::CompressionParameters) {
+        self.compression_level = params.level();
+        let overrides = params.overrides();
+        self.strategy_override = overrides.strategy.map(|s| s.tag());
+        // Keep `state.strategy_tag` consistent immediately so the borrowed
+        // one-shot eligibility gate (`borrowed_eligible`) and literal gates
+        // are correct even before the next `compress()` re-sync.
+        self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
+            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
+        });
+        self.state.matcher.set_param_overrides(Some(overrides));
     }
 
     /// Whether the borrowed (no per-block history copy) one-shot loop is
@@ -855,6 +898,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             block_checksums: None,
             #[cfg(feature = "lsm")]
             block_decompressed_sizes: alloc::vec::Vec::new(),
+            strategy_override: None,
         }
     }
 
@@ -963,8 +1007,12 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // strategy for the next frame. Frame-by-frame level changes go
         // through this same `compress()` entry point, so re-syncing here
         // covers level switches without touching the matcher dispatch.
-        self.state.strategy_tag =
-            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level);
+        // A public-parameter strategy override (#27) wins over the level's
+        // derived tag so the literal-compression gates and dict-attach
+        // cutoff below see the strategy the matcher actually runs.
+        self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
+            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
+        });
         let cached_entropy = if use_dictionary_state {
             self.dictionary_entropy_cache.as_ref()
         } else {

--- a/zstd/src/encoding/ldm/params.rs
+++ b/zstd/src/encoding/ldm/params.rs
@@ -66,6 +66,24 @@ impl LdmParams {
     ///
     /// Returns a fully-initialised `LdmParams` with no zero fields.
     pub(crate) fn adjust_for(window_log: u32, strategy: u32) -> Self {
+        Self {
+            window_log,
+            ..Self::default()
+        }
+        .derive(strategy)
+    }
+
+    /// Donor `ZSTD_ldm_adjustParameters` derivation over a (possibly
+    /// caller-seeded) parameter set: fill every zero-valued knob from
+    /// `window_log` / `strategy`, leaving non-zero fields untouched.
+    ///
+    /// This is the path the public-parameter LDM overrides (#27) use:
+    /// the caller seeds the knobs it wants to pin (the rest stay zero),
+    /// and `derive` completes the set with donor cross-field
+    /// consistency (e.g. `hash_rate_log = window_log - hash_log` when a
+    /// caller pins `hash_log`). Calling `adjust_for` and then clobbering
+    /// fields afterwards would break that consistency.
+    pub(crate) fn derive(self, strategy: u32) -> Self {
         // Runtime `assert!` (not `debug_assert!`) — the body uses
         // raw `LDM_HASH_RLOG - (strategy / 3)`, which underflows
         // `u32` for `strategy >= 24` (`7 - 8 = u32::MAX`) and
@@ -81,10 +99,7 @@ impl LdmParams {
              zstd_ldm.c:149 + zstd_ldm.c:167)"
         );
 
-        let mut params = Self {
-            window_log,
-            ..Self::default()
-        };
+        let mut params = self;
 
         // hash_rate_log: donor `zstd_ldm.c:141-153`. With `hash_log`
         // still zero (the only path we expose), donor falls into the

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1749,9 +1749,19 @@ impl Matcher for MatchGeneratorDriver {
             && self
                 .reset_size_log
                 .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
-        // The LDM override (if any) is part of the snapshot identity: the
-        // restored `storage` carries the producer this override configured.
-        let active_ldm = self.param_overrides.and_then(|ov| ov.ldm);
+        // The LDM override is part of the snapshot identity ONLY on the
+        // optimal (BinaryTree) path: that is the only backend whose cloned
+        // `storage` carries a `BtMatcher::ldm_producer`. On Fast / Dfast /
+        // Row and lazy-HashChain resets the producer slot does not exist,
+        // so folding the override there would over-key the snapshot and
+        // force needless re-primes when LDM is toggled. Gated like
+        // `fast_attach` (a key bit only participates where it changes the
+        // cloned matcher shape).
+        let active_ldm = if matches!(params.search, super::strategy::SearchMethod::BinaryTree) {
+            self.param_overrides.and_then(|ov| ov.ldm)
+        } else {
+            None
+        };
         self.reset_shape = Some((params, resolved_table_bits, fast_attach, active_ldm));
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1427,6 +1427,10 @@ impl Matcher for MatchGeneratorDriver {
         self.source_size_hint = Some(size);
     }
 
+    fn clear_param_overrides(&mut self) {
+        self.param_overrides = None;
+    }
+
     fn reset(&mut self, level: CompressionLevel) {
         let hint = self.source_size_hint.take();
         // Snapshot the hint's normalized ceil-log bucket for the primed-snapshot

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -186,6 +186,18 @@ const HC_CONFIG: HcConfig = HcConfig {
     target_len: HC_TARGET_LEN,
 };
 
+/// Base HashChain config synthesized when a public-parameter strategy
+/// override ([`super::parameters`]) routes a level to the HC / BT
+/// backend whose native level row didn't populate `hc` (e.g. forcing
+/// `Strategy::Lazy2` onto a level the table resolves to Fast). Mirrors
+/// the mid-band lazy defaults; the per-knob overrides then refine it.
+const HC_OVERRIDE_DEFAULT: HcConfig = HcConfig {
+    hash_log: super::match_table::storage::HC_HASH_LOG,
+    chain_log: super::match_table::storage::HC_CHAIN_LOG,
+    search_depth: HC_SEARCH_DEPTH,
+    target_len: HC_TARGET_LEN,
+};
+
 const BTULTRA2_HC_CONFIG: HcConfig = HcConfig {
     hash_log: 24,
     chain_log: 24,
@@ -378,6 +390,132 @@ impl LevelParams {
             | super::strategy::StrategyTag::BtUltra
             | super::strategy::StrategyTag::BtUltra2 => Some(4),
         }
+    }
+}
+
+/// Apply the public-parameter per-knob overrides (#27) onto the
+/// level-resolved [`LevelParams`], in place. Runs in [`Matcher::reset`]
+/// after the level params are computed and before backend selection, so
+/// a strategy override re-routes the backend uniformly. An all-`None`
+/// override is a no-op the caller skips via
+/// [`super::parameters::ParamOverrides::is_empty`], keeping the default
+/// level geometry byte-identical.
+fn apply_param_overrides(params: &mut LevelParams, ov: &super::parameters::ParamOverrides) {
+    use super::strategy::SearchMethod;
+
+    // 1. Strategy override re-derives tag / search / lazy depth.
+    if let Some(strategy) = ov.strategy {
+        let tag = strategy.tag();
+        params.strategy_tag = tag;
+        params.search = tag.search();
+        params.lazy_depth = strategy.lazy_depth();
+    }
+
+    // 2. Ensure the active backend's config row exists (synthesize a
+    //    default when a strategy override moved off the native row).
+    match params.search {
+        SearchMethod::Fast => {
+            params.fast.get_or_insert(FAST_L1);
+        }
+        SearchMethod::DoubleFast => {
+            params.dfast.get_or_insert(DFAST_L3);
+        }
+        SearchMethod::RowHash => {
+            params.row.get_or_insert(ROW_L5);
+        }
+        SearchMethod::HashChain | SearchMethod::BinaryTree => {
+            params.hc.get_or_insert(HC_OVERRIDE_DEFAULT);
+        }
+    }
+
+    // 3. window_log (bounds-checked at <= 30 by the builder).
+    if let Some(window_log) = ov.window_log {
+        params.window_log = window_log;
+    }
+
+    // 4. Per-backend numeric knobs map into the active config, mirroring
+    //    the donor `cParams` -> matcher translation documented on each
+    //    config struct.
+    match params.search {
+        SearchMethod::Fast => {
+            if let Some(fast) = params.fast.as_mut() {
+                if let Some(hash_log) = ov.hash_log {
+                    fast.hash_log = hash_log;
+                }
+                if let Some(min_match) = ov.min_match {
+                    fast.mls = min_match;
+                }
+            }
+        }
+        SearchMethod::DoubleFast => {
+            if let Some(dfast) = params.dfast.as_mut() {
+                // hashLog -> long table, chainLog -> short table (the
+                // dfast secondary index). Both bounds-checked <= 30, so
+                // the `u8` casts are lossless.
+                if let Some(hash_log) = ov.hash_log {
+                    dfast.long_hash_log = hash_log as u8;
+                }
+                if let Some(chain_log) = ov.chain_log {
+                    dfast.short_hash_log = chain_log as u8;
+                }
+            }
+        }
+        SearchMethod::RowHash => {
+            if let Some(row) = params.row.as_mut() {
+                if let Some(search_log) = ov.search_log {
+                    // Donor: rowLog = clamp(searchLog, 4, 6);
+                    //        nbAttempts = 1 << min(searchLog, rowLog).
+                    let row_log = (search_log as usize).clamp(4, 6);
+                    row.row_log = row_log;
+                    row.search_depth = 1usize << (search_log as usize).min(row_log);
+                }
+                if let Some(target_length) = ov.target_length {
+                    row.target_len = target_length as usize;
+                }
+                if let Some(min_match) = ov.min_match {
+                    row.mls = min_match as usize;
+                }
+            }
+        }
+        SearchMethod::HashChain | SearchMethod::BinaryTree => {
+            if let Some(hc) = params.hc.as_mut() {
+                if let Some(hash_log) = ov.hash_log {
+                    hc.hash_log = hash_log as usize;
+                }
+                if let Some(chain_log) = ov.chain_log {
+                    hc.chain_log = chain_log as usize;
+                }
+                if let Some(search_log) = ov.search_log {
+                    hc.search_depth = 1usize << search_log;
+                }
+                if let Some(target_length) = ov.target_length {
+                    hc.target_len = target_length as usize;
+                }
+            }
+        }
+    }
+}
+
+/// Map the resolved runtime strategy to the donor LDM strategy ordinal
+/// (1..=9) that [`super::ldm::params::LdmParams::adjust_for`] expects.
+/// The collapsed `Lazy` tag splits on `lazy_depth` (lazy = 4, lazy2 = 5).
+#[cfg(feature = "hash")]
+fn ldm_strategy_ordinal(tag: super::strategy::StrategyTag, lazy_depth: u8) -> u32 {
+    use super::strategy::StrategyTag;
+    match tag {
+        StrategyTag::Fast => 1,
+        StrategyTag::Dfast => 2,
+        StrategyTag::Greedy => 3,
+        StrategyTag::Lazy => {
+            if lazy_depth >= 2 {
+                5
+            } else {
+                4
+            }
+        }
+        StrategyTag::BtOpt => 7,
+        StrategyTag::BtUltra => 8,
+        StrategyTag::BtUltra2 => 9,
     }
 }
 
@@ -782,6 +920,15 @@ pub struct MatchGeneratorDriver {
     /// without editing `LEVEL_TABLE`; never compiled into production.
     #[cfg(test)]
     config_override: Option<(super::strategy::SearchMethod, super::strategy::ParseMode)>,
+    /// Fine-grained per-knob overrides from the public
+    /// [`super::parameters::CompressionParameters`] surface (#27).
+    /// `None` (or an all-`None` [`super::parameters::ParamOverrides`])
+    /// keeps the resolved level geometry byte-identical to plain
+    /// level-based compression. Applied in [`Matcher::reset`] after the
+    /// level params are resolved, before backend selection. Persists
+    /// across resets (it is frame configuration, not a one-shot) until
+    /// the caller changes it.
+    param_overrides: Option<super::parameters::ParamOverrides>,
     slice_size: usize,
     base_slice_size: usize,
     // Frame header window size must stay at the configured live-window budget.
@@ -941,6 +1088,7 @@ impl MatchGeneratorDriver {
             parse: super::strategy::ParseMode::Greedy,
             #[cfg(test)]
             config_override: None,
+            param_overrides: None,
             slice_size,
             base_slice_size: slice_size,
             // Report the ROUNDED-UP window size that the matcher
@@ -963,6 +1111,16 @@ impl MatchGeneratorDriver {
 
     fn level_params(level: CompressionLevel, source_size: Option<u64>) -> LevelParams {
         resolve_level_params(level, source_size)
+    }
+
+    /// Install the public-parameter per-knob overrides (#27) applied at
+    /// the next [`Matcher::reset`]. `None` (or an all-`None` set) restores
+    /// plain level-based geometry. Persists across resets until changed.
+    pub(crate) fn set_param_overrides(
+        &mut self,
+        overrides: Option<super::parameters::ParamOverrides>,
+    ) {
+        self.param_overrides = overrides;
     }
 
     /// Active backend family derived from the storage variant. Single
@@ -1311,6 +1469,16 @@ impl Matcher for MatchGeneratorDriver {
                 }
             }
         }
+        // Public-parameter overrides (#27): apply the per-knob set on top
+        // of the level-resolved params. A strategy override re-routes the
+        // backend, so this must precede `next_backend` selection. The
+        // all-`None` case is skipped so default level geometry stays
+        // byte-identical to plain level-based compression.
+        if let Some(ov) = self.param_overrides
+            && !ov.is_empty()
+        {
+            apply_param_overrides(&mut params, &ov);
+        }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
         self.dictionary_retained_budget = 0;
@@ -1501,6 +1669,38 @@ impl Matcher for MatchGeneratorDriver {
                     vec_pool.push(data);
                 });
             }
+        }
+        // LDM wiring (#27): attach (or clear) the long-distance-match
+        // producer on the optimal (BT) backend. LDM is the only
+        // back-reference path that crosses the regular window, so it
+        // only has a home on the `BtMatcher`; non-BT strategies drop the
+        // producer. Built AFTER `hc.reset()` because `BtMatcher::reset`
+        // clears an existing producer's table but does not null the
+        // slot — installing here gives the new frame a fresh producer.
+        #[cfg(feature = "hash")]
+        if let MatcherStorage::HashChain(hc) = &mut self.storage {
+            let producer = self
+                .param_overrides
+                .as_ref()
+                .and_then(|ov| ov.ldm)
+                .map(|ldm_ov| {
+                    let strategy_ord = ldm_strategy_ordinal(params.strategy_tag, params.lazy_depth);
+                    // Seed the caller-pinned knobs, then run the donor
+                    // derivation over the seed so the remaining (zero)
+                    // fields are filled with cross-field consistency
+                    // (e.g. `hash_rate_log = window_log - hash_log`).
+                    // Clobbering after `adjust_for` would break that and
+                    // hand the producer an inconsistent set.
+                    let seed = super::ldm::params::LdmParams {
+                        window_log: params.window_log as u32,
+                        hash_log: ldm_ov.hash_log.unwrap_or(0),
+                        hash_rate_log: ldm_ov.hash_rate_log.unwrap_or(0),
+                        min_match_length: ldm_ov.min_match.unwrap_or(0),
+                        bucket_size_log: ldm_ov.bucket_size_log.unwrap_or(0),
+                    };
+                    super::ldm::LdmProducer::new(seed.derive(strategy_ord))
+                });
+            hc.set_ldm_producer(producer);
         }
         // Record the resolved matcher shape for the primed-snapshot key. Captured
         // here (post-resolution, after the test-only param override) so the key
@@ -2289,6 +2489,7 @@ macro_rules! build_optimal_plan_impl_body {
         let frontier_limit = $current_len.min(HC_OPT_NUM - 1);
         let initial_reps = $initial_state.reps;
         let initial_litlen = $initial_state.litlen;
+        let ldm_block_offset = $initial_state.block_offset;
         let mut profile = $initial_state.profile;
         profile.sufficient_match_len = $self.hc.sufficient_match_len_for_pass(profile);
         // Const-fold from the strategy's associated `OPT_LEVEL`
@@ -2402,6 +2603,23 @@ macro_rules! build_optimal_plan_impl_body {
         };
         let has_ldm = !$self.backend.bt_mut().ldm_sequences.is_empty();
         if has_ldm {
+            // `ldm_sequences` are emitted in BLOCK-relative coordinates,
+            // but this optimal-parser pass runs over a SEGMENT of the
+            // block starting at block-offset `$block_offset` and uses
+            // segment-relative positions throughout. Fast-forward the raw
+            // seq-store cursor past the bytes covered by earlier segments
+            // so the (segment-relative) LDM windows below land at the
+            // correct positions. Idempotent: `ldm_skip_raw_seq_store_bytes`
+            // recomputes from `pos = 0`, so re-running it per segment is
+            // safe. Without this, every segment after the first re-applied
+            // the block's leading LDM windows at the wrong offset, emitting
+            // matches that copy the wrong bytes (undecodable frame).
+            if ldm_block_offset > 0 {
+                $self
+                    .backend
+                    .bt_mut()
+                    .ldm_skip_raw_seq_store_bytes(&mut opt_ldm.seq_store, ldm_block_offset);
+            }
             $self
                 .backend
                 .bt_mut()
@@ -3689,6 +3907,17 @@ impl HcMatchGenerator {
         }
     }
 
+    /// Install (or clear) the long-distance-match producer (#27). Only
+    /// the BT backend owns an `ldm_producer` slot; on the HC (lazy)
+    /// backend the producer is dropped because there is no optimal-parser
+    /// candidate buffer to seed. Call after [`Self::reset`].
+    #[cfg(feature = "hash")]
+    fn set_ldm_producer(&mut self, producer: Option<super::ldm::LdmProducer>) {
+        if let HcBackend::Bt(bt) = &mut self.backend {
+            bt.ldm_producer = producer;
+        }
+    }
+
     fn reset(&mut self, reuse_space: impl FnMut(Vec<u8>)) {
         self.table.reset(reuse_space);
         if let HcBackend::Bt(bt) = &mut self.backend {
@@ -3903,6 +4132,7 @@ impl HcMatchGenerator {
                 segment_abs_start,
                 remaining_len,
                 HcOptimalPlanState {
+                    block_offset: cursor,
                     reps: plan_reps,
                     litlen: plan_litlen,
                     profile,
@@ -3963,6 +4193,7 @@ impl HcMatchGenerator {
                 segment_abs_start,
                 remaining_len,
                 HcOptimalPlanState {
+                    block_offset: cursor,
                     reps: seed_reps,
                     litlen: seed_litlen,
                     profile: seed_profile,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -7186,6 +7186,55 @@ fn hc_prime_with_empty_dictionary_disables_btultra2_seed_pass() {
 }
 
 #[test]
+fn primed_snapshot_not_restored_across_ldm_config_change() {
+    // The CDict-equivalent primed snapshot clones `storage`, which on the
+    // BT backend carries `BtMatcher::ldm_producer`. A snapshot captured
+    // under one LDM configuration must NOT be restored into a reset that
+    // resolved a different LDM configuration (else the restored producer
+    // is stale). `PrimedKey` must fold the LDM override into the key so
+    // such a restore is refused and the caller re-primes.
+    use super::parameters::CompressionParameters;
+
+    let dict = b"abcdefghabcdefghabcdefgh";
+    let ldm_on = CompressionParameters::builder(CompressionLevel::Level(19))
+        .enable_long_distance_matching(true)
+        .build()
+        .unwrap()
+        .overrides();
+    let ldm_off = CompressionParameters::builder(CompressionLevel::Level(19))
+        .build()
+        .unwrap()
+        .overrides();
+
+    let mut driver = MatchGeneratorDriver::new(1024, 1);
+
+    // Capture a snapshot primed under LDM-on at level 19.
+    driver.set_param_overrides(Some(ldm_on));
+    driver.reset(CompressionLevel::Level(19));
+    driver.prime_with_dictionary(dict, [1, 4, 8]);
+    driver.capture_primed_dictionary(CompressionLevel::Level(19));
+
+    // Same dictionary + level, but LDM now OFF: the snapshot's LDM state
+    // is stale, so restore must be refused.
+    driver.set_param_overrides(Some(ldm_off));
+    driver.reset(CompressionLevel::Level(19));
+    assert!(
+        !driver.restore_primed_dictionary(CompressionLevel::Level(19)),
+        "primed snapshot restored across an LDM config change (stale producer)",
+    );
+
+    // Sanity: re-priming + capturing under LDM-off, then restoring under
+    // the IDENTICAL LDM-off config DOES match (the key is not over-tight).
+    driver.prime_with_dictionary(dict, [1, 4, 8]);
+    driver.capture_primed_dictionary(CompressionLevel::Level(19));
+    driver.reset(CompressionLevel::Level(19));
+    assert!(
+        driver.restore_primed_dictionary(CompressionLevel::Level(19)),
+        "primed snapshot not restored under identical LDM config",
+    );
+}
+
+#[test]
 fn hc_prime_with_dictionary_disables_btultra2_seed_pass() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
     driver.reset(CompressionLevel::Better);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -949,11 +949,17 @@ pub struct MatchGeneratorDriver {
     // resolved shape ([`reset_shape`](Self::reset_shape)), not this bucket.
     reset_size_log: Option<u8>,
     // Hint-resolved matcher shape from the last `reset`: the [`LevelParams`], the
-    // active backend's applied Dfast/Row hash-table width (`0` for HC/Fast), and
-    // the Fast attach-vs-copy mode. Combined with the frame's level into the
-    // [`PrimedKey`] that keys the primed snapshot, so it is only restored into a
-    // reset that resolved the identical matcher. `None` before the first `reset`.
-    reset_shape: Option<(LevelParams, usize, bool)>,
+    // active backend's applied Dfast/Row hash-table width (`0` for HC/Fast), the
+    // Fast attach-vs-copy mode, and the active LDM override (#27). Combined with
+    // the frame's level into the [`PrimedKey`] that keys the primed snapshot, so
+    // it is only restored into a reset that resolved the identical matcher AND
+    // LDM configuration. `None` before the first `reset`.
+    reset_shape: Option<(
+        LevelParams,
+        usize,
+        bool,
+        Option<super::parameters::LdmOverride>,
+    )>,
     // One-shot borrowed block range `[start, end)` staged by the borrowed
     // Fast frame path (`set_borrowed_block`) for the NEXT
     // `start_matching` / `skip_matching_with_hint`. `Some` routes that
@@ -1021,6 +1027,15 @@ struct PrimedKey {
     params: LevelParams,
     table_bits: usize,
     fast_attach: bool,
+    /// Fine-grained LDM override (#27) active at capture time. The
+    /// snapshot's cloned `storage` carries `BtMatcher::ldm_producer`,
+    /// which is configured from this override; restoring a snapshot
+    /// captured under a different LDM configuration (enable flip or
+    /// changed knobs) would reinstate a stale producer. `params` already
+    /// pins `window_log` / `strategy_tag` (the rest of the producer's
+    /// identity), so folding the override completes the LDM identity.
+    /// `None` = LDM off, matching `ParamOverrides::ldm`.
+    ldm: Option<super::parameters::LdmOverride>,
 }
 
 impl MatchGeneratorDriver {
@@ -1482,6 +1497,21 @@ impl Matcher for MatchGeneratorDriver {
             && !ov.is_empty()
         {
             apply_param_overrides(&mut params, &ov);
+            // `Self::level_params(level, hint)` applied the source-size cap
+            // for the LEVEL's native backend. If a strategy override moved
+            // the frame onto a different backend, `apply_param_overrides`
+            // synthesized that backend's DEFAULT config (FAST_L1 /
+            // HC_OVERRIDE_DEFAULT) with full-size table logs AFTER that cap
+            // ran. Re-apply the hint cap so a tiny hinted frame doesn't
+            // allocate the new backend's full-size tables. An explicit
+            // `window_log` override is the user's hard request and must
+            // survive the re-cap, so restore it afterwards.
+            if let Some(hint_size) = hint {
+                params = adjust_params_for_source_size(params, hint_size);
+                if let Some(window_log) = ov.window_log {
+                    params.window_log = window_log;
+                }
+            }
         }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
@@ -1719,7 +1749,10 @@ impl Matcher for MatchGeneratorDriver {
             && self
                 .reset_size_log
                 .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
-        self.reset_shape = Some((params, resolved_table_bits, fast_attach));
+        // The LDM override (if any) is part of the snapshot identity: the
+        // restored `storage` carries the producer this override configured.
+        let active_ldm = self.param_overrides.and_then(|ov| ov.ldm);
+        self.reset_shape = Some((params, resolved_table_bits, fast_attach, active_ldm));
     }
 
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
@@ -1901,7 +1934,7 @@ impl Matcher for MatchGeneratorDriver {
         // match this reset. Restoring it would let the encoder search past the
         // frame header's window (an undecodable match), so on a key mismatch we
         // refuse and the caller re-primes.
-        let Some((params, table_bits, fast_attach)) = self.reset_shape else {
+        let Some((params, table_bits, fast_attach, ldm)) = self.reset_shape else {
             return false;
         };
         let key = PrimedKey {
@@ -1909,6 +1942,7 @@ impl Matcher for MatchGeneratorDriver {
             params,
             table_bits,
             fast_attach,
+            ldm,
         };
         let (storage, budget) = match &self.primed {
             Some((storage, budget, captured_key)) if *captured_key == key => {
@@ -1924,7 +1958,7 @@ impl Matcher for MatchGeneratorDriver {
     fn capture_primed_dictionary(&mut self, level: super::CompressionLevel) {
         // No resolved shape means `reset` has not run for this frame — nothing
         // valid to key a snapshot on, so skip the capture.
-        let Some((params, table_bits, fast_attach)) = self.reset_shape else {
+        let Some((params, table_bits, fast_attach, ldm)) = self.reset_shape else {
             return;
         };
         let key = PrimedKey {
@@ -1932,6 +1966,7 @@ impl Matcher for MatchGeneratorDriver {
             params,
             table_bits,
             fast_attach,
+            ldm,
         };
         self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, key));
     }

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -370,6 +370,13 @@ pub trait Matcher {
     /// test stubs. The built-in runtime matcher (`MatchGeneratorDriver`)
     /// overrides this hook and applies the hint during level resolution.
     fn set_source_size_hint(&mut self, _size: u64) {}
+    /// Drop any per-frame fine-grained parameter overrides installed via
+    /// the public parameter API, reverting to plain level-based geometry
+    /// at the next [`reset`](Self::reset). Called by
+    /// [`FrameCompressor::set_compression_level`](crate::encoding::FrameCompressor::set_compression_level)
+    /// so switching back to a bare level after a customized frame does not
+    /// keep the old overrides sticky. Default no-op for custom matchers.
+    fn clear_param_overrides(&mut self) {}
     /// Prime matcher state with dictionary history before compressing the next frame.
     /// Default implementation is a no-op for custom matchers that do not support this.
     fn prime_with_dictionary(&mut self, _dict_content: &[u8], _offset_hist: [u32; 3]) {}

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -84,6 +84,7 @@ pub(crate) mod frame_compressor;
 #[cfg(feature = "lsm")]
 pub mod frame_emit_info;
 mod levels;
+pub(crate) mod parameters;
 #[cfg(feature = "bench_internals")]
 pub mod sequence_capture;
 mod streaming_encoder;
@@ -91,6 +92,10 @@ pub use frame_compressor::{EncoderDictionary, FrameCompressor};
 #[cfg(feature = "lsm")]
 pub use frame_emit_info::{BlockType, FrameBlock, FrameEmitInfo};
 pub use match_generator::MatchGeneratorDriver;
+pub use parameters::{
+    Bounds, CParameter, CompressionParameters, CompressionParametersBuilder, ParameterError,
+    Strategy,
+};
 pub use streaming_encoder::StreamingEncoder;
 
 use crate::io::{Read, Write};
@@ -189,6 +194,32 @@ pub fn compress_slice_to_vec(source: &[u8], level: CompressionLevel) -> Vec<u8> 
     // neither the reader nor the drain is used by the in-place
     // `compress_independent_frame` path.
     let mut enc: FrameCompressor = FrameCompressor::new(level);
+    enc.compress_independent_frame(source)
+}
+
+/// Compress a byte slice into a fresh `Vec<u8>` using fine-grained
+/// [`CompressionParameters`] (#27) instead of a bare
+/// [`CompressionLevel`].
+///
+/// One-shot wrapper over [`FrameCompressor::set_parameters`] +
+/// [`FrameCompressor::compress_independent_frame`]. The produced frame is
+/// a valid RFC 8878 stream regardless of the knobs chosen.
+///
+/// ```rust
+/// use structured_zstd::encoding::{
+///     compress_with_parameters, CompressionLevel, CompressionParameters, Strategy,
+/// };
+/// let data: &[u8] = b"the quick brown fox jumps over the lazy dog";
+/// let params = CompressionParameters::builder(CompressionLevel::Level(5))
+///     .strategy(Strategy::Greedy)
+///     .build()
+///     .unwrap();
+/// let compressed = compress_with_parameters(data, &params);
+/// assert!(!compressed.is_empty());
+/// ```
+pub fn compress_with_parameters(source: &[u8], params: &CompressionParameters) -> Vec<u8> {
+    let mut enc: FrameCompressor = FrameCompressor::new(params.level());
+    enc.set_parameters(params);
     enc.compress_independent_frame(source)
 }
 

--- a/zstd/src/encoding/opt/types.rs
+++ b/zstd/src/encoding/opt/types.rs
@@ -74,6 +74,13 @@ pub(crate) struct HcOptimalPlanState {
     pub(crate) reps: [u32; 3],
     pub(crate) litlen: usize,
     pub(crate) profile: HcOptimalCostProfile,
+    /// Block-relative byte offset of the SEGMENT this plan pass covers.
+    /// The optimal parser runs per-segment with segment-relative
+    /// positions, but the LDM `ldm_sequences` are block-relative, so the
+    /// raw LDM seq-store is fast-forwarded by this many bytes at the
+    /// start of each segment to land its windows at the right positions.
+    /// `0` for the first segment / when LDM is inactive.
+    pub(crate) block_offset: usize,
 }
 
 /// Bundle of scratch buffers the DP body owns for the duration of one

--- a/zstd/src/encoding/parameters.rs
+++ b/zstd/src/encoding/parameters.rs
@@ -10,12 +10,11 @@
 //! # Builder
 //!
 //! [`CompressionParameters`] is built through
-//! [`CompressionParameters::builder`]. A builder starts from a base
-//! [`CompressionLevel`](crate::encoding::CompressionLevel) (defaulting to
-//! [`CompressionLevel::Default`](crate::encoding::CompressionLevel::Default));
-//! every knob left unset inherits that level's resolved value, so a
-//! builder that overrides nothing reproduces plain level-based
-//! compression byte-for-byte.
+//! [`CompressionParameters::builder`], which takes an explicit base
+//! [`CompressionLevel`](crate::encoding::CompressionLevel) (there is no
+//! implicit default). Every knob left unset inherits that base level's
+//! resolved value, so a builder that overrides nothing reproduces plain
+//! level-based compression byte-for-byte.
 //!
 //! ```rust
 //! use structured_zstd::encoding::{CompressionLevel, CompressionParameters, Strategy};
@@ -39,11 +38,12 @@
 //!
 //! LDM is **off at every [`CompressionLevel`](crate::encoding::CompressionLevel)
 //! preset**, matching upstream `libzstd.so.1` where `ZSTD_compress(..., level)`
-//! never enables LDM — even at level 22. The only activation surface is
-//! [`CompressionParametersBuilder::enable_long_distance_matching`]. When
-//! enabled, the LDM producer attaches to the optimal (`btopt` / `btultra` /
-//! `btultra2`) match-finder; pair `enable_long_distance_matching(true)` with
-//! an optimal [`Strategy`] (or a level ≥ 16) for it to take effect.
+//! never enables LDM — even at level 22. It is activated either by
+//! [`CompressionParametersBuilder::enable_long_distance_matching`] or by any of
+//! the `ldm_*` setters, which each imply `enable_long_distance_matching(true)`.
+//! When enabled, the LDM producer attaches to the optimal (`btopt` / `btultra`
+//! / `btultra2`) match-finder; pair it with an optimal [`Strategy`] (or a level
+//! ≥ 16) for it to take effect.
 
 use crate::encoding::CompressionLevel;
 
@@ -411,8 +411,12 @@ impl CompressionParametersBuilder {
     }
 
     /// Enable or disable long-distance matching. C
-    /// `ZSTD_c_enableLongDistanceMatching`. Off at every level preset;
-    /// this is the only activation surface.
+    /// `ZSTD_c_enableLongDistanceMatching`. Off at every level preset.
+    /// This is the explicit activation toggle; the `ldm_*` knob setters
+    /// also enable LDM implicitly. The flag is plain last-write-wins, so
+    /// a trailing `enable_long_distance_matching(false)` disables LDM even
+    /// if an earlier `ldm_*` call set a knob (the knob is then ignored at
+    /// [`build`](Self::build)).
     pub fn enable_long_distance_matching(mut self, enable: bool) -> Self {
         self.enable_ldm = enable;
         self

--- a/zstd/src/encoding/parameters.rs
+++ b/zstd/src/encoding/parameters.rs
@@ -1,0 +1,662 @@
+//! Fine-grained compression parameters — the drop-in equivalent of C
+//! zstd's advanced `ZSTD_CCtx_setParameter` surface (#27).
+//!
+//! [`CompressionLevel`](crate::encoding::CompressionLevel) selects a
+//! whole tuning preset in one knob. This module exposes the individual
+//! knobs underneath it — window/hash/chain/search logs, the match
+//! strategy, and the long-distance-matching (LDM) block — so callers
+//! can override a level's defaults for domain-specific tuning.
+//!
+//! # Builder
+//!
+//! [`CompressionParameters`] is built through
+//! [`CompressionParameters::builder`]. A builder starts from a base
+//! [`CompressionLevel`](crate::encoding::CompressionLevel) (defaulting to
+//! [`CompressionLevel::Default`](crate::encoding::CompressionLevel::Default));
+//! every knob left unset inherits that level's resolved value, so a
+//! builder that overrides nothing reproduces plain level-based
+//! compression byte-for-byte.
+//!
+//! ```rust
+//! use structured_zstd::encoding::{CompressionLevel, CompressionParameters, Strategy};
+//!
+//! let params = CompressionParameters::builder(CompressionLevel::Level(19))
+//!     .window_log(22)
+//!     .strategy(Strategy::Btultra2)
+//!     .enable_long_distance_matching(true)
+//!     .build()
+//!     .expect("parameters within bounds");
+//! ```
+//!
+//! # Bounds
+//!
+//! Every knob has an inclusive `[lower, upper]` range, queryable via
+//! [`CParameter::bounds`] (the analogue of `ZSTD_cParam_getBounds`).
+//! [`CompressionParametersBuilder::build`] validates each set knob and
+//! returns [`ParameterError::OutOfBounds`] for the first violation.
+//!
+//! # Long-distance matching (LDM)
+//!
+//! LDM is **off at every [`CompressionLevel`](crate::encoding::CompressionLevel)
+//! preset**, matching upstream `libzstd.so.1` where `ZSTD_compress(..., level)`
+//! never enables LDM — even at level 22. The only activation surface is
+//! [`CompressionParametersBuilder::enable_long_distance_matching`]. When
+//! enabled, the LDM producer attaches to the optimal (`btopt` / `btultra` /
+//! `btultra2`) match-finder; pair `enable_long_distance_matching(true)` with
+//! an optimal [`Strategy`] (or a level ≥ 16) for it to take effect.
+
+use crate::encoding::CompressionLevel;
+
+/// Match-finder strategy — the drop-in equivalent of C zstd's
+/// `ZSTD_strategy` enum (`ZSTD_fast` … `ZSTD_btultra2`). The numeric
+/// ordinals match upstream (`fast = 1` … `btultra2 = 9`), so
+/// [`Strategy::ordinal`] / [`Strategy::from_ordinal`] round-trip with
+/// the C `ZSTD_c_strategy` parameter value.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Strategy {
+    /// `ZSTD_fast` (1) — single-table fast finder.
+    Fast,
+    /// `ZSTD_dfast` (2) — two parallel hash tables.
+    Dfast,
+    /// `ZSTD_greedy` (3) — commit the first acceptable match, no lookahead.
+    Greedy,
+    /// `ZSTD_lazy` (4) — one-position lazy lookahead.
+    Lazy,
+    /// `ZSTD_lazy2` (5) — two-position lazy lookahead.
+    Lazy2,
+    /// `ZSTD_btlazy2` (6) — binary-tree-assisted lazy2.
+    Btlazy2,
+    /// `ZSTD_btopt` (7) — optimal parser, no ultra refinements.
+    Btopt,
+    /// `ZSTD_btultra` (8) — optimal parser with refined price tables.
+    Btultra,
+    /// `ZSTD_btultra2` (9) — optimal parser with two-pass dynamic stats.
+    Btultra2,
+}
+
+impl Strategy {
+    /// Upstream `ZSTD_strategy` ordinal (`fast = 1` … `btultra2 = 9`).
+    pub const fn ordinal(self) -> u32 {
+        match self {
+            Self::Fast => 1,
+            Self::Dfast => 2,
+            Self::Greedy => 3,
+            Self::Lazy => 4,
+            Self::Lazy2 => 5,
+            Self::Btlazy2 => 6,
+            Self::Btopt => 7,
+            Self::Btultra => 8,
+            Self::Btultra2 => 9,
+        }
+    }
+
+    /// Construct from an upstream `ZSTD_strategy` ordinal. Returns
+    /// `None` outside `1..=9`.
+    pub const fn from_ordinal(ordinal: u32) -> Option<Self> {
+        Some(match ordinal {
+            1 => Self::Fast,
+            2 => Self::Dfast,
+            3 => Self::Greedy,
+            4 => Self::Lazy,
+            5 => Self::Lazy2,
+            6 => Self::Btlazy2,
+            7 => Self::Btopt,
+            8 => Self::Btultra,
+            9 => Self::Btultra2,
+            _ => return None,
+        })
+    }
+
+    /// Internal runtime strategy tag (collapses `btlazy2` onto the lazy
+    /// hash-chain tag at depth 2, matching `LEVEL_TABLE`).
+    pub(crate) const fn tag(self) -> crate::encoding::strategy::StrategyTag {
+        use crate::encoding::strategy::StrategyTag;
+        match self {
+            Self::Fast => StrategyTag::Fast,
+            Self::Dfast => StrategyTag::Dfast,
+            Self::Greedy => StrategyTag::Greedy,
+            // Lazy / Lazy2 / Btlazy2 all ride the runtime `Lazy` tag; the
+            // lazy lookahead depth carries the variance (see `lazy_depth`).
+            Self::Lazy | Self::Lazy2 | Self::Btlazy2 => StrategyTag::Lazy,
+            Self::Btopt => StrategyTag::BtOpt,
+            Self::Btultra => StrategyTag::BtUltra,
+            Self::Btultra2 => StrategyTag::BtUltra2,
+        }
+    }
+
+    /// Lazy lookahead depth for the greedy/lazy band (0/1/2). `Optimal`
+    /// strategies report 2 (the depth their hash-chain seed walk runs at).
+    pub(crate) const fn lazy_depth(self) -> u8 {
+        match self {
+            Self::Fast | Self::Dfast | Self::Greedy => 0,
+            Self::Lazy => 1,
+            _ => 2,
+        }
+    }
+}
+
+/// One tunable compression parameter — the analogue of a C zstd
+/// `ZSTD_cParameter`. Used to query bounds via [`CParameter::bounds`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CParameter {
+    /// Maximum back-reference distance, `log2`. C `ZSTD_c_windowLog`.
+    WindowLog,
+    /// Match-finder hash table size, `log2`. C `ZSTD_c_hashLog`.
+    HashLog,
+    /// Match-finder chain table size, `log2`. C `ZSTD_c_chainLog`.
+    ChainLog,
+    /// Number of search attempts, `log2`. C `ZSTD_c_searchLog`.
+    SearchLog,
+    /// Minimum match length in bytes. C `ZSTD_c_minMatch`.
+    MinMatch,
+    /// "Good enough" match length that ends the search. C `ZSTD_c_targetLength`.
+    TargetLength,
+    /// Match-finder [`Strategy`] (1..=9). C `ZSTD_c_strategy`.
+    Strategy,
+    /// LDM enable flag (0/1). C `ZSTD_c_enableLongDistanceMatching`.
+    EnableLongDistanceMatching,
+    /// LDM hash table size, `log2`. C `ZSTD_c_ldmHashLog`.
+    LdmHashLog,
+    /// LDM minimum match length in bytes. C `ZSTD_c_ldmMinMatch`.
+    LdmMinMatch,
+    /// LDM bucket size, `log2`. C `ZSTD_c_ldmBucketSizeLog`.
+    LdmBucketSizeLog,
+    /// LDM hash-insertion rate, `log2`. C `ZSTD_c_ldmHashRateLog`.
+    LdmHashRateLog,
+}
+
+/// Inclusive `[lower_bound, upper_bound]` range for a [`CParameter`],
+/// the drop-in equivalent of C zstd's `ZSTD_bounds`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Bounds {
+    /// Smallest accepted value (inclusive).
+    pub lower_bound: i64,
+    /// Largest accepted value (inclusive).
+    pub upper_bound: i64,
+}
+
+impl Bounds {
+    /// Whether `value` falls within `[lower_bound, upper_bound]`.
+    pub const fn contains(&self, value: i64) -> bool {
+        value >= self.lower_bound && value <= self.upper_bound
+    }
+}
+
+impl CParameter {
+    /// Inclusive value bounds for this parameter, mirroring
+    /// `ZSTD_cParam_getBounds`. Window/hash/chain logs cap at 30 (the
+    /// encoder's match-finder ceiling) rather than the 31 C allows on
+    /// 64-bit, because the back-reference history is indexed with `u32`
+    /// positions over a `2 * window` eviction band.
+    pub const fn bounds(self) -> Bounds {
+        let (lower_bound, upper_bound) = match self {
+            // ZSTD_WINDOWLOG_MIN .. encoder ceiling.
+            Self::WindowLog => (10, 30),
+            // ZSTD_HASHLOG_MIN .. ZSTD_HASHLOG_MAX.
+            Self::HashLog => (6, 30),
+            // ZSTD_CHAINLOG_MIN .. ZSTD_CHAINLOG_MAX (64-bit).
+            Self::ChainLog => (6, 30),
+            // ZSTD_SEARCHLOG_MIN .. ZSTD_SEARCHLOG_MAX (64-bit).
+            Self::SearchLog => (1, 30),
+            // ZSTD_MINMATCH_MIN .. ZSTD_MINMATCH_MAX.
+            Self::MinMatch => (3, 7),
+            // ZSTD_TARGETLENGTH_MIN .. ZSTD_TARGETLENGTH_MAX.
+            Self::TargetLength => (0, 131_072),
+            // ZSTD_fast .. ZSTD_btultra2.
+            Self::Strategy => (1, 9),
+            // Boolean flag.
+            Self::EnableLongDistanceMatching => (0, 1),
+            // ZSTD_LDM_HASHLOG_MIN .. ZSTD_LDM_HASHLOG_MAX.
+            Self::LdmHashLog => (6, 30),
+            // ZSTD_LDM_MINMATCH_MIN .. ZSTD_LDM_MINMATCH_MAX.
+            Self::LdmMinMatch => (4, 4096),
+            // ZSTD_LDM_BUCKETSIZELOG_MIN .. ZSTD_LDM_BUCKETSIZELOG_MAX.
+            Self::LdmBucketSizeLog => (1, 8),
+            // ZSTD_LDM_HASHRATELOG_MIN .. ZSTD_WINDOWLOG_MAX - ZSTD_HASHLOG_MIN.
+            Self::LdmHashRateLog => (0, 24),
+        };
+        Bounds {
+            lower_bound,
+            upper_bound,
+        }
+    }
+}
+
+/// Error returned by [`CompressionParametersBuilder::build`] when a knob
+/// is set outside its [`CParameter::bounds`].
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParameterError {
+    /// A parameter was set to a value outside its inclusive bounds.
+    OutOfBounds {
+        /// Which parameter violated its range.
+        parameter: CParameter,
+        /// The rejected value.
+        value: i64,
+        /// The inclusive `[lower, upper]` range it had to fall within.
+        bounds: Bounds,
+    },
+}
+
+impl core::fmt::Display for ParameterError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::OutOfBounds {
+                parameter,
+                value,
+                bounds,
+            } => write!(
+                f,
+                "compression parameter {parameter:?} = {value} out of bounds \
+                 [{}, {}]",
+                bounds.lower_bound, bounds.upper_bound
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ParameterError {}
+
+/// LDM tuning overrides — every knob is `Option`, falling back to the
+/// strategy-derived donor default (`LdmParams::adjust_for`) when unset.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct LdmOverride {
+    pub(crate) hash_log: Option<u32>,
+    pub(crate) min_match: Option<u32>,
+    pub(crate) bucket_size_log: Option<u32>,
+    pub(crate) hash_rate_log: Option<u32>,
+}
+
+/// Internal per-knob override set consumed by the match-generator's
+/// `reset` path. Every field left `None` inherits the base level's
+/// resolved value, so the default path is byte-identical to level-based
+/// compression.
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ParamOverrides {
+    pub(crate) window_log: Option<u8>,
+    pub(crate) hash_log: Option<u32>,
+    pub(crate) chain_log: Option<u32>,
+    pub(crate) search_log: Option<u32>,
+    pub(crate) min_match: Option<u32>,
+    pub(crate) target_length: Option<u32>,
+    pub(crate) strategy: Option<Strategy>,
+    /// `Some` when `enable_long_distance_matching(true)` was set; carries
+    /// the (possibly empty) LDM knob overrides.
+    pub(crate) ldm: Option<LdmOverride>,
+}
+
+impl ParamOverrides {
+    /// Whether any knob overrides the base level. An all-`None`
+    /// override is a no-op the `reset` path can skip entirely, keeping
+    /// the default level-based geometry byte-identical.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.window_log.is_none()
+            && self.hash_log.is_none()
+            && self.chain_log.is_none()
+            && self.search_log.is_none()
+            && self.min_match.is_none()
+            && self.target_length.is_none()
+            && self.strategy.is_none()
+            && self.ldm.is_none()
+    }
+}
+
+/// Fully-resolved fine-grained compression parameters. Build through
+/// [`CompressionParameters::builder`]; pass to
+/// [`FrameCompressor::set_parameters`](crate::encoding::FrameCompressor::set_parameters)
+/// or [`compress_with_parameters`](crate::encoding::compress_with_parameters).
+///
+/// Wraps a base [`CompressionLevel`](crate::encoding::CompressionLevel)
+/// plus the set of knobs that override it. A parameter set that
+/// overrides nothing is equivalent to compressing at its base level.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct CompressionParameters {
+    level: CompressionLevel,
+    overrides: ParamOverrides,
+}
+
+impl CompressionParameters {
+    /// Start a builder from a base compression level. Knobs left unset
+    /// inherit that level's resolved defaults.
+    pub fn builder(level: CompressionLevel) -> CompressionParametersBuilder {
+        CompressionParametersBuilder {
+            level,
+            window_log: None,
+            hash_log: None,
+            chain_log: None,
+            search_log: None,
+            min_match: None,
+            target_length: None,
+            strategy: None,
+            enable_ldm: false,
+            ldm: LdmOverride::default(),
+        }
+    }
+
+    /// The base compression level these parameters override.
+    pub fn level(&self) -> CompressionLevel {
+        self.level
+    }
+
+    /// Whether long-distance matching is enabled.
+    pub fn long_distance_matching_enabled(&self) -> bool {
+        self.overrides.ldm.is_some()
+    }
+
+    pub(crate) fn overrides(&self) -> ParamOverrides {
+        self.overrides
+    }
+}
+
+/// Builder for [`CompressionParameters`]. Each setter records one knob;
+/// [`Self::build`] validates them against [`CParameter::bounds`].
+#[derive(Copy, Clone, Debug)]
+pub struct CompressionParametersBuilder {
+    level: CompressionLevel,
+    window_log: Option<u32>,
+    hash_log: Option<u32>,
+    chain_log: Option<u32>,
+    search_log: Option<u32>,
+    min_match: Option<u32>,
+    target_length: Option<u32>,
+    strategy: Option<Strategy>,
+    enable_ldm: bool,
+    ldm: LdmOverride,
+}
+
+impl CompressionParametersBuilder {
+    /// Override the maximum back-reference distance (`log2`). C
+    /// `ZSTD_c_windowLog`.
+    pub fn window_log(mut self, value: u32) -> Self {
+        self.window_log = Some(value);
+        self
+    }
+
+    /// Override the match-finder hash table size (`log2`). C `ZSTD_c_hashLog`.
+    pub fn hash_log(mut self, value: u32) -> Self {
+        self.hash_log = Some(value);
+        self
+    }
+
+    /// Override the match-finder chain table size (`log2`). C `ZSTD_c_chainLog`.
+    pub fn chain_log(mut self, value: u32) -> Self {
+        self.chain_log = Some(value);
+        self
+    }
+
+    /// Override the search-attempts count (`log2`). C `ZSTD_c_searchLog`.
+    pub fn search_log(mut self, value: u32) -> Self {
+        self.search_log = Some(value);
+        self
+    }
+
+    /// Override the minimum match length in bytes. C `ZSTD_c_minMatch`.
+    pub fn min_match(mut self, value: u32) -> Self {
+        self.min_match = Some(value);
+        self
+    }
+
+    /// Override the "good enough" target match length. C `ZSTD_c_targetLength`.
+    pub fn target_length(mut self, value: u32) -> Self {
+        self.target_length = Some(value);
+        self
+    }
+
+    /// Override the match-finder [`Strategy`]. C `ZSTD_c_strategy`.
+    pub fn strategy(mut self, value: Strategy) -> Self {
+        self.strategy = Some(value);
+        self
+    }
+
+    /// Enable or disable long-distance matching. C
+    /// `ZSTD_c_enableLongDistanceMatching`. Off at every level preset;
+    /// this is the only activation surface.
+    pub fn enable_long_distance_matching(mut self, enable: bool) -> Self {
+        self.enable_ldm = enable;
+        self
+    }
+
+    /// Override the LDM hash table size (`log2`). C `ZSTD_c_ldmHashLog`.
+    /// Implies [`Self::enable_long_distance_matching(true)`](Self::enable_long_distance_matching).
+    pub fn ldm_hash_log(mut self, value: u32) -> Self {
+        self.enable_ldm = true;
+        self.ldm.hash_log = Some(value);
+        self
+    }
+
+    /// Override the LDM minimum match length. C `ZSTD_c_ldmMinMatch`.
+    /// Implies [`Self::enable_long_distance_matching(true)`](Self::enable_long_distance_matching).
+    pub fn ldm_min_match(mut self, value: u32) -> Self {
+        self.enable_ldm = true;
+        self.ldm.min_match = Some(value);
+        self
+    }
+
+    /// Override the LDM bucket size (`log2`). C `ZSTD_c_ldmBucketSizeLog`.
+    /// Implies [`Self::enable_long_distance_matching(true)`](Self::enable_long_distance_matching).
+    pub fn ldm_bucket_size_log(mut self, value: u32) -> Self {
+        self.enable_ldm = true;
+        self.ldm.bucket_size_log = Some(value);
+        self
+    }
+
+    /// Override the LDM hash-insertion rate (`log2`). C `ZSTD_c_ldmHashRateLog`.
+    /// Implies [`Self::enable_long_distance_matching(true)`](Self::enable_long_distance_matching).
+    pub fn ldm_hash_rate_log(mut self, value: u32) -> Self {
+        self.enable_ldm = true;
+        self.ldm.hash_rate_log = Some(value);
+        self
+    }
+
+    /// Validate every set knob against [`CParameter::bounds`] and
+    /// produce the resolved [`CompressionParameters`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ParameterError::OutOfBounds`] for the first knob whose
+    /// value falls outside its inclusive range.
+    pub fn build(self) -> Result<CompressionParameters, ParameterError> {
+        check(CParameter::WindowLog, self.window_log)?;
+        check(CParameter::HashLog, self.hash_log)?;
+        check(CParameter::ChainLog, self.chain_log)?;
+        check(CParameter::SearchLog, self.search_log)?;
+        check(CParameter::MinMatch, self.min_match)?;
+        check(CParameter::TargetLength, self.target_length)?;
+        if let Some(s) = self.strategy {
+            check(CParameter::Strategy, Some(s.ordinal()))?;
+        }
+        let ldm = if self.enable_ldm {
+            check(CParameter::LdmHashLog, self.ldm.hash_log)?;
+            check(CParameter::LdmMinMatch, self.ldm.min_match)?;
+            check(CParameter::LdmBucketSizeLog, self.ldm.bucket_size_log)?;
+            check(CParameter::LdmHashRateLog, self.ldm.hash_rate_log)?;
+            Some(self.ldm)
+        } else {
+            None
+        };
+        Ok(CompressionParameters {
+            level: self.level,
+            overrides: ParamOverrides {
+                // `window_log` is bounds-checked at <= 30, so the cast is lossless.
+                window_log: self.window_log.map(|v| v as u8),
+                hash_log: self.hash_log,
+                chain_log: self.chain_log,
+                search_log: self.search_log,
+                min_match: self.min_match,
+                target_length: self.target_length,
+                strategy: self.strategy,
+                ldm,
+            },
+        })
+    }
+}
+
+/// Validate one optional knob against its bounds.
+fn check(parameter: CParameter, value: Option<u32>) -> Result<(), ParameterError> {
+    if let Some(value) = value {
+        let bounds = parameter.bounds();
+        let value = i64::from(value);
+        if !bounds.contains(value) {
+            return Err(ParameterError::OutOfBounds {
+                parameter,
+                value,
+                bounds,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strategy_ordinals_round_trip() {
+        for ordinal in 1..=9 {
+            let s = Strategy::from_ordinal(ordinal).expect("valid ordinal");
+            assert_eq!(s.ordinal(), ordinal);
+        }
+        assert_eq!(Strategy::from_ordinal(0), None);
+        assert_eq!(Strategy::from_ordinal(10), None);
+    }
+
+    #[test]
+    fn builder_default_overrides_nothing() {
+        let p = CompressionParameters::builder(CompressionLevel::Level(7))
+            .build()
+            .unwrap();
+        assert!(p.overrides().is_empty());
+        assert_eq!(p.level(), CompressionLevel::Level(7));
+        assert!(!p.long_distance_matching_enabled());
+    }
+
+    #[test]
+    fn builder_records_each_knob() {
+        let p = CompressionParameters::builder(CompressionLevel::Level(19))
+            .window_log(22)
+            .hash_log(23)
+            .chain_log(24)
+            .search_log(7)
+            .min_match(4)
+            .target_length(256)
+            .strategy(Strategy::Btultra2)
+            .build()
+            .unwrap();
+        let o = p.overrides();
+        assert_eq!(o.window_log, Some(22));
+        assert_eq!(o.hash_log, Some(23));
+        assert_eq!(o.chain_log, Some(24));
+        assert_eq!(o.search_log, Some(7));
+        assert_eq!(o.min_match, Some(4));
+        assert_eq!(o.target_length, Some(256));
+        assert_eq!(o.strategy, Some(Strategy::Btultra2));
+        assert!(!o.is_empty());
+    }
+
+    #[test]
+    fn enable_ldm_sets_override_block() {
+        let p = CompressionParameters::builder(CompressionLevel::Level(19))
+            .enable_long_distance_matching(true)
+            .build()
+            .unwrap();
+        assert!(p.long_distance_matching_enabled());
+        assert_eq!(p.overrides().ldm, Some(LdmOverride::default()));
+    }
+
+    #[test]
+    fn ldm_knob_implies_enable() {
+        let p = CompressionParameters::builder(CompressionLevel::Level(19))
+            .ldm_hash_log(24)
+            .ldm_min_match(64)
+            .ldm_bucket_size_log(4)
+            .ldm_hash_rate_log(7)
+            .build()
+            .unwrap();
+        assert!(p.long_distance_matching_enabled());
+        let ldm = p.overrides().ldm.unwrap();
+        assert_eq!(ldm.hash_log, Some(24));
+        assert_eq!(ldm.min_match, Some(64));
+        assert_eq!(ldm.bucket_size_log, Some(4));
+        assert_eq!(ldm.hash_rate_log, Some(7));
+    }
+
+    #[test]
+    fn out_of_bounds_window_log_rejected() {
+        let err = CompressionParameters::builder(CompressionLevel::Default)
+            .window_log(31)
+            .build()
+            .unwrap_err();
+        match err {
+            ParameterError::OutOfBounds {
+                parameter, value, ..
+            } => {
+                assert_eq!(parameter, CParameter::WindowLog);
+                assert_eq!(value, 31);
+            }
+        }
+    }
+
+    #[test]
+    fn out_of_bounds_min_match_rejected() {
+        let err = CompressionParameters::builder(CompressionLevel::Default)
+            .min_match(2)
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ParameterError::OutOfBounds {
+                parameter: CParameter::MinMatch,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn ldm_bounds_only_checked_when_enabled() {
+        // An out-of-range LDM knob is only rejected when LDM is on. A
+        // builder that never enables LDM ignores the (unreachable)
+        // values entirely.
+        let err = CompressionParameters::builder(CompressionLevel::Default)
+            .ldm_bucket_size_log(9)
+            .build()
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ParameterError::OutOfBounds {
+                parameter: CParameter::LdmBucketSizeLog,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn bounds_match_c_reference() {
+        assert_eq!(
+            CParameter::WindowLog.bounds(),
+            Bounds {
+                lower_bound: 10,
+                upper_bound: 30
+            }
+        );
+        assert_eq!(
+            CParameter::Strategy.bounds(),
+            Bounds {
+                lower_bound: 1,
+                upper_bound: 9
+            }
+        );
+        assert_eq!(
+            CParameter::TargetLength.bounds(),
+            Bounds {
+                lower_bound: 0,
+                upper_bound: 131_072
+            }
+        );
+        assert!(CParameter::MinMatch.bounds().contains(3));
+        assert!(CParameter::MinMatch.bounds().contains(7));
+        assert!(!CParameter::MinMatch.bounds().contains(8));
+    }
+}

--- a/zstd/src/tests/mod.rs
+++ b/zstd/src/tests/mod.rs
@@ -583,6 +583,8 @@ pub mod dict_test;
 pub mod encode_corpus;
 pub mod fuzz_regressions;
 #[cfg(feature = "std")]
+pub mod parameters_test;
+#[cfg(feature = "std")]
 #[allow(dead_code)]
 pub mod roundtrip_integrity;
 

--- a/zstd/src/tests/parameters_test.rs
+++ b/zstd/src/tests/parameters_test.rs
@@ -277,3 +277,37 @@ fn ldm_large_window_multi_segment_round_trips() {
         );
     }
 }
+
+/// Reverting to a plain level via `set_compression_level` after a
+/// customized frame must drop the parameter overrides. Otherwise the
+/// strategy/LDM/log overrides stay sticky and the "plain" frame is still
+/// encoded with the previous tuning. The second frame must be
+/// byte-identical to a fresh plain-level compression of the same input.
+#[test]
+fn set_compression_level_clears_parameter_overrides() {
+    // Compressible fixture so the strategy choice actually changes the
+    // output (incompressible data raw-stores regardless of strategy).
+    let data = long_range_repetitive(64 * 1024);
+
+    let mut compressor: FrameCompressor = FrameCompressor::new(CompressionLevel::Default);
+    // First frame: a custom strategy override (greedy) far from the
+    // level-19 default (btultra2).
+    let params = CompressionParameters::builder(CompressionLevel::Level(19))
+        .strategy(Strategy::Greedy)
+        .build()
+        .unwrap();
+    compressor.set_parameters(&params);
+    let _first = compressor.compress_independent_frame(&data);
+
+    // Revert to a plain level and compress again.
+    compressor.set_compression_level(CompressionLevel::Level(19));
+    let reverted = compressor.compress_independent_frame(&data);
+
+    // Must match a brand-new compressor at plain level 19 (no overrides).
+    let expected = compress_slice_to_vec(&data, CompressionLevel::Level(19));
+    assert_eq!(
+        reverted, expected,
+        "set_compression_level did not clear sticky parameter overrides",
+    );
+    assert_eq!(decode(&reverted), data);
+}

--- a/zstd/src/tests/parameters_test.rs
+++ b/zstd/src/tests/parameters_test.rs
@@ -1,0 +1,279 @@
+//! Integration tests for the fine-grained compression parameter API (#27):
+//! builder → [`compress_with_parameters`] → decode round-trip, the LDM
+//! activation surface, the `Greedy` strategy override, and the
+//! default-equivalence invariant (an empty override reproduces plain
+//! level-based output byte-for-byte).
+
+extern crate std;
+
+use alloc::vec::Vec;
+
+use crate::decoding::StreamingDecoder;
+use crate::encoding::{
+    CompressionLevel, CompressionParameters, FrameCompressor, Strategy, compress_slice_to_vec,
+    compress_with_parameters,
+};
+use crate::io::Read;
+
+/// Deterministic LCG byte stream (mirrors `roundtrip_integrity`).
+fn generate_data(seed: u64, len: usize) -> Vec<u8> {
+    let mut state = seed;
+    let mut data = Vec::with_capacity(len);
+    for _ in 0..len {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        data.push((state >> 33) as u8);
+    }
+    data
+}
+
+/// A genuinely compressible long-range-repetitive fixture: a
+/// low-entropy base block (a short motif tiled to 4 KiB, so the cheap
+/// incompressibility sampler classifies it compressible) repeated many
+/// times with a few bytes of per-copy noise. Back-references at the
+/// 4 KiB base distance dominate, so the encoder compresses it well below
+/// input size (unlike a random base, which the sampler raw-stores).
+fn long_range_repetitive(total_len: usize) -> Vec<u8> {
+    // 16-byte motif → tiled to a 4 KiB base. Low entropy: the sampler
+    // sees the repetition and the block is compressed, not raw-stored.
+    let motif = generate_data(0xABCD_1234, 16);
+    let mut base = Vec::with_capacity(4096);
+    while base.len() < 4096 {
+        base.extend_from_slice(&motif);
+    }
+    base.truncate(4096);
+
+    let mut data = Vec::with_capacity(total_len);
+    let mut counter = 0u64;
+    while data.len() < total_len {
+        data.extend_from_slice(&base);
+        // A few bytes of per-copy noise so each repeat is a distinct
+        // long-range back-reference rather than one giant run.
+        counter = counter.wrapping_add(1);
+        data.extend_from_slice(&counter.to_le_bytes());
+    }
+    data.truncate(total_len);
+    data
+}
+
+fn decode(compressed: &[u8]) -> Vec<u8> {
+    let mut decoder = StreamingDecoder::new(compressed).unwrap();
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out).unwrap();
+    out
+}
+
+/// A parameter set that overrides nothing must produce byte-identical
+/// output to plain level-based compression — the default path is
+/// untouched.
+#[test]
+fn empty_override_is_byte_identical_to_level() {
+    let data = generate_data(7, 64 * 1024);
+    for level in [
+        CompressionLevel::Fastest,
+        CompressionLevel::Default,
+        CompressionLevel::Better,
+        CompressionLevel::Best,
+        CompressionLevel::Level(5),
+        CompressionLevel::Level(19),
+    ] {
+        let params = CompressionParameters::builder(level).build().unwrap();
+        let via_params = compress_with_parameters(&data, &params);
+        let via_level = compress_slice_to_vec(&data, level);
+        assert_eq!(
+            via_params, via_level,
+            "empty override diverged from level {level:?}",
+        );
+    }
+}
+
+/// Custom parameters must produce valid (decodable) frames that
+/// reproduce the input.
+#[test]
+fn custom_parameters_round_trip() {
+    let data = generate_data(99, 96 * 1024);
+
+    let cases = [
+        CompressionParameters::builder(CompressionLevel::Level(3))
+            .window_log(18)
+            .strategy(Strategy::Dfast)
+            .build()
+            .unwrap(),
+        CompressionParameters::builder(CompressionLevel::Level(9))
+            .strategy(Strategy::Lazy2)
+            .search_log(6)
+            .target_length(64)
+            .build()
+            .unwrap(),
+        CompressionParameters::builder(CompressionLevel::Level(19))
+            .window_log(22)
+            .hash_log(23)
+            .chain_log(24)
+            .strategy(Strategy::Btultra2)
+            .build()
+            .unwrap(),
+    ];
+
+    for params in cases {
+        let compressed = compress_with_parameters(&data, &params);
+        assert_eq!(
+            decode(&compressed),
+            data,
+            "round-trip failed for {params:?}"
+        );
+    }
+}
+
+/// `set_parameter(Strategy, Greedy)` produces a greedy-parsed frame at any
+/// level, and it decodes back to the input.
+#[test]
+fn greedy_strategy_override_round_trips() {
+    let data = generate_data(0x5151, 80 * 1024);
+    // Force greedy onto a level the table would resolve to lazy (7).
+    let params = CompressionParameters::builder(CompressionLevel::Level(7))
+        .strategy(Strategy::Greedy)
+        .build()
+        .unwrap();
+    let compressed = compress_with_parameters(&data, &params);
+    assert_eq!(decode(&compressed), data);
+    // Greedy on a highly-repetitive fixture compresses well below input
+    // size (the back-references dominate) and still round-trips.
+    let compressible = long_range_repetitive(80 * 1024);
+    let greedy = compress_with_parameters(
+        &compressible,
+        &CompressionParameters::builder(CompressionLevel::Level(5))
+            .strategy(Strategy::Greedy)
+            .build()
+            .unwrap(),
+    );
+    assert!(
+        greedy.len() < compressible.len() / 2,
+        "greedy did not compress repetitive fixture: {} vs {}",
+        greedy.len(),
+        compressible.len(),
+    );
+    assert_eq!(decode(&greedy), compressible);
+}
+
+/// LDM-on activation: `enable_long_distance_matching(true)` on an optimal
+/// strategy round-trips correctly through our decoder.
+#[cfg(feature = "hash")]
+#[test]
+fn ldm_on_round_trips() {
+    let data = long_range_repetitive(512 * 1024);
+    let params = CompressionParameters::builder(CompressionLevel::Level(19))
+        .enable_long_distance_matching(true)
+        .build()
+        .unwrap();
+    let compressed = compress_with_parameters(&data, &params);
+    assert_eq!(decode(&compressed), data);
+}
+
+/// LDM ratio: on a long-range-repetitive fixture, the LDM-on variant must
+/// be no larger than LDM-off. The LDM producer only adds candidates to the
+/// optimal parser, never removes valid regular matches, so enabling it can
+/// only keep or improve the ratio (within the regular window the two are
+/// often equal, hence `<=` rather than strict `<`).
+#[cfg(feature = "hash")]
+#[test]
+fn ldm_on_is_not_larger_than_ldm_off() {
+    let data = long_range_repetitive(1024 * 1024);
+
+    let off = CompressionParameters::builder(CompressionLevel::Level(19))
+        .build()
+        .unwrap();
+    let on = CompressionParameters::builder(CompressionLevel::Level(19))
+        .enable_long_distance_matching(true)
+        .build()
+        .unwrap();
+
+    let off_sz = compress_with_parameters(&data, &off).len();
+    let on_compressed = compress_with_parameters(&data, &on);
+    let on_sz = on_compressed.len();
+
+    // Correctness first: LDM-on must still decode to the input.
+    assert_eq!(decode(&on_compressed), data);
+    assert!(
+        on_sz <= off_sz,
+        "LDM-on ({on_sz}) larger than LDM-off ({off_sz})",
+    );
+}
+
+/// Custom LDM knobs override the strategy-derived defaults and still
+/// produce a decodable frame.
+#[cfg(feature = "hash")]
+#[test]
+fn ldm_custom_knobs_round_trip() {
+    let data = long_range_repetitive(512 * 1024);
+    let params = CompressionParameters::builder(CompressionLevel::Level(19))
+        .ldm_hash_log(20)
+        .ldm_min_match(48)
+        .ldm_bucket_size_log(4)
+        .ldm_hash_rate_log(6)
+        .build()
+        .unwrap();
+    assert_eq!(decode(&compress_with_parameters(&data, &params)), data);
+}
+
+/// `FrameCompressor::set_parameters` on the streaming path reuses one
+/// compressor across frames and produces decodable output.
+#[test]
+fn set_parameters_streaming_round_trip() {
+    let data = generate_data(0xC0FFEE, 70 * 1024);
+    let params = CompressionParameters::builder(CompressionLevel::Level(11))
+        .strategy(Strategy::Lazy2)
+        .window_log(20)
+        .build()
+        .unwrap();
+
+    let mut compressed = Vec::new();
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor.set_parameters(&params);
+    compressor.set_source(data.as_slice());
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+
+    assert_eq!(decode(&compressed), data);
+}
+
+/// A window_log override shrinks the advertised frame window: a frame
+/// built with window_log 17 must decode with a smaller declared window
+/// than one at the level default. We assert the round-trip and that the
+/// override path is honoured by decoding successfully under our decoder
+/// (which enforces the advertised window).
+#[test]
+fn window_log_override_round_trips() {
+    let data = long_range_repetitive(256 * 1024);
+    let params = CompressionParameters::builder(CompressionLevel::Level(9))
+        .window_log(17)
+        .build()
+        .unwrap();
+    let compressed = compress_with_parameters(&data, &params);
+    assert_eq!(decode(&compressed), data);
+}
+/// LDM at a large window (`window_log >= 24`) over a multi-block,
+/// multi-segment input. Regression for the LDM↔optimal-parser segment
+/// misalignment: `ldm_sequences` are block-relative, but the optimal
+/// parser runs per-segment with segment-relative positions, so every
+/// segment after the first must fast-forward the raw LDM seq-store by its
+/// block offset. Before the fix this emitted matches copying the wrong
+/// bytes (frame rejected by both our decoder and upstream `zstd -d`).
+#[cfg(feature = "hash")]
+#[test]
+fn ldm_large_window_multi_segment_round_trips() {
+    let data = long_range_repetitive(512 * 1024);
+    for window_log in [24, 25, 26] {
+        let params = CompressionParameters::builder(CompressionLevel::Level(19))
+            .window_log(window_log)
+            .enable_long_distance_matching(true)
+            .build()
+            .unwrap();
+        let compressed = compress_with_parameters(&data, &params);
+        assert_eq!(
+            decode(&compressed),
+            data,
+            "LDM round-trip failed at window_log {window_log}",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Drop-in equivalent of C zstd's `ZSTD_CCtx_setParameter` surface: a
`CompressionParameters` builder over a base `CompressionLevel` that overrides
individual match-finder knobs and activates long-distance matching (LDM).

- **`CompressionParameters` + builder** — `window_log`, `hash_log`, `chain_log`,
  `search_log`, `min_match`, `target_length`, `strategy`, plus the LDM block
  (`enable_long_distance_matching`, `ldm_hash_log`/`ldm_min_match`/
  `ldm_bucket_size_log`/`ldm_hash_rate_log`). Per-knob bounds validation in
  `build()`; `CParameter::bounds()` mirrors `ZSTD_cParam_getBounds`.
- **Public `Strategy` enum (1..=9)** incl. `Greedy`; `FrameCompressor::set_parameters`
  and a `compress_with_parameters` one-shot helper.
- **Override threading** — strategy override re-routes the backend; per-knob
  values map into the Fast/Dfast/Row/Hc configs. An empty override is
  **byte-identical** to plain level-based compression.
- **LDM activation** — attach `LdmProducer` to the optimal `BtMatcher` when
  enabled; custom LDM knobs derive over donor-consistent defaults. LDM stays
  **off at every level preset** (distro parity with `libzstd.so.1`).

## Encoder correctness fix

This is the first-ever activation surface for LDM (#18 producer), and it
surfaced a pre-existing LDM ↔ optimal-parser bug (#111): the optimal parser
runs **per-segment** with segment-relative positions while `ldm_sequences` are
**block-relative**, so `opt_ldm` must fast-forward the raw seq-store by each
segment's block offset. Without it, segments after the first emitted matches
copying the wrong bytes — frames rejected by **both this decoder and upstream
`zstd -d`**. Fixed via a new `HcOptimalPlanState.block_offset` field.

## Testing

- `cargo nextest run --workspace`: **753 passed**, 0 failed
- 18 parameter tests: builder/bounds/validation (unit) + integration
  (empty-override byte-identity, custom params round-trip, Greedy override,
  LDM on/ratio/custom-knobs/large-window-multi-segment, streaming,
  window_log override)
- Clippy clean, doc tests pass, `no_std` (no-default-features) + CLI compile
- Cross-decoded LDM frames (incl. `window_log` 24/25/26) through upstream
  `zstd` v1.5.7 — match the original
- Level-22 byte-parity corpus gate stays green (LDM off by default)

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fine-grained compression parameter API with builder-style tuning and LDM knobs.
  * One-shot compression helper accepting custom parameters.
  * Streaming compression accepts runtime parameter overrides; switching compression level clears overrides.

* **Documentation**
  * README updated with usage examples, builder guidance, and how to query parameter bounds.

* **Tests / Bug Fixes**
  * New tests for parameter round-trips, LDM behavior, large-window/regression scenarios, and streaming-path compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->