### PR TITLE
fix(release): unfreeze release-plz (private tag namespace for wasm crate)

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -19,9 +19,20 @@ release = false
 # its own. release-plz may still bump its version on dependency updates; that
 # version is non-authoritative — the npm publish stamps the package version
 # from the release tag (Proposal A, single source of truth = Cargo.toml).
+#
+# Private tag namespace (`structured-zstd-wasm-v*`, never actually created
+# because `release = false`). This crate was added after the workspace's last
+# shared `v*` tag (v0.0.30), so resolving its "last release" against the shared
+# `v{{ version }}` pattern pointed release-plz at the v0.0.30 worktree — where
+# this package does not yet exist — and crashed `release-pr` with
+# "Failed to find package". A namespace with no matching tag makes release-plz
+# treat it as unreleased and skip that broken baseline diff. The main crate
+# keeps the shared `v*` tag, so the npm version flow (tag → npm version) is
+# unaffected.
 [[package]]
 name = "structured-zstd-wasm"
 release = false
+git_tag_name = "structured-zstd-wasm-v{{ version }}"
 
 [changelog]
 commit_parsers = [


### PR DESCRIPTION
## Summary

`release-plz` has failed on every push to `main` since #364 (which added the `structured-zstd-wasm` crate), freezing the release + npm publish pipeline:

```
failed to determine next versions
  get cargo package structured-zstd-wasm from worktree at "<v0.0.30 worktree>"
  Failed to find package "structured-zstd-wasm"
```

**Root cause:** the workspace shares one tag namespace (`git_tag_name = "v{{ version }}"`). release-plz resolves every package's last release to the latest `v*` tag = `v0.0.30`, then checks out that worktree to diff the package's prior state. `structured-zstd-wasm` was added *after* `v0.0.30` was tagged (#356), so it does not exist in that worktree and the lookup crashes — taking down `release-pr`, the version bump, the tag, the GitHub Release, and therefore the npm publish (`release.yml` stamps the npm version from the release tag).

## Fix

Give `structured-zstd-wasm` a private `git_tag_name` (`structured-zstd-wasm-v{{ version }}`) with no existing matching tag. release-plz then treats it as an initial release and skips the broken v0.0.30 baseline diff. The crate is already `release = false` (npm-managed, version stamped from the main release tag), so no wasm-specific tag is ever created, and the main crate stays on the shared `v*` tag — the npm version flow (release tag → `npm version`) is unchanged.

## Validation

Reproduced locally with `release-plz update` against the repo:

- **Before:** `Failed to find package "structured-zstd-wasm"` (matches the CI failure).
- **After:**
  ```
  INFO No release tag found matching pattern `^structured-zstd-wasm-v...`.
       Package structured-zstd-wasm will be treated as initial release.
  INFO structured-zstd: next version is 0.0.31
  * structured-zstd: 0.0.30 -> 0.0.31
  ```
  No crash; the main crate's release flow (`v0.0.31` → npm) is preserved.

Closes #369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to prevent crashes from version resolution errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->