### PR TITLE
fix(wasm): add floating version requirement to structured-zstd dep

### DIFF
--- a/zstd-wasm/Cargo.toml
+++ b/zstd-wasm/Cargo.toml
@@ -24,7 +24,17 @@ wasm-bindgen = "0.2"
 # Pull the core codec with no default features (no std) and the simd128 kernel
 # tier. The actual SIMD selection is compile-time via `-C target-feature`:
 # the +simd128 payload engages it, the scalar payload does not.
-structured-zstd = { path = "../zstd", default-features = false, features = ["kernel_simd128"] }
+#
+# Floating `version = "0"` (NOT an exact pin) so `cargo package`'s
+# "all deps must have a version requirement" check passes without ANY
+# per-release update: `^0` matches every `0.x.x` (0.0.31, 0.1.1, ...), so it
+# survives the 0.0 -> 0.1 transition too; only the eventual 1.0.0 boundary
+# would ever need a one-time bump. This crate is `release = false`, so
+# release-plz never rewrites the requirement for us, and an exact pin would
+# go stale on the next core bump and break packaging again. The requirement
+# is purely ceremonial: `path` always wins for local/workspace builds and
+# this crate is never published to crates.io.
+structured-zstd = { version = "0", path = "../zstd", default-features = false, features = ["kernel_simd128"] }
 
 # Size-tuned wasm-pack release profile: optimise for size + a wasm-opt -Oz
 # post-pass, since payload bytes are the budget for a published wasm module.


### PR DESCRIPTION
## Problem

The `release-plz` job fails at the `cargo package` step:

```
error: failed to verify manifest at `zstd-wasm/Cargo.toml`
Caused by:
  all dependencies must have a version requirement specified when packaging.
  dependency `structured-zstd` does not specify a version
```

release-plz runs `cargo package` across the workspace to compute next versions, and cargo rejects any **path** dependency that lacks a version requirement. `zstd-wasm` declared `structured-zstd` as path-only.

## Fix

Add `version = "0"` to the `structured-zstd` dependency in `zstd-wasm/Cargo.toml`.

Why floating `"0"` (`^0`, matches every `0.x.x`) rather than an exact pin:

- `zstd-wasm` is `release = false`, so release-plz never rewrites this requirement for us. An exact pin (e.g. `"0.0.31"` = `^0.0.31` = `>=0.0.31,<0.0.32`) would stop matching on the very next core bump and break packaging again.
- `"0.0"` (`^0.0`) would survive patch bumps but break at the `0.0` -> `0.1` transition.
- `"0"` (`^0`) matches all `0.x.x` (including `0.1.1`), needing a one-time manual change only at the `1.0.0` boundary.

The requirement is purely ceremonial: `path` always wins for local/workspace builds, and the crate is never published to crates.io (npm-only distribution).

## Verification

`cargo package -p structured-zstd-wasm --no-verify` now succeeds (previously failed on the missing version requirement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration to improve package compatibility with future versions while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->