### PR TITLE
ci(bench): continuous wasm dashboard shard vs @bokuweb/zstd-wasm

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -78,7 +78,7 @@
         margin-top: 14px;
         min-height: 460px;
       }
-      #chart, #chart-profile, #chart-aggregate {
+      #chart, #chart-profile, #chart-aggregate, #chart-wasm {
         width: 100% !important;
         height: 440px !important;
       }
@@ -2267,12 +2267,18 @@
       async function initWasmSection() {
         wasmRenderMetricOptions(wasmState.selectors.metric);
         const response = await fetch("./benchmark-wasm.json", { cache: "no-store" });
-        if (!response.ok) {
+        if (response.status === 404) {
           // 404 = no wasm run has published yet. Leave the section with its
           // empty-state message rather than treating it as a hard error.
           renderWasmChart();
           bindWasmControls();
           return;
+        }
+        if (!response.ok) {
+          // Any other non-2xx (500, 403, broken publish) is a real failure,
+          // not a "no data yet" state — surface it via the section's .catch
+          // instead of masking it as the empty state.
+          throw new Error(`Unable to load benchmark-wasm.json (${response.status})`);
         }
         const payload = await response.json();
         wasmState.records = payload.records || [];

--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -332,6 +332,45 @@
         <div id="aggregate-status" style="margin-top: 8px; font-size: 0.88rem"></div>
       </section>
 
+      <section class="card" id="wasm-section" style="margin-top: 14px">
+        <h2 style="margin: 0 0 8px; font-size: 1.2rem">WebAssembly: structured-zstd vs @bokuweb/zstd-wasm</h2>
+        <p style="font-size: 0.9rem">
+          Tracks our two wasm payloads (<strong>simd128</strong> +
+          <strong>scalar</strong>) against the most popular npm wasm zstd,
+          <code>@bokuweb/zstd-wasm</code> (an emscripten build of the C
+          reference), over time. Source: <code>node
+          zstd-wasm/bench/bench.mjs</code>, run as a push-to-main shard
+          (<code>bench-wasm</code> in <code>ci.yml</code>). Pick a
+          <strong>Metric</strong> (compress speed, decompress speed, or
+          output ratio), a payload <strong>Kind</strong> (plain or
+          dictionary), a <strong>Scenario</strong> and a
+          <strong>Level</strong>; each line is one engine plotted across
+          snapshots. For the speed metrics the secondary axis also shows
+          our throughput as a multiple of bokuweb (<code>&gt;1 =
+          faster</code>); for the ratio metric lower is better
+          (<code>compressed/input</code>).
+        </p>
+        <div class="filters">
+          <label>Metric
+            <select id="wf-metric"></select>
+          </label>
+          <label>Kind
+            <select id="wf-kind"></select>
+          </label>
+          <label>Scenario
+            <select id="wf-scenario"></select>
+          </label>
+          <label>Level
+            <select id="wf-level"></select>
+          </label>
+        </div>
+        <div class="chart-wrap">
+          <canvas id="chart-wasm"></canvas>
+        </div>
+        <div id="legend-wasm" class="html-legend"></div>
+        <div id="wasm-status" style="margin-top: 8px; font-size: 0.88rem"></div>
+      </section>
+
       <details class="card">
         <summary><strong>Raw timings (secondary view)</strong></summary>
         <p style="margin-top: 8px">
@@ -1976,8 +2015,293 @@
         renderRawSummary();
       }
 
+      // ---- WebAssembly section (structured-zstd vs @bokuweb/zstd-wasm) ----
+      // Self-contained: reads its own `benchmark-wasm.json` timeseries
+      // (produced by the push-only `bench-wasm` CI shard) and renders one
+      // chart of our two wasm tiers vs the bokuweb competitor over time.
+      // Kept fully independent of the Rust↔FFI relative payload above —
+      // it's an engine triplet, not a two-sided delta — and degrades
+      // gracefully when the payload is missing (no wasm run published
+      // yet) so the rest of the dashboard is unaffected.
+      const WASM_REF_ENGINE = "bokuweb";
+      const WASM_ENGINE_STYLE = {
+        "ours-simd128": { label: "ours simd128", color: "hsl(150 65% 38%)" },
+        "ours-scalar": { label: "ours scalar", color: "hsl(190 60% 40%)" },
+        bokuweb: { label: "bokuweb (C ref)", color: "hsl(20 75% 50%)" },
+      };
+      // Logical metric → how to pull a comparable value out of a record.
+      // Speed metrics carry bytes/sec (converted to MiB/s for the axis);
+      // ratio is the output fraction (compressed/input, lower=better).
+      const WASM_METRICS = {
+        compress_speed: {
+          label: "Compress speed (MiB/s)",
+          axisTitle: "Throughput (MiB/s)",
+          value: (r) => (typeof r.compress_bytes_per_sec === "number" ? r.compress_bytes_per_sec / (1024 * 1024) : null),
+          higherIsBetter: true,
+        },
+        decompress_speed: {
+          label: "Decompress speed (MiB/s)",
+          axisTitle: "Throughput (MiB/s)",
+          value: (r) => (typeof r.decompress_bytes_per_sec === "number" ? r.decompress_bytes_per_sec / (1024 * 1024) : null),
+          higherIsBetter: true,
+        },
+        ratio: {
+          label: "Output ratio (compressed/input, lower=better)",
+          axisTitle: "Output ratio (lower=better)",
+          value: (r) => (typeof r.ratio === "number" ? r.ratio : null),
+          higherIsBetter: false,
+        },
+      };
+
+      const wasmState = {
+        records: [],
+        chart: null,
+        selectors: {
+          metric: el("wf-metric"),
+          kind: el("wf-kind"),
+          scenario: el("wf-scenario"),
+          level: el("wf-level"),
+        },
+      };
+
+      function wasmRenderMetricOptions(select) {
+        const fragment = document.createDocumentFragment();
+        for (const [value, def] of Object.entries(WASM_METRICS)) {
+          const option = document.createElement("option");
+          option.value = value;
+          option.textContent = def.label;
+          fragment.appendChild(option);
+        }
+        select.replaceChildren(fragment);
+      }
+
+      function wasmRenderPlainOptions(select, values, allLabel) {
+        const fragment = document.createDocumentFragment();
+        if (allLabel) {
+          const allOption = document.createElement("option");
+          allOption.value = ALWAYS;
+          allOption.textContent = allLabel;
+          fragment.appendChild(allOption);
+        }
+        for (const value of values) {
+          const option = document.createElement("option");
+          option.value = String(value);
+          option.textContent = String(value);
+          fragment.appendChild(option);
+        }
+        select.replaceChildren(fragment);
+      }
+
+      function wasmCurrentFilter() {
+        return {
+          metric: wasmState.selectors.metric.value || "compress_speed",
+          kind: wasmState.selectors.kind.value || "plain",
+          scenario: wasmState.selectors.scenario.value,
+          level: wasmState.selectors.level.value,
+        };
+      }
+
+      // Build chart data for the current filter: one absolute-value line per
+      // engine across snapshots, plus (for speed metrics) one dashed
+      // "ours/bokuweb" multiple per ours-* engine on the secondary axis so
+      // the competitive position is legible without mental arithmetic.
+      function buildWasmChart(filter) {
+        const metricDef = WASM_METRICS[filter.metric] || WASM_METRICS.compress_speed;
+        const rows = wasmState.records.filter((r) =>
+          r.kind === filter.kind &&
+          (filter.scenario === ALWAYS || r.scenario === filter.scenario) &&
+          String(r.level) === String(filter.level),
+        );
+
+        const snapshots = uniq(rows.map((r) => r.generated_at || r.commit_sha || "local-run"));
+        // engine → snapshot → mean value (a scenario=all filter averages
+        // across scenarios for the snapshot, matching the native charts'
+        // cumulative-mean behaviour).
+        const perEngine = new Map();
+        for (const r of rows) {
+          const v = metricDef.value(r);
+          if (v === null) continue;
+          const snap = r.generated_at || r.commit_sha || "local-run";
+          let byEngine = perEngine.get(r.engine);
+          if (!byEngine) { byEngine = new Map(); perEngine.set(r.engine, byEngine); }
+          let cell = byEngine.get(snap);
+          if (!cell) { cell = { sum: 0, count: 0 }; byEngine.set(snap, cell); }
+          cell.sum += v;
+          cell.count += 1;
+        }
+        const meanAt = (engine, snap) => {
+          const cell = perEngine.get(engine)?.get(snap);
+          return cell && cell.count ? cell.sum / cell.count : null;
+        };
+
+        const engines = Array.from(perEngine.keys());
+        // Stable engine order: ours first, reference last.
+        engines.sort((a, b) => {
+          if (a === WASM_REF_ENGINE) return 1;
+          if (b === WASM_REF_ENGINE) return -1;
+          return a.localeCompare(b);
+        });
+
+        const datasets = [];
+        for (const engine of engines) {
+          const style = WASM_ENGINE_STYLE[engine] || { label: engine, color: "hsl(260 50% 50%)" };
+          datasets.push({
+            label: style.label,
+            data: snapshots.map((s) => meanAt(engine, s)),
+            yAxisID: "y",
+            borderColor: style.color,
+            backgroundColor: style.color.replace(")", " / 0.2)").replace("hsl(", "hsla("),
+            borderWidth: 2,
+            pointRadius: 3,
+            spanGaps: true,
+            tension: 0.25,
+          });
+        }
+
+        // Secondary axis: ours/bokuweb speed multiple (>1 = we're faster).
+        // Skipped for the ratio metric, where a per-engine ratio multiple
+        // is less intuitive than the absolute lower-is-better lines.
+        let showSecondary = false;
+        if (metricDef.higherIsBetter) {
+          for (const engine of engines) {
+            if (engine === WASM_REF_ENGINE) continue;
+            const style = WASM_ENGINE_STYLE[engine] || { label: engine, color: "hsl(260 50% 50%)" };
+            const data = snapshots.map((s) => {
+              const ours = meanAt(engine, s);
+              const ref = meanAt(WASM_REF_ENGINE, s);
+              return ours !== null && ref !== null && ref > 0 ? ours / ref : null;
+            });
+            if (data.some((v) => v !== null)) showSecondary = true;
+            datasets.push({
+              label: `${style.label} ÷ bokuweb (×)`,
+              data,
+              yAxisID: "y1",
+              borderColor: style.color,
+              backgroundColor: "transparent",
+              borderWidth: 2,
+              borderDash: [5, 4],
+              pointRadius: 2,
+              spanGaps: true,
+              tension: 0.25,
+            });
+          }
+        }
+
+        return { snapshots, datasets, metricDef, showSecondary };
+      }
+
+      function renderWasmChart() {
+        const statusEl = el("wasm-status");
+        if (!wasmState.records.length) {
+          statusEl.textContent = "No wasm benchmark data published yet — the bench-wasm shard runs on the next push that touches the wasm payloads.";
+          return;
+        }
+        const filter = wasmCurrentFilter();
+        const { snapshots, datasets, metricDef, showSecondary } = buildWasmChart(filter);
+        if (!snapshots.length || !datasets.length) {
+          if (wasmState.chart) {
+            wasmState.chart.data.labels = [];
+            wasmState.chart.data.datasets = [];
+            wasmState.chart.update("none");
+          }
+          el("legend-wasm").replaceChildren();
+          const scen = filter.scenario === ALWAYS ? "all" : filter.scenario;
+          statusEl.textContent = `No wasm points for kind=${filter.kind}, scenario=${scen}, level=${filter.level}.`;
+          return;
+        }
+        const scenDesc = filter.scenario === ALWAYS ? "scenario=all" : `scenario=${filter.scenario}`;
+        statusEl.textContent =
+          `Showing ${snapshots.length} snapshot(s) — ${metricDef.label}, kind=${filter.kind}, ${scenDesc}, level=${filter.level}.`;
+
+        const scales = {
+          x: {
+            title: { display: true, text: "Snapshot (generated_at / commit)" },
+            ticks: { autoSkip: true, maxTicksLimit: 12, maxRotation: 60, minRotation: 30 },
+          },
+          y: {
+            type: "linear",
+            position: "left",
+            title: { display: true, text: metricDef.axisTitle },
+            beginAtZero: !metricDef.higherIsBetter ? false : true,
+          },
+        };
+        if (showSecondary) {
+          scales.y1 = {
+            type: "linear",
+            position: "right",
+            title: { display: true, text: "ours ÷ bokuweb (×, >1 = faster)" },
+            grid: { drawOnChartArea: false },
+          };
+        }
+
+        if (wasmState.chart) {
+          wasmState.chart.options.scales = scales;
+          wasmState.chart.data.labels = snapshots;
+          wasmState.chart.data.datasets = datasets;
+          wasmState.chart.update("none");
+        } else {
+          wasmState.chart = new Chart(el("chart-wasm"), {
+            type: "line",
+            data: { labels: snapshots, datasets },
+            options: {
+              responsive: true,
+              maintainAspectRatio: false,
+              interaction: { mode: "index", intersect: false },
+              scales,
+              plugins: {
+                legend: { display: false },
+                tooltip: { mode: "index", intersect: false },
+              },
+            },
+          });
+        }
+        renderHtmlLegend(wasmState.chart, el("legend-wasm"));
+      }
+
+      function bindWasmControls() {
+        for (const control of Object.values(wasmState.selectors)) {
+          control.addEventListener("change", renderWasmChart);
+        }
+      }
+
+      async function initWasmSection() {
+        wasmRenderMetricOptions(wasmState.selectors.metric);
+        const response = await fetch("./benchmark-wasm.json", { cache: "no-store" });
+        if (!response.ok) {
+          // 404 = no wasm run has published yet. Leave the section with its
+          // empty-state message rather than treating it as a hard error.
+          renderWasmChart();
+          bindWasmControls();
+          return;
+        }
+        const payload = await response.json();
+        wasmState.records = payload.records || [];
+
+        const kinds = uniq(wasmState.records.map((r) => r.kind));
+        const scenarios = uniq(wasmState.records.map((r) => r.scenario));
+        const levels = uniq(wasmState.records.map((r) => r.level)).sort((a, b) => Number(a) - Number(b));
+        wasmRenderPlainOptions(wasmState.selectors.kind, kinds, null);
+        wasmRenderPlainOptions(wasmState.selectors.scenario, scenarios, "all");
+        wasmRenderPlainOptions(wasmState.selectors.level, levels, null);
+
+        // Default to a meaningful starting view: plain kind, all scenarios,
+        // the donor default level (3) if present.
+        if (kinds.includes("plain")) wasmState.selectors.kind.value = "plain";
+        wasmState.selectors.scenario.value = ALWAYS;
+        if (levels.map(String).includes("3")) wasmState.selectors.level.value = "3";
+
+        bindWasmControls();
+        renderWasmChart();
+      }
+
       main().catch((err) => {
         setStatusText(String(err), "outside-band");
+      });
+
+      // Independent of main(): a wasm-payload fetch failure must not blank
+      // the Rust↔FFI dashboard, and vice versa.
+      initWasmSection().catch((err) => {
+        el("wasm-status").textContent = `wasm section error: ${err}`;
       });
     </script>
   </body>

--- a/.github/scripts/merge-wasm-bench.py
+++ b/.github/scripts/merge-wasm-bench.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Merge this run's wasm bench records into the persisted gh-pages timeseries.
+
+Mirrors `merge-benchmarks.py`'s accumulate-then-trim behaviour for the wasm
+section: the dashboard's `benchmark-wasm.json` is an append-only history of
+(scenario, level, engine) datapoints across commits. Each push adds one
+snapshot; old snapshots age out after `RETENTION_DAYS`.
+
+Env vars:
+  WASM_RUN_FILE       this run's records (default: benchmark-wasm-run.json)
+  WASM_EXISTING_FILE  persisted history to merge into (optional — first run
+                      on a fresh gh-pages has none)
+  WASM_OUTPUT_FILE    merged output path (default: benchmark-wasm.json)
+"""
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+RETENTION_DAYS = 180
+MAX_RECORDS = 20000
+
+
+def parse_generated_at(row):
+    stamp = row.get("generated_at")
+    if not stamp:
+        return None
+    try:
+        return datetime.fromisoformat(str(stamp).replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def record_key(row):
+    # One datapoint per (snapshot, kind, scenario, level, engine). A re-run
+    # of the same commit (CI retry) overwrites rather than duplicates.
+    return (
+        row.get("commit_sha"),
+        row.get("generated_at"),
+        row.get("kind"),
+        row.get("scenario"),
+        row.get("level"),
+        row.get("engine"),
+    )
+
+
+def load_records(path):
+    if not path:
+        return []
+    p = Path(path)
+    if not p.is_file():
+        return []
+    payload = json.loads(p.read_text())
+    return payload.get("records", [])
+
+
+def main():
+    run_file = os.environ.get("WASM_RUN_FILE", "benchmark-wasm-run.json")
+    existing_file = os.environ.get("WASM_EXISTING_FILE")
+    output_file = os.environ.get("WASM_OUTPUT_FILE", "benchmark-wasm.json")
+
+    run_path = Path(run_file)
+    if not run_path.is_file():
+        print(f"ERROR: WASM_RUN_FILE={run_file} not found", file=sys.stderr)
+        return 2
+    run_payload = json.loads(run_path.read_text())
+    run_records = run_payload.get("records", [])
+    if not run_records:
+        print("ERROR: this run produced no wasm records to merge", file=sys.stderr)
+        return 1
+
+    merged = {}
+    for row in load_records(existing_file) + run_records:
+        merged[record_key(row)] = row
+
+    values = sorted(
+        merged.values(),
+        key=lambda row: (
+            parse_generated_at(row) or datetime.min.replace(tzinfo=timezone.utc),
+            str(row.get("kind") or ""),
+            str(row.get("scenario") or ""),
+            row.get("level") if isinstance(row.get("level"), int) else 0,
+            str(row.get("engine") or ""),
+        ),
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=RETENTION_DAYS)
+    retained = [
+        row for row in values
+        if (parsed := parse_generated_at(row)) is None or parsed >= cutoff
+    ]
+    if len(retained) > MAX_RECORDS:
+        retained = retained[-MAX_RECORDS:]
+
+    payload = {
+        "version": 1,
+        "reference_engine": run_payload.get("reference_engine", "bokuweb"),
+        "engines": run_payload.get("engines", []),
+        "records": retained,
+    }
+    Path(output_file).write_text(json.dumps(payload, indent=2) + "\n")
+    print(
+        f"Merged {len(run_records)} new + {len(merged) - len(run_records)} "
+        f"existing → {len(retained)} retained wasm records → {output_file}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/merge-wasm-bench.py
+++ b/.github/scripts/merge-wasm-bench.py
@@ -51,7 +51,15 @@ def load_records(path):
     p = Path(path)
     if not p.is_file():
         return []
-    payload = json.loads(p.read_text())
+    try:
+        payload = json.loads(p.read_text())
+    except (json.JSONDecodeError, ValueError) as exc:
+        # A corrupted persisted file (partial write, manual tamper) must not
+        # block every future wasm publish. Warn loudly (visible in CI logs)
+        # and rebuild from this run's records — history re-accumulates over
+        # subsequent pushes rather than wedging the shard permanently.
+        print(f"WARN: corrupted existing file {path}, starting fresh: {exc}", file=sys.stderr)
+        return []
     return payload.get("records", [])
 
 

--- a/.github/scripts/parse-wasm-bench.py
+++ b/.github/scripts/parse-wasm-bench.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Parse the wasm bench harness stdout into per-run dashboard records.
+
+`zstd-wasm/bench/bench.mjs` emits one `REPORT` line per (scenario, level,
+engine) and one `REPORT_DICT` line per (dict scenario, level, engine),
+comparing our two wasm payloads (`ours-simd128`, `ours-scalar`) against the
+most popular npm competitor (`bokuweb` = `@bokuweb/zstd-wasm`). Unlike the
+native matrix this is an engine *triplet*, not a Rust↔FFI pair, so it lands
+in its own dashboard section rather than the relative deltas payload.
+
+This script reads the captured stdout and emits one flat record per
+(kind, scenario, level, engine) carrying ratio + compress/decompress
+throughput. `merge-wasm-bench.py` folds these into the persisted
+`benchmark-wasm.json` timeseries on gh-pages.
+
+Env vars:
+  WASM_BENCH_RAW_FILE   path to the captured `node bench.mjs` stdout (required)
+  GITHUB_SHA            commit sha stamped onto every record (optional)
+  STRUCTURED_ZSTD_BENCH_GENERATED_AT
+                        snapshot timestamp; defaults to now (UTC) (optional)
+  STRUCTURED_ZSTD_BENCH_COMMIT_MESSAGE
+                        commit subject; falls back to `git log -1` (optional)
+
+Output: `benchmark-wasm-run.json` in the current working directory.
+"""
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Both report kinds share the same key=value field set; only the leading
+# token differs. `REPORT_STREAM` (streaming-vs-one-shot, ours only) is
+# intentionally ignored — it has no competitor baseline so it doesn't
+# belong in the vs-bokuweb section.
+REPORT_KINDS = {"REPORT": "plain", "REPORT_DICT": "dict"}
+
+
+def parse_kv(tokens):
+    """Turn `key=value` tokens into a dict; tokens without `=` are skipped."""
+    out = {}
+    for tok in tokens:
+        if "=" not in tok:
+            continue
+        key, _, value = tok.partition("=")
+        out[key] = value
+    return out
+
+
+def throughput_bps(input_bytes, ns):
+    """Bytes/sec relative to the original input size (matches the native
+    dashboard's `input_bytes / seconds` throughput convention). Returns
+    None when timing is missing or non-positive so the dashboard can skip
+    the point rather than plot a bogus zero."""
+    if ns is None or ns <= 0 or input_bytes is None:
+        return None
+    return input_bytes / (ns / 1_000_000_000.0)
+
+
+def resolve_commit_message(commit_sha):
+    explicit = os.environ.get("STRUCTURED_ZSTD_BENCH_COMMIT_MESSAGE")
+    if explicit:
+        first = explicit.strip().splitlines()
+        return first[0].strip() if first else None
+    try:
+        subject = subprocess.run(
+            ["git", "log", "-1", "--format=%s", commit_sha or "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        return subject or None
+    except Exception:
+        return None
+
+
+def main():
+    raw_path = os.environ.get("WASM_BENCH_RAW_FILE")
+    if not raw_path:
+        print("ERROR: set WASM_BENCH_RAW_FILE=<captured bench.mjs stdout>", file=sys.stderr)
+        return 2
+    raw = Path(raw_path)
+    if not raw.is_file():
+        print(f"ERROR: WASM_BENCH_RAW_FILE={raw_path} does not exist", file=sys.stderr)
+        return 2
+
+    commit_sha = os.environ.get("GITHUB_SHA")
+    commit_message = resolve_commit_message(commit_sha)
+    generated_at = (
+        os.environ.get("STRUCTURED_ZSTD_BENCH_GENERATED_AT")
+        or datetime.now(timezone.utc).isoformat()
+    )
+
+    records = []
+    engines = []
+    roundtrip_failures = []
+    for raw_line in raw.read_text().splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        tokens = line.split()
+        kind = REPORT_KINDS.get(tokens[0])
+        if kind is None:
+            continue
+        kv = parse_kv(tokens[1:])
+        scenario = kv.get("scenario")
+        engine = kv.get("engine")
+        level_raw = kv.get("level")
+        if scenario is None or engine is None or level_raw is None:
+            print(f"WARN: skipping malformed {tokens[0]} line: {line}", file=sys.stderr)
+            continue
+        try:
+            level = int(level_raw)
+            input_bytes = int(kv["input_bytes"])
+            framed_bytes = int(kv["framed_bytes"])
+            ratio = float(kv["ratio"])
+            compress_ns = int(kv["compress_ns"])
+            decompress_ns = int(kv["decompress_ns"])
+        except (KeyError, ValueError) as exc:
+            print(f"WARN: skipping {tokens[0]} line (bad field {exc}): {line}", file=sys.stderr)
+            continue
+        roundtrip_ok = kv.get("roundtrip") == "ok"
+        if not roundtrip_ok:
+            roundtrip_failures.append(f"{kind}/{scenario}/L{level}/{engine}")
+        if engine not in engines:
+            engines.append(engine)
+        records.append({
+            "kind": kind,
+            "scenario": scenario,
+            "level": level,
+            "engine": engine,
+            "input_bytes": input_bytes,
+            "framed_bytes": framed_bytes,
+            "ratio": ratio,
+            "compress_ns": compress_ns,
+            "decompress_ns": decompress_ns,
+            "compress_bytes_per_sec": throughput_bps(input_bytes, compress_ns),
+            "decompress_bytes_per_sec": throughput_bps(input_bytes, decompress_ns),
+            "roundtrip_ok": roundtrip_ok,
+            "commit_sha": commit_sha,
+            "commit_message": commit_message,
+            "generated_at": generated_at,
+        })
+
+    if not records:
+        print("ERROR: no REPORT / REPORT_DICT lines parsed from wasm bench output", file=sys.stderr)
+        return 1
+
+    payload = {
+        "version": 1,
+        # The competitor every `ours-*` engine is benchmarked against; the
+        # dashboard divides our throughput by this engine's to show the
+        # speed ratio over time.
+        "reference_engine": "bokuweb",
+        "engines": engines,
+        "commit_sha": commit_sha,
+        "commit_message": commit_message,
+        "generated_at": generated_at,
+        "records": records,
+    }
+    Path("benchmark-wasm-run.json").write_text(json.dumps(payload, indent=2) + "\n")
+    print(
+        f"Parsed {len(records)} wasm records "
+        f"({len(engines)} engines: {', '.join(engines)})",
+        file=sys.stderr,
+    )
+    if roundtrip_failures:
+        # A round-trip failure means a payload produced a frame that did not
+        # decode back to the input — the numbers for that cell are
+        # meaningless. Surface it loudly; the bench harness itself already
+        # exits non-zero, so CI fails regardless, but we keep the records so
+        # the dashboard can still show the surrounding (valid) series.
+        print(
+            f"WARN: {len(roundtrip_failures)} round-trip failure(s): "
+            + ", ".join(roundtrip_failures),
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust_core: ${{ steps.filter.outputs.rust_core }}
+      wasm_core: ${{ steps.filter.outputs.wasm_core }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -55,6 +56,19 @@ jobs:
           filters: |
             rust_core:
               - 'zstd/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+            # The wasm-vs-bokuweb dashboard shard (`bench-wasm`) only needs
+            # to re-run when something that can move the wasm payloads'
+            # speed/ratio changed: the core crate (compiled into the wasm
+            # module), the wasm crate / npm glue itself, the bench harness,
+            # or the dep/toolchain pins. A push touching only the native
+            # bench scripts, docs, or unrelated CI leaves the wasm numbers
+            # untouched, so the wasm shard stays green-skipped on it.
+            wasm_core:
+              - 'zstd/**'
+              - 'zstd-wasm/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
@@ -292,6 +306,121 @@ jobs:
               exit 1
             fi
           done
+
+  bench-wasm:
+    # #366: continuous wasm dashboard shard. The native bench matrix runs
+    # a prebuilt criterion binary (Rust vs C FFI); this shard instead
+    # builds the npm payloads and runs `node zstd-wasm/bench/bench.mjs`,
+    # which measures our two wasm tiers (simd128 + scalar) against the
+    # most popular npm competitor (@bokuweb/zstd-wasm). Its REPORT* lines
+    # feed a dedicated wasm section on the gh-pages dashboard so the
+    # wasm speed/ratio vs bokuweb is tracked over time, not just checked
+    # locally before an npm publish.
+    #
+    # Push-to-main only (consistent with the rest of the bench pipeline
+    # being push-only — #362) and gated on `wasm_core` so it skips pushes
+    # that can't move the wasm numbers. It is INDEPENDENT of the native
+    # `bench-matrix` cascade (which is `rust_core`-gated): a wasm-only
+    # change must still update the dashboard. It publishes only
+    # `benchmark-wasm.json` to gh-pages — `index.html` stays owned by
+    # `benchmark-pages` / `pages-only.yml` — so the two publishers write
+    # disjoint files and never race for the same blob.
+    name: Bench wasm vs bokuweb (dashboard shard)
+    needs: [lint, changes]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changes.outputs.wasm_core == 'true'
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: wasm-bench
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Build npm payloads (simd128 + scalar)
+        working-directory: zstd-wasm/npm
+        run: |
+          npm ci || npm install
+          npm run build
+
+      - name: Run wasm bench (capture REPORT* lines)
+        working-directory: zstd-wasm/bench
+        # `pipefail` + `tee`: bench.mjs exits non-zero on any round-trip
+        # failure, which must fail the shard. `tee` keeps the captured
+        # stdout for the parser regardless of pass/fail.
+        run: |
+          npm ci || npm install
+          set -o pipefail
+          node bench.mjs | tee "$GITHUB_WORKSPACE/wasm-bench-raw.txt"
+
+      - name: Parse REPORT* lines into dashboard records
+        env:
+          WASM_BENCH_RAW_FILE: ${{ github.workspace }}/wasm-bench-raw.txt
+          STRUCTURED_ZSTD_BENCH_GENERATED_AT: ${{ github.event.head_commit.timestamp || github.event.repository.updated_at }}
+        run: python3 .github/scripts/parse-wasm-bench.py
+
+      - name: Upload wasm bench artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-wasm-run
+          path: benchmark-wasm-run.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Generate bot token
+        id: bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
+      - name: Checkout gh-pages with push token
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          token: ${{ steps.bot-token.outputs.token }}
+          path: gh-pages
+
+      - name: Merge into persisted wasm timeseries and publish
+        env:
+          WASM_RUN_FILE: ${{ github.workspace }}/benchmark-wasm-run.json
+          WASM_EXISTING_FILE: ${{ github.workspace }}/gh-pages/dev/bench/benchmark-wasm.json
+          WASM_OUTPUT_FILE: ${{ github.workspace }}/gh-pages/dev/bench/benchmark-wasm.json
+        run: |
+          mkdir -p gh-pages/dev/bench
+          python3 .github/scripts/merge-wasm-bench.py
+          cd gh-pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dev/bench/benchmark-wasm.json
+          if git diff --cached --quiet; then
+            echo "No wasm timeseries change to publish."
+            exit 0
+          fi
+          git commit -m "chore(bench): publish wasm vs bokuweb dashboard data"
+          # Disjoint-file publishers can still collide on a concurrent
+          # gh-pages push; rebase onto the latest remote tip and retry a
+          # few times before giving up.
+          for attempt in 1 2 3; do
+            if git push origin gh-pages; then
+              echo "Published on attempt $attempt."
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt); rebasing on remote gh-pages."
+            git pull --rebase origin gh-pages
+          done
+          echo "::error::failed to publish wasm timeseries after 3 attempts"
+          exit 1
 
   codecov:
     needs: lint

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -155,3 +155,32 @@ calibration/pre-test coefficients):
 - **speed status**: `rust_faster` when `> 1.05`, `near_parity` when `0.99..=1.05`, `rust_slower` when `< 0.99`
 
 Criterion also writes its usual detailed estimates under `target/criterion/`.
+
+## WebAssembly Comparison (vs @bokuweb/zstd-wasm)
+
+The native matrix above compares pure-Rust against C FFI. The WebAssembly
+build is tracked separately against the most popular npm wasm zstd,
+[`@bokuweb/zstd-wasm`](https://www.npmjs.com/package/@bokuweb/zstd-wasm) (an
+emscripten build of the C reference).
+
+- **Harness:** `node zstd-wasm/bench/bench.mjs` — loads both of our payloads
+  (`simd128` + `scalar`) plus bokuweb, runs the shared fixtures, and emits
+  `REPORT` / `REPORT_DICT` lines (engine triplet: `ours-simd128`,
+  `ours-scalar`, `bokuweb`).
+- **CI shard:** `bench-wasm` in `ci.yml`. Push-to-main only (like the rest of
+  the bench pipeline) and gated on `wasm_core` path changes; independent of the
+  native `rust_core`-gated matrix so a wasm-only change still updates the
+  dashboard. It builds the npm payloads, runs the harness, parses the
+  `REPORT*` lines (`.github/scripts/parse-wasm-bench.py`), and merges the
+  result into the persisted `gh-pages/dev/bench/benchmark-wasm.json` timeseries
+  (`.github/scripts/merge-wasm-bench.py`, 180-day retention).
+- **Dashboard:** the `dev/bench` page renders a dedicated *WebAssembly* section
+  plotting compress speed, decompress speed, and output ratio per engine over
+  time, with our throughput shown as a multiple of bokuweb (`>1` = faster).
+- **Local run:** `cd zstd-wasm/npm && npm ci && npm run build` then
+  `cd ../bench && npm ci && node bench.mjs` (also the pre-publish gate before
+  shipping the npm package).
+
+`benchmark-wasm.json` record dimensions: `kind` (`plain` / `dict`),
+`scenario`, `level`, `engine`; metrics: `ratio`, `compress_bytes_per_sec`,
+`decompress_bytes_per_sec`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The level → strategy column matches donor `ZSTD_defaultCParameters[0]` at `zst
 
 Per-merge benchmarks publish to GitHub Pages: **[structured-world.github.io/structured-zstd/dev/bench](https://structured-world.github.io/structured-zstd/dev/bench/)**.
 
-The CI matrix covers `x86_64-linux-gnu`, `i686-linux-gnu`, and `x86_64-musl`; the dashboard exposes per-target / stage / scenario / level filtering. The encoder architecture rewrite ([#111](https://github.com/structured-world/structured-zstd/issues/111)) is the active surface for compression-side work; the public benchmark report tracks the delta vs upstream C zstd over time.
+The CI matrix covers `x86_64-linux-gnu`, `i686-linux-gnu`, and `x86_64-musl`; the dashboard exposes per-target / stage / scenario / level filtering. The encoder architecture rewrite ([#111](https://github.com/structured-world/structured-zstd/issues/111)) is the active surface for compression-side work; the public benchmark report tracks the delta vs upstream C zstd over time. A dedicated dashboard section also tracks the WebAssembly build (`simd128` + `scalar`) against the most popular npm wasm zstd, [`@bokuweb/zstd-wasm`](https://www.npmjs.com/package/@bokuweb/zstd-wasm), over time.
 
 See [BENCHMARKS.md](https://github.com/structured-world/structured-zstd/blob/main/BENCHMARKS.md) for the methodology — small payloads, entropy extremes, a `100 MiB` large-stream scenario, repository corpus fixtures, and optional local Silesia corpora.
 


### PR DESCRIPTION
## Summary

Tracks the WebAssembly build (`simd128` + `scalar`) against the most popular npm wasm zstd, [`@bokuweb/zstd-wasm`](https://www.npmjs.com/package/@bokuweb/zstd-wasm), on the gh-pages perf dashboard over time. Previously the wasm-vs-competitor comparison ran only locally as a pre-publish gate, so a wasm perf/ratio regression would only surface if someone re-ran the bench by hand.

## What changed

- **CI shard `bench-wasm`** (`ci.yml`): push-to-main only, gated on a new `wasm_core` path filter (`zstd/**`, `zstd-wasm/**`, `Cargo.*`, toolchain). Builds the npm payloads, runs `node zstd-wasm/bench/bench.mjs`, captures its `REPORT*` lines, and publishes a dedicated wasm timeseries to gh-pages. Independent of the `rust_core`-gated native matrix so a wasm-only change still updates the dashboard. Publishes only `benchmark-wasm.json` (index.html stays owned by `benchmark-pages` / `pages-only`), so the two publishers write disjoint files and never race; a rebase-retry loop guards the rare concurrent-push case.
- **Aggregation scripts**: `parse-wasm-bench.py` turns the `REPORT` / `REPORT_DICT` engine triplet (`ours-simd128`, `ours-scalar`, `bokuweb`) into records carrying ratio + compress/decompress throughput; `merge-wasm-bench.py` accumulates them into the persisted `benchmark-wasm.json` with 180-day retention and per-snapshot dedup.
- **Dashboard** (`index.html`): a dedicated *WebAssembly* section plots compress speed, decompress speed, and output ratio per engine over time, with our throughput shown as a multiple of bokuweb (`>1 = faster`). Degrades gracefully when no wasm data is published yet — the rest of the dashboard is unaffected.
- **Docs**: BENCHMARKS.md (new section) + README.md.

## Acceptance criteria

- [x] Push-to-main runs the wasm bench shard; `REPORT*` lines captured + aggregated.
- [x] `dev/bench` dashboard shows wasm simd128/scalar vs bokuweb ratio + speed over time.
- [x] No PR-time cost (shard is push-only).

## Testing

All verified against real output, not synthetic:

- Real payload build + `node bench.mjs` (exit 0, all roundtrips ok).
- Parser on real output → **84 records** (72 plain + 12 dict = 6×4×3 + 2×2×3).
- Merge: accumulation (6→12), dedup of a re-run snapshot (stays 12), retention.
- Dashboard in a node mock-DOM harness on real data: 3 engine lines + 2 ÷bokuweb ratio lines; switching to the ratio metric drops the secondary axis; values correct.
- 404 path (no data yet): empty-state message, no chart created, main dashboard unaffected.
- `node --check` (JS), `py_compile` (scripts), YAML validity (ci.yml).

## Note on the issue plan

The issue suggested extending `aggregate-bench-levels.py` / `merge-benchmarks.py`, but those run inside `rust_core`-gated jobs — routing wasm through them would break the "push-to-main runs the wasm shard" criterion (a wasm-only change wouldn't update the dashboard). Implemented as a self-contained wasm pipeline instead; the goal (continuous wasm tracking) is fully met.

Closes #366

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated WebAssembly performance dashboard with time-series comparisons across simd128, scalar, and a reference npm implementation.
  * Dashboard UI now includes metric/scenario/level selectors, per-engine lines and ratio overlays, live legend, and status messaging for empty or missing data.
  * CI now runs WebAssembly benchmarks and automatically updates the dashboard data on changes.

* **Documentation**
  * Updated performance docs and README to cover WebAssembly benchmarking and dashboard coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->