### PR TITLE
chore: release v0.0.32

### DIFF
--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structured-zstd"
-version = "0.0.31"
+version = "0.0.32"
 rust-version = "1.92"
 authors = [
     "Moritz Borcherding <moritz.borcherding@web.de>",


### PR DESCRIPTION
Bumps `structured-zstd` to 0.0.32 so `cargo publish` (which reads the version from `zstd/Cargo.toml`) emits 0.0.32 to crates.io, matching the npm `@structured-world/structured-zstd@0.0.32` that the `v0.0.32` release already published (the npm job stamps the version from the tag name).

Background: the `v0.0.32` tag was created manually to reset the release-plz baseline off the broken `v0.0.31` tag (whose `zstd-wasm` manifest lacked a version requirement, deadlocking the release-pr job). The tag landed on `e253a27e` where the manifest still read 0.0.31, so the crates.io publish tried to re-publish 0.0.31 and failed. This commit supplies the missing manifest bump; after merge the `v0.0.32` tag will be moved onto the merge commit and the crates.io publish re-run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump (0.0.31 → 0.0.32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->