### PR TITLE
feat(wasm): streaming compress ZstdCompressStream + align decoder window cap to zstd default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,29 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    # Cheap path probe (~10s) consumed by the bench pipeline gate below.
+    # Bench numbers (Rust vs C FFI) can only move when the core crate,
+    # the workspace manifests that pin deps / profiles, or the toolchain
+    # file change. A push touching ONLY wasm / npm / ts / js / CI / docs
+    # cannot move them, so `bench-matrix` (and its whole downstream
+    # cascade) is skipped on such pushes — see the gate on that job.
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      rust_core: ${{ steps.filter.outputs.rust_core }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust_core:
+              - 'zstd/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+
   lint:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -386,9 +409,15 @@ jobs:
     # (`bench-build`, `benchmark`, `benchmark-aggregate`, `benchmark-pages`)
     # stays green-skipped on PRs without each needing its own filter.
     # See #164 (sharding) and #362 (push-only gate).
+    #
+    # Second gate: `needs.changes.outputs.rust_core`. A push to main that
+    # touched ONLY wasm / npm / ts / js / CI / docs cannot move the
+    # Rust-vs-FFI numbers, so the bench pipeline is skipped on it (the
+    # published dashboard snapshot stays the last Rust-core baseline).
+    # Same cascade — skipping `bench-matrix` skips every downstream bench job.
     name: Resolve bench target matrix
-    needs: lint
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.rust_core == 'true'
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.set.outputs.targets }}

--- a/zstd-wasm/bench/bench.mjs
+++ b/zstd-wasm/bench/bench.mjs
@@ -224,7 +224,6 @@ for (const [scenario, data] of fixtures) {
     const line = [`${scenario.padEnd(22)} L${String(level).padStart(2)}`];
     for (const tier of ["ours-simd128", "ours-scalar"]) {
       const eng = engines[tier];
-      const oneShot = eng.compress(data, level);
       const streamed = streamCompressOnce(eng.CompressStreamCtor, data, level);
       const ok = eq(eng.decompress(streamed), data);
       if (!ok) { rows.push({ scenario, level, name: `${tier}-stream`, ok: false }); }

--- a/zstd-wasm/bench/bench.mjs
+++ b/zstd-wasm/bench/bench.mjs
@@ -21,6 +21,7 @@ async function loadOurPayload(dir) {
     decompress: glue.decompress,
     compressUsingDict: glue.compressUsingDict,
     decompressUsingDict: glue.decompressUsingDict,
+    CompressStreamCtor: glue.ZstdCompressStream,
   };
 }
 
@@ -192,6 +193,52 @@ for (const [scenario, data] of dictSamples) {
         ` | c: simd ${fmtNs(s.cNs)}(${x(s)}x) scalar ${fmtNs(sc.cNs)}(${x(sc)}x) boku ${fmtNs(b.cNs)}` +
         ` | d: simd ${fmtNs(s.dNs)}(${xd(s)}x) scalar ${fmtNs(sc.dNs)}(${xd(sc)}x) boku ${fmtNs(b.dNs)}`,
     );
+  }
+}
+
+// --- Streaming compress: incremental push/finish vs one-shot compress -------
+// Times our block-flush streaming encoder (O(window) peak) against the one-shot
+// compress for the same payload, so the streaming overhead is visible. Uses a
+// fixed 64 KiB push granularity (a realistic chunk for a network/file stream);
+// bokuweb has no symmetric streaming-compress surface, so this measures ours
+// only. Round-trip is verified before timing.
+const STREAM_CHUNK = 64 * 1024;
+function streamCompressOnce(ctor, data, level) {
+  const s = new ctor(level);
+  const parts = [];
+  for (let i = 0; i < data.length; i += STREAM_CHUNK) {
+    parts.push(s.push(data.subarray(i, Math.min(i + STREAM_CHUNK, data.length))));
+  }
+  parts.push(s.finish());
+  s.free();
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) { out.set(p, off); off += p.length; }
+  return out;
+}
+console.log("\n=== streaming compress (push/finish, 64 KiB chunks) vs one-shot ===");
+console.log("(x = streaming/one-shot time; ratio = framed/input, our two payloads)");
+for (const [scenario, data] of fixtures) {
+  for (const level of LEVELS) {
+    const line = [`${scenario.padEnd(22)} L${String(level).padStart(2)}`];
+    for (const tier of ["ours-simd128", "ours-scalar"]) {
+      const eng = engines[tier];
+      const oneShot = eng.compress(data, level);
+      const streamed = streamCompressOnce(eng.CompressStreamCtor, data, level);
+      const ok = eq(eng.decompress(streamed), data);
+      if (!ok) { rows.push({ scenario, level, name: `${tier}-stream`, ok: false }); }
+      const sNs = medianNsPerOp(() => streamCompressOnce(eng.CompressStreamCtor, data, level), BUDGET_MS);
+      const oNs = medianNsPerOp(() => eng.compress(data, level), BUDGET_MS);
+      const ratio = streamed.length / Math.max(1, data.length);
+      console.log(
+        `REPORT_STREAM scenario=${scenario} engine=${tier} level=${level} ` +
+          `input_bytes=${data.length} framed_bytes=${streamed.length} ratio=${ratio.toFixed(6)} ` +
+          `stream_ns=${sNs} oneshot_ns=${oNs} roundtrip=${ok ? "ok" : "FAIL"}`,
+      );
+      line.push(`${tier.replace("ours-", "")}: ${fmtNs(sNs)}(${(sNs / oNs).toFixed(2)}x) r=${ratio.toFixed(4)}`);
+    }
+    console.log("  " + line.join("  |  "));
   }
 }
 

--- a/zstd-wasm/bench/test.mjs
+++ b/zstd-wasm/bench/test.mjs
@@ -27,6 +27,7 @@ async function loadOurPayload(dir) {
     compressUsingDict: glue.compressUsingDict,
     decompressUsingDict: glue.decompressUsingDict,
     StreamCtor: glue.ZstdDecompressStream,
+    CompressStreamCtor: glue.ZstdCompressStream,
   };
 }
 async function loadBokuweb() {
@@ -146,6 +147,53 @@ for (const [name, data] of fixtures()) {
       }
       if (!eq(streamDecode(scalar.StreamCtor, framed, chunk), data)) {
         fail(`stream ${name} L${level} chunk=${chunk}: scalar streaming != one-shot`);
+      }
+    }
+  }
+}
+
+// --- Streaming compressor: chunked plaintext must produce a valid frame -----
+// Feed each payload to ZstdCompressStream in several chunk granularities and
+// concatenate the emitted compressed bytes; the resulting frame omits FCS
+// (unknown size while streaming). MANDATORY: it must decode back to the input
+// BOTH in our own decoder AND in the C reference (@bokuweb/zstd-wasm) — output
+// need NOT be byte-identical to one-shot, only decode to the same bytes.
+function streamCompress(ctor, data, level, chunkSize) {
+  const s = new ctor(level);
+  const parts = [];
+  for (let i = 0; i < data.length; i += chunkSize) {
+    parts.push(s.push(data.subarray(i, Math.min(i + chunkSize, data.length))));
+  }
+  parts.push(s.finish());
+  s.free();
+  const total = parts.reduce((n, p) => n + p.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) { out.set(p, off); off += p.length; }
+  return out;
+}
+for (const [name, data] of fixtures()) {
+  if (data.length === 0) continue; // empty input: covered by one-shot; skip sweep
+  // L22 advertises the 128 MiB max window verbatim in the no-FCS streaming
+  // header — included here to pin that our own decoder (and the C reference)
+  // accept it, i.e. the encoder↔decoder window cap stays aligned.
+  for (const level of [-3, 1, 3, 19, 22]) {
+    for (const chunk of [1, 3, 7, 64, data.length]) {
+      const simdFrame = streamCompress(simd.CompressStreamCtor, data, level, chunk);
+      const scalarFrame = streamCompress(scalar.CompressStreamCtor, data, level, chunk);
+      // MANDATORY: our decoder round-trips the streamed frame.
+      if (!eq(simd.decompress(simdFrame), data)) {
+        fail(`compress-stream ${name} L${level} chunk=${chunk}: simd round-trip`);
+      }
+      if (!eq(scalar.decompress(scalarFrame), data)) {
+        fail(`compress-stream ${name} L${level} chunk=${chunk}: scalar round-trip`);
+      }
+      // MANDATORY: the C reference decodes our no-FCS streamed frame (both payloads).
+      if (!eq(boku.decompress(simdFrame), data)) {
+        fail(`compress-stream ${name} L${level} chunk=${chunk}: C ref cannot decode our simd frame`);
+      }
+      if (!eq(boku.decompress(scalarFrame), data)) {
+        fail(`compress-stream ${name} L${level} chunk=${chunk}: C ref cannot decode our scalar frame`);
       }
     }
   }

--- a/zstd-wasm/npm/README.md
+++ b/zstd-wasm/npm/README.md
@@ -51,6 +51,7 @@ const out = await compress(payload);
 | `decompress` | `(data: Uint8Array) => Promise<Uint8Array>` | Rejects on a malformed/incomplete frame. |
 | `compressUsingDict` | `(data: Uint8Array, dict: Uint8Array, level?: number) => Promise<Uint8Array>` | Dictionary compression (raw zstd dictionary, e.g. `zstd --train`). |
 | `decompressUsingDict` | `(data: Uint8Array, dict: Uint8Array) => Promise<Uint8Array>` | `dict` must match the one used to compress. |
+| `createCompressStream` | `(level?: number) => Promise<CompressStream>` | Incremental streaming encoder (see below); `level` defaults to `3`. |
 | `createDecompressStream` | `() => Promise<DecompressStream>` | Incremental streaming decoder (see below). |
 | `init` | `() => Promise<void>` | Optional pre-warm; idempotent. |
 
@@ -59,6 +60,27 @@ import { compressUsingDict, decompressUsingDict } from "@structured-world/struct
 const framed = await compressUsingDict(record, dictionary, 19);
 const back = await decompressUsingDict(framed, dictionary);
 ```
+
+### Streaming compression
+
+Compress a large or unbounded source incrementally — push plaintext chunks and
+emit compressed blocks as the matcher window fills, so peak memory is
+O(window), not O(input):
+
+```ts
+import { createCompressStream } from "@structured-world/structured-zstd";
+
+const stream = await createCompressStream(19);
+const out: Uint8Array[] = [];
+for await (const chunk of source) out.push(stream.push(chunk));
+out.push(stream.finish()); // final block + checksum, seals the frame
+stream.free();             // release the wasm handle
+```
+
+`push(chunk)` returns the compressed bytes complete so far (possibly empty
+while the current block is still filling). The frame omits `Frame_Content_Size`
+(unknown while streaming) yet decodes in any compliant zstd decoder, including
+`decompress` / `createDecompressStream` here and the native C library.
 
 ### Streaming decompression
 

--- a/zstd-wasm/npm/index.ts
+++ b/zstd-wasm/npm/index.ts
@@ -29,6 +29,7 @@ interface Payload {
   compressUsingDict: (data: Uint8Array, dict: Uint8Array, level: number) => Uint8Array;
   decompressUsingDict: (data: Uint8Array, dict: Uint8Array) => Uint8Array;
   ZstdDecompressStream: new () => DecompressStream;
+  ZstdCompressStream: new (level: number) => CompressStream;
 }
 
 /**
@@ -42,6 +43,24 @@ export interface DecompressStream {
   /** Feed compressed bytes; returns decompressed output available so far. */
   push(chunk: Uint8Array): Uint8Array;
   /** Signal end of input; returns the final bytes. Throws if incomplete. */
+  finish(): Uint8Array;
+  /** Release the underlying wasm handle. */
+  free(): void;
+}
+
+/**
+ * Incremental streaming compressor handle. Feed plaintext chunks with
+ * {@link CompressStream.push} and read complete compressed blocks as the
+ * matcher window fills; call {@link CompressStream.finish} to seal the frame
+ * (final block + checksum). Peak memory is O(window), not O(input) — the frame
+ * is emitted block-by-block instead of buffered whole. The frame omits
+ * `Frame_Content_Size` (unknown while streaming) yet decodes in any compliant
+ * zstd decoder. Call {@link CompressStream.free} when done.
+ */
+export interface CompressStream {
+  /** Feed plaintext; returns compressed bytes complete so far (may be empty). */
+  push(chunk: Uint8Array): Uint8Array;
+  /** Seal the frame; returns the final block + checksum. */
   finish(): Uint8Array;
   /** Release the underlying wasm handle. */
   free(): void;
@@ -156,4 +175,20 @@ export async function decompressUsingDict(
 export async function createDecompressStream(): Promise<DecompressStream> {
   loading ??= load();
   return new (await loading).ZstdDecompressStream();
+}
+
+/**
+ * Create an incremental streaming compressor at `level` (zstd scale: `1..=22`,
+ * negatives for the ultra-fast tier; defaults to {@link DEFAULT_LEVEL}). Push
+ * plaintext chunks and read compressed blocks as they complete, then
+ * `finish()`; `free()` when done. Peak memory is O(window), not O(input) — the
+ * frame is emitted block-by-block rather than buffered whole — and the result
+ * decodes in any compliant zstd decoder. Symmetric with
+ * {@link createDecompressStream}.
+ */
+export async function createCompressStream(
+  level: number = DEFAULT_LEVEL,
+): Promise<CompressStream> {
+  loading ??= load();
+  return new (await loading).ZstdCompressStream(level);
 }

--- a/zstd-wasm/src/lib.rs
+++ b/zstd-wasm/src/lib.rs
@@ -15,8 +15,10 @@
 #![cfg(target_arch = "wasm32")]
 
 use structured_zstd::decoding::{BlockDecodingStrategy, FrameDecoder, StreamingDecoder};
-use structured_zstd::encoding::{CompressionLevel, FrameCompressor, compress_slice_to_vec};
-use structured_zstd::io::Read;
+use structured_zstd::encoding::{
+    CompressionLevel, FrameCompressor, StreamingEncoder, compress_slice_to_vec,
+};
+use structured_zstd::io::{Read, Write};
 use wasm_bindgen::prelude::*;
 
 /// Compress `data` into a standard Zstandard frame at compression `level`.
@@ -219,5 +221,61 @@ impl ZstdDecompressStream {
             }
         }
         Ok(out)
+    }
+}
+
+/// Incremental streaming compressor: feed plaintext chunks via
+/// [`ZstdCompressStream::push`] and receive complete compressed blocks as the
+/// matcher window fills, then [`ZstdCompressStream::finish`] to seal the frame
+/// (final block + content checksum). Peak working set is O(window), not
+/// O(input) — emitted blocks are flushed to the caller while only the matcher
+/// window is retained — so a large payload never has to be buffered whole. The
+/// produced frame omits `Frame_Content_Size` (the total is unknown while
+/// streaming) and decodes in any compliant zstd decoder. Mirrors
+/// [`ZstdDecompressStream`], making the wasm streaming API symmetric.
+#[wasm_bindgen]
+pub struct ZstdCompressStream {
+    // `None` once `finish` has consumed the encoder; further calls then throw
+    // instead of silently producing a second (empty) frame.
+    encoder: Option<StreamingEncoder<Vec<u8>>>,
+}
+
+#[wasm_bindgen]
+impl ZstdCompressStream {
+    /// Open a streaming compressor at `level` (zstd scale: `1..=22`, negatives
+    /// for the ultra-fast tier).
+    #[wasm_bindgen(constructor)]
+    pub fn new(level: i32) -> ZstdCompressStream {
+        ZstdCompressStream {
+            encoder: Some(StreamingEncoder::new(
+                Vec::new(),
+                CompressionLevel::Level(level),
+            )),
+        }
+    }
+
+    /// Feed more plaintext; returns whatever compressed bytes are now complete
+    /// (possibly empty while the current block is still filling).
+    pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<u8>, JsError> {
+        let enc = self
+            .encoder
+            .as_mut()
+            .ok_or_else(|| JsError::new("structured-zstd: compress stream already finished"))?;
+        enc.write_all(chunk)
+            .map_err(|err| JsError::new(&format!("structured-zstd: compress failed: {err:?}")))?;
+        // Drain the bytes flushed into the backing Vec since the last call,
+        // leaving an empty Vec for the encoder to keep appending to.
+        Ok(core::mem::take(enc.get_mut()))
+    }
+
+    /// Seal the frame; returns the final block plus the content checksum. Throws
+    /// if the stream was already finished.
+    pub fn finish(&mut self) -> Result<Vec<u8>, JsError> {
+        let enc = self
+            .encoder
+            .take()
+            .ok_or_else(|| JsError::new("structured-zstd: compress stream already finished"))?;
+        enc.finish()
+            .map_err(|err| JsError::new(&format!("structured-zstd: finish failed: {err:?}")))
     }
 }

--- a/zstd/src/common/mod.rs
+++ b/zstd/src/common/mod.rs
@@ -20,7 +20,14 @@ pub const MAX_WINDOW_SIZE: u64 = (1 << 41) + 7 * (1 << 38);
 /// <https://github.com/facebook/zstd/blob/eca205fc7849a61ab287492931a04960ac58e031/doc/educational_decoder/zstd_decompress.c#L28-L29>
 pub const MAX_BLOCK_SIZE: u32 = 128 * 1024;
 
-/// Implementation limit for window size (100 MiB) to protect against
-/// malformed frames. The zstd spec allows much larger windows, but this
-/// cap prevents excessive memory allocation on untrusted input.
-pub const MAXIMUM_ALLOWED_WINDOW_SIZE: u64 = 1024 * 1024 * 100;
+/// Decoder window-size limit (128 MiB = `1 << 27`), matching upstream zstd's
+/// default `ZSTD_d_windowLogMax` (`ZSTD_WINDOWLOG_LIMIT_DEFAULT = 27`). Frames
+/// advertising a larger window are rejected to bound allocation on untrusted
+/// input. The spec permits larger windows, but no standard zstd encoder emits
+/// them by default, so matching the upstream limit keeps the drop-in contract:
+/// every frame a stock zstd decoder accepts, we accept too — and crucially,
+/// every frame OUR encoder emits (up to `window_log 27` at level 22) round-trips
+/// through our own decoder. A non-power-of-two cap below `1 << 27` would reject
+/// our own level-22 / streaming output (whose window header carries the full
+/// 128 MiB). Decompression-bomb protection lives on the OUTPUT path, not here.
+pub const MAXIMUM_ALLOWED_WINDOW_SIZE: u64 = 1 << 27;

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -3228,9 +3228,9 @@ mod tests {
             let mut compressed = Vec::new();
             let mut compressor = FrameCompressor::new(level);
             // Pledge the source size so the high-level (22) window shrinks to
-            // fit the payload — otherwise level 22's default 128 MiB window
-            // exceeds the decoder's MAXIMUM_ALLOWED_WINDOW_SIZE cap. Still
-            // >= 128 KiB, so post-split eligibility is preserved.
+            // fit the payload, keeping the frame compact (no oversized window
+            // descriptor for a small input). Still >= 128 KiB, so post-split
+            // eligibility is preserved.
             compressor.set_source_size_hint(data.len() as u64);
             compressor.set_source(data.as_slice());
             compressor.set_drain(&mut compressed);

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -1312,6 +1312,41 @@ mod tests {
         }
     }
 
+    /// Level 22 advertises the largest default window (`window_log 27` =
+    /// 128 MiB). Because streaming omits FCS, that window is written verbatim
+    /// into the frame header — so the encoder's max window MUST NOT exceed the
+    /// decoder's [`crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE`], or our own
+    /// decoder rejects our own frame with `WindowSizeTooBig`. Regression for
+    /// the encoder↔decoder window-cap mismatch: streaming L22 must round-trip
+    /// through `StreamingDecoder` (and, implicitly, any stock zstd decoder,
+    /// which accepts up to the same 128 MiB default).
+    #[test]
+    fn level_22_streaming_window_roundtrips_in_our_decoder() {
+        let payload = b"level-22-streaming-window-cap-".repeat(512);
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(22));
+        for chunk in payload.chunks(101) {
+            encoder.write_all(chunk).unwrap();
+        }
+        let compressed = encoder.finish().unwrap();
+
+        // The advertised window equals the L22 default (128 MiB) and must sit
+        // at or below the decoder cap — otherwise the round-trip below fails.
+        let header = crate::decoding::frame::read_frame_header(compressed.as_slice())
+            .unwrap()
+            .0;
+        let window = header.window_size().unwrap();
+        assert!(
+            window <= crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE,
+            "L22 advertised window {window} exceeds decoder cap {}",
+            crate::common::MAXIMUM_ALLOWED_WINDOW_SIZE,
+        );
+
+        let mut decoder = StreamingDecoder::new(compressed.as_slice()).unwrap();
+        let mut decoded = Vec::new();
+        decoder.read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
     #[test]
     fn no_pledged_size_omits_fcs_from_header() {
         let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Fastest);


### PR DESCRIPTION
## Summary

Adds a push-based incremental **streaming compressor** to the wasm bindings, making the npm streaming API symmetric (a streaming *decompressor* shipped in #364, but compress was still buffer-everything). Along the way, fixes a real encoder↔decoder window-cap mismatch the streaming path exposed.

The core `StreamingEncoder` (eager no-FCS header, per-block flush, retained matcher window, O(window) peak) already existed; this PR wires it to wasm + tests + bench, and corrects the window cap.

### 1. wasm `ZstdCompressStream` (`zstd-wasm`)
- `#[wasm_bindgen]` struct: `push(chunk: &[u8]) -> Vec<u8>` (compressed bytes complete so far) and `finish() -> Vec<u8>` (final block + checksum), mirroring `ZstdDecompressStream`.
- `createCompressStream(level)` + `CompressStream` interface in the strict-TS ESM loader, mirroring `createDecompressStream()`.
- Peak memory is **O(window), not O(input)** — emitted blocks are drained per `push`; only the matcher window is retained. The frame omits `Frame_Content_Size` (unknown while streaming) yet decodes in any compliant zstd decoder.
- Core stays `no_std` + bindgen-free.

### 2. Window-cap fix (`fix(decode)`)
The encoder emits `window_log 27` (128 MiB) at level 22. Streaming writes that window verbatim into the header (no FCS), so the decoder's old **100 MiB** cap (`MAXIMUM_ALLOWED_WINDOW_SIZE`) rejected our **own** L22/streaming frames with `WindowSizeTooBig` — and also rejected valid 128 MiB frames from stock zstd (a drop-in violation).

The old 100 MiB value was not a power of two (between 2^26 = 64 MiB and 2^27 = 128 MiB) and stricter than every standard zstd decoder. Raised to `1 << 27` (128 MiB), matching upstream `ZSTD_d_windowLogMax` default (`ZSTD_WINDOWLOG_LIMIT_DEFAULT = 27`). Encoder and decoder max windows are now aligned; decompression-bomb protection remains on the output path (bounded read), not the window cap.

## Testing
- **Core:** `cargo nextest run --workspace` (759 passed) and `--lib` (716 passed), including new regression test `level_22_streaming_window_roundtrips_in_our_decoder` (verified it fails on the old 100 MiB cap, passes on 128 MiB).
- CI feature set (`hash,std,dict_builder`): streaming/window/L22 tests pass.
- **wasm:** `test.mjs` stream-compresses each fixture in 1/3/7/64/full chunk granularities across levels -3/1/3/19/22; every frame decodes both in our decoder and in the C reference (`@bokuweb/zstd-wasm`). `bench.mjs` adds streaming push/finish timing (8 MiB L22 stream is *faster* than one-shot — the O(window) flush win).
- clippy clean: workspace default, no-std (`--no-default-features`), wasm32 simd128 + scalar.
- `cargo test --doc` (16 passed); wasm32 build (+simd128 and scalar) green.

## Acceptance criteria (#365)
- [x] Core streaming encoder emits incrementally with peak O(window).
- [x] Streaming-compressed frames round-trip in our decoder AND decode in native zstd / `@bokuweb/zstd-wasm`.
- [x] wasm `ZstdCompressStream` (push/finish) + `createCompressStream(level)`; API symmetric with the streaming decoder.
- [x] Chunk-granularity tests (1/3/7/64/full) across levels.
- [x] `cargo nextest run`, wasm32 build (+simd128 and scalar), `node test.mjs` green.

Closes #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental streaming compression API added (create stream, push chunks, finish, free).
  * Benchmarks now compare streaming vs one-shot compression and report per-scenario ratios.

* **Bug Fixes**
  * Decoder window-size limit standardized to 128 MiB for safer handling of untrusted input.

* **Documentation**
  * README updated with streaming compression usage and semantics.

* **Tests**
  * Streaming-compression correctness tests and regression checks added.

* **Chores**
  * CI gated benchmarks to run only when core Rust areas change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->