### PR TITLE
perf(decode): cut HUF/FSE entropy-build overhead on the decode hot path

### DIFF
--- a/zstd/src/bit_io/bit_reader.rs
+++ b/zstd/src/bit_io/bit_reader.rs
@@ -25,6 +25,11 @@ impl<'s> BitReader<'s> {
         self.idx -= n;
     }
 
+    // `#[inline]` so the hot caller (`read_probabilities`, which calls this
+    // per FSE NCount symbol with mostly-constant `n`) folds it in and
+    // const-propagates `n`, collapsing the multi-byte branch for the common
+    // small-width reads instead of paying a call per symbol.
+    #[inline]
     pub fn get_bits(&mut self, n: usize) -> Result<u64, GetBitsError> {
         if n > 64 {
             return Err(GetBitsError::TooManyBits {
@@ -60,13 +65,13 @@ impl<'s> BitReader<'s> {
             let full_bytes_needed = (n - bits_left_in_current_byte) / 8;
             let bits_in_last_byte_needed = n - bits_left_in_current_byte - full_bytes_needed * 8;
 
-            assert!(
+            debug_assert!(
                 bits_left_in_current_byte + full_bytes_needed * 8 + bits_in_last_byte_needed == n
             );
 
             let mut bit_shift = bits_left_in_current_byte; //this many bits are already set in value
 
-            assert!(self.idx.is_multiple_of(8));
+            debug_assert!(self.idx.is_multiple_of(8));
 
             //collect full bytes
             for _ in 0..full_bytes_needed {
@@ -75,7 +80,7 @@ impl<'s> BitReader<'s> {
                 bit_shift += 8;
             }
 
-            assert!(n - bit_shift == bits_in_last_byte_needed);
+            debug_assert!(n - bit_shift == bits_in_last_byte_needed);
 
             if bits_in_last_byte_needed > 0 {
                 let val_las_byte =
@@ -85,7 +90,7 @@ impl<'s> BitReader<'s> {
             }
         }
 
-        assert!(self.idx == old_idx + n);
+        debug_assert!(self.idx == old_idx + n);
 
         Ok(value)
     }

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -110,6 +110,11 @@ impl<'t, E: FseEntry> FSEDecoderImpl<'t, E> {
     /// unchecked indexing in `read_entry`) into a clear fail-fast
     /// panic that surfaces the API misuse immediately instead of
     /// leaving the bitstream and decode state silently desynchronised.
+    // Checked, refill-per-call state advance. The hot decode paths (sequence
+    // loop, HUF weights decode) batch their refills and use
+    // `update_state_fast`; the only remaining caller is the test/fuzz
+    // `round_trip` helper, which wants the bounds-checked path.
+    #[cfg(any(test, feature = "fuzz_exports"))]
     pub fn update_state<K: CpuKernel>(&mut self, bits: &mut BitReaderReversed<'_, K>) {
         // Public-API safety guard: `FSEDecoder::new` builds a decoder
         // with a zero-default `state` (Entry { new_state: 0, num_bits:

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -513,11 +513,24 @@ impl HuffmanTable {
 
                 self.weights.clear();
 
+                // The weights FSE table is built with a max accuracy_log of 6
+                // (the `build_decoder(fse_stream, 6)` call above), so each state
+                // update reads at most 6 bits. Refilling once per loop step
+                // (two interleaved updates = up to 12 bits) lets both updates
+                // use the unchecked fast advance instead of a per-symbol refill
+                // branch, mirroring the donor's single reload per decode step.
+                // `bits_remaining()` still tracks end-of-stream via `extra_bits`
+                // (maintained by `refill_slow`), so the termination checks below
+                // fire identically.
+                const WEIGHTS_REFILL_BUDGET: u8 = 12;
+
                 // The two decoders take turns decoding a single symbol and updating their state.
                 loop {
+                    br.ensure_bits(WEIGHTS_REFILL_BUDGET);
+
                     let w = dec1.decode_symbol();
                     self.weights.push(w);
-                    dec1.update_state(&mut br);
+                    dec1.update_state_fast(&mut br);
 
                     if br.bits_remaining() <= -1 {
                         //collect final states
@@ -527,7 +540,7 @@ impl HuffmanTable {
 
                     let w = dec2.decode_symbol();
                     self.weights.push(w);
-                    dec2.update_state(&mut br);
+                    dec2.update_state_fast(&mut br);
 
                     if br.bits_remaining() <= -1 {
                         //collect final states

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -662,8 +662,7 @@ impl HuffmanTable {
             self.bit_ranks[(*num_bits) as usize] += 1;
         }
 
-        //fill with dummy symbols
-        self.packed_decode.resize(1 << self.max_num_bits, 0);
+        let table_size = 1usize << self.max_num_bits;
 
         //starting codes for each rank
         self.rank_indexes.clear();
@@ -675,12 +674,26 @@ impl HuffmanTable {
                 + self.bit_ranks[bits as usize] as usize * (1 << (max_bits - bits));
         }
 
+        // The rank walk partitions [0, table_size) into one contiguous run
+        // per code length (no gaps, no overlap), so the fill loop below
+        // initialises every slot — the donor likewise skips the table
+        // pre-zero (`ZSTD_memset ... is not necessary`). Assert the total
+        // span equals `table_size` before trusting the unchecked `set_len`.
         assert!(
-            self.rank_indexes[0] == self.packed_decode.len(),
+            self.rank_indexes[0] == table_size,
             "rank_idx[0]: {} should be: {}",
             self.rank_indexes[0],
-            self.packed_decode.len()
+            table_size
         );
+
+        // Write into the uninitialised tail (`spare_capacity_mut`) and only
+        // `set_len` after the fill completes, avoiding the redundant
+        // zero-then-overwrite of a `resize(_, 0)`. `slots` borrows only the
+        // `packed_decode` field, so the loop's reads of `bits` and writes to
+        // `rank_indexes` (disjoint fields) coexist.
+        self.packed_decode.clear();
+        self.packed_decode.reserve(table_size);
+        let slots = self.packed_decode.spare_capacity_mut();
 
         for symbol in 0..self.bits.len() {
             let bits_for_symbol = self.bits[symbol];
@@ -692,11 +705,25 @@ impl HuffmanTable {
                 // byte = nbBits. `num_bits ≤ 11` always fits in the
                 // upper byte alongside an 8-bit symbol.
                 let base_idx = self.rank_indexes[bits_for_symbol as usize];
-                let len = 1 << (max_bits - bits_for_symbol);
+                let len = 1usize << (max_bits - bits_for_symbol);
                 self.rank_indexes[bits_for_symbol as usize] += len;
                 let packed = u16::from(symbol as u8) | (u16::from(bits_for_symbol) << 8);
-                self.packed_decode[base_idx..base_idx + len].fill(packed);
+                // Constant-`packed` write of a contiguous run: LLVM lowers
+                // this to the same vectorised broadcast store as `<[u16]>::fill`
+                // (the donor's hand-rolled 64-bit `HUF_DEltX1` broadcast), just
+                // into uninitialised memory.
+                for slot in &mut slots[base_idx..base_idx + len] {
+                    slot.write(packed);
+                }
             }
+        }
+
+        // SAFETY: the rank walk covers [0, table_size) exactly (asserted via
+        // `rank_indexes[0] == table_size`); `reserve(table_size)` guaranteed
+        // capacity; every slot in that range was written by the loop above,
+        // so no uninitialised entry is exposed.
+        unsafe {
+            self.packed_decode.set_len(table_size);
         }
 
         Ok(())


### PR DESCRIPTION
Three donor-parity decode wins on the entropy-reconstruction path, found by profiling the z000033 decode loop on the i9 (the HUF table build + forward NCount parse were ~20%+ of decode, all generic scalar code the per-kernel dispatch never touches).

## Changes
- **`perf(decode): batch refill in HUF weight FSE-decode`** — the HUF weight decode interleaves two FSE decoders; each was advanced via the checked `update_state` (a refill branch per symbol + a non-inlined call). The weight FSE table has accuracy_log ≤ 6, so one `ensure_bits(12)` per loop step covers both interleaved updates and lets them use the inlined `update_state_fast`, mirroring the donor's single reload per decode step. `bits_remaining()` still tracks end-of-stream via `extra_bits`, so termination is byte-identical. The checked `update_state` is now only reached by the test/fuzz `round_trip` helper, so it is gated behind `cfg(any(test, fuzz_exports))`.
- **`perf(decode): inline forward BitReader::get_bits, drop release-mode asserts`** — `read_probabilities` (FSE NCount parse) calls the forward `get_bits` once per symbol with a mostly-constant width. It had no `#[inline]` and four internal arithmetic-identity `assert!`s that ran in release. → `#[inline]` (folds + const-propagates the width, collapsing the multi-byte branch) + `debug_assert!` (the asserts validate the function's own span math, not input — input is guarded by the early `Err` returns).
- **`perf(decode): drop redundant zero-fill of HUF decode table`** — `build_table_from_weights` pre-zeroed the whole decode table and then the rank-walk fill overwrote every entry. The walk covers `[0, table_size)` exactly (asserted), so switch to a `spare_capacity_mut` + `set_len` fill (the pattern the FSE `build_decoding_table` already uses), dropping the redundant memset.

## Results
Same-session interleaved A/B on the i9 (z000033 L3 decode, main vs branch HEAD, 3 rounds each): branch consistently faster, ~−1.0…−1.2% wall. Modest but real and in the right direction, with the entropy-build path now matching donor shape (batched refill, inlined NCount reads, no double-write).

## Testing
- 782 lib + cross-validation tests pass; decode is byte-identical (roundtrip + cross-validation suites cover the FSE-weight and NCount paths).
- Clippy clean on `--no-default-features` (no_std), musl (`kernel_scalar,hash` and all-kernels default), and wasm32 `simd128`. Changed functions are scalar/portable (entropy table build + header parse have no SIMD kernel variant in the donor either); the per-kernel sequence/literal monoliths are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal validity checks to improve release-build performance while maintaining debug-time verification.
  * Enhanced bit-level and Huffman decoding paths with performance improvements, including faster symbol decoding and optimized lookup table construction.
  * Improved test and fuzzing infrastructure with conditional compilation for testing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->