### PR TITLE
ci(bench): fix dashboard dict ratio/labelling + wasm-pack binaryen flake

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1001,10 +1001,23 @@
       // rust_value and ffi_value, so the source dimension is just bench
       // bookkeeping and doesn't change what the chart shows.
       function isCompressStage(stage) {
-        return stage === "compress";
+        // Prefix match (symmetric with `isDecompressStage`) so the dictionary
+        // stage `compress-dict` is recognised as a compress stage. `decompress`
+        // / `decompress-dict` start the substring `compress` at index 2, so
+        // they are correctly excluded here.
+        return typeof stage === "string" && stage.indexOf("compress") === 0;
       }
       function isDecompressStage(stage) {
         return typeof stage === "string" && stage.indexOf("decompress") === 0;
+      }
+      // Payload kind derived from the bench stage: the `-dict` stages
+      // (`compress-dict` / `decompress-dict`) are the trained-dictionary
+      // variants, everything else is plain. Used to keep dict and plain points
+      // on distinct Level-Profile buckets so a level measured both ways (e.g.
+      // a numeric level with and without a dictionary, or the `*_ldm` vs
+      // `*_ldm_dict` pair) does not average its plain and dict metrics together.
+      function stageKind(stage) {
+        return typeof stage === "string" && stage.endsWith("-dict") ? "dict" : "plain";
       }
 
       // Shared mapper from (row.metric, row.stage) → chart logical
@@ -1173,10 +1186,13 @@
           if (typeof row.rust_value !== "number" || typeof row.ffi_value !== "number") continue;
           const lm = profileLogicalMetric(row);
           if (!lm) continue;
-          const key = `${row.level}|${lm}`;
+          // Bucket plain and dict separately so a level measured both ways does
+          // not merge its plain and dict metrics (see `stageKind`).
+          const kind = stageKind(row.stage);
+          const key = `${row.level}|${kind}|${lm}`;
           const cohort = cohortKey(row);
           const latestKey = cohort ? `${key}|${cohort}` : key;
-          matchingRows.push({ row, lm, key, latestKey });
+          matchingRows.push({ row, lm, kind, key, latestKey });
           if (filter.snapshot === PROFILE_LATEST) {
             const previous = latestPerKey.get(latestKey);
             if (!previous || compareSnapshotIdentity(row, previous) > 0) {
@@ -1190,14 +1206,14 @@
           (b.generated_at || b.commit_sha || "local-run");
 
         const byLevelLogical = new Map();
-        for (const { row, lm, key, latestKey } of matchingRows) {
+        for (const { row, kind, key, latestKey } of matchingRows) {
           if (filter.snapshot === PROFILE_LATEST) {
             const winner = latestPerKey.get(latestKey);
             if (!winner || !sameSnapshotLabel(row, winner)) continue;
           }
           let agg = byLevelLogical.get(key);
           if (!agg) {
-            agg = { level: row.level, rust_sum: 0, ffi_sum: 0, count: 0 };
+            agg = { level: row.level, kind, rust_sum: 0, ffi_sum: 0, count: 0 };
             byLevelLogical.set(key, agg);
           }
           agg.rust_sum += row.rust_value;
@@ -1205,24 +1221,35 @@
           agg.count += 1;
         }
 
-        const levelSet = new Set();
-        for (const agg of byLevelLogical.values()) levelSet.add(agg.level);
-        const levels = Array.from(levelSet)
-          .map((value) => ({ value, parsed: parseLevelId(value) }))
+        // One X-axis bucket per (level, kind) so the plain and dict variants of
+        // the same level occupy distinct points instead of averaging together.
+        const levelKindMap = new Map();
+        for (const agg of byLevelLogical.values()) {
+          const id = `${agg.level}|${agg.kind}`;
+          if (!levelKindMap.has(id)) {
+            levelKindMap.set(id, { value: agg.level, kind: agg.kind });
+          }
+        }
+        const levels = Array.from(levelKindMap.values())
+          .map((entry) => ({ ...entry, parsed: parseLevelId(entry.value) }))
           .sort((a, b) => {
-            if (a.parsed && b.parsed) return a.parsed.numeric - b.parsed.numeric;
-            if (a.parsed) return -1;
-            if (b.parsed) return 1;
+            // Numeric level order first; parsed-less levels last. For the same
+            // level, plain precedes its dict variant so the two sit adjacent.
+            const an = a.parsed ? a.parsed.numeric : Number.POSITIVE_INFINITY;
+            const bn = b.parsed ? b.parsed.numeric : Number.POSITIVE_INFINITY;
+            if (an !== bn) return an - bn;
+            if (a.kind !== b.kind) return a.kind === "plain" ? -1 : 1;
             return a.value.localeCompare(b.value);
           });
 
-        const levelLabels = levels.map((entry) =>
-          entry.parsed ? entry.parsed.label : entry.value,
-        );
+        const levelLabels = levels.map((entry) => {
+          const base = entry.parsed ? entry.parsed.label : entry.value;
+          return entry.kind === "dict" ? `${base} (dict)` : base;
+        });
 
         // Speed records carry bytes/sec; convert to MiB/s for axis legibility.
-        const lookup = (level, lm, side) => {
-          const agg = byLevelLogical.get(`${level}|${lm}`);
+        const lookup = (level, kind, lm, side) => {
+          const agg = byLevelLogical.get(`${level}|${kind}|${lm}`);
           if (!agg || agg.count === 0) return null;
           const sum = side === "rust" ? agg.rust_sum : agg.ffi_sum;
           const mean = sum / agg.count;
@@ -1233,7 +1260,7 @@
         };
 
         const series = (lm, side) =>
-          levels.map((e) => lookup(e.value, lm, side));
+          levels.map((e) => lookup(e.value, e.kind, lm, side));
 
         return {
           levels: levelLabels,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,11 +346,34 @@ jobs:
         with:
           node-version: "24"
 
+      # `wasm-pack build --release` runs the `-Oz` wasm-opt pass, for which it
+      # downloads a pinned binaryen tarball from GitHub releases at build time.
+      # That download is network-flaky (transient 5xx / rate-limit) and was
+      # failing the whole dashboard shard. Cache wasm-pack's tool dir so the
+      # tarball is fetched at most once across runs.
+      - name: Cache wasm-pack binaryen download
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/.wasm-pack
+          key: wasm-pack-binaryen-${{ runner.os }}
+
       - name: Build npm payloads (simd128 + scalar)
         working-directory: zstd-wasm/npm
         run: |
           npm ci || npm install
-          npm run build
+          # Retry the build: on a cold binaryen cache the wasm-opt tarball
+          # download can transiently fail. Hard-fail after 3 attempts so a real
+          # (non-transient) breakage still fails the shard.
+          attempt=0
+          until npm run build; do
+            attempt=$((attempt + 1))
+            if [ "$attempt" -ge 3 ]; then
+              echo "wasm build failed after $attempt attempts" >&2
+              exit 1
+            fi
+            echo "wasm build attempt $attempt failed (likely transient binaryen fetch); retrying..." >&2
+            sleep 15
+          done
 
       - name: Run wasm bench (capture REPORT* lines)
         working-directory: zstd-wasm/bench


### PR DESCRIPTION
Two bench-dashboard / CI fixes bundled (both `ci`/dashboard config, no library code touched).

## Dashboard: dict ratio + plain/dict separation on Level Profile
`isCompressStage` matched the stage with a strict `=== "compress"`, so `compress-dict` rows were dropped from `profileLogicalMetric`. Dictionary levels (the `*_ldm_dict` variants, and any level measured with a dictionary) lost their compression-ratio and compress-speed series and showed only the decompress points that leaked in via the `decompress`-prefix match — appearing as bare labels on the compress graph with no ratio.

- `isCompressStage` now matches `compress` as a prefix (symmetric with `isDecompressStage`; `decompress` starts the substring at index 2 so it stays excluded), so `compress-dict` ratio + speed are surfaced.
- The Level Profile now buckets by `(level, kind, metric)` where kind is derived from the `-dict` stage suffix. Plain and dict variants occupy distinct X-axis points (dict labelled `… (dict)`), so a level measured both ways no longer averages its plain and dict metrics together.

Result: 2 ldm points under compress (plain) and 2 under compress-dict, with the dict ratio visible. The parser already emits the `compress-dict` `compression_ratio` records; this was purely a dashboard-side drop.

## CI: wasm-pack binaryen download flake
The `bench-wasm` shard failed when wasm-pack's `-Oz` pass downloaded its pinned binaryen tarball from GitHub releases and the fetch transiently failed (5xx / rate-limit), aborting the shard before it pushed dashboard data (the v117 asset exists — HTTP 200 — so it was transient, not a removed release).

- Cache `~/.cache/.wasm-pack` so the tarball is fetched at most once.
- Retry the wasm build up to 3 times to ride out a cold-cache transient; still hard-fails afterwards so a genuine breakage is not masked.

## Testing
- Dashboard JS: extracted + `node --check` clean; logic verified against the parser's `compress-dict` record shape (`run-benchmarks.sh`).
- ci.yml: YAML validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard charts now separate dictionary-trained and standard compression stages on the X-axis (keeps plain and dict measurements distinct and labels dict points with “(dict)”), preventing unintended averaging across stage types.

* **Chores**
  * Improved WebAssembly build resilience by caching build tools and adding automatic retry logic (up to 3 attempts) to reduce flaky failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->