### PR TITLE
feat: dictionary CDict-equivalent (encoder + C ABI + wasm + CLI); L22 dict memory 8.2x->1.13x

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -34,6 +34,19 @@ name = "structured-zstd-wasm"
 release = false
 git_tag_name = "structured-zstd-wasm-v{{ version }}"
 
+# C ABI cdylib (drop-in libzstd.so.1) — distributed as a system library, never
+# from crates.io (`publish = false` in c-api/Cargo.toml), so it takes no git
+# release of its own. Same baseline-diff trap as the wasm crate above: added
+# after the last shared `v*` tag (v0.0.33), so resolving its "last release"
+# against the shared `v{{ version }}` pattern checks out the v0.0.33 worktree
+# where this package does not yet exist and crashes `release-pr` with "Failed
+# to find package structured-zstd-c". A private tag namespace with no matching
+# tag makes release-plz treat it as unreleased and skip the broken baseline diff.
+[[package]]
+name = "structured-zstd-c"
+release = false
+git_tag_name = "structured-zstd-c-v{{ version }}"
+
 [changelog]
 commit_parsers = [
     { message = "^chore", skip = true },

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -1,0 +1,340 @@
+//! Compression / decompression dictionary objects: `ZSTD_CDict` / `ZSTD_DDict`
+//! and the one-shot `*_usingCDict` / `*_usingDDict` entry points.
+//!
+//! These mirror upstream's prepared-dictionary model: a dictionary is parsed
+//! once into a `CDict` (encoder side) or `DDict` (decoder side) and then used
+//! across many compress / decompress calls. The encoder-side reuse (parsed
+//! dictionary + primed match-finder snapshot) is realised by caching a
+//! [`FrameCompressor`] on the `ZSTD_CCtx`, keyed by the `CDict` pointer; the
+//! decoder caches the loaded dictionary on the `ZSTD_DCtx` keyed by the `DDict`
+//! pointer. The match-finder tables a dictionary primes are sized to the
+//! dictionary's own cParams tier (see the codec's `set_dictionary_size_hint`),
+//! so a `CDict` does not drag a source-window-sized table around.
+
+use core::ffi::{c_int, c_uint};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use codec::decoding::ContentChecksum;
+use codec::encoding::{CompressionLevel, EncoderDictionary, FrameCompressor};
+
+use crate::context::{ZSTD_CCtx, ZSTD_DCtx, free_boxed, try_box};
+use crate::error::{ZSTD_ErrorCode, code_for_decoder_error, encode};
+use crate::ffi::{in_slice, out_slice};
+
+/// `ZSTD_dictMagicNumber` (`zstd.h`). A serialized zstd dictionary begins with
+/// this little-endian magic; bytes `[4..8]` hold the dictionary ID. Raw-content
+/// dictionaries carry no magic and report ID 0.
+const DICT_MAGIC: u32 = 0xEC30_A437;
+
+/// Parse the dictionary ID from a serialized dictionary header, or `0` for a
+/// raw-content dictionary (no magic) / too-short buffer. Matches
+/// `ZSTD_getDictID_fromDict` semantics.
+fn dict_id_from_bytes(dict: &[u8]) -> u32 {
+    if dict.len() < 8 || u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) != DICT_MAGIC {
+        return 0;
+    }
+    u32::from_le_bytes([dict[4], dict[5], dict[6], dict[7]])
+}
+
+/// Opaque prepared compression dictionary. Owns the dictionary bytes plus the
+/// compression level baked in at creation (upstream `ZSTD_createCDict` takes the
+/// level here, and `ZSTD_compress_usingCDict` uses it). The bytes are parsed
+/// into a `FrameCompressor` lazily on the owning `CCtx` the first time they are
+/// used, so the `CDict` itself stays a cheap byte + id holder that many
+/// contexts can reference concurrently.
+#[allow(non_camel_case_types)]
+pub struct ZSTD_CDict {
+    pub(crate) raw: Vec<u8>,
+    pub(crate) id: u32,
+    pub(crate) level: c_int,
+}
+
+/// Opaque prepared decompression dictionary: the dictionary bytes plus its ID.
+#[allow(non_camel_case_types)]
+pub struct ZSTD_DDict {
+    pub(crate) raw: Vec<u8>,
+    pub(crate) id: u32,
+}
+
+/// `ZSTD_CDict* ZSTD_createCDict(const void* dictBuffer, size_t dictSize, int
+/// compressionLevel)` — parse and validate a dictionary for repeated
+/// compression at `compressionLevel`. Returns `NULL` on allocation failure or
+/// if the dictionary cannot be parsed for encoding, matching upstream's
+/// NULL-on-failure contract.
+///
+/// # Safety
+/// `dictBuffer` must be valid for `dictSize` bytes (or `NULL` with `dictSize == 0`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createCDict(
+    dict_buffer: *const u8,
+    dict_size: usize,
+    compression_level: c_int,
+) -> *mut ZSTD_CDict {
+    let dict = unsafe { in_slice(dict_buffer, dict_size) };
+    // Validate the dictionary parses for encoding (build the encoder entropy
+    // tables once here as a fail-fast; the per-context attach re-parses from the
+    // retained bytes). A dictionary that cannot be parsed yields NULL.
+    let outcome = catch_unwind(AssertUnwindSafe(|| EncoderDictionary::from_bytes(dict)));
+    match outcome {
+        Ok(Ok(_)) => {}
+        _ => return core::ptr::null_mut(),
+    }
+    let id = dict_id_from_bytes(dict);
+    try_box(ZSTD_CDict {
+        raw: dict.to_vec(),
+        id,
+        level: compression_level,
+    })
+}
+
+/// `ZSTD_CDict* ZSTD_createCDict_byReference(const void* dictBuffer, size_t
+/// dictSize, int compressionLevel)` (static API). We always copy the dictionary
+/// bytes into the `CDict`, so by-reference creation is identical to
+/// [`ZSTD_createCDict`] from the caller's perspective (the caller's buffer need
+/// not outlive the `CDict`).
+///
+/// # Safety
+/// Same as [`ZSTD_createCDict`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createCDict_byReference(
+    dict_buffer: *const u8,
+    dict_size: usize,
+    compression_level: c_int,
+) -> *mut ZSTD_CDict {
+    unsafe { ZSTD_createCDict(dict_buffer, dict_size, compression_level) }
+}
+
+/// `size_t ZSTD_freeCDict(ZSTD_CDict* CDict)` — free the dictionary; `NULL` is a
+/// no-op returning 0.
+///
+/// # Safety
+/// `cdict` must be a pointer from [`ZSTD_createCDict`] not already freed, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_freeCDict(cdict: *mut ZSTD_CDict) -> usize {
+    unsafe { free_boxed(cdict) };
+    0
+}
+
+/// `size_t ZSTD_sizeof_CDict(const ZSTD_CDict* cdict)` — heap footprint of the
+/// dictionary object, or 0 for `NULL`.
+///
+/// # Safety
+/// `cdict` must be a live pointer from [`ZSTD_createCDict`], or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_sizeof_CDict(cdict: *const ZSTD_CDict) -> usize {
+    if cdict.is_null() {
+        return 0;
+    }
+    let cdict = unsafe { &*cdict };
+    core::mem::size_of::<ZSTD_CDict>() + cdict.raw.capacity()
+}
+
+/// `unsigned ZSTD_getDictID_fromCDict(const ZSTD_CDict* cdict)` — the dictionary
+/// ID, or 0 for a raw-content dictionary / `NULL`.
+///
+/// # Safety
+/// `cdict` must be a live pointer from [`ZSTD_createCDict`], or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_getDictID_fromCDict(cdict: *const ZSTD_CDict) -> c_uint {
+    if cdict.is_null() {
+        return 0;
+    }
+    unsafe { &*cdict }.id
+}
+
+/// `size_t ZSTD_compress_usingCDict(ZSTD_CCtx* cctx, void* dst, size_t
+/// dstCapacity, const void* src, size_t srcSize, const ZSTD_CDict* cdict)` —
+/// compress `src` with `cdict` at the level baked into the `CDict`. The `cctx`
+/// caches the parsed dictionary + primed matcher keyed by the `CDict` pointer,
+/// so repeated calls with the same `CDict` skip the re-parse / re-prime.
+///
+/// # Safety
+/// `cctx` / `cdict` must be live handles; `dst` / `src` valid for their lengths
+/// (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compress_usingCDict(
+    cctx: *mut ZSTD_CCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+    cdict: *const ZSTD_CDict,
+) -> usize {
+    if cctx.is_null() || cdict.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    let cdict_ref = unsafe { &*cdict };
+    let src = unsafe { in_slice(src, src_size) };
+    let key = cdict as usize;
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        // (Re)build the cached compressor when the attached dictionary or level
+        // changes. A new compressor primes the dictionary into a fresh
+        // dict-tier matcher; the snapshot it then captures is reused on the next
+        // same-CDict call.
+        if cctx.dict_compressor.is_none()
+            || cctx.dict_key != key
+            || cctx.dict_level != cdict_ref.level
+        {
+            let mut enc: FrameCompressor =
+                FrameCompressor::new(CompressionLevel::from_level(cdict_ref.level));
+            // Upstream ZSTD_compress_usingCDict leaves checksum off unless the
+            // CDict's params enabled it; we match the plain default.
+            enc.set_content_checksum(false);
+            enc.set_dictionary_from_bytes(&cdict_ref.raw)
+                .map_err(|_| ())?;
+            cctx.dict_compressor = Some(enc);
+            cctx.dict_key = key;
+            cctx.dict_level = cdict_ref.level;
+        }
+        // Disjoint borrows: the cached compressor and the scratch buffer are
+        // distinct fields, so split the &mut here to avoid aliasing.
+        let ZSTD_CCtx {
+            scratch,
+            dict_compressor,
+            ..
+        } = cctx;
+        let enc = dict_compressor.as_mut().expect("just ensured Some");
+        scratch.clear();
+        enc.compress_independent_frame_into(src, scratch);
+        Ok::<(), ()>(())
+    }));
+    match outcome {
+        Ok(Ok(())) => {}
+        _ => {
+            // A panic / parse failure can leave the cached compressor in an
+            // unknown state; drop it so the next call rebuilds cleanly.
+            cctx.dict_compressor = None;
+            cctx.dict_key = 0;
+            return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+        }
+    }
+    let len = cctx.scratch.len();
+    if len > dst_capacity {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
+    }
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    dst[..len].copy_from_slice(&cctx.scratch);
+    len
+}
+
+/// `ZSTD_DDict* ZSTD_createDDict(const void* dictBuffer, size_t dictSize)` —
+/// prepare a dictionary for repeated decompression. Returns `NULL` on
+/// allocation failure.
+///
+/// # Safety
+/// `dictBuffer` must be valid for `dictSize` bytes (or `NULL` with `dictSize == 0`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createDDict(
+    dict_buffer: *const u8,
+    dict_size: usize,
+) -> *mut ZSTD_DDict {
+    let dict = unsafe { in_slice(dict_buffer, dict_size) };
+    let id = dict_id_from_bytes(dict);
+    try_box(ZSTD_DDict {
+        raw: dict.to_vec(),
+        id,
+    })
+}
+
+/// `ZSTD_DDict* ZSTD_createDDict_byReference(const void* dictBuffer, size_t
+/// dictSize)` (static API) — identical to [`ZSTD_createDDict`]; we copy the
+/// bytes so the caller's buffer need not outlive the `DDict`.
+///
+/// # Safety
+/// Same as [`ZSTD_createDDict`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createDDict_byReference(
+    dict_buffer: *const u8,
+    dict_size: usize,
+) -> *mut ZSTD_DDict {
+    unsafe { ZSTD_createDDict(dict_buffer, dict_size) }
+}
+
+/// `size_t ZSTD_freeDDict(ZSTD_DDict* ddict)` — free the dictionary; `NULL` is a
+/// no-op returning 0.
+///
+/// # Safety
+/// `ddict` must be a pointer from [`ZSTD_createDDict`] not already freed, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_freeDDict(ddict: *mut ZSTD_DDict) -> usize {
+    unsafe { free_boxed(ddict) };
+    0
+}
+
+/// `size_t ZSTD_sizeof_DDict(const ZSTD_DDict* ddict)` — heap footprint, or 0
+/// for `NULL`.
+///
+/// # Safety
+/// `ddict` must be a live pointer from [`ZSTD_createDDict`], or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_sizeof_DDict(ddict: *const ZSTD_DDict) -> usize {
+    if ddict.is_null() {
+        return 0;
+    }
+    let ddict = unsafe { &*ddict };
+    core::mem::size_of::<ZSTD_DDict>() + ddict.raw.capacity()
+}
+
+/// `unsigned ZSTD_getDictID_fromDDict(const ZSTD_DDict* ddict)` — the dictionary
+/// ID, or 0 for a raw-content dictionary / `NULL`.
+///
+/// # Safety
+/// `ddict` must be a live pointer from [`ZSTD_createDDict`], or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_getDictID_fromDDict(ddict: *const ZSTD_DDict) -> c_uint {
+    if ddict.is_null() {
+        return 0;
+    }
+    unsafe { &*ddict }.id
+}
+
+/// `size_t ZSTD_decompress_usingDDict(ZSTD_DCtx* dctx, void* dst, size_t
+/// dstCapacity, const void* src, size_t srcSize, const ZSTD_DDict* ddict)` —
+/// decompress a dictionary-compressed frame. The `dctx` caches the loaded
+/// dictionary keyed by the `DDict` pointer, so repeated calls with the same
+/// `DDict` skip re-loading it.
+///
+/// # Safety
+/// `dctx` / `ddict` must be live handles; `dst` / `src` valid for their lengths
+/// (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
+    dctx: *mut ZSTD_DCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+    ddict: *const ZSTD_DDict,
+) -> usize {
+    if dctx.is_null() || ddict.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    let ddict_ref = unsafe { &*ddict };
+    let src = unsafe { in_slice(src, src_size) };
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    let key = ddict as usize;
+
+    if dctx.ddict_key != key {
+        let added = catch_unwind(AssertUnwindSafe(|| {
+            dctx.decoder.add_dict_from_bytes(&ddict_ref.raw)
+        }));
+        match added {
+            Ok(Ok(())) => dctx.ddict_key = key,
+            _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
+        }
+    }
+    dctx.decoder.set_content_checksum(ContentChecksum::Verify);
+    let outcome = catch_unwind(AssertUnwindSafe(|| dctx.decoder.decode_all(src, dst)));
+    match outcome {
+        Ok(Ok(written)) => written,
+        Ok(Err(err)) => encode(code_for_decoder_error(&err)),
+        Err(_) => {
+            dctx.decoder = codec::decoding::FrameDecoder::new();
+            dctx.ddict_key = 0;
+            encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
+        }
+    }
+}

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -345,7 +345,17 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
         }));
         match added {
             Ok(Ok(())) => dctx.ddict_serial = key,
-            _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
+            // A clean parse failure leaves the decoder untouched, so it stays
+            // reusable as-is.
+            Ok(Err(_)) => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
+            // A panic may have mutated the decoder mid-load, leaving it poisoned;
+            // replace it with a fresh one and drop the stale cache key so the
+            // next call re-loads cleanly rather than trusting a broken decoder.
+            Err(_) => {
+                dctx.decoder = codec::decoding::FrameDecoder::new();
+                dctx.ddict_serial = 0;
+                return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+            }
         }
     }
     dctx.decoder.set_content_checksum(ContentChecksum::Verify);

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -5,13 +5,15 @@
 //! once into a `CDict` (encoder side) or `DDict` (decoder side) and then used
 //! across many compress / decompress calls. The encoder-side reuse (parsed
 //! dictionary + primed match-finder snapshot) is realised by caching a
-//! [`FrameCompressor`] on the `ZSTD_CCtx`, keyed by the `CDict` pointer; the
-//! decoder caches the loaded dictionary on the `ZSTD_DCtx` keyed by the `DDict`
-//! pointer. The match-finder tables a dictionary primes are sized to the
+//! [`FrameCompressor`] on the `ZSTD_CCtx`, keyed by the `CDict`'s never-reused
+//! serial; the decoder caches the loaded dictionary on the `ZSTD_DCtx` keyed by
+//! the `DDict`'s serial (a raw-address key would be ABA-unsafe across free +
+//! realloc). The match-finder tables a dictionary primes are sized to the
 //! dictionary's own cParams tier (see the codec's `set_dictionary_size_hint`),
 //! so a `CDict` does not drag a source-window-sized table around.
 
 use core::ffi::{c_int, c_uint};
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use codec::decoding::ContentChecksum;
@@ -20,6 +22,20 @@ use codec::encoding::{CompressionLevel, EncoderDictionary, FrameCompressor};
 use crate::context::{ZSTD_CCtx, ZSTD_DCtx, free_boxed, try_box};
 use crate::error::{ZSTD_ErrorCode, code_for_decoder_error, encode};
 use crate::ffi::{in_slice, out_slice};
+
+/// Monotonic source for [`ZSTD_CDict`] / [`ZSTD_DDict`] identities. A context
+/// caches its prepared compressor / loaded dictionary keyed by this serial, not
+/// by the handle's raw address: an address can be recycled when a dictionary is
+/// freed and a new one allocated in the same slot, so a pointer-keyed cache
+/// would silently keep using the old prepared state for the new handle (ABA).
+/// A serial is assigned once at creation and never reused, so identity stays
+/// stable across free + realloc. `0` is reserved for "no dictionary attached".
+static DICT_SERIAL: AtomicU64 = AtomicU64::new(1);
+
+/// Assign the next never-reused dictionary identity. See [`DICT_SERIAL`].
+pub(crate) fn next_dict_serial() -> u64 {
+    DICT_SERIAL.fetch_add(1, Ordering::Relaxed)
+}
 
 /// `ZSTD_dictMagicNumber` (`zstd.h`). A serialized zstd dictionary begins with
 /// this little-endian magic; bytes `[4..8]` hold the dictionary ID. Raw-content
@@ -47,6 +63,8 @@ pub struct ZSTD_CDict {
     pub(crate) raw: Vec<u8>,
     pub(crate) id: u32,
     pub(crate) level: c_int,
+    /// Never-reused identity for context cache validation (see [`DICT_SERIAL`]).
+    pub(crate) serial: u64,
 }
 
 /// Opaque prepared decompression dictionary: the dictionary bytes plus its ID.
@@ -54,6 +72,8 @@ pub struct ZSTD_CDict {
 pub struct ZSTD_DDict {
     pub(crate) raw: Vec<u8>,
     pub(crate) id: u32,
+    /// Never-reused identity for context cache validation (see [`DICT_SERIAL`]).
+    pub(crate) serial: u64,
 }
 
 /// `ZSTD_CDict* ZSTD_createCDict(const void* dictBuffer, size_t dictSize, int
@@ -84,6 +104,7 @@ pub unsafe extern "C" fn ZSTD_createCDict(
         raw: dict.to_vec(),
         id,
         level: compression_level,
+        serial: next_dict_serial(),
     })
 }
 
@@ -145,7 +166,7 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromCDict(cdict: *const ZSTD_CDict) -> c
 /// `size_t ZSTD_compress_usingCDict(ZSTD_CCtx* cctx, void* dst, size_t
 /// dstCapacity, const void* src, size_t srcSize, const ZSTD_CDict* cdict)` —
 /// compress `src` with `cdict` at the level baked into the `CDict`. The `cctx`
-/// caches the parsed dictionary + primed matcher keyed by the `CDict` pointer,
+/// caches the parsed dictionary + primed matcher keyed by the `CDict`'s serial,
 /// so repeated calls with the same `CDict` skip the re-parse / re-prime.
 ///
 /// # Safety
@@ -166,7 +187,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
     let cctx = unsafe { &mut *cctx };
     let cdict_ref = unsafe { &*cdict };
     let src = unsafe { in_slice(src, src_size) };
-    let key = cdict as usize;
+    let key = cdict_ref.serial;
 
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         // (Re)build the cached compressor when the attached dictionary or level
@@ -174,7 +195,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
         // dict-tier matcher; the snapshot it then captures is reused on the next
         // same-CDict call.
         if cctx.dict_compressor.is_none()
-            || cctx.dict_key != key
+            || cctx.dict_serial != key
             || cctx.dict_level != cdict_ref.level
         {
             let mut enc: FrameCompressor =
@@ -185,7 +206,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
             enc.set_dictionary_from_bytes(&cdict_ref.raw)
                 .map_err(|_| ())?;
             cctx.dict_compressor = Some(enc);
-            cctx.dict_key = key;
+            cctx.dict_serial = key;
             cctx.dict_level = cdict_ref.level;
         }
         // Disjoint borrows: the cached compressor and the scratch buffer are
@@ -206,7 +227,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
             // A panic / parse failure can leave the cached compressor in an
             // unknown state; drop it so the next call rebuilds cleanly.
             cctx.dict_compressor = None;
-            cctx.dict_key = 0;
+            cctx.dict_serial = 0;
             return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
         }
     }
@@ -235,6 +256,7 @@ pub unsafe extern "C" fn ZSTD_createDDict(
     try_box(ZSTD_DDict {
         raw: dict.to_vec(),
         id,
+        serial: next_dict_serial(),
     })
 }
 
@@ -293,7 +315,7 @@ pub unsafe extern "C" fn ZSTD_getDictID_fromDDict(ddict: *const ZSTD_DDict) -> c
 /// `size_t ZSTD_decompress_usingDDict(ZSTD_DCtx* dctx, void* dst, size_t
 /// dstCapacity, const void* src, size_t srcSize, const ZSTD_DDict* ddict)` —
 /// decompress a dictionary-compressed frame. The `dctx` caches the loaded
-/// dictionary keyed by the `DDict` pointer, so repeated calls with the same
+/// dictionary keyed by the `DDict`'s serial, so repeated calls with the same
 /// `DDict` skip re-loading it.
 ///
 /// # Safety
@@ -315,14 +337,14 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
     let ddict_ref = unsafe { &*ddict };
     let src = unsafe { in_slice(src, src_size) };
     let dst = unsafe { out_slice(dst, dst_capacity) };
-    let key = ddict as usize;
+    let key = ddict_ref.serial;
 
-    if dctx.ddict_key != key {
+    if dctx.ddict_serial != key {
         let added = catch_unwind(AssertUnwindSafe(|| {
             dctx.decoder.add_dict_from_bytes(&ddict_ref.raw)
         }));
         match added {
-            Ok(Ok(())) => dctx.ddict_key = key,
+            Ok(Ok(())) => dctx.ddict_serial = key,
             _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
         }
     }
@@ -333,7 +355,7 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
         Ok(Err(err)) => encode(code_for_decoder_error(&err)),
         Err(_) => {
             dctx.decoder = codec::decoding::FrameDecoder::new();
-            dctx.ddict_key = 0;
+            dctx.ddict_serial = 0;
             encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
         }
     }

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -56,20 +56,21 @@ pub(crate) unsafe fn free_boxed<T>(ptr: *mut T) {
 ///
 /// For the dictionary path ([`ZSTD_compress_usingCDict`](crate::cdict::ZSTD_compress_usingCDict))
 /// it also caches a [`FrameCompressor`] with the dictionary already attached,
-/// keyed by the `ZSTD_CDict` pointer + level, so back-to-back compressions with
-/// the same `CDict` reuse the parsed dictionary + primed match-finder snapshot
-/// instead of re-parsing and re-priming each call (the encoder-side analogue of
-/// upstream's `ZSTD_CCtx_refCDict` reuse).
+/// keyed by the `ZSTD_CDict`'s never-reused serial + level, so back-to-back
+/// compressions with the same `CDict` reuse the parsed dictionary + primed
+/// match-finder snapshot instead of re-parsing and re-priming each call (the
+/// encoder-side analogue of upstream's `ZSTD_CCtx_refCDict` reuse).
 #[allow(non_camel_case_types)]
 pub struct ZSTD_CCtx {
     pub(crate) scratch: Vec<u8>,
     /// `FrameCompressor` with a dictionary attached, lazily built by the CDict
     /// path. `None` until the first `ZSTD_compress_usingCDict`.
     pub(crate) dict_compressor: Option<FrameCompressor>,
-    /// Identity of the `CDict` currently attached to `dict_compressor`
-    /// (the `ZSTD_CDict` pointer as `usize`; `0` = none) plus the level it was
-    /// built at, so a different CDict or level rebuilds the cached compressor.
-    pub(crate) dict_key: usize,
+    /// Identity of the `CDict` currently attached to `dict_compressor` (its
+    /// never-reused serial; `0` = none) plus the level it was built at, so a
+    /// different CDict or level rebuilds the cached compressor. Keyed by serial
+    /// rather than raw address so a freed-then-realloc'd handle can't alias.
+    pub(crate) dict_serial: u64,
     pub(crate) dict_level: c_int,
 }
 
@@ -79,9 +80,11 @@ pub struct ZSTD_CCtx {
 pub struct ZSTD_DCtx {
     pub(crate) decoder: FrameDecoder,
     /// Identity of the `DDict` whose content was last loaded into `decoder`
-    /// (the `ZSTD_DDict` pointer as `usize`; `0` = none), so repeated
+    /// (its never-reused serial; `0` = none), so repeated
     /// `ZSTD_decompress_usingDDict` calls with the same DDict skip re-adding it.
-    pub(crate) ddict_key: usize,
+    /// Reset to `0` whenever `decoder` is replaced, so a fresh decoder is never
+    /// trusted to still hold the previously-loaded dictionary.
+    pub(crate) ddict_serial: u64,
 }
 
 /// `ZSTD_CCtx* ZSTD_createCCtx(void)`. Returns `NULL` on allocation failure
@@ -91,7 +94,7 @@ pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     try_box(ZSTD_CCtx {
         scratch: Vec::new(),
         dict_compressor: None,
-        dict_key: 0,
+        dict_serial: 0,
         dict_level: 0,
     })
 }
@@ -169,7 +172,7 @@ pub unsafe extern "C" fn ZSTD_compressCCtx(
 pub extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
     try_box(ZSTD_DCtx {
         decoder: FrameDecoder::new(),
-        ddict_key: 0,
+        ddict_serial: 0,
     })
 }
 
@@ -237,8 +240,12 @@ pub unsafe extern "C" fn ZSTD_decompressDCtx(
             // A panic mid-decode can leave the decoder's internal state
             // partially consumed; replace it with a fresh one (same as
             // ZSTD_createDCtx) so a later call on this reused DCtx starts clean
-            // instead of observing a broken invariant.
+            // instead of observing a broken invariant. The fresh decoder no
+            // longer holds any previously-loaded dictionary, so clear the DDict
+            // cache key too — otherwise the next ZSTD_decompress_usingDDict with
+            // the same handle would skip re-loading it and decode without it.
             dctx.decoder = FrameDecoder::new();
+            dctx.ddict_serial = 0;
             encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
         }
     }

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -19,7 +19,7 @@ use crate::ffi::{in_slice, out_slice};
 /// allocation failure. Unlike `Box::new`, this never aborts the host process on
 /// OOM, matching libzstd's `ZSTD_create*` NULL-on-failure contract. Pair every
 /// non-null result with [`free_boxed`].
-fn try_box<T>(value: T) -> *mut T {
+pub(crate) fn try_box<T>(value: T) -> *mut T {
     let layout = core::alloc::Layout::new::<T>();
     // Both context types own a `Vec` / `FrameDecoder`, so they are never
     // zero-sized and the allocator path always applies.
@@ -39,7 +39,7 @@ fn try_box<T>(value: T) -> *mut T {
 ///
 /// # Safety
 /// `ptr` must be a live, not-yet-freed pointer from [`try_box::<T>`], or `null`.
-unsafe fn free_boxed<T>(ptr: *mut T) {
+pub(crate) unsafe fn free_boxed<T>(ptr: *mut T) {
     if ptr.is_null() {
         return;
     }
@@ -53,16 +53,35 @@ unsafe fn free_boxed<T>(ptr: *mut T) {
 
 /// Opaque compression context. Carries a reusable output buffer so repeated
 /// `ZSTD_compressCCtx` calls amortise the destination allocation.
+///
+/// For the dictionary path ([`ZSTD_compress_usingCDict`](crate::cdict::ZSTD_compress_usingCDict))
+/// it also caches a [`FrameCompressor`] with the dictionary already attached,
+/// keyed by the `ZSTD_CDict` pointer + level, so back-to-back compressions with
+/// the same `CDict` reuse the parsed dictionary + primed match-finder snapshot
+/// instead of re-parsing and re-priming each call (the encoder-side analogue of
+/// upstream's `ZSTD_CCtx_refCDict` reuse).
 #[allow(non_camel_case_types)]
 pub struct ZSTD_CCtx {
-    scratch: Vec<u8>,
+    pub(crate) scratch: Vec<u8>,
+    /// `FrameCompressor` with a dictionary attached, lazily built by the CDict
+    /// path. `None` until the first `ZSTD_compress_usingCDict`.
+    pub(crate) dict_compressor: Option<FrameCompressor>,
+    /// Identity of the `CDict` currently attached to `dict_compressor`
+    /// (the `ZSTD_CDict` pointer as `usize`; `0` = none) plus the level it was
+    /// built at, so a different CDict or level rebuilds the cached compressor.
+    pub(crate) dict_key: usize,
+    pub(crate) dict_level: c_int,
 }
 
 /// Opaque decompression context. Wraps a reusable [`FrameDecoder`] so its
 /// internal buffers persist across `ZSTD_decompressDCtx` calls.
 #[allow(non_camel_case_types)]
 pub struct ZSTD_DCtx {
-    decoder: FrameDecoder,
+    pub(crate) decoder: FrameDecoder,
+    /// Identity of the `DDict` whose content was last loaded into `decoder`
+    /// (the `ZSTD_DDict` pointer as `usize`; `0` = none), so repeated
+    /// `ZSTD_decompress_usingDDict` calls with the same DDict skip re-adding it.
+    pub(crate) ddict_key: usize,
 }
 
 /// `ZSTD_CCtx* ZSTD_createCCtx(void)`. Returns `NULL` on allocation failure
@@ -71,6 +90,9 @@ pub struct ZSTD_DCtx {
 pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     try_box(ZSTD_CCtx {
         scratch: Vec::new(),
+        dict_compressor: None,
+        dict_key: 0,
+        dict_level: 0,
     })
 }
 
@@ -147,6 +169,7 @@ pub unsafe extern "C" fn ZSTD_compressCCtx(
 pub extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
     try_box(ZSTD_DCtx {
         decoder: FrameDecoder::new(),
+        ddict_key: 0,
     })
 }
 

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -114,6 +114,10 @@ pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> usize {
 /// `size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx)` — current heap footprint,
 /// or 0 for `NULL`.
 ///
+/// Counts the inline struct and the reusable output `scratch`. The cached
+/// `dict_compressor`'s primed match-finder tables and dictionary snapshot are
+/// not yet summed (the encoder lacks a heap-size accessor); tracked in #388.
+///
 /// # Safety
 /// `cctx` must be a live pointer from [`ZSTD_createCCtx`], or `NULL`.
 #[unsafe(no_mangle)]

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -114,9 +114,11 @@ pub unsafe extern "C" fn ZSTD_freeCCtx(cctx: *mut ZSTD_CCtx) -> usize {
 /// `size_t ZSTD_sizeof_CCtx(const ZSTD_CCtx* cctx)` — current heap footprint,
 /// or 0 for `NULL`.
 ///
-/// Counts the inline struct and the reusable output `scratch`. The cached
-/// `dict_compressor`'s primed match-finder tables and dictionary snapshot are
-/// not yet summed (the encoder lacks a heap-size accessor); tracked in #388.
+/// Counts the inline struct, the reusable output `scratch`, and (after the
+/// first `ZSTD_compress_usingCDict`) the cached `dict_compressor`'s heap: its
+/// primed match-finder tables / history, the recycled-buffer pool, the
+/// dictionary snapshot, and the retained dictionary content. Matches upstream
+/// `ZSTD_sizeof_CCtx`, which includes the CDict-copied working tables.
 ///
 /// # Safety
 /// `cctx` must be a live pointer from [`ZSTD_createCCtx`], or `NULL`.
@@ -126,7 +128,12 @@ pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> usize {
         return 0;
     }
     let cctx = unsafe { &*cctx };
-    core::mem::size_of::<ZSTD_CCtx>() + cctx.scratch.capacity()
+    core::mem::size_of::<ZSTD_CCtx>()
+        + cctx.scratch.capacity()
+        + cctx
+            .dict_compressor
+            .as_ref()
+            .map_or(0, |enc| enc.heap_size())
 }
 
 /// `size_t ZSTD_compressCCtx(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity,

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -23,6 +23,7 @@
 //! `no_std + alloc` surface lives in the pure-Rust [`codec`] crate this depends
 //! on; consumers wanting an embedded build link `codec` directly.
 
+mod cdict;
 mod context;
 mod dict;
 mod error;
@@ -35,6 +36,7 @@ mod tests;
 
 // The `extern "C"` entry points are exported by their `#[no_mangle]` symbols;
 // re-export the public types so rustdoc and in-crate tests can name them.
+pub use cdict::{ZSTD_CDict, ZSTD_DDict};
 pub use context::{ZSTD_CCtx, ZSTD_DCtx};
 pub use dict::ZDICT_params_t;
 pub use error::ZSTD_ErrorCode;

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -3,6 +3,11 @@
 //! real symbol behaviour; the C-consumer link test in `tests/` is added
 //! separately and verifies a real `#include <zstd.h>` consumer.
 
+use crate::cdict::{
+    ZSTD_compress_usingCDict, ZSTD_createCDict, ZSTD_createDDict, ZSTD_decompress_usingDDict,
+    ZSTD_freeCDict, ZSTD_freeDDict, ZSTD_getDictID_fromCDict, ZSTD_getDictID_fromDDict,
+    ZSTD_sizeof_CDict, ZSTD_sizeof_DDict,
+};
 use crate::context::{
     ZSTD_compressCCtx, ZSTD_createCCtx, ZSTD_createDCtx, ZSTD_decompressDCtx, ZSTD_freeCCtx,
     ZSTD_freeDCtx, ZSTD_sizeof_CCtx,
@@ -397,4 +402,115 @@ fn zdict_train_produces_a_valid_dictionary() {
         unsafe { ZDICT_getDictID(garbage.as_ptr(), garbage.len()) },
         0
     );
+}
+
+/// Train a dictionary from many small similar records and return the bytes.
+fn trained_dictionary() -> Vec<u8> {
+    let mut samples: Vec<u8> = Vec::new();
+    let mut sizes: Vec<usize> = Vec::new();
+    for i in 0..512u32 {
+        let s = format!("tenant=demo table=orders key={i} region=eu payload=aaaaabbbbbccccc\n");
+        sizes.push(s.len());
+        samples.extend_from_slice(s.as_bytes());
+    }
+    let mut dict = vec![0u8; 64 * 1024];
+    let n = unsafe {
+        ZDICT_trainFromBuffer(
+            dict.as_mut_ptr(),
+            dict.len(),
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+        )
+    };
+    assert_eq!(ZDICT_isError(n), 0, "training reported an error");
+    dict.truncate(n);
+    dict
+}
+
+#[test]
+fn cdict_ddict_roundtrip_and_reuse() {
+    let dict = trained_dictionary();
+    let dict_id = unsafe { ZDICT_getDictID(dict.as_ptr(), dict.len()) };
+    assert_ne!(dict_id, 0);
+
+    let cdict = unsafe { ZSTD_createCDict(dict.as_ptr(), dict.len(), 19) };
+    assert!(!cdict.is_null(), "ZSTD_createCDict returned NULL");
+    let ddict = unsafe { ZSTD_createDDict(dict.as_ptr(), dict.len()) };
+    assert!(!ddict.is_null(), "ZSTD_createDDict returned NULL");
+
+    // The prepared dictionaries echo the trained ID and report a non-zero size.
+    assert_eq!(unsafe { ZSTD_getDictID_fromCDict(cdict) }, dict_id);
+    assert_eq!(unsafe { ZSTD_getDictID_fromDDict(ddict) }, dict_id);
+    assert!(unsafe { ZSTD_sizeof_CDict(cdict) } >= dict.len());
+    assert!(unsafe { ZSTD_sizeof_DDict(ddict) } >= dict.len());
+
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
+    assert!(!cctx.is_null() && !dctx.is_null());
+
+    // Compress two distinct payloads through the SAME cctx + cdict to exercise
+    // the cached-compressor reuse path (second call must not re-parse/re-prime
+    // yet must still produce a correctly-decodable frame).
+    let payloads = [
+        b"tenant=demo table=orders key=99999 region=eu payload=aaaaabbbbbccccc\n".to_vec(),
+        {
+            let mut v = Vec::new();
+            for i in 1000..1100u32 {
+                v.extend_from_slice(
+                    format!("tenant=demo table=orders key={i} region=eu payload=aaaaabbbbbccccc\n")
+                        .as_bytes(),
+                );
+            }
+            v
+        },
+    ];
+
+    for payload in &payloads {
+        let bound = ZSTD_compressBound(payload.len());
+        let mut compressed = vec![0u8; bound];
+        let clen = unsafe {
+            ZSTD_compress_usingCDict(
+                cctx,
+                compressed.as_mut_ptr(),
+                compressed.len(),
+                payload.as_ptr(),
+                payload.len(),
+                cdict,
+            )
+        };
+        assert_eq!(ZSTD_isError(clen), 0, "compress_usingCDict errored");
+        compressed.truncate(clen);
+
+        let mut restored = vec![0u8; payload.len()];
+        let dlen = unsafe {
+            ZSTD_decompress_usingDDict(
+                dctx,
+                restored.as_mut_ptr(),
+                restored.len(),
+                compressed.as_ptr(),
+                compressed.len(),
+                ddict,
+            )
+        };
+        assert_eq!(ZSTD_isError(dlen), 0, "decompress_usingDDict errored");
+        assert_eq!(dlen, payload.len());
+        assert_eq!(&restored, payload, "dictionary round-trip mismatch");
+    }
+
+    unsafe {
+        ZSTD_freeCCtx(cctx);
+        ZSTD_freeDCtx(dctx);
+        ZSTD_freeCDict(cdict);
+        ZSTD_freeDDict(ddict);
+    }
+}
+
+#[test]
+fn create_cdict_rejects_non_dictionary() {
+    // A buffer with no dictionary magic and no valid entropy is not a parseable
+    // encoder dictionary; createCDict must return NULL (never crash).
+    let garbage = [0xABu8; 64];
+    let cdict = unsafe { ZSTD_createCDict(garbage.as_ptr(), garbage.len(), 3) };
+    assert!(cdict.is_null(), "createCDict accepted a non-dictionary");
 }

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -507,6 +507,48 @@ fn cdict_ddict_roundtrip_and_reuse() {
 }
 
 #[test]
+fn sizeof_cctx_counts_cached_dictionary_compressor() {
+    // After a ZSTD_compress_usingCDict call, the context caches a primed
+    // FrameCompressor whose match-finder tables dominate its real footprint.
+    // ZSTD_sizeof_CCtx must grow to reflect that heap, not just the inline
+    // struct + scratch (regression: it previously omitted the cached compressor).
+    let dict = trained_dictionary();
+    let cdict = unsafe { ZSTD_createCDict(dict.as_ptr(), dict.len(), 19) };
+    assert!(!cdict.is_null());
+    let cctx = ZSTD_createCCtx();
+    assert!(!cctx.is_null());
+
+    let before = unsafe { ZSTD_sizeof_CCtx(cctx) };
+
+    let payload = b"tenant=demo table=orders key=1 region=eu payload=aaaaabbbbbccccc\n";
+    let mut compressed = vec![0u8; ZSTD_compressBound(payload.len())];
+    let clen = unsafe {
+        ZSTD_compress_usingCDict(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            payload.as_ptr(),
+            payload.len(),
+            cdict,
+        )
+    };
+    assert_eq!(ZSTD_isError(clen), 0);
+
+    let after = unsafe { ZSTD_sizeof_CCtx(cctx) };
+    // The primed match-finder tables for a level-19 dictionary are well above
+    // 64 KiB, so the reported size must jump substantially once they exist.
+    assert!(
+        after > before + 64 * 1024,
+        "sizeof_CCtx must include the cached dict compressor's heap: before={before}, after={after}"
+    );
+
+    unsafe {
+        ZSTD_freeCCtx(cctx);
+        ZSTD_freeCDict(cdict);
+    }
+}
+
+#[test]
 fn create_cdict_rejects_non_dictionary() {
     // A buffer with no dictionary magic and no valid entropy is not a parseable
     // encoder dictionary; createCDict must return NULL (never crash).

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,7 @@ tracing-indicatif = { version = "0.3.14" }
 console = { version = "0.16.3" }
 tracing-subscriber = { version = "0.3.23" }
 # Keep a version requirement for `cargo package` while allowing any 0.0.x fork release.
-structured-zstd = { version = "0.0", path = "../zstd", features = ["std"] }
+structured-zstd = { version = "0.0", path = "../zstd", features = ["std", "dict_builder"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,9 @@ struct Options {
     bench: bool,
     bench_start: i32,
     bench_end: i32,
+    /// Long-distance matching (`--long`), enabled on the encoder via the
+    /// compression-parameters API.
+    long: bool,
 }
 
 /// Upstream `zstd --maxdict` default (110 KiB).
@@ -139,6 +142,7 @@ fn parse_args(
         bench: false,
         bench_start: CompressionLevel::DEFAULT_LEVEL,
         bench_end: 0,
+        long: false,
     };
     let mut ultra = false;
     let mut iter = args.iter().enumerate().peekable();
@@ -190,7 +194,9 @@ fn parse_args(
                     } else if let Some(v) = long.strip_prefix("dictID=") {
                         opts.dict_id = Some(v.parse::<u32>().wrap_err("invalid --dictID")?);
                     } else if long.starts_with("long") {
-                        // `--long[=N]` (LDM) — accepted; LDM wiring is a follow-up.
+                        // `--long` or `--long=N` (the window-log hint is accepted
+                        // but the encoder derives the LDM window from the level).
+                        opts.long = true;
                     } else {
                         bail!("unknown option: --{long}");
                     }
@@ -321,12 +327,18 @@ fn print_help() {
          \x20 -z, --compress       compress (default)\n\
          \x20 -d, --decompress     decompress\n\
          \x20 -t, --test           test a compressed file's integrity\n\
+         \x20 -l, --list           list information about .zst files\n\
+         \x20 --train FILEs        train a dictionary from sample files\n\
+         \x20 -b[N] [-e[N]]        benchmark level N (through e)\n\
          \n\
          Options:\n\
          \x20 -<N>                 compression level (1-19; 20-22 need --ultra)\n\
          \x20 --fast[=N]           ultra-fast negative level\n\
          \x20 --ultra              allow levels 20-22\n\
+         \x20 --long[=N]           enable long-distance matching\n\
          \x20 -D FILE              use FILE as a dictionary\n\
+         \x20 --maxdict=N          dictionary size cap for --train\n\
+         \x20 --dictID=N           dictionary ID for --train\n\
          \x20 -o FILE              write output to FILE\n\
          \x20 -c, --stdout         write to stdout\n\
          \x20 -f, --force          overwrite output / allow stdout to terminal\n\
@@ -432,6 +444,7 @@ fn run_benchmark(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> 
                 opts.store,
                 dict,
                 Some(data.len() as u64),
+                opts.long,
             )?;
             best_compress = best_compress.min(t.elapsed().as_secs_f64());
             if start.elapsed().as_secs_f64() >= BUDGET_SECS {
@@ -582,7 +595,15 @@ fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Resu
     match opts.mode {
         Mode::Compress => {
             let stdout = io::stdout();
-            compress_stream(reader, stdout.lock(), opts.level, opts.store, dict, None)
+            compress_stream(
+                reader,
+                stdout.lock(),
+                opts.level,
+                opts.store,
+                dict,
+                None,
+                opts.long,
+            )
         }
         Mode::Decompress => {
             let stdout = io::stdout();
@@ -649,6 +670,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 opts.store,
                 dict,
                 Some(source_size as u64),
+                opts.long,
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut out, dict)?,
             Mode::Test | Mode::List | Mode::Train => unreachable!(),
@@ -673,6 +695,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 opts.store,
                 dict,
                 Some(source_size as u64),
+                opts.long,
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut sink, dict)?,
             Mode::Test | Mode::List | Mode::Train => unreachable!(),
@@ -694,6 +717,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
 }
 
 /// Streaming compression core (file or stdout), optionally dictionary-primed.
+#[allow(clippy::too_many_arguments)]
 fn compress_stream<R: Read, W: Write>(
     mut reader: R,
     writer: W,
@@ -701,6 +725,7 @@ fn compress_stream<R: Read, W: Write>(
     store: bool,
     dict: Option<&[u8]>,
     size_hint: Option<u64>,
+    long: bool,
 ) -> color_eyre::Result<()> {
     let compression_level = if store {
         CompressionLevel::Uncompressed
@@ -708,6 +733,17 @@ fn compress_stream<R: Read, W: Write>(
         CompressionLevel::from_level(level)
     };
     let mut encoder = structured_zstd::encoding::StreamingEncoder::new(writer, compression_level);
+    // Long-distance matching (`--long`) is a per-knob override applied via the
+    // compression-parameters API; skip it for `--store` (raw frames don't match).
+    if long && !store {
+        let params = structured_zstd::encoding::CompressionParameters::builder(compression_level)
+            .enable_long_distance_matching(true)
+            .build()
+            .map_err(|err| eyre!("failed to build LDM parameters: {err:?}"))?;
+        encoder
+            .set_parameters(&params)
+            .wrap_err("failed to enable long-distance matching")?;
+    }
     if let Some(size) = size_hint {
         // The size is known (a regular file), so pledge it: the frame records
         // Frame_Content_Size (decoders can pre-allocate, `zstd -l` reports it)
@@ -1038,6 +1074,13 @@ mod tests {
     }
 
     #[test]
+    fn long_flag_enables_ldm() {
+        assert!(parse(&["-19", "--long", "in.txt"]).unwrap().long);
+        assert!(parse(&["--long=27", "in.txt"]).unwrap().long);
+        assert!(!parse(&["-19", "in.txt"]).unwrap().long);
+    }
+
+    #[test]
     fn benchmark_flags_parse_level_range() {
         let opts = parse(&["-b3", "-e7", "in.txt"]).unwrap();
         assert!(opts.bench);
@@ -1085,6 +1128,7 @@ mod tests {
             bench: false,
             bench_start: 3,
             bench_end: 0,
+            long: false,
         };
         assert_eq!(
             derive_output_path(&opts, Path::new("archive.tar.zst")).unwrap(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -174,7 +174,16 @@ fn parse_args(
                 "keep" => opts.keep = true,
                 "rm" => opts.remove_source = true,
                 "ultra" => ultra = true,
-                "no-check" | "no-content-size" | "no-dictID" | "quiet" | "verbose" => {}
+                // Verbosity aliases are honest no-ops (our logging is fixed).
+                "quiet" | "verbose" => {}
+                // These change the wire format (suppress the checksum, the
+                // Frame_Content_Size field, or the Dictionary_ID). They are not
+                // wired through to the encoder yet, so accepting them silently
+                // would hand the caller the default layout instead of the
+                // requested one. Reject until they are honoured.
+                "no-check" | "no-content-size" | "no-dictID" => {
+                    bail!("--{long} is not supported yet");
+                }
                 "version" => {
                     print_version();
                     return Ok(Parsed::Handled);
@@ -184,21 +193,23 @@ fn parse_args(
                     return Ok(Parsed::Handled);
                 }
                 _ => {
-                    if let Some(n) = long.strip_prefix("fast") {
-                        // `--fast` or `--fast=N`.
-                        opts.level = match n.strip_prefix('=') {
-                            Some(v) => -(v.parse::<i32>().wrap_err("invalid --fast level")?),
-                            None => -1,
-                        };
+                    if long == "fast" {
+                        // `--fast` is the level -1 alias.
+                        opts.level = -1;
+                    } else if let Some(v) = long.strip_prefix("fast=") {
+                        // `--fast=N` is level -N. Exact-match the prefix so a
+                        // typo like `--faster` falls through to unknown-option.
+                        opts.level = -(v.parse::<i32>().wrap_err("invalid --fast level")?);
                     } else if let Some(path) = long.strip_prefix("use-dict=") {
                         opts.dict = Some(PathBuf::from(path));
                     } else if let Some(v) = long.strip_prefix("maxdict=") {
                         opts.max_dict = v.parse::<usize>().wrap_err("invalid --maxdict size")?;
                     } else if let Some(v) = long.strip_prefix("dictID=") {
                         opts.dict_id = Some(v.parse::<u32>().wrap_err("invalid --dictID")?);
-                    } else if long.starts_with("long") {
+                    } else if long == "long" || long.strip_prefix("long=").is_some() {
                         // `--long` or `--long=N` (the window-log hint is accepted
                         // but the encoder derives the LDM window from the level).
+                        // Exact-match so `--longer` is an unknown option.
                         opts.long = true;
                     } else {
                         bail!("unknown option: --{long}");
@@ -541,33 +552,107 @@ fn train_dictionary(opts: &Options) -> color_eyre::Result<()> {
     Ok(())
 }
 
+/// Read into `buf` until it is full or EOF, returning the number of bytes read.
+/// Unlike a single `read`, this fills as much as the source has, so a header
+/// parse sees the whole header even when the OS hands back short reads.
+fn read_filling<R: Read>(reader: &mut R, buf: &mut [u8]) -> color_eyre::Result<usize> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match reader.read(&mut buf[filled..]) {
+            Ok(0) => break,
+            Ok(n) => filled += n,
+            Err(err) if err.kind() == ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err).wrap_err("failed to read frame header"),
+        }
+    }
+    Ok(filled)
+}
+
 /// Column header for `--list`, matching upstream's `zstd -l` layout.
 fn print_list_header() {
     println!("Frames  Compressed  Uncompressed  Ratio  Check  DictID  Filename");
 }
 
-/// Print one `--list` row: walk every frame header in the file (no body
-/// decode), summing compressed + declared content sizes. Decompressed size is
-/// `--` when any frame omits the Frame_Content_Size field.
-fn list_file(path: &Path) -> color_eyre::Result<()> {
-    use structured_zstd::decoding::{
-        FrameContentSize, find_frame_compressed_size, read_frame_header_info,
-    };
+/// Largest possible zstd frame header: 4-byte magic + 1-byte descriptor + up to
+/// 8-byte Frame_Content_Size + up to 4-byte Dictionary_ID + 1-byte
+/// Window_Descriptor (RFC 8878 §3.1.1.1).
+const MAX_FRAME_HEADER_LEN: usize = 18;
 
-    let bytes = fs::read(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
-    let compressed = bytes.len() as u64;
-    let mut offset = 0usize;
+/// Print one `--list` row: walk every frame in the file (no body decode),
+/// summing compressed + declared content sizes. Decompressed size is `--` when
+/// any frame omits the Frame_Content_Size field.
+///
+/// Reads each frame header, then walks the 3-byte block headers by `seek`ing
+/// past every block body, so peak memory stays O(1) regardless of archive size
+/// (a multi-GB file is never loaded whole).
+fn list_file(path: &Path) -> color_eyre::Result<()> {
+    use std::io::{Seek, SeekFrom};
+    use structured_zstd::decoding::{FrameContentSize, read_frame_header_info};
+
+    let mut file =
+        File::open(path).wrap_err_with(|| format!("failed to open {}", path.display()))?;
+    let compressed = file
+        .metadata()
+        .wrap_err_with(|| format!("failed to stat {}", path.display()))?
+        .len();
+    let mut offset = 0u64;
     let mut frames = 0u64;
     let mut decompressed = Some(0u64);
     let mut check = false;
     let mut dict_id = None;
 
-    while offset < bytes.len() {
-        let rest = &bytes[offset..];
-        let info = read_frame_header_info(rest, false)
+    while offset < compressed {
+        // Read just enough for the frame header (a short read near EOF is fine —
+        // `read_frame_header_info` reports the exact length it consumed).
+        file.seek(SeekFrom::Start(offset))?;
+        let mut header_buf = [0u8; MAX_FRAME_HEADER_LEN];
+        let header_read = read_filling(&mut file, &mut header_buf)?;
+        let info = read_frame_header_info(&header_buf[..header_read], false)
             .map_err(|err| eyre!("{}: not a zstd frame: {err:?}", path.display()))?;
-        let frame_len = find_frame_compressed_size(rest)
-            .map_err(|err| eyre!("{}: malformed frame: {err:?}", path.display()))?;
+
+        // The frame's Block_Maximum_Size bounds every block (RFC 8878 §3.1.1.2).
+        let block_size_max = info.window_size.min(128 * 1024);
+        // Walk block headers, seeking past each body, to find the frame's end.
+        let mut block_offset = offset + info.header_size as u64;
+        loop {
+            file.seek(SeekFrom::Start(block_offset))?;
+            let mut block_header = [0u8; 3];
+            file.read_exact(&mut block_header)
+                .map_err(|_| eyre!("{}: truncated mid-frame", path.display()))?;
+            let raw = u32::from(block_header[0])
+                | (u32::from(block_header[1]) << 8)
+                | (u32::from(block_header[2]) << 16);
+            let last_block = (raw & 1) != 0;
+            let block_type = (raw >> 1) & 0b11;
+            let block_size = u64::from(raw >> 3);
+            if block_size > block_size_max {
+                bail!("{}: block exceeds Block_Maximum_Size", path.display());
+            }
+            // On-disk bytes after the header: RLE stores one byte, Raw/Compressed
+            // store Block_Size, the reserved type is invalid.
+            let on_disk = match block_type {
+                1 => 1,
+                0 | 2 => block_size,
+                _ => bail!("{}: reserved block type", path.display()),
+            };
+            block_offset = block_offset
+                .checked_add(3 + on_disk)
+                .filter(|end| *end <= compressed)
+                .ok_or_else(|| eyre!("{}: truncated mid-frame", path.display()))?;
+            if last_block {
+                break;
+            }
+        }
+        // A trailing 4-byte content checksum follows the last block when present.
+        let frame_end = if info.content_checksum {
+            block_offset
+                .checked_add(4)
+                .filter(|end| *end <= compressed)
+                .ok_or_else(|| eyre!("{}: truncated content checksum", path.display()))?
+        } else {
+            block_offset
+        };
+
         match info.content_size {
             FrameContentSize::Known(n) => decompressed = decompressed.map(|d| d + n),
             FrameContentSize::Unknown => decompressed = None,
@@ -577,7 +662,7 @@ fn list_file(path: &Path) -> color_eyre::Result<()> {
             dict_id = info.dictionary_id;
         }
         frames += 1;
-        offset += frame_len;
+        offset = frame_end;
     }
 
     let ratio = match decompressed {
@@ -601,10 +686,18 @@ fn list_file(path: &Path) -> color_eyre::Result<()> {
     Ok(())
 }
 
-/// stdin → stdout for a `-` input or no inputs.
+/// stdin → stdout (or → `-o` file) for a `-` input or no inputs.
 fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> {
     let stdin = io::stdin();
     let reader = stdin.lock();
+    // `-o` redirects stdin's (de)compressed output to a file, unless `-c`
+    // explicitly forces stdout. stdin has no declared size, so no size hint.
+    if let Some(output) = &opts.output
+        && !opts.to_stdout
+        && matches!(opts.mode, Mode::Compress | Mode::Decompress)
+    {
+        return write_stream_to_file(opts, reader, output, None, dict);
+    }
     match opts.mode {
         Mode::Compress => {
             let stdout = io::stdout();
@@ -629,6 +722,62 @@ fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Resu
             unreachable!("--list / --train handled in run() before streaming")
         }
     }
+}
+
+/// Remove the source file after a successful (de)compression when `--rm` is set
+/// (and `-k` was not). A no-op otherwise.
+fn remove_source_if_requested(opts: &Options, input: &Path) -> color_eyre::Result<()> {
+    if opts.remove_source && !opts.keep {
+        fs::remove_file(input).wrap_err("failed to remove source file after success")?;
+    }
+    Ok(())
+}
+
+/// Run the (de)compression core into an arbitrary writer for the current mode.
+fn run_stream_core<R: Read, W: Write>(
+    opts: &Options,
+    reader: R,
+    writer: W,
+    size_hint: Option<u64>,
+    dict: Option<&[u8]>,
+) -> color_eyre::Result<()> {
+    match opts.mode {
+        Mode::Compress => compress_stream(
+            reader, writer, opts.level, opts.store, dict, size_hint, opts.long,
+        ),
+        Mode::Decompress => decompress_stream(reader, writer, dict),
+        Mode::Test | Mode::List | Mode::Train => {
+            unreachable!("test / list / train modes never stream to a writer here")
+        }
+    }
+}
+
+/// Stream `reader` into `output` atomically: write to a sibling temp file, then
+/// rename into place on success (and clean the temp up on failure). Honours the
+/// `-f` overwrite gate.
+fn write_stream_to_file<R: Read>(
+    opts: &Options,
+    mut reader: R,
+    output: &Path,
+    size_hint: Option<u64>,
+    dict: Option<&[u8]>,
+) -> color_eyre::Result<()> {
+    ensure_regular_output_destination(output)?;
+    if output.exists() && !opts.force {
+        bail!("{} already exists; use -f to overwrite", output.display());
+    }
+    let (temp_path, temp_file) = create_temporary_output_file(output)?;
+    let result: color_eyre::Result<()> = (|| {
+        let mut sink = temp_file;
+        run_stream_core(opts, &mut reader, &mut sink, size_hint, dict)?;
+        sink.flush().wrap_err("failed to flush output")?;
+        Ok(())
+    })();
+    if let Err(err) = result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    replace_output_file(&temp_path, output)
 }
 
 /// Resolve the output path for a file input under the current mode.
@@ -671,62 +820,22 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
         return Ok(());
     }
 
-    // stdout sink: bypass the temp-file dance.
+    // stdout sink: bypass the temp-file dance. `--rm` still applies to the
+    // source file once the stream completes, so run the removal before
+    // returning rather than short-circuiting past it.
     if opts.to_stdout {
         let stdout = io::stdout();
         let mut out = stdout.lock();
-        match opts.mode {
-            Mode::Compress => compress_stream(
-                &mut reader,
-                &mut out,
-                opts.level,
-                opts.store,
-                dict,
-                Some(source_size as u64),
-                opts.long,
-            )?,
-            Mode::Decompress => decompress_stream(&mut reader, &mut out, dict)?,
-            Mode::Test | Mode::List | Mode::Train => unreachable!(),
-        }
-        return Ok(());
+        run_stream_core(opts, &mut reader, &mut out, Some(source_size as u64), dict)?;
+        return remove_source_if_requested(opts, input);
     }
 
     let output = derive_output_path(opts, input)?;
     ensure_distinct_paths(input, &output)?;
-    ensure_regular_output_destination(&output)?;
-    if output.exists() && !opts.force {
-        bail!("{} already exists; use -f to overwrite", output.display());
-    }
-    let (temp_path, temp_file) = create_temporary_output_file(&output)?;
-    let result: color_eyre::Result<()> = (|| {
-        let mut sink = temp_file;
-        match opts.mode {
-            Mode::Compress => compress_stream(
-                &mut reader,
-                &mut sink,
-                opts.level,
-                opts.store,
-                dict,
-                Some(source_size as u64),
-                opts.long,
-            )?,
-            Mode::Decompress => decompress_stream(&mut reader, &mut sink, dict)?,
-            Mode::Test | Mode::List | Mode::Train => unreachable!(),
-        }
-        sink.flush().wrap_err("failed to flush output")?;
-        Ok(())
-    })();
-    if let Err(err) = result {
-        let _ = fs::remove_file(&temp_path);
-        return Err(err);
-    }
-    replace_output_file(&temp_path, &output)?;
+    write_stream_to_file(opts, reader, &output, Some(source_size as u64), dict)?;
 
     info!("{} -> {}", input.display(), output.display());
-    if opts.remove_source && !opts.keep {
-        fs::remove_file(input).wrap_err("failed to remove source file after success")?;
-    }
-    Ok(())
+    remove_source_if_requested(opts, input)
 }
 
 /// Streaming compression core (file or stdout), optionally dictionary-primed.
@@ -1003,6 +1112,27 @@ mod tests {
     }
 
     #[test]
+    fn list_file_walks_multi_frame_archive_by_seeking() {
+        use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
+        // Two concatenated frames: the seek-based frame walk must land exactly on
+        // the second frame's start, or parsing it would fail. A wrong frame
+        // length (the old fs::read path computed it differently) would surface as
+        // an error here.
+        let mut archive = compress_slice_to_vec(&[7u8; 4096], CompressionLevel::Default);
+        archive.extend_from_slice(&compress_slice_to_vec(
+            b"second frame payload, distinct content",
+            CompressionLevel::Default,
+        ));
+
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("szstd-list-test-{}.zst", std::process::id()));
+        fs::write(&path, &archive).unwrap();
+        let result = list_file(&path);
+        let _ = fs::remove_file(&path);
+        result.expect("list_file must walk both frames without error");
+    }
+
+    #[test]
     fn argv0_unzstd_defaults_to_decompress() {
         assert_eq!(program_mode("unzstd"), (Mode::Decompress, false));
         assert_eq!(program_mode("/usr/bin/unzstd"), (Mode::Decompress, false));
@@ -1121,6 +1251,30 @@ mod tests {
     fn unknown_flag_errors() {
         assert!(parse(&["--definitely-not-a-flag"]).is_err());
         assert!(parse(&["-Z"]).is_err());
+    }
+
+    #[test]
+    fn fast_and_long_match_exactly_not_by_prefix() {
+        // Exact options succeed.
+        assert_eq!(parse(&["--fast"]).unwrap().level, -1);
+        assert_eq!(parse(&["--fast=5"]).unwrap().level, -5);
+        assert!(parse(&["--long"]).unwrap().long);
+        // Typos must NOT be silently accepted as `--fast`/`--long`; they fall
+        // through to the unknown-option path.
+        assert!(parse(&["--faster"]).is_err());
+        assert!(parse(&["--longer"]).is_err());
+    }
+
+    #[test]
+    fn unsupported_format_flags_are_rejected_not_ignored() {
+        // These change the wire format but are not wired through yet — accepting
+        // them silently would hand the caller the wrong frame layout.
+        assert!(parse(&["--no-check"]).is_err());
+        assert!(parse(&["--no-content-size"]).is_err());
+        assert!(parse(&["--no-dictID"]).is_err());
+        // Verbosity aliases stay honest no-ops.
+        assert!(parse(&["--quiet"]).is_ok());
+        assert!(parse(&["--verbose"]).is_ok());
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@
 //! peak memory stays O(window), not O(file).
 
 mod progress;
-use progress::ProgressMonitor;
+use progress::{ProgressMonitor, fmt_size};
 
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufReader, ErrorKind, Read, Write};
@@ -28,6 +28,7 @@ enum Mode {
     Compress,
     Decompress,
     Test,
+    List,
 }
 
 /// Parsed command line.
@@ -140,6 +141,7 @@ fn parse_args(
                 "compress" => opts.mode = Mode::Compress,
                 "decompress" | "uncompress" => opts.mode = Mode::Decompress,
                 "test" => opts.mode = Mode::Test,
+                "list" => opts.mode = Mode::List,
                 "stdout" | "to-stdout" => opts.to_stdout = true,
                 "force" => opts.force = true,
                 "keep" => opts.keep = true,
@@ -181,6 +183,7 @@ fn parse_args(
                 'd' => opts.mode = Mode::Decompress,
                 'z' => opts.mode = Mode::Compress,
                 't' => opts.mode = Mode::Test,
+                'l' => opts.mode = Mode::List,
                 'c' => opts.to_stdout = true,
                 'f' => opts.force = true,
                 'k' => opts.keep = true,
@@ -287,6 +290,19 @@ fn run(opts: Options) -> color_eyre::Result<()> {
     };
     let dict = dict_bytes.as_deref();
 
+    // `--list` walks frame headers without decoding; it needs a seekable file
+    // (not a stream), so it is handled separately from the (de)compress flow.
+    if opts.mode == Mode::List {
+        if opts.inputs.is_empty() || opts.inputs.iter().any(|i| i == "-") {
+            bail!("--list requires regular files (cannot list stdin)");
+        }
+        print_list_header();
+        for input in &opts.inputs {
+            list_file(Path::new(input))?;
+        }
+        return Ok(());
+    }
+
     if opts.inputs.is_empty() {
         return process_stdin_stdout(&opts, dict);
     }
@@ -297,6 +313,66 @@ fn run(opts: Options) -> color_eyre::Result<()> {
             process_file(&opts, Path::new(input), dict)?;
         }
     }
+    Ok(())
+}
+
+/// Column header for `--list`, matching upstream's `zstd -l` layout.
+fn print_list_header() {
+    println!("Frames  Compressed  Uncompressed  Ratio  Check  DictID  Filename");
+}
+
+/// Print one `--list` row: walk every frame header in the file (no body
+/// decode), summing compressed + declared content sizes. Decompressed size is
+/// `--` when any frame omits the Frame_Content_Size field.
+fn list_file(path: &Path) -> color_eyre::Result<()> {
+    use structured_zstd::decoding::{
+        FrameContentSize, find_frame_compressed_size, read_frame_header_info,
+    };
+
+    let bytes = fs::read(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
+    let compressed = bytes.len() as u64;
+    let mut offset = 0usize;
+    let mut frames = 0u64;
+    let mut decompressed = Some(0u64);
+    let mut check = false;
+    let mut dict_id = None;
+
+    while offset < bytes.len() {
+        let rest = &bytes[offset..];
+        let info = read_frame_header_info(rest, false)
+            .map_err(|err| eyre!("{}: not a zstd frame: {err:?}", path.display()))?;
+        let frame_len = find_frame_compressed_size(rest)
+            .map_err(|err| eyre!("{}: malformed frame: {err:?}", path.display()))?;
+        match info.content_size {
+            FrameContentSize::Known(n) => decompressed = decompressed.map(|d| d + n),
+            FrameContentSize::Unknown => decompressed = None,
+        }
+        check |= info.content_checksum;
+        if frames == 0 {
+            dict_id = info.dictionary_id;
+        }
+        frames += 1;
+        offset += frame_len;
+    }
+
+    let ratio = match decompressed {
+        Some(d) if d > 0 => format!("{:.3}", d as f64 / compressed as f64),
+        _ => "--".to_string(),
+    };
+    let decompressed_str = match decompressed {
+        Some(d) => fmt_size(d as f64),
+        None => "--".to_string(),
+    };
+    println!(
+        "{frames:>6}  {:>10}  {:>12}  {ratio:>5}  {:>5}  {:>6}  {}",
+        fmt_size(compressed as f64),
+        decompressed_str,
+        if check { "XXH64" } else { "None" },
+        dict_id
+            .map(|id| id.to_string())
+            .unwrap_or_else(|| "0".to_string()),
+        path.display(),
+    );
     Ok(())
 }
 
@@ -316,6 +392,7 @@ fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Resu
         Mode::Test => decompress_stream(reader, io::sink(), dict).map(|_| {
             info!("stdin: OK");
         }),
+        Mode::List => unreachable!("--list is handled in run() before streaming"),
     }
 }
 
@@ -336,7 +413,9 @@ fn derive_output_path(opts: &Options, input: &Path) -> color_eyre::Result<PathBu
                 ),
             }
         }
-        Mode::Test => unreachable!("test mode never writes an output file"),
+        Mode::Test | Mode::List => {
+            unreachable!("test / list modes never write an output file")
+        }
     }
 }
 
@@ -371,7 +450,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 Some(source_size as u64),
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut out, dict)?,
-            Mode::Test => unreachable!(),
+            Mode::Test | Mode::List => unreachable!(),
         }
         return Ok(());
     }
@@ -395,7 +474,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 Some(source_size as u64),
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut sink, dict)?,
-            Mode::Test => unreachable!(),
+            Mode::Test | Mode::List => unreachable!(),
         }
         sink.flush().wrap_err("failed to flush output")?;
         Ok(())
@@ -428,10 +507,13 @@ fn compress_stream<R: Read, W: Write>(
         CompressionLevel::from_level(level)
     };
     let mut encoder = structured_zstd::encoding::StreamingEncoder::new(writer, compression_level);
-    if let Some(hint) = size_hint {
+    if let Some(size) = size_hint {
+        // The size is known (a regular file), so pledge it: the frame records
+        // Frame_Content_Size (decoders can pre-allocate, `zstd -l` reports it)
+        // and the matcher sizes its tables to the source. stdin keeps it unset.
         encoder
-            .set_source_size_hint(hint)
-            .wrap_err("failed to configure source size hint")?;
+            .set_pledged_content_size(size)
+            .wrap_err("failed to set pledged content size")?;
     }
     if let Some(raw) = dict {
         encoder

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -60,6 +60,8 @@ struct Options {
     bench: bool,
     bench_start: i32,
     bench_end: i32,
+    /// Per-level benchmark time budget in seconds (`-i`, default 1).
+    bench_secs: f64,
     /// Long-distance matching (`--long`), enabled on the encoder via the
     /// compression-parameters API.
     long: bool,
@@ -142,6 +144,7 @@ fn parse_args(
         bench: false,
         bench_start: CompressionLevel::DEFAULT_LEVEL,
         bench_end: 0,
+        bench_secs: 1.0,
         long: false,
     };
     let mut ultra = false;
@@ -236,9 +239,12 @@ fn parse_args(
                                 opts.bench_end = v;
                             }
                         }
-                        // `-i` (iteration seconds) accepted; the basic bench
-                        // uses a fixed time budget, so the value is informational.
-                        'i' => {}
+                        // `-i[N]`: per-level benchmark time budget in seconds.
+                        'i' => {
+                            if let Some(v) = value {
+                                opts.bench_secs = (v.max(1)) as f64;
+                            }
+                        }
                         _ => unreachable!(),
                     }
                     ci = chars.len();
@@ -247,7 +253,15 @@ fn parse_args(
                 'c' => opts.to_stdout = true,
                 'f' => opts.force = true,
                 'k' => opts.keep = true,
-                'q' | 'v' => {}
+                // `-S` (benchmark each file separately) is the default here;
+                // `-q`/`-v` verbosity are accepted no-ops.
+                'q' | 'v' | 'S' => {}
+                'B' => {
+                    // `-B[N]` benchmark block size: accepted (the encoder uses
+                    // its fixed block size); consume any attached value.
+                    ci = chars.len();
+                    continue;
+                }
                 'V' => {
                     print_version();
                     return Ok(Parsed::Handled);
@@ -419,7 +433,6 @@ fn run_benchmark(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> 
         bail!("-b: input is empty");
     }
     // Per-level time budget; best (fastest) pass wins, like upstream's -i loop.
-    const BUDGET_SECS: f64 = 1.0;
     let mb = data.len() as f64 / 1e6;
     println!(
         "benchmarking {} ({})  levels {}..={}",
@@ -447,7 +460,7 @@ fn run_benchmark(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> 
                 opts.long,
             )?;
             best_compress = best_compress.min(t.elapsed().as_secs_f64());
-            if start.elapsed().as_secs_f64() >= BUDGET_SECS {
+            if start.elapsed().as_secs_f64() >= opts.bench_secs {
                 break;
             }
         }
@@ -459,7 +472,7 @@ fn run_benchmark(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> 
             let t = Instant::now();
             decompress_stream(compressed.as_slice(), &mut out, dict)?;
             best_decompress = best_decompress.min(t.elapsed().as_secs_f64());
-            if start.elapsed().as_secs_f64() >= BUDGET_SECS {
+            if start.elapsed().as_secs_f64() >= opts.bench_secs {
                 break;
             }
         }
@@ -1128,6 +1141,7 @@ mod tests {
             bench: false,
             bench_start: 3,
             bench_end: 0,
+            bench_secs: 1.0,
             long: false,
         };
         assert_eq!(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,7 @@ enum Mode {
     Decompress,
     Test,
     List,
+    Train,
 }
 
 /// Parsed command line.
@@ -51,7 +52,14 @@ struct Options {
     remove_source: bool,
     /// Positional inputs; empty or a lone `-` means stdin.
     inputs: Vec<String>,
+    /// Target dictionary size for `--train` (`--maxdict`, upstream default 112640).
+    max_dict: usize,
+    /// Explicit dictionary ID for `--train` (`--dictID`).
+    dict_id: Option<u32>,
 }
+
+/// Upstream `zstd --maxdict` default (110 KiB).
+const DEFAULT_MAX_DICT: usize = 112_640;
 
 /// Outcome of argument parsing: either run with `Options`, or a terminal
 /// message already handled (help / version).
@@ -122,6 +130,8 @@ fn parse_args(
         keep: false,
         remove_source: false,
         inputs: Vec::new(),
+        max_dict: DEFAULT_MAX_DICT,
+        dict_id: None,
     };
     let mut ultra = false;
     let mut iter = args.iter().enumerate().peekable();
@@ -142,6 +152,9 @@ fn parse_args(
                 "decompress" | "uncompress" => opts.mode = Mode::Decompress,
                 "test" => opts.mode = Mode::Test,
                 "list" => opts.mode = Mode::List,
+                "train" | "train-fastcover" | "train-cover" | "train-legacy" => {
+                    opts.mode = Mode::Train
+                }
                 "stdout" | "to-stdout" => opts.to_stdout = true,
                 "force" => opts.force = true,
                 "keep" => opts.keep = true,
@@ -165,6 +178,10 @@ fn parse_args(
                         };
                     } else if let Some(path) = long.strip_prefix("use-dict=") {
                         opts.dict = Some(PathBuf::from(path));
+                    } else if let Some(v) = long.strip_prefix("maxdict=") {
+                        opts.max_dict = v.parse::<usize>().wrap_err("invalid --maxdict size")?;
+                    } else if let Some(v) = long.strip_prefix("dictID=") {
+                        opts.dict_id = Some(v.parse::<u32>().wrap_err("invalid --dictID")?);
                     } else if long.starts_with("long") {
                         // `--long[=N]` (LDM) — accepted; LDM wiring is a follow-up.
                     } else {
@@ -232,7 +249,9 @@ fn parse_args(
         bail!("level {} requires --ultra (levels 20-22)", opts.level);
     }
     validate_level(opts.level)?;
-    if opts.output.is_some() && opts.inputs.len() > 1 {
+    // `-o` names a single output, so it can't fan out over multiple inputs —
+    // except `--train`, where many sample files legitimately feed one dictionary.
+    if opts.mode != Mode::Train && opts.output.is_some() && opts.inputs.len() > 1 {
         bail!("-o cannot be combined with multiple input files");
     }
     Ok(Parsed::Run(opts))
@@ -290,6 +309,12 @@ fn run(opts: Options) -> color_eyre::Result<()> {
     };
     let dict = dict_bytes.as_deref();
 
+    // `--train` builds a dictionary from the sample files rather than
+    // (de)compressing them; handle it before the streaming flow.
+    if opts.mode == Mode::Train {
+        return train_dictionary(&opts);
+    }
+
     // `--list` walks frame headers without decoding; it needs a seekable file
     // (not a stream), so it is handled separately from the (de)compress flow.
     if opts.mode == Mode::List {
@@ -313,6 +338,51 @@ fn run(opts: Options) -> color_eyre::Result<()> {
             process_file(&opts, Path::new(input), dict)?;
         }
     }
+    Ok(())
+}
+
+/// `--train`: build a FastCOVER dictionary from the concatenated sample files
+/// and write it to `-o` (default `dictionary`). Mirrors upstream
+/// `zstd --train FILEs -o dict --maxdict=N [--dictID=N]`.
+fn train_dictionary(opts: &Options) -> color_eyre::Result<()> {
+    use structured_zstd::dictionary::{
+        FastCoverOptions, FinalizeOptions, create_fastcover_dict_from_source,
+    };
+
+    if opts.inputs.is_empty() {
+        bail!("--train requires one or more sample files");
+    }
+    let mut corpus = Vec::new();
+    for input in &opts.inputs {
+        let bytes =
+            fs::read(input).wrap_err_with(|| format!("failed to read training sample {input}"))?;
+        corpus.extend_from_slice(&bytes);
+    }
+    let output = opts
+        .output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("dictionary"));
+
+    let mut dict = Vec::new();
+    create_fastcover_dict_from_source(
+        corpus.as_slice(),
+        &mut dict,
+        opts.max_dict,
+        &FastCoverOptions::default(),
+        FinalizeOptions {
+            dict_id: opts.dict_id,
+        },
+    )
+    .map_err(|err| eyre!("dictionary training failed: {err}"))?;
+
+    fs::write(&output, &dict)
+        .wrap_err_with(|| format!("failed to write dictionary {}", output.display()))?;
+    info!(
+        "trained {} ({}) from {} sample file(s)",
+        output.display(),
+        fmt_size(dict.len() as f64),
+        opts.inputs.len()
+    );
     Ok(())
 }
 
@@ -392,7 +462,9 @@ fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Resu
         Mode::Test => decompress_stream(reader, io::sink(), dict).map(|_| {
             info!("stdin: OK");
         }),
-        Mode::List => unreachable!("--list is handled in run() before streaming"),
+        Mode::List | Mode::Train => {
+            unreachable!("--list / --train handled in run() before streaming")
+        }
     }
 }
 
@@ -413,8 +485,8 @@ fn derive_output_path(opts: &Options, input: &Path) -> color_eyre::Result<PathBu
                 ),
             }
         }
-        Mode::Test | Mode::List => {
-            unreachable!("test / list modes never write an output file")
+        Mode::Test | Mode::List | Mode::Train => {
+            unreachable!("test / list / train modes never write an output file")
         }
     }
 }
@@ -450,7 +522,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 Some(source_size as u64),
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut out, dict)?,
-            Mode::Test | Mode::List => unreachable!(),
+            Mode::Test | Mode::List | Mode::Train => unreachable!(),
         }
         return Ok(());
     }
@@ -474,7 +546,7 @@ fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre
                 Some(source_size as u64),
             )?,
             Mode::Decompress => decompress_stream(&mut reader, &mut sink, dict)?,
-            Mode::Test | Mode::List => unreachable!(),
+            Mode::Test | Mode::List | Mode::Train => unreachable!(),
         }
         sink.flush().wrap_err("failed to flush output")?;
         Ok(())
@@ -810,6 +882,33 @@ mod tests {
     }
 
     #[test]
+    fn train_flags_parse_and_allow_many_samples_with_output() {
+        let opts = parse(&[
+            "--train",
+            "--maxdict=4096",
+            "--dictID=42",
+            "-o",
+            "dict.bin",
+            "s1.txt",
+            "s2.txt",
+            "s3.txt",
+        ])
+        .unwrap();
+        assert_eq!(opts.mode, Mode::Train);
+        assert_eq!(opts.max_dict, 4096);
+        assert_eq!(opts.dict_id, Some(42));
+        assert_eq!(opts.output, Some(PathBuf::from("dict.bin")));
+        // --train legitimately fans many samples into one -o dictionary.
+        assert_eq!(opts.inputs.len(), 3);
+    }
+
+    #[test]
+    fn list_mode_parses() {
+        assert_eq!(parse(&["-l", "a.zst"]).unwrap().mode, Mode::List);
+        assert_eq!(parse(&["--list", "a.zst"]).unwrap().mode, Mode::List);
+    }
+
+    #[test]
     fn dash_is_a_stdin_input() {
         let opts = parse(&["-d", "-"]).unwrap();
         assert_eq!(opts.inputs, vec!["-".to_string()]);
@@ -840,6 +939,8 @@ mod tests {
             keep: false,
             remove_source: false,
             inputs: vec!["archive.tar.zst".to_string()],
+            max_dict: DEFAULT_MAX_DICT,
+            dict_id: None,
         };
         assert_eq!(
             derive_output_path(&opts, Path::new("archive.tar.zst")).unwrap(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -56,6 +56,10 @@ struct Options {
     max_dict: usize,
     /// Explicit dictionary ID for `--train` (`--dictID`).
     dict_id: Option<u32>,
+    /// Benchmark mode (`-b`); benchmarks `bench_start..=bench_end`.
+    bench: bool,
+    bench_start: i32,
+    bench_end: i32,
 }
 
 /// Upstream `zstd --maxdict` default (110 KiB).
@@ -132,6 +136,9 @@ fn parse_args(
         inputs: Vec::new(),
         max_dict: DEFAULT_MAX_DICT,
         dict_id: None,
+        bench: false,
+        bench_start: CompressionLevel::DEFAULT_LEVEL,
+        bench_end: 0,
     };
     let mut ultra = false;
     let mut iter = args.iter().enumerate().peekable();
@@ -201,6 +208,36 @@ fn parse_args(
                 'z' => opts.mode = Mode::Compress,
                 't' => opts.mode = Mode::Test,
                 'l' => opts.mode = Mode::List,
+                'b' | 'e' | 'i' => {
+                    // `-b[N]` benchmark (start level), `-e[N]` end level for a
+                    // range, `-i[N]` iteration budget. The number is attached
+                    // (`-b19`), upstream-style; bare `-b` benchmarks the default.
+                    let rest: String = chars[ci + 1..].iter().collect();
+                    let value = if rest.is_empty() {
+                        None
+                    } else {
+                        Some(rest.parse::<i32>().wrap_err("invalid numeric suffix")?)
+                    };
+                    match c {
+                        'b' => {
+                            opts.bench = true;
+                            if let Some(v) = value {
+                                opts.bench_start = v;
+                            }
+                        }
+                        'e' => {
+                            if let Some(v) = value {
+                                opts.bench_end = v;
+                            }
+                        }
+                        // `-i` (iteration seconds) accepted; the basic bench
+                        // uses a fixed time budget, so the value is informational.
+                        'i' => {}
+                        _ => unreachable!(),
+                    }
+                    ci = chars.len();
+                    continue;
+                }
                 'c' => opts.to_stdout = true,
                 'f' => opts.force = true,
                 'k' => opts.keep = true,
@@ -251,8 +288,11 @@ fn parse_args(
     validate_level(opts.level)?;
     // `-o` names a single output, so it can't fan out over multiple inputs —
     // except `--train`, where many sample files legitimately feed one dictionary.
-    if opts.mode != Mode::Train && opts.output.is_some() && opts.inputs.len() > 1 {
+    if opts.mode != Mode::Train && !opts.bench && opts.output.is_some() && opts.inputs.len() > 1 {
         bail!("-o cannot be combined with multiple input files");
+    }
+    if opts.bench && opts.bench_end < opts.bench_start {
+        opts.bench_end = opts.bench_start;
     }
     Ok(Parsed::Run(opts))
 }
@@ -309,6 +349,12 @@ fn run(opts: Options) -> color_eyre::Result<()> {
     };
     let dict = dict_bytes.as_deref();
 
+    // `-b` benchmarks compression/decompression across levels instead of
+    // producing output files; handle it before the streaming flow.
+    if opts.bench {
+        return run_benchmark(&opts, dict);
+    }
+
     // `--train` builds a dictionary from the sample files rather than
     // (de)compressing them; handle it before the streaming flow.
     if opts.mode == Mode::Train {
@@ -337,6 +383,89 @@ fn run(opts: Options) -> color_eyre::Result<()> {
         } else {
             process_file(&opts, Path::new(input), dict)?;
         }
+    }
+    Ok(())
+}
+
+/// `-b`: benchmark compression + decompression of the input across the
+/// requested level range, reporting ratio and best-of throughput. A simplified
+/// `zstd -b#` (per-level row); honours `-D` so dictionary throughput can be
+/// measured. Time-budgeted per level rather than fixed-iteration.
+fn run_benchmark(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> {
+    use std::time::Instant;
+
+    if opts.inputs.is_empty() || opts.inputs.iter().any(|i| i == "-") {
+        bail!("-b requires one or more regular input files to benchmark");
+    }
+    let mut data = Vec::new();
+    for input in &opts.inputs {
+        data.extend_from_slice(
+            &fs::read(input).wrap_err_with(|| format!("failed to read {input}"))?,
+        );
+    }
+    if data.is_empty() {
+        bail!("-b: input is empty");
+    }
+    // Per-level time budget; best (fastest) pass wins, like upstream's -i loop.
+    const BUDGET_SECS: f64 = 1.0;
+    let mb = data.len() as f64 / 1e6;
+    println!(
+        "benchmarking {} ({})  levels {}..={}",
+        opts.inputs.join(", "),
+        fmt_size(data.len() as f64),
+        opts.bench_start,
+        opts.bench_end,
+    );
+
+    for level in opts.bench_start..=opts.bench_end {
+        validate_level(level)?;
+        let mut compressed = Vec::new();
+        let mut best_compress = f64::MAX;
+        let start = Instant::now();
+        loop {
+            compressed.clear();
+            let t = Instant::now();
+            compress_stream(
+                data.as_slice(),
+                &mut compressed,
+                level,
+                opts.store,
+                dict,
+                Some(data.len() as u64),
+            )?;
+            best_compress = best_compress.min(t.elapsed().as_secs_f64());
+            if start.elapsed().as_secs_f64() >= BUDGET_SECS {
+                break;
+            }
+        }
+
+        let mut best_decompress = f64::MAX;
+        let start = Instant::now();
+        loop {
+            let mut out = Vec::new();
+            let t = Instant::now();
+            decompress_stream(compressed.as_slice(), &mut out, dict)?;
+            best_decompress = best_decompress.min(t.elapsed().as_secs_f64());
+            if start.elapsed().as_secs_f64() >= BUDGET_SECS {
+                break;
+            }
+        }
+
+        let ratio = data.len() as f64 / compressed.len() as f64;
+        let c_speed = if best_compress > 0.0 {
+            mb / best_compress
+        } else {
+            f64::INFINITY
+        };
+        let d_speed = if best_decompress > 0.0 {
+            mb / best_decompress
+        } else {
+            f64::INFINITY
+        };
+        println!(
+            "{level:>3}  {:>10}  {ratio:>7.3}  {c_speed:>7.1} MB/s comp  {d_speed:>8.1} MB/s decomp",
+            fmt_size(compressed.len() as f64),
+        );
     }
     Ok(())
 }
@@ -909,6 +1038,18 @@ mod tests {
     }
 
     #[test]
+    fn benchmark_flags_parse_level_range() {
+        let opts = parse(&["-b3", "-e7", "in.txt"]).unwrap();
+        assert!(opts.bench);
+        assert_eq!(opts.bench_start, 3);
+        assert_eq!(opts.bench_end, 7);
+        // Bare `-b` benchmarks the default level (single-level range).
+        let opts = parse(&["-b", "in.txt"]).unwrap();
+        assert!(opts.bench);
+        assert_eq!(opts.bench_end, opts.bench_start);
+    }
+
+    #[test]
     fn dash_is_a_stdin_input() {
         let opts = parse(&["-d", "-"]).unwrap();
         assert_eq!(opts.inputs, vec!["-".to_string()]);
@@ -941,6 +1082,9 @@ mod tests {
             inputs: vec!["archive.tar.zst".to_string()],
             max_dict: DEFAULT_MAX_DICT,
             dict_id: None,
+            bench: false,
+            bench_start: 3,
+            bench_end: 0,
         };
         assert_eq!(
             derive_output_path(&opts, Path::new("archive.tar.zst")).unwrap(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -197,19 +197,27 @@ fn parse_args(
                         // `--fast` is the level -1 alias.
                         opts.level = -1;
                     } else if let Some(v) = long.strip_prefix("fast=") {
-                        // `--fast=N` is level -N. Exact-match the prefix so a
+                        // `--fast=N` is level -N for a positive N. Parse as
+                        // unsigned so `--fast=-5` is rejected rather than flipping
+                        // sign into a positive level. Exact-match the prefix so a
                         // typo like `--faster` falls through to unknown-option.
-                        opts.level = -(v.parse::<i32>().wrap_err("invalid --fast level")?);
+                        let n = v.parse::<u32>().wrap_err("invalid --fast level")?;
+                        opts.level = -i32::try_from(n).wrap_err("--fast level too large")?;
                     } else if let Some(path) = long.strip_prefix("use-dict=") {
                         opts.dict = Some(PathBuf::from(path));
                     } else if let Some(v) = long.strip_prefix("maxdict=") {
                         opts.max_dict = v.parse::<usize>().wrap_err("invalid --maxdict size")?;
                     } else if let Some(v) = long.strip_prefix("dictID=") {
                         opts.dict_id = Some(v.parse::<u32>().wrap_err("invalid --dictID")?);
-                    } else if long == "long" || long.strip_prefix("long=").is_some() {
-                        // `--long` or `--long=N` (the window-log hint is accepted
-                        // but the encoder derives the LDM window from the level).
-                        // Exact-match so `--longer` is an unknown option.
+                    } else if long == "long" {
+                        opts.long = true;
+                    } else if let Some(v) = long.strip_prefix("long=") {
+                        // `--long=N`: the window-log hint must be numeric (it is
+                        // accepted but the encoder derives the LDM window from the
+                        // level). Reject `--long=` / `--long=abc` instead of
+                        // treating them as a silent no-op. Exact-match so
+                        // `--longer` is an unknown option.
+                        let _ = v.parse::<u32>().wrap_err("invalid --long window log")?;
                         opts.long = true;
                     } else {
                         bail!("unknown option: --{long}");
@@ -595,6 +603,11 @@ fn list_file(path: &Path) -> color_eyre::Result<()> {
         .metadata()
         .wrap_err_with(|| format!("failed to stat {}", path.display()))?
         .len();
+    // An empty file is not a zstd stream: without this guard the walk loop
+    // below never runs and we would print a spurious 0-frame success row.
+    if compressed == 0 {
+        bail!("{}: not a zstd frame: empty file", path.display());
+    }
     let mut offset = 0u64;
     let mut frames = 0u64;
     let mut decompressed = Some(0u64);
@@ -1263,6 +1276,13 @@ mod tests {
         // through to the unknown-option path.
         assert!(parse(&["--faster"]).is_err());
         assert!(parse(&["--longer"]).is_err());
+        // Invalid payloads are rejected, not silently reinterpreted:
+        // `--fast=-5` must not flip into a positive level, and `--long=` /
+        // `--long=abc` must not be accepted as a no-op.
+        assert!(parse(&["--fast=-5"]).is_err());
+        assert!(parse(&["--long="]).is_err());
+        assert!(parse(&["--long=abc"]).is_err());
+        assert!(parse(&["--long=27"]).unwrap().long);
     }
 
     #[test]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,87 +1,77 @@
+//! `zstd` command-line interface with upstream-compatible flag dispatch.
+//!
+//! The argument model mirrors upstream zstd v1.5.7: mode + level FLAGS (not
+//! subcommands), `argv[0]` dispatch (`unzstd` / `zstdcat` change the default
+//! mode), stdin/stdout streaming, and the conventional `-o`/`-f`/`-k`/`-D`
+//! file flags. Compression/decompression run through the streaming codec, so
+//! peak memory stays O(window), not O(file).
+
 mod progress;
 use progress::ProgressMonitor;
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{BufReader, ErrorKind};
-use std::path::Path;
-use std::path::PathBuf;
+use std::io::{self, BufReader, ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
 
-use progress::fmt_size;
-
-use clap::{Parser, Subcommand};
-use color_eyre::eyre::{ContextCompat, WrapErr, eyre};
+use color_eyre::eyre::{WrapErr, bail, eyre};
 use structured_zstd::encoding::CompressionLevel;
 use tracing::info;
 use tracing_indicatif::IndicatifLayer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
-#[derive(Parser)]
-#[command(version, about)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Commands>,
+const ZSTD_SUFFIX: &str = ".zst";
+
+/// Operation selected by mode flags / `argv[0]`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Mode {
+    Compress,
+    Decompress,
+    Test,
 }
 
-// TODO: implement a dictionary creation command, and a command for benchmarking
-#[derive(Subcommand)]
-enum Commands {
-    /// Compress a single file. If no output file is specified,
-    /// output will be written to <INPUT_FILE>.zst
-    Compress {
-        /// File to compress
-        input_file: PathBuf,
-        /// Where the compressed file is written
-        /// [default: <INPUT_FILE>.zst]
-        output_file: Option<PathBuf>,
-        /// Compression level (higher = smaller, slower).
-        ///
-        /// Numeric levels follow the zstd convention where 0 means
-        /// "use the default level" (currently 3).
-        ///
-        /// -  0: Default (same as 3)
-        /// -  1: Fastest (fast hash, ~zstd level 1)
-        /// -  3: Default (dfast, ~zstd level 3)
-        /// -  7: Better  (lazy2, ~zstd level 7)
-        /// - 11: Best    (deep lazy2, ~zstd level 11)
-        /// - Negative: ultra-fast modes (less compression, more speed)
-        /// - 12-22: progressively higher ratio (capped at lazy2 backend)
-        ///
-        /// Use --store to write an uncompressed zstd frame.
-        #[arg(
-            short,
-            long,
-            value_name = "LEVEL",
-            default_value_t = CompressionLevel::DEFAULT_LEVEL,
-            // clap's ranged parser expects i64 bounds here (RangedI64ValueParser),
-            // even though the target value type is i32.
-            value_parser = clap::value_parser!(i32).range(
-                (CompressionLevel::MIN_LEVEL as i64)..=(CompressionLevel::MAX_LEVEL as i64)
-            ),
-            verbatim_doc_comment,
-            allow_hyphen_values = true,
-        )]
-        level: i32,
-        /// Write an uncompressed zstd frame (no compression).
-        ///
-        /// When set, compression itself ignores `--level` and writes a raw
-        /// zstd frame. The CLI still validates `--level` range at parse time.
-        #[arg(long)]
-        store: bool,
-    },
-    Decompress {
-        /// .zst archive to decompress
-        input_file: PathBuf,
-        /// Where the compressed file is written
-        /// [default: <ARCHIVE_NAME>]
-        output_file: Option<PathBuf>,
-    },
+/// Parsed command line.
+struct Options {
+    mode: Mode,
+    /// Numeric compression level (zstd scale). `store` overrides it.
+    level: i32,
+    store: bool,
+    /// Raw dictionary blob path (`-D`), applied to both compress and decompress.
+    dict: Option<PathBuf>,
+    /// Force output to stdout (`-c` / `zstdcat` / a `-` input).
+    to_stdout: bool,
+    /// Explicit output path (`-o`); at most one input is allowed with it.
+    output: Option<PathBuf>,
+    force: bool,
+    keep: bool,
+    /// Remove source files after a successful (de)compression (`--rm`; implied
+    /// by upstream's default when not `-k`/stdout, but we keep the input unless
+    /// `--rm` is given — safer default for a young tool).
+    remove_source: bool,
+    /// Positional inputs; empty or a lone `-` means stdin.
+    inputs: Vec<String>,
+}
+
+/// Outcome of argument parsing: either run with `Options`, or a terminal
+/// message already handled (help / version).
+enum Parsed {
+    Run(Options),
+    Handled,
 }
 
 fn main() -> color_eyre::Result<()> {
-    // Process CLI arguments
-    let cli = Cli::parse();
-    // Initialize logging (with indicatif integration)
+    let raw: Vec<String> = std::env::args().collect();
+    let prog = raw.first().map(String::as_str).unwrap_or("zstd");
+    let (default_mode, argv0_stdout) = program_mode(prog);
+
+    let parsed = parse_args(&raw[1..], default_mode, argv0_stdout)?;
+    let options = match parsed {
+        Parsed::Run(options) => options,
+        Parsed::Handled => return Ok(()),
+    };
+
+    // Logging (with indicatif progress integration) goes to stderr so it never
+    // contaminates a `-c` stdout data stream.
     let indicatif_layer = IndicatifLayer::new();
     tracing_subscriber::registry()
         .with(
@@ -92,95 +82,389 @@ fn main() -> color_eyre::Result<()> {
         .with(indicatif_layer)
         .init();
 
-    let command: Commands = cli.command.wrap_err("no subcommand provided").unwrap();
-    match command {
-        Commands::Compress {
-            input_file,
-            output_file,
-            level,
-            store,
-        } => {
-            let output_file = output_file.unwrap_or_else(|| add_extension(&input_file, ".zst"));
-            compress(input_file, output_file, level, store)?;
+    run(options)
+}
+
+/// Default mode + forced-stdout from `argv[0]` (the conventional symlink
+/// dispatch). `unzstd` decompresses; `zstdcat` decompresses to stdout.
+fn program_mode(prog: &str) -> (Mode, bool) {
+    let name = Path::new(prog)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(prog);
+    // Strip a trailing `.exe` for Windows symlink names.
+    let stem = name.strip_suffix(".exe").unwrap_or(name);
+    match stem {
+        "unzstd" => (Mode::Decompress, false),
+        "zstdcat" | "zcat" => (Mode::Decompress, true),
+        // "zstd", "zstdmt", anything else → compress by default.
+        _ => (Mode::Compress, false),
+    }
+}
+
+/// Manual upstream-style parse: bare `-N` is a level, short flags combine
+/// (`-dc`), `-o`/`-D` take a value, `--long-opts` are matched whole. `clap`'s
+/// derive cannot model bare numeric levels, so we parse argv directly.
+fn parse_args(
+    args: &[String],
+    default_mode: Mode,
+    argv0_stdout: bool,
+) -> color_eyre::Result<Parsed> {
+    let mut opts = Options {
+        mode: default_mode,
+        level: CompressionLevel::DEFAULT_LEVEL,
+        store: false,
+        dict: None,
+        to_stdout: argv0_stdout,
+        output: None,
+        force: false,
+        keep: false,
+        remove_source: false,
+        inputs: Vec::new(),
+    };
+    let mut ultra = false;
+    let mut iter = args.iter().enumerate().peekable();
+    let mut positional_only = false;
+
+    while let Some((idx, arg)) = iter.next() {
+        if positional_only || arg == "-" || !arg.starts_with('-') {
+            opts.inputs.push(arg.clone());
+            continue;
         }
-        Commands::Decompress {
-            input_file,
-            output_file,
-        } => {
-            let output_file = output_file.unwrap_or(
-                input_file
-                    .file_stem()
-                    .expect("input has a file name")
-                    .into(),
-            );
-            decompress(input_file, output_file)?;
+        if arg == "--" {
+            positional_only = true;
+            continue;
+        }
+        if let Some(long) = arg.strip_prefix("--") {
+            match long {
+                "compress" => opts.mode = Mode::Compress,
+                "decompress" | "uncompress" => opts.mode = Mode::Decompress,
+                "test" => opts.mode = Mode::Test,
+                "stdout" | "to-stdout" => opts.to_stdout = true,
+                "force" => opts.force = true,
+                "keep" => opts.keep = true,
+                "rm" => opts.remove_source = true,
+                "ultra" => ultra = true,
+                "no-check" | "no-content-size" | "no-dictID" | "quiet" | "verbose" => {}
+                "version" => {
+                    print_version();
+                    return Ok(Parsed::Handled);
+                }
+                "help" => {
+                    print_help();
+                    return Ok(Parsed::Handled);
+                }
+                _ => {
+                    if let Some(n) = long.strip_prefix("fast") {
+                        // `--fast` or `--fast=N`.
+                        opts.level = match n.strip_prefix('=') {
+                            Some(v) => -(v.parse::<i32>().wrap_err("invalid --fast level")?),
+                            None => -1,
+                        };
+                    } else if let Some(path) = long.strip_prefix("use-dict=") {
+                        opts.dict = Some(PathBuf::from(path));
+                    } else if long.starts_with("long") {
+                        // `--long[=N]` (LDM) — accepted; LDM wiring is a follow-up.
+                    } else {
+                        bail!("unknown option: --{long}");
+                    }
+                }
+            }
+            continue;
+        }
+        // Short flag cluster, e.g. `-dcf`, `-19`, `-D dict`, `-o out`.
+        let chars: Vec<char> = arg[1..].chars().collect();
+        let mut ci = 0;
+        while ci < chars.len() {
+            let c = chars[ci];
+            match c {
+                'd' => opts.mode = Mode::Decompress,
+                'z' => opts.mode = Mode::Compress,
+                't' => opts.mode = Mode::Test,
+                'c' => opts.to_stdout = true,
+                'f' => opts.force = true,
+                'k' => opts.keep = true,
+                'q' | 'v' => {}
+                'V' => {
+                    print_version();
+                    return Ok(Parsed::Handled);
+                }
+                'h' | 'H' => {
+                    print_help();
+                    return Ok(Parsed::Handled);
+                }
+                'D' | 'o' => {
+                    // Value is the rest of this token, or the next argument.
+                    let rest: String = chars[ci + 1..].iter().collect();
+                    let value = if rest.is_empty() {
+                        iter.next()
+                            .map(|(_, v)| v.clone())
+                            .ok_or_else(|| eyre!("option -{c} requires a value"))?
+                    } else {
+                        rest
+                    };
+                    if c == 'D' {
+                        opts.dict = Some(PathBuf::from(value));
+                    } else {
+                        opts.output = Some(PathBuf::from(value));
+                    }
+                    ci = chars.len();
+                    continue;
+                }
+                '0'..='9' => {
+                    // The rest of the cluster is the (possibly multi-digit) level.
+                    let digits: String = chars[ci..].iter().collect();
+                    opts.level = digits.parse::<i32>().wrap_err("invalid level")?;
+                    ci = chars.len();
+                    continue;
+                }
+                _ => bail!("unknown flag: -{c} (in {arg})"),
+            }
+            ci += 1;
+        }
+        let _ = idx;
+    }
+
+    if !ultra && opts.level > 19 {
+        bail!("level {} requires --ultra (levels 20-22)", opts.level);
+    }
+    validate_level(opts.level)?;
+    if opts.output.is_some() && opts.inputs.len() > 1 {
+        bail!("-o cannot be combined with multiple input files");
+    }
+    Ok(Parsed::Run(opts))
+}
+
+fn validate_level(level: i32) -> color_eyre::Result<()> {
+    let (min, max) = (CompressionLevel::MIN_LEVEL, CompressionLevel::MAX_LEVEL);
+    if !(min..=max).contains(&level) {
+        bail!("compression level {level} out of range [{min}, {max}]");
+    }
+    Ok(())
+}
+
+fn print_version() {
+    println!(
+        "zstd (structured-zstd) {} — pure-Rust Zstandard",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+fn print_help() {
+    print_version();
+    println!(
+        "\nUsage: zstd [OPTIONS] [FILE...]\n\
+         \n\
+         Modes:\n\
+         \x20 -z, --compress       compress (default)\n\
+         \x20 -d, --decompress     decompress\n\
+         \x20 -t, --test           test a compressed file's integrity\n\
+         \n\
+         Options:\n\
+         \x20 -<N>                 compression level (1-19; 20-22 need --ultra)\n\
+         \x20 --fast[=N]           ultra-fast negative level\n\
+         \x20 --ultra              allow levels 20-22\n\
+         \x20 -D FILE              use FILE as a dictionary\n\
+         \x20 -o FILE              write output to FILE\n\
+         \x20 -c, --stdout         write to stdout\n\
+         \x20 -f, --force          overwrite output / allow stdout to terminal\n\
+         \x20 -k, --keep           keep (do not delete) source files\n\
+         \x20 --rm                 remove source files after success\n\
+         \x20 -V, --version        print version\n\
+         \x20 -h, --help           print this help\n\
+         \n\
+         With no FILE, or when FILE is `-`, read stdin / write stdout."
+    );
+}
+
+fn run(opts: Options) -> color_eyre::Result<()> {
+    let dict_bytes = match &opts.dict {
+        Some(path) => Some(
+            fs::read(path)
+                .wrap_err_with(|| format!("failed to read dictionary file {}", path.display()))?,
+        ),
+        None => None,
+    };
+    let dict = dict_bytes.as_deref();
+
+    if opts.inputs.is_empty() {
+        return process_stdin_stdout(&opts, dict);
+    }
+    for input in &opts.inputs {
+        if input == "-" {
+            process_stdin_stdout(&opts, dict)?;
+        } else {
+            process_file(&opts, Path::new(input), dict)?;
         }
     }
     Ok(())
 }
 
-fn compress(input: PathBuf, output: PathBuf, level: i32, store: bool) -> color_eyre::Result<()> {
-    info!("compressing {input:?} to {output:?}");
+/// stdin → stdout for a `-` input or no inputs.
+fn process_stdin_stdout(opts: &Options, dict: Option<&[u8]>) -> color_eyre::Result<()> {
+    let stdin = io::stdin();
+    let reader = stdin.lock();
+    match opts.mode {
+        Mode::Compress => {
+            let stdout = io::stdout();
+            compress_stream(reader, stdout.lock(), opts.level, opts.store, dict, None)
+        }
+        Mode::Decompress => {
+            let stdout = io::stdout();
+            decompress_stream(reader, stdout.lock(), dict)
+        }
+        Mode::Test => decompress_stream(reader, io::sink(), dict).map(|_| {
+            info!("stdin: OK");
+        }),
+    }
+}
+
+/// Resolve the output path for a file input under the current mode.
+fn derive_output_path(opts: &Options, input: &Path) -> color_eyre::Result<PathBuf> {
+    if let Some(out) = &opts.output {
+        return Ok(out.clone());
+    }
+    match opts.mode {
+        Mode::Compress => Ok(add_extension(input, ZSTD_SUFFIX)),
+        Mode::Decompress => {
+            let name = input.to_string_lossy();
+            match name.strip_suffix(ZSTD_SUFFIX) {
+                Some(stripped) => Ok(PathBuf::from(stripped)),
+                None => bail!(
+                    "{}: unknown suffix (expected {ZSTD_SUFFIX}); use -o to set the output",
+                    input.display()
+                ),
+            }
+        }
+        Mode::Test => unreachable!("test mode never writes an output file"),
+    }
+}
+
+fn process_file(opts: &Options, input: &Path, dict: Option<&[u8]>) -> color_eyre::Result<()> {
+    let source = File::open(input)
+        .wrap_err_with(|| format!("failed to open input file {}", input.display()))?;
+    let source_size: usize = source
+        .metadata()?
+        .len()
+        .try_into()
+        .wrap_err("input file too large for this platform")?;
+    let mut reader = ProgressMonitor::new(BufReader::new(source), source_size);
+
+    // Test mode: decompress into the void, report integrity.
+    if opts.mode == Mode::Test {
+        decompress_stream(&mut reader, io::sink(), dict)?;
+        info!("{}: OK", input.display());
+        return Ok(());
+    }
+
+    // stdout sink: bypass the temp-file dance.
+    if opts.to_stdout {
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        match opts.mode {
+            Mode::Compress => compress_stream(
+                &mut reader,
+                &mut out,
+                opts.level,
+                opts.store,
+                dict,
+                Some(source_size as u64),
+            )?,
+            Mode::Decompress => decompress_stream(&mut reader, &mut out, dict)?,
+            Mode::Test => unreachable!(),
+        }
+        return Ok(());
+    }
+
+    let output = derive_output_path(opts, input)?;
+    ensure_distinct_paths(input, &output)?;
+    ensure_regular_output_destination(&output)?;
+    if output.exists() && !opts.force {
+        bail!("{} already exists; use -f to overwrite", output.display());
+    }
+    let (temp_path, temp_file) = create_temporary_output_file(&output)?;
+    let result: color_eyre::Result<()> = (|| {
+        let mut sink = temp_file;
+        match opts.mode {
+            Mode::Compress => compress_stream(
+                &mut reader,
+                &mut sink,
+                opts.level,
+                opts.store,
+                dict,
+                Some(source_size as u64),
+            )?,
+            Mode::Decompress => decompress_stream(&mut reader, &mut sink, dict)?,
+            Mode::Test => unreachable!(),
+        }
+        sink.flush().wrap_err("failed to flush output")?;
+        Ok(())
+    })();
+    if let Err(err) = result {
+        let _ = fs::remove_file(&temp_path);
+        return Err(err);
+    }
+    replace_output_file(&temp_path, &output)?;
+
+    info!("{} -> {}", input.display(), output.display());
+    if opts.remove_source && !opts.keep {
+        fs::remove_file(input).wrap_err("failed to remove source file after success")?;
+    }
+    Ok(())
+}
+
+/// Streaming compression core (file or stdout), optionally dictionary-primed.
+fn compress_stream<R: Read, W: Write>(
+    mut reader: R,
+    writer: W,
+    level: i32,
+    store: bool,
+    dict: Option<&[u8]>,
+    size_hint: Option<u64>,
+) -> color_eyre::Result<()> {
     let compression_level = if store {
         CompressionLevel::Uncompressed
     } else {
         CompressionLevel::from_level(level)
     };
-    ensure_distinct_paths(&input, &output)?;
-    ensure_regular_output_destination(&output)?;
-
-    let source_file = File::open(&input).wrap_err("failed to open input file")?;
-    let source_size: usize = source_file
-        .metadata()?
-        .len()
-        .try_into()
-        .wrap_err("input file too large for this platform")?;
-    let buffered_source = BufReader::new(source_file);
-    let mut encoder_input = ProgressMonitor::new(buffered_source, source_size);
-
-    let (temporary_output_path, temporary_output) = create_temporary_output_file(&output)?;
-
-    let compression_result: color_eyre::Result<File> = (|| {
-        let mut encoder =
-            structured_zstd::encoding::StreamingEncoder::new(temporary_output, compression_level);
+    let mut encoder = structured_zstd::encoding::StreamingEncoder::new(writer, compression_level);
+    if let Some(hint) = size_hint {
         encoder
-            .set_source_size_hint(source_size as u64)
+            .set_source_size_hint(hint)
             .wrap_err("failed to configure source size hint")?;
-        std::io::copy(&mut encoder_input, &mut encoder).wrap_err("streaming compression failed")?;
-        encoder.finish().wrap_err("failed to finalize zstd frame")
-    })();
-
-    let temporary_output = match compression_result {
-        Ok(file) => file,
-        Err(err) => {
-            let _ = fs::remove_file(&temporary_output_path);
-            return Err(err);
-        }
-    };
-
-    let compressed_size = match temporary_output.metadata() {
-        Ok(metadata) => metadata.len(),
-        Err(err) => {
-            drop(temporary_output);
-            let _ = fs::remove_file(&temporary_output_path);
-            return Err(err).wrap_err("failed to get compressed file size");
-        }
-    };
-    drop(temporary_output);
-    replace_output_file(&temporary_output_path, &output)?;
-
-    let compression_ratio = if source_size == 0 {
-        0.0
-    } else {
-        compressed_size as f64 / source_size as f64 * 100.0
-    };
-    info!(
-        "{} ——> {} ({compression_ratio:.2}%)",
-        fmt_size(source_size as f64),
-        fmt_size(compressed_size as f64)
-    );
+    }
+    if let Some(raw) = dict {
+        encoder
+            .set_dictionary_from_bytes(raw)
+            .wrap_err("failed to load dictionary for compression")?;
+    }
+    io::copy(&mut reader, &mut encoder).wrap_err("streaming compression failed")?;
+    encoder.finish().wrap_err("failed to finalize zstd frame")?;
     Ok(())
 }
+
+/// Streaming decompression core (file, stdout, or sink), optionally dict-primed.
+fn decompress_stream<R: Read, W: Write>(
+    reader: R,
+    mut writer: W,
+    dict: Option<&[u8]>,
+) -> color_eyre::Result<()> {
+    let mut decoder = match dict {
+        Some(raw) => {
+            structured_zstd::decoding::StreamingDecoder::new_with_dictionary_bytes(reader, raw)
+                .map_err(|err| eyre!("failed to init dictionary decoder: {err:?}"))?
+        }
+        None => structured_zstd::decoding::StreamingDecoder::new(reader)
+            .map_err(|err| eyre!("invalid zstd frame: {err:?}"))?,
+    };
+    io::copy(&mut decoder, &mut writer).wrap_err("streaming decompression failed")?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// File-output plumbing (atomic temp-write + replace, alias guards). Unchanged
+// from the original CLI; shared by compress and decompress.
+// ---------------------------------------------------------------------------
 
 fn ensure_distinct_paths(input: &Path, output: &Path) -> color_eyre::Result<()> {
     let canonical_input = match fs::canonicalize(input) {
@@ -358,457 +642,127 @@ fn ensure_regular_output_destination(output: &Path) -> color_eyre::Result<()> {
     Ok(())
 }
 
-fn decompress(input: PathBuf, output: PathBuf) -> color_eyre::Result<()> {
-    info!("extracting {input:?} to {output:?}");
-    ensure_distinct_paths(&input, &output)?;
-    ensure_regular_output_destination(&output)?;
-
-    let source_file = File::open(&input).wrap_err("failed to open input file")?;
-    let source_size: usize = source_file
-        .metadata()?
-        .len()
-        .try_into()
-        .wrap_err("input file too large for this platform")?;
-    let buffered_source = BufReader::new(source_file);
-    let decoder_input = ProgressMonitor::new(buffered_source, source_size);
-
-    let (temporary_output_path, temporary_output) = create_temporary_output_file(&output)?;
-
-    let decompression_result: color_eyre::Result<File> = (|| {
-        let mut decoder = structured_zstd::decoding::StreamingDecoder::new(decoder_input)?;
-        let mut sink = temporary_output;
-        std::io::copy(&mut decoder, &mut sink).wrap_err("streaming decompression failed")?;
-        Ok(sink)
-    })();
-
-    let temporary_output = match decompression_result {
-        Ok(file) => file,
-        Err(err) => {
-            let _ = fs::remove_file(&temporary_output_path);
-            return Err(err);
-        }
-    };
-
-    let inflated_size = match temporary_output.metadata() {
-        Ok(metadata) => metadata.len(),
-        Err(err) => {
-            drop(temporary_output);
-            let _ = fs::remove_file(&temporary_output_path);
-            return Err(err).wrap_err("failed to get decompressed file size");
-        }
-    };
-    drop(temporary_output);
-    replace_output_file(&temporary_output_path, &output)?;
-
-    info!(
-        "inflated {} ——> {}",
-        fmt_size(source_size as f64),
-        fmt_size(inflated_size as f64),
-    );
-    Ok(())
-}
-
-/// A temporary utility function that appends a file extension
-/// to the provided path buf.
-///
-/// Pending removal when our MSRV reaches 1.91 so we can use
-///
-/// <https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.add_extension>
+/// Append a file extension to `path` (pending stdlib `PathBuf::add_extension`,
+/// stable in 1.91).
 fn add_extension<P: AsRef<Path>>(path: &Path, extension: P) -> PathBuf {
     let mut output = path.to_path_buf().into_os_string();
     output.push(extension.as_ref().as_os_str());
-
     output.into()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    #[cfg(unix)]
-    use std::os::unix::fs::PermissionsExt;
-    #[cfg(unix)]
-    use std::os::unix::fs::symlink;
-    use std::path::Path;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use super::*;
 
-    use clap::Parser;
-
-    use super::{Cli, compress, decompress, replace_output_file};
-    use std::path::PathBuf;
-
-    use crate::add_extension;
+    fn parse(args: &[&str]) -> color_eyre::Result<Options> {
+        let owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        match parse_args(&owned, Mode::Compress, false)? {
+            Parsed::Run(opts) => Ok(opts),
+            Parsed::Handled => bail!("parse handled (help/version) unexpectedly"),
+        }
+    }
 
     #[test]
     fn extension_added() {
-        let filename = PathBuf::from("README.md");
         assert_eq!(
-            add_extension(&filename, ".zst"),
+            add_extension(Path::new("README.md"), ".zst"),
             PathBuf::from("README.md.zst")
         );
     }
 
     #[test]
-    fn cli_rejects_unsupported_compression_level_at_parse_time() {
-        let too_high =
-            (structured_zstd::encoding::CompressionLevel::MAX_LEVEL as i64 + 1).to_string();
-        let parse = Cli::try_parse_from([
-            "structured-zstd",
-            "compress",
-            "in.bin",
-            "--level",
-            too_high.as_str(),
-        ]);
-        assert!(parse.is_err());
+    fn argv0_unzstd_defaults_to_decompress() {
+        assert_eq!(program_mode("unzstd"), (Mode::Decompress, false));
+        assert_eq!(program_mode("/usr/bin/unzstd"), (Mode::Decompress, false));
     }
 
     #[test]
-    fn cli_accepts_negative_compression_level() {
-        let parse = Cli::try_parse_from(["structured-zstd", "compress", "in.bin", "--level", "-3"]);
-        assert!(parse.is_ok());
+    fn argv0_zstdcat_decompresses_to_stdout() {
+        assert_eq!(program_mode("zstdcat"), (Mode::Decompress, true));
+        assert_eq!(program_mode("zstd"), (Mode::Compress, false));
     }
 
     #[test]
-    fn cli_rejects_too_negative_compression_level() {
-        let too_low =
-            (structured_zstd::encoding::CompressionLevel::MIN_LEVEL as i64 - 1).to_string();
-        let parse = Cli::try_parse_from([
-            "structured-zstd",
-            "compress",
-            "in.bin",
-            "--level",
-            too_low.as_str(),
-        ]);
-        assert!(parse.is_err());
+    fn bare_numeric_flag_is_a_level() {
+        let opts = parse(&["-19", "in.txt"]).unwrap();
+        assert_eq!(opts.level, 19);
+        assert_eq!(opts.mode, Mode::Compress);
+        assert_eq!(opts.inputs, vec!["in.txt".to_string()]);
     }
 
     #[test]
-    fn cli_store_still_validates_level_range_at_parse_time() {
-        let too_high =
-            (structured_zstd::encoding::CompressionLevel::MAX_LEVEL as i64 + 1).to_string();
-        let parse = Cli::try_parse_from([
-            "structured-zstd",
-            "compress",
-            "in.bin",
-            "--store",
-            "--level",
-            too_high.as_str(),
-        ]);
-        assert!(parse.is_err());
+    fn levels_above_19_require_ultra() {
+        assert!(parse(&["-22", "in.txt"]).is_err());
+        let opts = parse(&["--ultra", "-22", "in.txt"]).unwrap();
+        assert_eq!(opts.level, 22);
     }
 
     #[test]
-    fn compress_rejects_same_input_and_output_paths() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let input = std::env::temp_dir().join(format!("structured-zstd-cli-alias-{unique}.txt"));
-        fs::write(&input, b"streaming-cli-alias-check").unwrap();
-
-        let err = compress(input.clone(), input.clone(), 3, false).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("input and output"),
-            "unexpected error: {message}"
-        );
-
-        let _ = fs::remove_file(input);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn compress_rejects_hardlinked_output_paths() {
-        let dir = unique_test_dir("structured-zstd-cli-hardlink-alias");
-        let input = dir.join("input.txt");
-        let output = dir.join("output.zst");
-        fs::write(&input, b"streaming-cli-hardlink-check").unwrap();
-        fs::hard_link(&input, &output).unwrap();
-
-        let err = compress(input.clone(), output.clone(), 3, false).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("input and output"),
-            "unexpected error: {message}"
-        );
-
-        let _ = fs::remove_dir_all(dir);
+    fn fast_flag_maps_to_negative_level() {
+        assert_eq!(parse(&["--fast"]).unwrap().level, -1);
+        assert_eq!(parse(&["--fast=5"]).unwrap().level, -5);
     }
 
     #[test]
-    fn compress_reports_open_error_for_missing_input() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let missing_input =
-            std::env::temp_dir().join(format!("structured-zstd-cli-missing-input-{unique}.txt"));
-        let output =
-            std::env::temp_dir().join(format!("structured-zstd-cli-missing-output-{unique}.zst"));
-
-        let err = compress(missing_input, output.clone(), 3, false).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("failed to open input file"),
-            "unexpected error: {message}"
-        );
-
-        let _ = fs::remove_file(output);
+    fn clustered_short_flags() {
+        // -d (decompress) + -c (stdout) + -k (keep) in one token.
+        let opts = parse(&["-dck", "a.zst"]).unwrap();
+        assert_eq!(opts.mode, Mode::Decompress);
+        assert!(opts.to_stdout);
+        assert!(opts.keep);
     }
 
     #[test]
-    fn compress_rejects_non_regular_output_before_creating_temp_file() {
-        let dir = unique_test_dir("structured-zstd-cli-preflight-output");
-        let input = dir.join("input.txt");
-        write_file(&input, b"streaming-cli-preflight");
-        let output = dir.join("existing-dir");
-        fs::create_dir(&output).unwrap();
-
-        let err = compress(input, output.clone(), 3, false).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("not a regular file"),
-            "unexpected error: {message}"
-        );
-
-        let tmp_count = fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.file_name())
-            .filter(|name| name.to_string_lossy().contains(".tmp."))
-            .count();
-        assert_eq!(tmp_count, 0, "temporary output should not be created");
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    fn unique_test_dir(prefix: &str) -> PathBuf {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
-        fs::create_dir(&dir).unwrap();
-        dir
-    }
-
-    fn write_file(path: &Path, content: &[u8]) {
-        fs::write(path, content).unwrap();
+    fn dict_and_output_take_values() {
+        let opts = parse(&["-D", "dict.bin", "-o", "out.zst", "in.txt"]).unwrap();
+        assert_eq!(opts.dict, Some(PathBuf::from("dict.bin")));
+        assert_eq!(opts.output, Some(PathBuf::from("out.zst")));
+        // Attached value form: -Ddict.bin
+        let opts = parse(&["-Ddict.bin", "in.txt"]).unwrap();
+        assert_eq!(opts.dict, Some(PathBuf::from("dict.bin")));
     }
 
     #[test]
-    fn replace_output_file_rejects_non_regular_destination() {
-        let dir = unique_test_dir("structured-zstd-cli-non-regular");
-        let temporary_output = dir.join("result.tmp");
-        write_file(&temporary_output, b"compressed");
-        let destination = dir.join("existing-dir");
-        fs::create_dir(&destination).unwrap();
-
-        let err = replace_output_file(&temporary_output, &destination).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("not a regular file"),
-            "unexpected error: {message}"
-        );
-        assert!(destination.is_dir());
-        assert!(
-            !temporary_output.exists(),
-            "temporary file should be cleaned up when destination is invalid"
-        );
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn replace_output_file_preserves_existing_permissions() {
-        let dir = unique_test_dir("structured-zstd-cli-preserve-permissions");
-        let destination = dir.join("result.zst");
-        write_file(&destination, b"old-data");
-        fs::set_permissions(&destination, fs::Permissions::from_mode(0o640)).unwrap();
-
-        let temporary_output = dir.join("result.tmp");
-        write_file(&temporary_output, b"new-data");
-        fs::set_permissions(&temporary_output, fs::Permissions::from_mode(0o600)).unwrap();
-
-        replace_output_file(&temporary_output, &destination).unwrap();
-
-        let mode = fs::metadata(&destination).unwrap().permissions().mode() & 0o777;
-        assert_eq!(mode, 0o640);
-        assert_eq!(fs::read(&destination).unwrap(), b"new-data");
-        assert!(!temporary_output.exists());
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn replace_output_file_rejects_broken_symlink_destination() {
-        let dir = unique_test_dir("structured-zstd-cli-broken-symlink");
-        let temporary_output = dir.join("result.tmp");
-        write_file(&temporary_output, b"compressed");
-        let destination = dir.join("result.zst");
-        let missing_target = dir.join("missing-target.zst");
-        symlink(&missing_target, &destination).unwrap();
-
-        let err = replace_output_file(&temporary_output, &destination).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("not a regular file"),
-            "unexpected error: {message}"
-        );
-        assert!(
-            !temporary_output.exists(),
-            "temporary file should be cleaned up when destination is invalid"
-        );
-        assert!(
-            fs::symlink_metadata(&destination)
-                .unwrap()
-                .file_type()
-                .is_symlink(),
-            "destination symlink should remain untouched"
-        );
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    /// Build a real `.zst` file in `dir` from `plain_content`, return paths
-    /// (compressed_path, plain_content_path). The compressed file is what
-    /// the decompress tests use as input.
-    fn build_zst_fixture(dir: &Path, plain_content: &[u8]) -> (PathBuf, PathBuf) {
-        let plain_path = dir.join("plain.txt");
-        fs::write(&plain_path, plain_content).unwrap();
-        let compressed_path = dir.join("plain.zst");
-        compress(plain_path.clone(), compressed_path.clone(), 3, false).unwrap();
-        (compressed_path, plain_path)
+    fn output_rejects_multiple_inputs() {
+        assert!(parse(&["-o", "out.zst", "a.txt", "b.txt"]).is_err());
     }
 
     #[test]
-    fn decompress_rejects_same_input_and_output_paths() {
-        let dir = unique_test_dir("structured-zstd-cli-decompress-alias");
-        let (compressed, _plain) = build_zst_fixture(&dir, b"streaming-cli-decompress-alias");
-
-        let err = decompress(compressed.clone(), compressed.clone()).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("input and output"),
-            "unexpected error: {message}"
-        );
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn decompress_rejects_hardlinked_output_paths() {
-        let dir = unique_test_dir("structured-zstd-cli-decompress-hardlink");
-        let (compressed, _plain) = build_zst_fixture(&dir, b"streaming-cli-decompress-hardlink");
-        let output = dir.join("output.bin");
-        fs::hard_link(&compressed, &output).unwrap();
-
-        let err = decompress(compressed.clone(), output.clone()).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("input and output"),
-            "unexpected error: {message}"
-        );
-
-        let _ = fs::remove_dir_all(dir);
+    fn dash_is_a_stdin_input() {
+        let opts = parse(&["-d", "-"]).unwrap();
+        assert_eq!(opts.inputs, vec!["-".to_string()]);
     }
 
     #[test]
-    fn decompress_reports_open_error_for_missing_input() {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let missing_input = std::env::temp_dir().join(format!(
-            "structured-zstd-cli-decompress-missing-input-{unique}.zst"
-        ));
-        let output = std::env::temp_dir().join(format!(
-            "structured-zstd-cli-decompress-missing-output-{unique}.bin"
-        ));
-
-        let err = decompress(missing_input, output.clone()).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("failed to open input file"),
-            "unexpected error: {message}"
-        );
-
-        // Output must not exist — ensure_distinct_paths or canonicalize
-        // failed before any file was created.
-        assert!(
-            !output.exists(),
-            "output file must not be created when input is missing"
-        );
+    fn double_dash_forces_positional() {
+        let opts = parse(&["--", "-weird-name.txt"]).unwrap();
+        assert_eq!(opts.inputs, vec!["-weird-name.txt".to_string()]);
     }
 
     #[test]
-    fn decompress_rejects_non_regular_output_before_creating_temp_file() {
-        let dir = unique_test_dir("structured-zstd-cli-decompress-preflight-output");
-        let (compressed, _plain) = build_zst_fixture(&dir, b"streaming-cli-decompress-preflight");
-        let output = dir.join("existing-dir");
-        fs::create_dir(&output).unwrap();
-
-        let err = decompress(compressed, output.clone()).unwrap_err();
-        let message = format!("{err:#}");
-        assert!(
-            message.contains("not a regular file"),
-            "unexpected error: {message}"
-        );
-
-        let tmp_count = fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.file_name())
-            .filter(|name| name.to_string_lossy().contains(".tmp."))
-            .count();
-        assert_eq!(tmp_count, 0, "temporary output should not be created");
-
-        let _ = fs::remove_dir_all(dir);
+    fn unknown_flag_errors() {
+        assert!(parse(&["--definitely-not-a-flag"]).is_err());
+        assert!(parse(&["-Z"]).is_err());
     }
 
     #[test]
-    fn decompress_cleans_temp_file_on_decode_failure() {
-        let dir = unique_test_dir("structured-zstd-cli-decompress-decode-fail");
-        // Garbage bytes — not a zstd frame. StreamingDecoder construction
-        // or copy will fail; the temp file MUST be removed on error.
-        let input = dir.join("garbage.zst");
-        write_file(&input, b"not-a-real-zstd-frame-header");
-        let output = dir.join("output.bin");
-
-        let err = decompress(input, output.clone()).unwrap_err();
-        let _ = format!("{err:#}");
-
-        let tmp_count = fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(Result::ok)
-            .map(|entry| entry.file_name())
-            .filter(|name| name.to_string_lossy().contains(".tmp."))
-            .count();
+    fn decompress_suffix_stripping() {
+        let opts = Options {
+            mode: Mode::Decompress,
+            level: 3,
+            store: false,
+            dict: None,
+            to_stdout: false,
+            output: None,
+            force: false,
+            keep: false,
+            remove_source: false,
+            inputs: vec!["archive.tar.zst".to_string()],
+        };
         assert_eq!(
-            tmp_count, 0,
-            "temporary decompressed file must be cleaned up on decode failure"
+            derive_output_path(&opts, Path::new("archive.tar.zst")).unwrap(),
+            PathBuf::from("archive.tar")
         );
-        assert!(
-            !output.exists(),
-            "final output must not be created on decode failure"
-        );
-
-        let _ = fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn decompress_roundtrips_known_content() {
-        let dir = unique_test_dir("structured-zstd-cli-decompress-roundtrip");
-        let content = b"streaming-cli-decompress-roundtrip\nline-two\n".repeat(32);
-        let (compressed, _plain) = build_zst_fixture(&dir, &content);
-        let recovered = dir.join("recovered.bin");
-
-        decompress(compressed, recovered.clone()).unwrap();
-        let got = fs::read(&recovered).unwrap();
-        assert_eq!(got, content);
-
-        let _ = fs::remove_dir_all(dir);
+        assert!(derive_output_path(&opts, Path::new("noext")).is_err());
     }
 }

--- a/zstd-wasm/npm/index.ts
+++ b/zstd-wasm/npm/index.ts
@@ -50,8 +50,16 @@ interface Payload {
     dict: Uint8Array,
     checksum?: ContentChecksum,
   ) => Uint8Array;
-  ZstdDecompressStream: new (checksum?: ContentChecksum) => DecompressStream;
-  ZstdCompressStream: new (level: number, checksum?: boolean) => CompressStream;
+  ZstdDecompressStream: (new (checksum?: ContentChecksum) => DecompressStream) & {
+    withDictionary: (dict: Uint8Array, checksum?: ContentChecksum) => DecompressStream;
+  };
+  ZstdCompressStream: (new (level: number, checksum?: boolean) => CompressStream) & {
+    withDictionary: (
+      level: number,
+      dict: Uint8Array,
+      checksum?: boolean,
+    ) => CompressStream;
+  };
 }
 
 /**
@@ -263,4 +271,39 @@ export async function createCompressStream(
 ): Promise<CompressStream> {
   loading ??= load();
   return new (await loading).ZstdCompressStream(level, checksum);
+}
+
+/**
+ * Create an incremental streaming compressor seeded with a raw zstd `dict`
+ * (e.g. from `zstd --train`), at `level`. Mirrors `ZSTD_CCtx_loadDictionary` on
+ * a streaming context: the dictionary primes the matcher and the first block's
+ * entropy, so small / similar payloads compress far better. Decode the produced
+ * frames with {@link createDecompressStreamWithDictionary} (same `dict`) or the
+ * one-shot {@link decompressUsingDict}. Rejects if the dictionary is invalid.
+ *
+ * @param checksum Defaults to `false`; pass `true` for a trailing XXH64 checksum.
+ */
+export async function createCompressStreamWithDictionary(
+  dict: Uint8Array,
+  level: number = DEFAULT_LEVEL,
+  checksum?: boolean,
+): Promise<CompressStream> {
+  loading ??= load();
+  return (await loading).ZstdCompressStream.withDictionary(level, dict, checksum);
+}
+
+/**
+ * Create an incremental streaming decompressor primed with a raw zstd `dict`.
+ * `dict` must be the same dictionary the frame was compressed with (e.g. via
+ * {@link createCompressStreamWithDictionary}). Mirrors
+ * `ZSTD_DCtx_loadDictionary`. Rejects if the dictionary is malformed.
+ *
+ * @param checksum Applies to the whole stream; see {@link createDecompressStream}.
+ */
+export async function createDecompressStreamWithDictionary(
+  dict: Uint8Array,
+  checksum?: ContentChecksum,
+): Promise<DecompressStream> {
+  loading ??= load();
+  return (await loading).ZstdDecompressStream.withDictionary(dict, checksum);
 }

--- a/zstd-wasm/src/lib.rs
+++ b/zstd-wasm/src/lib.rs
@@ -218,6 +218,30 @@ impl ZstdDecompressStream {
         }
     }
 
+    /// Open a streaming decompressor primed with a raw zstd dictionary blob
+    /// (`ZSTD_DCtx_loadDictionary`): `dict` must be the same dictionary the
+    /// frame was compressed with (e.g. via [`ZstdCompressStream`]'s
+    /// `withDictionary`). `checksum` behaves as in [`Self::new`]. Throws if the
+    /// dictionary is malformed.
+    #[wasm_bindgen(js_name = withDictionary)]
+    pub fn with_dictionary(
+        dict: &[u8],
+        checksum: Option<ContentChecksum>,
+    ) -> Result<ZstdDecompressStream, JsError> {
+        let mut decoder = FrameDecoder::new();
+        decoder.set_content_checksum(core_checksum(checksum));
+        decoder.add_dict_from_bytes(dict).map_err(|err| {
+            JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
+        })?;
+        Ok(ZstdDecompressStream {
+            decoder,
+            pending: Vec::new(),
+            header_done: false,
+            checksum: false,
+            finished: false,
+        })
+    }
+
     /// Feed more compressed bytes; returns whatever decompressed output is now
     /// available (possibly empty while a block is still incomplete).
     pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<u8>, JsError> {
@@ -344,6 +368,31 @@ impl ZstdCompressStream {
         ZstdCompressStream {
             encoder: Some(encoder),
         }
+    }
+
+    /// Open a streaming compressor at `level` seeded with a raw zstd dictionary
+    /// blob (e.g. from `zstd --train`), mirroring `ZSTD_CCtx_loadDictionary` on
+    /// a streaming context: the dictionary primes the matcher and seeds the
+    /// first block's entropy + repeat offsets, and its ID is written into the
+    /// frame header. Decode the produced frames with [`ZstdDecompressStream`]
+    /// opened via its matching `withDictionary` constructor (or the one-shot
+    /// `decompressUsingDict`). Throws if the dictionary is invalid.
+    #[wasm_bindgen(js_name = withDictionary)]
+    pub fn with_dictionary(
+        level: i32,
+        dict: &[u8],
+        checksum: Option<bool>,
+    ) -> Result<ZstdCompressStream, JsError> {
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Level(level));
+        encoder
+            .set_content_checksum(checksum.unwrap_or(false))
+            .expect("fresh streaming encoder accepts the content-checksum toggle");
+        encoder.set_dictionary_from_bytes(dict).map_err(|err| {
+            JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
+        })?;
+        Ok(ZstdCompressStream {
+            encoder: Some(encoder),
+        })
     }
 
     /// Feed more plaintext; returns whatever compressed bytes are now complete

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -148,7 +148,7 @@ impl BtMatcher {
     /// (counted by the owner's `size_of`), so only the `Vec` fields contribute.
     pub(crate) fn heap_size(&self) -> usize {
         let u32_sz = core::mem::size_of::<u32>();
-        let mut total = self.opt_nodes_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
+        let scratch = self.opt_nodes_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
             + self.opt_candidates_scratch.capacity() * core::mem::size_of::<MatchCandidate>()
             + self.opt_store_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
             + (self.opt_segment_plan_scratch.capacity() + self.opt_seed_plan_scratch.capacity())
@@ -159,11 +159,12 @@ impl BtMatcher {
                 + self.opt_ml_price_generation.capacity())
                 * u32_sz
             + self.ldm_sequences.capacity() * core::mem::size_of::<HcRawSeq>();
+        // The LDM producer is only present under the `hash` feature.
         #[cfg(feature = "hash")]
-        {
-            total += self.ldm_producer.as_ref().map_or(0, |p| p.heap_size());
-        }
-        total
+        let ldm = self.ldm_producer.as_ref().map_or(0, |p| p.heap_size());
+        #[cfg(not(feature = "hash"))]
+        let ldm = 0;
+        scratch + ldm
     }
 
     /// Per-frame reset — clears scratch buffers, resets cost model,

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -143,6 +143,29 @@ impl BtMatcher {
         }
     }
 
+    /// Heap bytes the optimal-parser scratch buffers and the optional LDM
+    /// producer hold. The fixed-size price arrays and `opt_state` are inline
+    /// (counted by the owner's `size_of`), so only the `Vec` fields contribute.
+    pub(crate) fn heap_size(&self) -> usize {
+        let u32_sz = core::mem::size_of::<u32>();
+        let mut total = self.opt_nodes_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
+            + self.opt_candidates_scratch.capacity() * core::mem::size_of::<MatchCandidate>()
+            + self.opt_store_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
+            + (self.opt_segment_plan_scratch.capacity() + self.opt_seed_plan_scratch.capacity())
+                * core::mem::size_of::<HcOptimalSequence>()
+            + (self.opt_ll_price_scratch.capacity()
+                + self.opt_ll_price_generation.capacity()
+                + self.opt_ml_price_scratch.capacity()
+                + self.opt_ml_price_generation.capacity())
+                * u32_sz
+            + self.ldm_sequences.capacity() * core::mem::size_of::<HcRawSeq>();
+        #[cfg(feature = "hash")]
+        {
+            total += self.ldm_producer.as_ref().map_or(0, |p| p.heap_size());
+        }
+        total
+    }
+
     /// Per-frame reset — clears scratch buffers, resets cost model,
     /// drops cached price stamps.
     pub(crate) fn reset(&mut self) {

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -261,6 +261,19 @@ impl DfastMatchGenerator {
         self.position_base += reducer as usize;
     }
 
+    /// Heap bytes this matcher owns: history, the long/short hash tables, the
+    /// window-block deque, and any attached dictionary tables.
+    pub(crate) fn heap_size(&self) -> usize {
+        let u32_sz = core::mem::size_of::<u32>();
+        self.window_blocks.capacity() * core::mem::size_of::<usize>()
+            + self.history.capacity()
+            + (self.short_hash.capacity() + self.long_hash.capacity()) * u32_sz
+            + self
+                .dict
+                .table()
+                .map_or(0, |t| (t.long.capacity() + t.short.capacity()) * u32_sz)
+    }
+
     pub(crate) fn reset(&mut self) {
         // Floor-advance reset (issue #337 technique, completing it for the
         // dfast backend — `MatchTable` already does this). Instead of

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -154,6 +154,20 @@ pub(crate) struct CachedDictionaryEntropy {
 }
 
 impl CachedDictionaryEntropy {
+    /// Heap bytes the cached dictionary entropy holds: the literals Huffman
+    /// table plus any `Custom` LL/ML/OF FSE tables (the `Arc`-boxed `FSETable`
+    /// payload and its flat state array). `Default` / `Rle` variants own no heap.
+    pub(crate) fn heap_size(&self) -> usize {
+        let mut total = self.huff.as_ref().map_or(0, |h| h.heap_size());
+        for prev in [&self.ll_previous, &self.ml_previous, &self.of_previous] {
+            if let Some(PreviousFseTable::Custom(table)) = prev {
+                total +=
+                    core::mem::size_of::<crate::fse::fse_encoder::FSETable>() + table.heap_size();
+            }
+        }
+        total
+    }
+
     /// Derive the encoder-side entropy tables a dictionary seeds for the first
     /// block of each frame (the donor `cdict->cBlockState`): the literals
     /// Huffman table plus the literal-length / match-length / offset FSE
@@ -992,14 +1006,19 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// Total heap bytes this compressor's allocations hold, excluding the
     /// inline struct: the match-finder tables / history / recycled buffers and
     /// the primed-dictionary snapshot (via the matcher), the retained
-    /// dictionary content, and the per-block sidecar buffers. Lets a context
-    /// report its true footprint through `ZSTD_sizeof_CCtx`.
+    /// dictionary content, the cached dictionary entropy tables (literals
+    /// Huffman + LL/ML/OF FSE), and the per-block sidecar buffers. Lets a
+    /// context report its true footprint through `ZSTD_sizeof_CCtx`.
     pub fn heap_size(&self) -> usize {
         let mut total = self.state.matcher.heap_size();
         total += self
             .dictionary
             .as_ref()
             .map_or(0, |d| d.inner.dict_content.capacity());
+        total += self
+            .dictionary_entropy_cache
+            .as_ref()
+            .map_or(0, CachedDictionaryEntropy::heap_size);
         #[cfg(all(feature = "lsm", feature = "hash"))]
         {
             total += self

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -146,11 +146,39 @@ pub struct FrameCompressor<
 }
 
 #[derive(Clone, Default)]
-struct CachedDictionaryEntropy {
-    huff: Option<crate::huff0::huff0_encoder::HuffmanTable>,
-    ll_previous: Option<PreviousFseTable>,
-    ml_previous: Option<PreviousFseTable>,
-    of_previous: Option<PreviousFseTable>,
+pub(crate) struct CachedDictionaryEntropy {
+    pub(crate) huff: Option<crate::huff0::huff0_encoder::HuffmanTable>,
+    pub(crate) ll_previous: Option<PreviousFseTable>,
+    pub(crate) ml_previous: Option<PreviousFseTable>,
+    pub(crate) of_previous: Option<PreviousFseTable>,
+}
+
+impl CachedDictionaryEntropy {
+    /// Derive the encoder-side entropy tables a dictionary seeds for the first
+    /// block of each frame (the donor `cdict->cBlockState`): the literals
+    /// Huffman table plus the literal-length / match-length / offset FSE
+    /// "previous" tables. Shared by [`FrameCompressor`] and
+    /// [`crate::encoding::StreamingEncoder`] so both seed identically.
+    pub(crate) fn from_dictionary(dictionary: &crate::decoding::Dictionary) -> Self {
+        Self {
+            huff: dictionary.huf.table.to_encoder_table(),
+            ll_previous: dictionary
+                .fse
+                .literal_lengths
+                .to_encoder_table()
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
+            ml_previous: dictionary
+                .fse
+                .match_lengths
+                .to_encoder_table()
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
+            of_previous: dictionary
+                .fse
+                .offsets
+                .to_encoder_table()
+                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
+        }
+    }
 }
 
 /// Shared owner for a custom "previous" FSE encoder table. `Arc` on
@@ -1801,24 +1829,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 },
             );
         }
-        self.dictionary_entropy_cache = Some(CachedDictionaryEntropy {
-            huff: dictionary.huf.table.to_encoder_table(),
-            ll_previous: dictionary
-                .fse
-                .literal_lengths
-                .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
-            ml_previous: dictionary
-                .fse
-                .match_lengths
-                .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
-            of_previous: dictionary
-                .fse
-                .offsets
-                .to_encoder_table()
-                .map(|table| PreviousFseTable::Custom(SharedFseTable::new(table))),
-        });
+        self.dictionary_entropy_cache = Some(CachedDictionaryEntropy::from_dictionary(dictionary));
         // A previously-captured CDict prime snapshot belongs to the OLD
         // dictionary; drop it so the first frame with the new dictionary
         // re-primes (and re-captures) instead of restoring stale tables.

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2853,6 +2853,89 @@ mod tests {
     }
 
     #[test]
+    fn dict_primed_btultra2_restore_is_floor_safe_and_byte_identical() {
+        // Regression guard for the dictionary primed-snapshot RESTORE path on
+        // the binary-tree (btultra2 / Level 22) backend — the path a minimal /
+        // decoupled prepared-dict refactor rewrites.
+        //
+        // The trap it pins: a reused compressor compresses frame A (which fills
+        // the live hash/chain tables with frame-A positions and advances the
+        // window floor), then frame B of the SAME resolved shape (same size →
+        // same PrimedKey → the snapshot RESTORE path) but DIFFERENT content. The
+        // restore must reinstate the clean post-prime dict state with NO live
+        // frame-A entries surviving above the restored floor; a restore that
+        // leaks stale frame-A positions would surface FALSE matches and produce
+        // a different (or undecodable) frame B. The invariant: a snapshot
+        // restore is a pure timing optimization and MUST be byte-identical to a
+        // cold compressor compressing frame B from scratch, and must round-trip.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let dict_id = super::EncoderDictionary::from_bytes(dict_raw)
+            .expect("dict bytes should parse")
+            .id();
+        // 48 KiB > the btultra2 8 KiB attach cutoff → the copy-snapshot
+        // capture/restore path. Two distinct payloads of the SAME size so frame
+        // B resolves to frame A's snapshot key and takes the restore path.
+        let make_payload = |seed: u64, target: usize| {
+            let mut p = Vec::with_capacity(target);
+            let mut i = seed;
+            while p.len() < target {
+                p.extend_from_slice(
+                    format!(
+                        "tenant=demo op=put key={i} value=aaaaabbbbbcccccddddd-{}\n",
+                        i % 89
+                    )
+                    .as_bytes(),
+                );
+                i = i.wrapping_add(1);
+            }
+            p.truncate(target);
+            p
+        };
+        let size = 48 * 1024usize;
+        let frame_a = make_payload(0, size);
+        let frame_b = make_payload(1_000_000, size);
+
+        let mut warm: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Level(22));
+        warm.set_encoder_dictionary(
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+        )
+        .expect("dict attach");
+        // Frame A: cold cache — primes the dict + captures the snapshot, and
+        // fills the live tables with frame-A positions.
+        let _wa = warm.compress_independent_frame(frame_a.as_slice());
+        // Frame B: warm cache — takes the snapshot RESTORE path (same size).
+        let warm_b = warm.compress_independent_frame(frame_b.as_slice());
+
+        // Cold compressor compressing frame B from scratch: the ground truth.
+        let mut cold: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Level(22));
+        cold.set_encoder_dictionary(
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+        )
+        .expect("dict attach");
+        let cold_b = cold.compress_independent_frame(frame_b.as_slice());
+
+        assert_eq!(
+            warm_b, cold_b,
+            "frame B via snapshot restore must be byte-identical to a cold compress \
+             (a restore that leaks frame-A live-table entries would diverge here)"
+        );
+
+        // Round-trip frame B through a dict-primed decoder.
+        let (hdr, _) =
+            crate::decoding::frame::read_frame_header(warm_b.as_slice()).expect("frame header");
+        assert_eq!(hdr.dictionary_id(), Some(dict_id));
+        let mut decoder = FrameDecoder::new();
+        decoder
+            .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
+            .unwrap();
+        let mut decoded = Vec::with_capacity(frame_b.len());
+        decoder
+            .decode_all_to_vec(warm_b.as_slice(), &mut decoded)
+            .unwrap();
+        assert_eq!(decoded.as_slice(), frame_b.as_slice());
+    }
+
+    #[test]
     fn set_dictionary_from_bytes_matches_full_decode_byte_for_byte() {
         // The encoder-only dict parse (`decode_dict_for_encoding`, used by
         // `set_dictionary_from_bytes`) skips the FSE/HUF decoder-table build and

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2936,6 +2936,80 @@ mod tests {
     }
 
     #[test]
+    fn dict_primed_btultra2_ldm_restore_is_byte_identical() {
+        // Same restore-path byte-identity guard as
+        // `dict_primed_btultra2_restore_is_floor_safe_and_byte_identical`, but
+        // with long-distance matching ENABLED. The BtMatcher's LDM producer is
+        // part of the snapshot; a refactor that decouples it (so the snapshot
+        // does not retain the empty LDM table) must reinstate an equivalent
+        // empty producer on restore. This pins that the warm-cache (restore)
+        // frame stays byte-identical to a cold compress when LDM is on.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let dict_id = super::EncoderDictionary::from_bytes(dict_raw)
+            .expect("dict bytes should parse")
+            .id();
+        let make_payload = |seed: u64, target: usize| {
+            let mut p = Vec::with_capacity(target);
+            let mut i = seed;
+            while p.len() < target {
+                p.extend_from_slice(
+                    format!(
+                        "tenant=demo op=put key={i} value=aaaaabbbbbcccccddddd-{}\n",
+                        i % 89
+                    )
+                    .as_bytes(),
+                );
+                i = i.wrapping_add(1);
+            }
+            p.truncate(target);
+            p
+        };
+        let ldm_params =
+            crate::encoding::CompressionParameters::builder(super::CompressionLevel::Level(22))
+                .enable_long_distance_matching(true)
+                .build()
+                .expect("LDM-only params build");
+        let size = 48 * 1024usize;
+        let frame_a = make_payload(0, size);
+        let frame_b = make_payload(1_000_000, size);
+
+        let mut warm: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Level(22));
+        warm.set_parameters(&ldm_params);
+        warm.set_encoder_dictionary(
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+        )
+        .expect("dict attach");
+        let _wa = warm.compress_independent_frame(frame_a.as_slice());
+        let warm_b = warm.compress_independent_frame(frame_b.as_slice());
+
+        let mut cold: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Level(22));
+        cold.set_parameters(&ldm_params);
+        cold.set_encoder_dictionary(
+            super::EncoderDictionary::from_bytes(dict_raw).expect("dict parse"),
+        )
+        .expect("dict attach");
+        let cold_b = cold.compress_independent_frame(frame_b.as_slice());
+
+        assert_eq!(
+            warm_b, cold_b,
+            "LDM-on frame B via snapshot restore must be byte-identical to a cold compress"
+        );
+
+        let (hdr, _) =
+            crate::decoding::frame::read_frame_header(warm_b.as_slice()).expect("frame header");
+        assert_eq!(hdr.dictionary_id(), Some(dict_id));
+        let mut decoder = FrameDecoder::new();
+        decoder
+            .add_dict(crate::decoding::Dictionary::decode_dict(dict_raw).unwrap())
+            .unwrap();
+        let mut decoded = Vec::with_capacity(frame_b.len());
+        decoder
+            .decode_all_to_vec(warm_b.as_slice(), &mut decoded)
+            .unwrap();
+        assert_eq!(decoded.as_slice(), frame_b.as_slice());
+    }
+
+    #[test]
     fn set_dictionary_from_bytes_matches_full_decode_byte_for_byte() {
         // The encoder-only dict parse (`decode_dict_for_encoding`, used by
         // `set_dictionary_from_bytes`) skips the FSE/HUF decoder-table build and

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1020,6 +1020,17 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // is applied separately and should not force larger matcher sizing.
             self.state.matcher.set_source_size_hint(size_hint);
         }
+        // Hand the matcher the dictionary's content size so its binary-tree /
+        // hash-chain tables shrink to the dictionary's cParams tier (donor CDict
+        // economics: the dictionary supplies long matches, so a source-sized live
+        // table is wasted peak memory). The eviction window stays source-sized so
+        // the dictionary bytes remain referenceable. Set before `reset` (which
+        // consumes it) and only when a dictionary will actually be primed.
+        if use_dictionary_state && let Some(dict) = self.dictionary.as_ref() {
+            self.state
+                .matcher
+                .set_dictionary_size_hint(dict.inner.dict_content.len());
+        }
         // Clearing buffers to allow re-using of the compressor
         self.state.matcher.reset(self.compression_level);
         self.state.offset_hist = [1, 4, 8];

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -989,6 +989,31 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         self.source_size_hint = Some(size);
     }
 
+    /// Total heap bytes this compressor's allocations hold, excluding the
+    /// inline struct: the match-finder tables / history / recycled buffers and
+    /// the primed-dictionary snapshot (via the matcher), the retained
+    /// dictionary content, and the per-block sidecar buffers. Lets a context
+    /// report its true footprint through `ZSTD_sizeof_CCtx`.
+    pub fn heap_size(&self) -> usize {
+        let mut total = self.state.matcher.heap_size();
+        total += self
+            .dictionary
+            .as_ref()
+            .map_or(0, |d| d.inner.dict_content.capacity());
+        #[cfg(all(feature = "lsm", feature = "hash"))]
+        {
+            total += self
+                .block_checksums
+                .as_ref()
+                .map_or(0, |v| v.capacity() * core::mem::size_of::<u32>());
+        }
+        #[cfg(feature = "lsm")]
+        {
+            total += self.block_decompressed_sizes.capacity() * core::mem::size_of::<u32>();
+        }
+        total
+    }
+
     /// Compress the uncompressed data from the provided source as one Zstd frame and write it to the provided drain
     ///
     /// This will repeatedly call [Read::read] on the source to fill up blocks until the source returns 0 on the read call.

--- a/zstd/src/encoding/ldm/mod.rs
+++ b/zstd/src/encoding/ldm/mod.rs
@@ -138,6 +138,11 @@ impl LdmProducer {
         Self::new(LdmParams::adjust_for(window_log, strategy))
     }
 
+    /// Heap bytes this producer owns: the LDM hash table and the split-scratch.
+    pub(crate) fn heap_size(&self) -> usize {
+        self.hash_table.heap_size() + self.splits_scratch.capacity() * core::mem::size_of::<usize>()
+    }
+
     /// Reset bucket cursors, zero the hash entries, and re-seed
     /// the rolling-hash state. Use at frame boundaries.
     pub(crate) fn clear(&mut self) {

--- a/zstd/src/encoding/ldm/table.rs
+++ b/zstd/src/encoding/ldm/table.rs
@@ -163,6 +163,11 @@ impl LdmHashTable {
         }
     }
 
+    /// Heap bytes held by the entry array and the per-bucket offset array.
+    pub(crate) fn heap_size(&self) -> usize {
+        self.entries.capacity() * core::mem::size_of::<LdmEntry>() + self.bucket_offsets.capacity()
+    }
+
     /// Reset every bucket to "empty" without reallocating, and
     /// rewind the rebase base so a fresh frame can start its
     /// absolute positions from any value (including 0) without

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1023,6 +1023,16 @@ enum MatcherStorage {
 }
 
 impl MatcherStorage {
+    /// Heap bytes the active backend variant holds (tables, history, scratch).
+    fn heap_size(&self) -> usize {
+        match self {
+            Self::Simple(m) => m.heap_size(),
+            Self::Dfast(m) => m.heap_size(),
+            Self::Row(m) => m.heap_size(),
+            Self::HashChain(m) => m.heap_size(),
+        }
+    }
+
     /// [`super::strategy::BackendTag`] family of the active variant.
     fn backend(&self) -> super::strategy::BackendTag {
         use super::strategy::BackendTag;
@@ -1644,6 +1654,20 @@ impl Matcher for MatchGeneratorDriver {
 
     fn set_dictionary_size_hint(&mut self, size: usize) {
         self.dictionary_size_hint = Some(size);
+    }
+
+    /// Heap bytes this driver owns: the active backend's tables/history, the
+    /// recycled input-buffer pool, and the primed-dictionary snapshot (a cloned
+    /// backend kept for CDict-equivalent reuse). The inline struct itself is
+    /// accounted by the owner's `size_of`.
+    fn heap_size(&self) -> usize {
+        let pool: usize = self.vec_pool.capacity() * core::mem::size_of::<Vec<u8>>()
+            + self.vec_pool.iter().map(Vec::capacity).sum::<usize>();
+        let snapshot = self
+            .primed
+            .as_ref()
+            .map_or(0, |(storage, _, _)| storage.heap_size());
+        pool + self.storage.heap_size() + snapshot
     }
 
     fn clear_param_overrides(&mut self) {
@@ -2691,6 +2715,15 @@ pub(crate) enum HcBackend {
 }
 
 impl HcBackend {
+    /// Heap bytes held by the backend. `Hc` is zero-sized; `Bt` boxes a
+    /// `BtMatcher`, so count the boxed payload plus its own scratch heap.
+    fn heap_size(&self) -> usize {
+        match self {
+            Self::Hc => 0,
+            Self::Bt(bt) => core::mem::size_of::<super::bt::BtMatcher>() + bt.heap_size(),
+        }
+    }
+
     /// Mutable accessor on the BT matcher; panics if the active
     /// backend is `Hc`. The HC-or-Bt branches in orchestrator code use
     /// `let HcBackend::Bt(bt) = &self.backend` directly for readonly
@@ -4533,6 +4566,12 @@ macro_rules! bt_insert_and_collect_matches_body {
 pub(crate) use bt_insert_and_collect_matches_body;
 
 impl HcMatchGenerator {
+    /// Heap bytes this generator owns: the shared match table plus the BT
+    /// backend's optimal-parser / LDM scratch (the HC knobs are inline).
+    fn heap_size(&self) -> usize {
+        self.table.heap_size() + self.backend.heap_size()
+    }
+
     fn should_run_btultra2_seed_pass<S: super::strategy::Strategy>(
         &self,
         current_len: usize,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -693,6 +693,12 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 27, lazy_depth: 2, fast: None, dfast: None, hc: Some(BTULTRA2_HC_CONFIG_L22), row: None },
 ];
 
+/// Donor `ZSTD_getCParamRowSize` addend for an unknown-source compress that
+/// carries a dictionary (`zstd_compress.c`: `addedSize = unknown && dictSize > 0
+/// ? 500 : 0`). Added to the dictionary size when picking the dict-driven
+/// cParams tier so our tier selection lands on the same column donor would.
+const DICT_CPARAM_ROW_ADDEND: u64 = 500;
+
 /// Smallest window_log the encoder will use regardless of source size.
 pub(crate) const MIN_WINDOW_LOG: u8 = 10;
 /// Conservative floor for source-size-hinted window tuning.
@@ -1022,6 +1028,14 @@ pub struct MatchGeneratorDriver {
     dictionary_retained_budget: usize,
     // Source size hint for next frame (set via set_source_size_hint, cleared on reset).
     source_size_hint: Option<u64>,
+    // Dictionary content size for the next frame (set via set_dictionary_size_hint,
+    // consumed on reset). When present on a binary-tree / hash-chain backend, the
+    // match-finder hash/chain tables are sized from the DICTIONARY (donor CDict
+    // economics: a loaded dictionary supplies the long matches, so the live tables
+    // can shrink to the dict's size tier) while the eviction window stays
+    // source-sized. Mirrors donor `ZSTD_getCParamRowSize`, which picks the cParams
+    // table column from `dictSize` for a dictionary-bearing compress.
+    dictionary_size_hint: Option<usize>,
     // Normalized `ceil_log2` bucket of the frame's source-size hint, captured at
     // `reset` (where `source_size_hint` is consumed) via [`source_size_ceil_log`].
     // `None` means the frame was unhinted. Drives `prime_with_dictionary`'s donor
@@ -1202,6 +1216,7 @@ impl MatchGeneratorDriver {
             reset_shape: None,
             dictionary_retained_budget: 0,
             source_size_hint: None,
+            dictionary_size_hint: None,
             borrowed_pending: None,
             primed: None,
         }
@@ -1568,12 +1583,17 @@ impl Matcher for MatchGeneratorDriver {
         self.source_size_hint = Some(size);
     }
 
+    fn set_dictionary_size_hint(&mut self, size: usize) {
+        self.dictionary_size_hint = Some(size);
+    }
+
     fn clear_param_overrides(&mut self) {
         self.param_overrides = None;
     }
 
     fn reset(&mut self, level: CompressionLevel) {
         let hint = self.source_size_hint.take();
+        let dict_hint = self.dictionary_size_hint.take();
         // Snapshot the hint's normalized ceil-log bucket for the primed-snapshot
         // key and prime_with_dictionary's attach/copy mode decision (the hint is
         // consumed here, but priming happens just after reset). Storing the
@@ -1637,6 +1657,33 @@ impl Matcher for MatchGeneratorDriver {
                 if let Some(window_log) = ov.window_log {
                     params.window_log = window_log;
                 }
+            }
+        }
+        // Dictionary-driven table sizing (donor CDict economics). When a
+        // dictionary is loaded, donor sizes the match-finder hash/chain tables
+        // from the dictionary's `ZSTD_getCParamRowSize` tier, NOT from the
+        // source size: the dictionary supplies the long-distance matches, so a
+        // window-sized live table is wasted memory. The frame's eviction window
+        // (`window_log`) stays source-derived so the dictionary bytes remain
+        // referenceable; only the hash/chain WIDTHS shrink to the dict tier.
+        // This is the encoder-side equivalent of copying a CDict's small tables
+        // while keeping a source-sized window (`ZSTD_resetCCtx_byCopyingCDict`:
+        // `params.cParams = *cdict_cParams; params.cParams.windowLog = windowLog`).
+        // Only the binary-tree / hash-chain backend reads `hc.{hash,chain}_log`;
+        // the Simple/Dfast/Row backends derive their widths from the source
+        // window in their `reset` arms, matching donor's dict handling there.
+        if let (Some(dict_size), Some(hc)) = (dict_hint, params.hc.as_mut()) {
+            // Donor `ZSTD_getCParamRowSize`: for a dictionary-bearing compress
+            // the cParams column is chosen from `dictSize + 500` (the unknown-
+            // source-with-dict row-size). Reuse the level resolver with that
+            // size to read the dict-tier hash/chain widths, then cap (min) so an
+            // explicit larger level table never grows past the dict tier and a
+            // dict bigger than the level's own tables never inflates them.
+            let dict_row_size = (dict_size as u64).saturating_add(DICT_CPARAM_ROW_ADDEND);
+            let dict_params = resolve_level_params(level, Some(dict_row_size));
+            if let Some(dict_hc) = dict_params.hc {
+                hc.hash_log = hc.hash_log.min(dict_hc.hash_log);
+                hc.chain_log = hc.chain_log.min(dict_hc.chain_log);
             }
         }
         let next_backend = params.backend();

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2226,12 +2226,23 @@ impl Matcher for MatchGeneratorDriver {
             fast_attach,
             ldm,
         };
-        let (storage, budget) = match &self.primed {
+        let (mut storage, budget) = match &self.primed {
             Some((storage, budget, captured_key)) if *captured_key == key => {
                 (storage.clone(), *budget)
             }
             _ => return false,
         };
+        // A binary-tree snapshot is stored WITHOUT its live hash / chain / hash3
+        // tables (they hold no dictionary entries — the dict lives in `dms` +
+        // history; see `capture_primed_dictionary`). Re-allocate them zeroed to
+        // the snapshot's geometry, exactly reproducing the post-prime state (all
+        // `HC_EMPTY`). This is a full storage replace, so no stale live-table
+        // entry from a prior frame can survive — `ensure_tables` only allocates
+        // when the length mismatches, so a full (HC / non-BT) snapshot whose
+        // tables are already present is left untouched.
+        if let MatcherStorage::HashChain(hc) = &mut storage {
+            hc.table.ensure_tables();
+        }
         self.storage = storage;
         self.dictionary_retained_budget = budget;
         true
@@ -2250,7 +2261,42 @@ impl Matcher for MatchGeneratorDriver {
             fast_attach,
             ldm,
         };
-        self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, key));
+        // Donor CDict-equivalent retained state. On the binary-tree backend the
+        // dictionary is decoupled into `dms` (the donor `dictMatchState`); the
+        // live hash / chain / hash3 tables carry NO dict entries at capture
+        // (`skip_matching_dict_bt` keeps the dict out of the live tree), so they
+        // are pure zeros. Storing them in the snapshot wastes the full table
+        // footprint (a second window-tier table set resident for the whole
+        // compress). Instead, move the live tables OUT of the working storage,
+        // clone only the dict-state (history + `dms` + window/offset/dict-limit),
+        // then move the live tables back — the snapshot keeps just what donor's
+        // CDict keeps, and `restore_primed_dictionary` re-allocates the zeroed
+        // live tables. HC / lazy levels keep the dict IN the live chain (no
+        // `dms`), so their snapshot must retain the full tables: full clone.
+        let bt_decoupled = matches!(
+            &self.storage,
+            MatcherStorage::HashChain(hc) if hc.table.uses_bt
+        );
+        if bt_decoupled {
+            let MatcherStorage::HashChain(hc) = &mut self.storage else {
+                unreachable!("bt_decoupled implies HashChain storage");
+            };
+            let hash_table = core::mem::take(&mut hc.table.hash_table);
+            let chain_table = core::mem::take(&mut hc.table.chain_table);
+            let hash3_table = core::mem::take(&mut hc.table.hash3_table);
+            // Clone the dict-state-only storage (live tables now empty Vecs).
+            let snapshot = self.storage.clone();
+            // Move the live tables back into the working storage.
+            let MatcherStorage::HashChain(hc) = &mut self.storage else {
+                unreachable!("storage variant is stable across the take/put");
+            };
+            hc.table.hash_table = hash_table;
+            hc.table.chain_table = chain_table;
+            hc.table.hash3_table = hash3_table;
+            self.primed = Some((snapshot, self.dictionary_retained_budget, key));
+        } else {
+            self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, key));
+        }
     }
 
     fn invalidate_primed_dictionary(&mut self) {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2243,6 +2243,22 @@ impl Matcher for MatchGeneratorDriver {
         if let MatcherStorage::HashChain(hc) = &mut storage {
             hc.table.ensure_tables();
         }
+        // The snapshot does not retain the LDM producer (it holds no dict state;
+        // see `capture_primed_dictionary`). Carry over the frame's freshly-reset
+        // producer — built this frame by `reset` with the same params the
+        // snapshot key pins, and empty (no input processed yet), so it is
+        // equivalent to the producer the snapshot was captured with.
+        #[cfg(feature = "hash")]
+        {
+            let fresh_ldm = if let MatcherStorage::HashChain(hc) = &mut self.storage {
+                hc.take_ldm_producer()
+            } else {
+                None
+            };
+            if let MatcherStorage::HashChain(hc) = &mut storage {
+                hc.set_ldm_producer(fresh_ldm);
+            }
+        }
         self.storage = storage;
         self.dictionary_retained_budget = budget;
         true
@@ -2284,15 +2300,24 @@ impl Matcher for MatchGeneratorDriver {
             let hash_table = core::mem::take(&mut hc.table.hash_table);
             let chain_table = core::mem::take(&mut hc.table.chain_table);
             let hash3_table = core::mem::take(&mut hc.table.hash3_table);
-            // Clone the dict-state-only storage (live tables now empty Vecs).
+            // The LDM producer carries no dictionary state (LDM is not
+            // dict-primed; its hash table is empty at capture), so it is not
+            // retained either — `restore` reinstates the frame's freshly-reset
+            // producer. Take it out so the clone does not duplicate its table.
+            #[cfg(feature = "hash")]
+            let ldm_producer = hc.take_ldm_producer();
+            // Clone the dict-state-only storage (live tables now empty Vecs,
+            // LDM producer detached).
             let snapshot = self.storage.clone();
-            // Move the live tables back into the working storage.
+            // Move the live tables (and LDM producer) back into the working storage.
             let MatcherStorage::HashChain(hc) = &mut self.storage else {
                 unreachable!("storage variant is stable across the take/put");
             };
             hc.table.hash_table = hash_table;
             hc.table.chain_table = chain_table;
             hc.table.hash3_table = hash3_table;
+            #[cfg(feature = "hash")]
+            hc.set_ldm_producer(ldm_producer);
             self.primed = Some((snapshot, self.dictionary_retained_budget, key));
         } else {
             self.primed = Some((self.storage.clone(), self.dictionary_retained_budget, key));
@@ -4609,6 +4634,20 @@ impl HcMatchGenerator {
     fn set_ldm_producer(&mut self, producer: Option<super::ldm::LdmProducer>) {
         if let HcBackend::Bt(bt) = &mut self.backend {
             bt.ldm_producer = producer;
+        }
+    }
+
+    /// Move the LDM producer out of the BT backend, leaving `None`. Used by the
+    /// dictionary snapshot path: the producer carries no dictionary state (LDM
+    /// is not dict-primed; its hash table is empty at capture), so it is not
+    /// retained in the snapshot — the working frame's freshly-reset producer is
+    /// reinstated on restore instead.
+    #[cfg(feature = "hash")]
+    fn take_ldm_producer(&mut self) -> Option<super::ldm::LdmProducer> {
+        if let HcBackend::Bt(bt) = &mut self.backend {
+            bt.ldm_producer.take()
+        } else {
+            None
         }
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -693,11 +693,70 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 27, lazy_depth: 2, fast: None, dfast: None, hc: Some(BTULTRA2_HC_CONFIG_L22), row: None },
 ];
 
-/// Donor `ZSTD_getCParamRowSize` addend for an unknown-source compress that
-/// carries a dictionary (`zstd_compress.c`: `addedSize = unknown && dictSize > 0
-/// ? 500 : 0`). Added to the dictionary size when picking the dict-driven
-/// cParams tier so our tier selection lands on the same column donor would.
-const DICT_CPARAM_ROW_ADDEND: u64 = 500;
+/// Donor `minSrcSize` assumption when building a dictionary's prepared cParams
+/// with an unknown source (`zstd_compress.c` `ZSTD_adjustCParams_internal`,
+/// `ZSTD_cpm_createCDict`: `if (dictSize && srcSize == UNKNOWN) srcSize =
+/// minSrcSize` where `minSrcSize = (1<<9) + 1`). Used by [`cdict_table_logs`].
+const DICT_MIN_SRC_SIZE: u64 = 513;
+
+/// Donor `ZSTD_dictAndWindowLog` (`zstd_compress.c`): the window log large
+/// enough to address both the source and the dictionary, used when downsizing
+/// the hash / chain logs for a dictionary-bearing compress. `window_log` is the
+/// (already source-clamped) compress window; `src_size` / `dict_size` are the
+/// assumed source and the dictionary length.
+fn dict_and_window_log(window_log: u8, src_size: u64, dict_size: u64) -> u32 {
+    if dict_size == 0 {
+        return window_log as u32;
+    }
+    let window_size: u64 = 1u64 << window_log;
+    let dict_and_window = dict_size.saturating_add(window_size);
+    if window_size >= dict_size.saturating_add(src_size) {
+        // Window already covers source + dictionary.
+        window_log as u32
+    } else {
+        // ceil(log2(dictAndWindowSize)) = highbit32(x - 1) + 1.
+        source_size_ceil_log(dict_and_window) as u32
+    }
+}
+
+/// Donor `ZSTD_createCDict` table geometry: the `(hash_log, chain_log)` a
+/// dictionary's prepared match-finder tables get, mirroring
+/// `ZSTD_adjustCParams_internal` under `ZSTD_cpm_createCDict`. A dictionary
+/// supplies the long matches, so donor downsizes the table widths toward the
+/// dict-and-window log (assuming a `minSrcSize` source) while the live window
+/// stays source-sized. `window_log` is the resolved compress window; `hash_log`
+/// / `chain_log` are the level's own widths; `uses_bt` selects the binary-tree
+/// `cycleLog` (`chainLog - 1`) vs the hash-chain one (`chainLog`).
+fn cdict_table_logs(
+    window_log: u8,
+    hash_log: usize,
+    chain_log: usize,
+    uses_bt: bool,
+    dict_size: usize,
+) -> (usize, usize) {
+    let dict_size = dict_size as u64;
+    // createCDict assumes a minSrcSize source when the real size is unknown.
+    let src_size = DICT_MIN_SRC_SIZE;
+    // Source-size window resize (donor caps windowLog by ceil_log2(src+dict)).
+    let tsize = src_size.saturating_add(dict_size);
+    let resized_window_log = (window_log as u32)
+        .min(source_size_ceil_log(tsize) as u32)
+        .max(1);
+    let daw = dict_and_window_log(resized_window_log as u8, src_size, dict_size);
+    // `ZSTD_cycleLog(chainLog, strategy)`: chainLog - 1 for binary-tree finders.
+    let cycle_log = (chain_log as u32).saturating_sub(uses_bt as u32);
+    let new_hash_log = if hash_log as u32 > daw + 1 {
+        (daw + 1) as usize
+    } else {
+        hash_log
+    };
+    let new_chain_log = if cycle_log > daw {
+        chain_log.saturating_sub((cycle_log - daw) as usize)
+    } else {
+        chain_log
+    };
+    (new_hash_log, new_chain_log)
+}
 
 /// Smallest window_log the encoder will use regardless of source size.
 pub(crate) const MIN_WINDOW_LOG: u8 = 10;
@@ -1659,32 +1718,36 @@ impl Matcher for MatchGeneratorDriver {
                 }
             }
         }
-        // Dictionary-driven table sizing (donor CDict economics). When a
-        // dictionary is loaded, donor sizes the match-finder hash/chain tables
-        // from the dictionary's `ZSTD_getCParamRowSize` tier, NOT from the
-        // source size: the dictionary supplies the long-distance matches, so a
-        // window-sized live table is wasted memory. The frame's eviction window
-        // (`window_log`) stays source-derived so the dictionary bytes remain
-        // referenceable; only the hash/chain WIDTHS shrink to the dict tier.
-        // This is the encoder-side equivalent of copying a CDict's small tables
-        // while keeping a source-sized window (`ZSTD_resetCCtx_byCopyingCDict`:
-        // `params.cParams = *cdict_cParams; params.cParams.windowLog = windowLog`).
-        // Only the binary-tree / hash-chain backend reads `hc.{hash,chain}_log`;
-        // the Simple/Dfast/Row backends derive their widths from the source
-        // window in their `reset` arms, matching donor's dict handling there.
+        // Dictionary-driven table sizing — parity with donor `ZSTD_createCDict`
+        // (`ZSTD_getCParams_internal(level, UNKNOWN, dictSize, ZSTD_cpm_createCDict)`
+        // → `ZSTD_adjustCParams_internal`). A loaded dictionary supplies the
+        // long-distance matches, so donor sizes the prepared match-finder tables
+        // to the DICTIONARY (assuming a `minSrcSize` source), not the live
+        // window: it downsizes `hashLog`/`chainLog` toward the dict-and-window
+        // log while leaving the frame's eviction `window_log` source-derived so
+        // the dictionary bytes stay referenceable (`ZSTD_resetCCtx_byCopyingCDict`
+        // copies the small CDict tables but keeps the source window). We apply
+        // the same downsizing to the level's own hc geometry and cap (min) so a
+        // dict never inflates the level tables. Only the binary-tree / hash-chain
+        // backend reads `hc.{hash,chain}_log`; Simple/Dfast/Row derive their
+        // widths from the source window in their `reset` arms.
         if let (Some(dict_size), Some(hc)) = (dict_hint, params.hc.as_mut()) {
-            // Donor `ZSTD_getCParamRowSize`: for a dictionary-bearing compress
-            // the cParams column is chosen from `dictSize + 500` (the unknown-
-            // source-with-dict row-size). Reuse the level resolver with that
-            // size to read the dict-tier hash/chain widths, then cap (min) so an
-            // explicit larger level table never grows past the dict tier and a
-            // dict bigger than the level's own tables never inflates them.
-            let dict_row_size = (dict_size as u64).saturating_add(DICT_CPARAM_ROW_ADDEND);
-            let dict_params = resolve_level_params(level, Some(dict_row_size));
-            if let Some(dict_hc) = dict_params.hc {
-                hc.hash_log = hc.hash_log.min(dict_hc.hash_log);
-                hc.chain_log = hc.chain_log.min(dict_hc.chain_log);
-            }
+            let uses_bt = matches!(
+                params.strategy_tag,
+                super::strategy::StrategyTag::Btlazy2
+                    | super::strategy::StrategyTag::BtOpt
+                    | super::strategy::StrategyTag::BtUltra
+                    | super::strategy::StrategyTag::BtUltra2
+            );
+            let (dict_hash_log, dict_chain_log) = cdict_table_logs(
+                params.window_log,
+                hc.hash_log,
+                hc.chain_log,
+                uses_bt,
+                dict_size,
+            );
+            hc.hash_log = hc.hash_log.min(dict_hash_log);
+            hc.chain_log = hc.chain_log.min(dict_chain_log);
         }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1755,7 +1755,12 @@ impl Matcher for MatchGeneratorDriver {
         // dict never inflates the level tables. Only the binary-tree / hash-chain
         // backend reads `hc.{hash,chain}_log`; Simple/Dfast/Row derive their
         // widths from the source window in their `reset` arms.
-        if let Some(dict_size) = dict_hint {
+        // A zero-length dictionary is "no dictionary": running the CDict sizing
+        // path for `Some(0)` is not a no-op — `cdict_table_logs(.., 0)` still
+        // collapses the HC/BT tables toward the 513-byte donor tier via
+        // `DICT_MIN_SRC_SIZE`, tanking ratio/perf on the next frame. Priming
+        // already treats empty content as empty, so skip the downsizing here too.
+        if let Some(dict_size) = dict_hint.filter(|&size| size > 0) {
             // Derive the dict-tier geometry from the level's FULL (un-source-capped)
             // hc widths. `Self::level_params(level, hint)` already source-capped
             // `params.hc`; feeding those capped widths into `cdict_table_logs` and

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1731,23 +1731,36 @@ impl Matcher for MatchGeneratorDriver {
         // dict never inflates the level tables. Only the binary-tree / hash-chain
         // backend reads `hc.{hash,chain}_log`; Simple/Dfast/Row derive their
         // widths from the source window in their `reset` arms.
-        if let (Some(dict_size), Some(hc)) = (dict_hint, params.hc.as_mut()) {
-            let uses_bt = matches!(
-                params.strategy_tag,
-                super::strategy::StrategyTag::Btlazy2
-                    | super::strategy::StrategyTag::BtOpt
-                    | super::strategy::StrategyTag::BtUltra
-                    | super::strategy::StrategyTag::BtUltra2
-            );
-            let (dict_hash_log, dict_chain_log) = cdict_table_logs(
-                params.window_log,
-                hc.hash_log,
-                hc.chain_log,
-                uses_bt,
-                dict_size,
-            );
-            hc.hash_log = hc.hash_log.min(dict_hash_log);
-            hc.chain_log = hc.chain_log.min(dict_chain_log);
+        if let Some(dict_size) = dict_hint {
+            // Derive the dict-tier geometry from the level's FULL (un-source-capped)
+            // hc widths. `Self::level_params(level, hint)` already source-capped
+            // `params.hc`; feeding those capped widths into `cdict_table_logs` and
+            // then `.min()`-ing would double-cap, so on a small hinted source with a
+            // large dictionary the prepared tables collapse below what the dict needs
+            // — defeating the `ZSTD_createCDict` geometry this mirrors. Take the
+            // un-hinted base widths instead and assign the result directly:
+            // `cdict_table_logs` only ever downsizes, so it never exceeds the base
+            // level geometry, while the eviction `window_log` stays source-derived so
+            // the dictionary bytes remain referenceable.
+            let base_hc = Self::level_params(level, None).hc;
+            if let (Some(hc), Some(base_hc)) = (params.hc.as_mut(), base_hc) {
+                let uses_bt = matches!(
+                    params.strategy_tag,
+                    super::strategy::StrategyTag::Btlazy2
+                        | super::strategy::StrategyTag::BtOpt
+                        | super::strategy::StrategyTag::BtUltra
+                        | super::strategy::StrategyTag::BtUltra2
+                );
+                let (dict_hash_log, dict_chain_log) = cdict_table_logs(
+                    params.window_log,
+                    base_hc.hash_log,
+                    base_hc.chain_log,
+                    uses_bt,
+                    dict_size,
+                );
+                hc.hash_log = dict_hash_log;
+                hc.chain_log = dict_chain_log;
+            }
         }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1966,6 +1966,16 @@ impl Matcher for MatchGeneratorDriver {
                     data.resize(data.capacity(), 0);
                     vec_pool.push(data);
                 });
+                // When the source size is known, pre-size the history mirror to
+                // the expected total (dictionary + payload) so per-block growth
+                // does not overshoot via Vec capacity doubling (donor sizes its
+                // window buffer exactly). Dominates peak once the match-finder
+                // tables are dictionary-tier-small. Unhinted streams skip this
+                // and keep doubling growth.
+                if let Some(src) = hint {
+                    let expected = (src as usize).saturating_add(dict_hint.unwrap_or(0));
+                    hc.table.reserve_history(expected);
+                }
             }
         }
         // LDM wiring (#27): attach (or clear) the long-distance-match

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1741,9 +1741,17 @@ impl Matcher for MatchGeneratorDriver {
             // un-hinted base widths instead and assign the result directly:
             // `cdict_table_logs` only ever downsizes, so it never exceeds the base
             // level geometry, while the eviction `window_log` stays source-derived so
-            // the dictionary bytes remain referenceable.
-            let base_hc = Self::level_params(level, None).hc;
-            if let (Some(hc), Some(base_hc)) = (params.hc.as_mut(), base_hc) {
+            // the dictionary bytes remain referenceable. Active public-parameter
+            // overrides (#27) are applied to the base too, so a strategy override
+            // that routes onto HashChain/BinaryTree still gets dict-tier sizing and
+            // explicit hash/chain overrides feed through as the geometry ceiling.
+            let mut base_params = Self::level_params(level, None);
+            if let Some(ov) = self.param_overrides
+                && !ov.is_empty()
+            {
+                apply_param_overrides(&mut base_params, &ov);
+            }
+            if let (Some(hc), Some(base_hc)) = (params.hc.as_mut(), base_params.hc) {
                 let uses_bt = matches!(
                     params.strategy_tag,
                     super::strategy::StrategyTag::Btlazy2

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -680,6 +680,22 @@ impl MatchTable {
     /// dictionary-tier-small. Correctness-neutral: the mirror still grows on
     /// demand if `expected_bytes` underestimates. Only worth calling when the
     /// total is known (source-size hinted); an unhinted stream keeps doubling.
+    /// Heap bytes this table owns: history, the hash / hash3 / chain tables,
+    /// the chunk-length deque, and any attached immutable dictionary tables.
+    pub(crate) fn heap_size(&self) -> usize {
+        let u32_sz = core::mem::size_of::<u32>();
+        let usize_sz = core::mem::size_of::<usize>();
+        self.chunk_lens.capacity() * usize_sz
+            + self.history.capacity()
+            + (self.hash_table.capacity()
+                + self.hash3_table.capacity()
+                + self.chain_table.capacity())
+                * u32_sz
+            + self.dms.table().map_or(0, |t| {
+                (t.hash_table.capacity() + t.chain_table.capacity()) * u32_sz
+            })
+    }
+
     pub(crate) fn reserve_history(&mut self, expected_bytes: usize) {
         // Eviction keeps the live mirror within `max_window_size`; one pending
         // block can sit on top before `add_data` rolls it out, so the tightest

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -671,6 +671,28 @@ impl MatchTable {
     /// bytes, so the input buffer carries no live data. (Callers must
     /// therefore treat the callback as recycle-only, not as an eviction
     /// report; eviction bytes come from the `window_size` delta.)
+    /// Pre-size the contiguous `history` mirror to `expected_bytes` (capped to
+    /// the window eviction bound) so the per-block `add_data`
+    /// `extend_from_slice` growth does not overshoot through `Vec` capacity
+    /// doubling. Donor allocates its window buffer at `windowSize + blockSize`
+    /// exactly; left to `Vec` doubling, a ~1 MiB history lands in a 2 MiB
+    /// allocation — wasted peak that dominates once the match-finder tables are
+    /// dictionary-tier-small. Correctness-neutral: the mirror still grows on
+    /// demand if `expected_bytes` underestimates. Only worth calling when the
+    /// total is known (source-size hinted); an unhinted stream keeps doubling.
+    pub(crate) fn reserve_history(&mut self, expected_bytes: usize) {
+        // Eviction keeps the live mirror within `max_window_size`; one pending
+        // block can sit on top before `add_data` rolls it out, so the tightest
+        // sufficient capacity is `max_window_size + MAX_BLOCK_SIZE`.
+        let cap = self
+            .max_window_size
+            .saturating_add(crate::common::MAX_BLOCK_SIZE as usize);
+        let want = expected_bytes.min(cap);
+        if want > self.history.capacity() {
+            self.history.reserve_exact(want - self.history.len());
+        }
+    }
+
     pub(crate) fn add_data(&mut self, data: Vec<u8>, mut reuse_space: impl FnMut(Vec<u8>)) {
         assert!(data.len() <= self.max_window_size);
         check_stream_abs_headroom(self.history_abs_start, self.window_size, data.len());

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -453,6 +453,12 @@ pub trait Matcher {
     fn supports_dictionary_priming(&self) -> bool {
         false
     }
+    /// Heap bytes this matcher's allocations hold (tables, history, scratch),
+    /// excluding the inline struct itself. Lets a context report its true
+    /// footprint via `ZSTD_sizeof_CCtx`. Defaults to `0` for custom matchers.
+    fn heap_size(&self) -> usize {
+        0
+    }
     /// The size of the window the decoder will need to execute all sequences produced by this matcher.
     ///
     /// Must return a positive (non-zero) value; returning 0 causes

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -406,6 +406,13 @@ pub trait Matcher {
     /// test stubs. The built-in runtime matcher (`MatchGeneratorDriver`)
     /// overrides this hook and applies the hint during level resolution.
     fn set_source_size_hint(&mut self, _size: u64) {}
+    /// Hint the byte size of the dictionary that will be primed into the next
+    /// frame. The built-in runtime matcher uses it to size the binary-tree /
+    /// hash-chain match-finder tables from the dictionary's cParams tier rather
+    /// than the source window (donor CDict economics), while keeping the
+    /// eviction window source-sized. Default no-op for custom matchers and test
+    /// stubs; consumed at the next [`reset`](Self::reset).
+    fn set_dictionary_size_hint(&mut self, _size: usize) {}
     /// Drop any per-frame fine-grained parameter overrides installed via
     /// the public parameter API, reverting to plain level-based geometry
     /// at the next [`reset`](Self::reset). Called by

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -691,6 +691,20 @@ impl RowMatchGenerator {
         }
     }
 
+    /// Heap bytes this matcher owns: history, the row head/position/tag tables,
+    /// the chunk-length deque, and any attached dictionary row index.
+    pub(crate) fn heap_size(&self) -> usize {
+        let u32_sz = core::mem::size_of::<u32>();
+        self.chunk_lens.capacity() * core::mem::size_of::<usize>()
+            + self.history.capacity()
+            + self.row_heads.capacity()
+            + self.row_positions.capacity() * u32_sz
+            + self.row_tags.capacity()
+            + self.dict.table().map_or(0, |t| {
+                t.heads.capacity() + t.positions.capacity() * u32_sz + t.tags.capacity()
+            })
+    }
+
     pub(crate) fn set_hash_bits(&mut self, bits: usize) {
         let clamped = bits.clamp(self.row_log + 1, ROW_HASH_BITS);
         let row_hash_log = clamped.saturating_sub(self.row_log);

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -157,6 +157,11 @@ impl FastHashTable {
         self.mls
     }
 
+    /// Heap bytes held by the table's `Vec<u32>` (its allocated capacity).
+    pub(crate) fn heap_size(&self) -> usize {
+        self.table.capacity() * core::mem::size_of::<u32>()
+    }
+
     /// Clear the table back to all-sentinel. Used on encoder reset
     /// between independent frames so a stale absolute index from the
     /// previous frame can't get mistaken for a current-frame match.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -403,6 +403,16 @@ impl FastKernelMatcher {
         1u64 << self.window_log
     }
 
+    /// Heap bytes this matcher owns: the history buffer, the hash table, the
+    /// recycle/pending slots, and any attached dictionary hash table.
+    pub(crate) fn heap_size(&self) -> usize {
+        self.history.capacity()
+            + self.hash_table.heap_size()
+            + self.pending.as_ref().map_or(0, |v| v.capacity())
+            + self.recycled_space.as_ref().map_or(0, |v| v.capacity())
+            + self.dict.table().map_or(0, |t| t.heap_size())
+    }
+
     /// Flat byte view of the match window the kernel scans against.
     ///
     /// Single read accessor for the window storage so the storage

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -34,6 +34,12 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     frame_started: bool,
     pledged_content_size: Option<u64>,
     bytes_consumed: u64,
+    /// Effective strategy tag when a public-parameter
+    /// [`Strategy`](crate::encoding::Strategy) override (#27) is active, mirroring
+    /// [`FrameCompressor`](crate::encoding::FrameCompressor)'s field. `Some`
+    /// survives frame start so the literal-compression gates run the same
+    /// strategy the matcher does; `None` keeps the level-derived tag.
+    strategy_override: Option<crate::encoding::strategy::StrategyTag>,
     /// `ZSTD_f_zstd1_magicless` — omit the 4-byte magic number prefix.
     /// Default false. See [`Self::set_magicless`].
     magicless: bool,
@@ -85,7 +91,10 @@ impl<W: Write> StreamingEncoder<W, MatchGeneratorDriver> {
         }
         self.compression_level = params.level();
         let overrides = params.overrides();
-        self.state.strategy_tag = overrides.strategy.map(|s| s.tag()).unwrap_or_else(|| {
+        // Persist the strategy override so `ensure_frame_started`'s level-based
+        // resync does not discard it (matching `FrameCompressor::set_parameters`).
+        self.strategy_override = overrides.strategy.map(|s| s.tag());
+        self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
             crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
         });
         self.state.matcher.set_param_overrides(Some(overrides));
@@ -120,6 +129,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             frame_started: false,
             pledged_content_size: None,
             bytes_consumed: 0,
+            strategy_override: None,
             magicless: false,
             content_checksum: true,
             dictionary: None,
@@ -347,10 +357,20 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         }
 
         self.ensure_level_supported()?;
-        let use_dictionary = self.dictionary.is_some();
+        // A dictionary is only active when it can actually be primed: the level
+        // compresses (not `Uncompressed`) AND the matcher supports priming AND a
+        // dictionary is attached. Mirrors `FrameCompressor`'s `use_dictionary_state`
+        // so a streaming frame never advertises a `Dictionary_ID`, disables
+        // single-segment, or seeds dict entropy/offsets unless the dictionary is
+        // genuinely in play (otherwise it would emit frames that needlessly
+        // require a dictionary at decode time).
+        let use_dictionary_state =
+            !matches!(self.compression_level, CompressionLevel::Uncompressed)
+                && self.state.matcher.supports_dictionary_priming()
+                && self.dictionary.is_some();
         // The dictionary content size drives dict-tier match-finder sizing
         // (consumed inside `reset`), so hand it over BEFORE reset.
-        if let Some(dict) = self.dictionary.as_ref() {
+        if use_dictionary_state && let Some(dict) = self.dictionary.as_ref() {
             self.state
                 .matcher
                 .set_dictionary_size_hint(dict.inner.dict_content.len());
@@ -358,16 +378,19 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         self.state.matcher.reset(self.compression_level);
         // Seed the repeat-offset history from the dictionary (donor
         // `ZSTD_compress_insertDictionary`), or the default rep codes otherwise.
-        self.state.offset_hist = self
-            .dictionary
-            .as_ref()
-            .map(|dict| dict.inner.offset_hist)
-            .unwrap_or([1, 4, 8]);
+        self.state.offset_hist = if use_dictionary_state {
+            self.dictionary
+                .as_ref()
+                .map(|dict| dict.inner.offset_hist)
+                .unwrap_or([1, 4, 8])
+        } else {
+            [1, 4, 8]
+        };
         // Prime the match-finder with the dictionary content + offsets.
         // `dict` borrows `self.dictionary`; `self.state.matcher` is a disjoint
         // field, so the immutable dict borrow and the mutable matcher borrow
         // coexist (field-level borrow splitting) with no conflict.
-        if let Some(dict) = self.dictionary.as_ref() {
+        if use_dictionary_state && let Some(dict) = self.dictionary.as_ref() {
             let offset_hist = dict.inner.offset_hist;
             self.state
                 .matcher
@@ -375,7 +398,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         }
         // Seed the first block's entropy from the dictionary's cached encoder
         // tables (donor `cdict->cBlockState`), or clear to defaults.
-        if let Some(cache) = self.dictionary_entropy_cache.as_ref() {
+        if use_dictionary_state && let Some(cache) = self.dictionary_entropy_cache.as_ref() {
             self.state.last_huff_table.clone_from(&cache.huff);
             self.state
                 .fse_tables
@@ -417,9 +440,12 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         // literal-compression gates (`min_literals_to_compress`, `min_gain`
         // in `encoding::blocks::compressed`) see the correct strategy for
         // every frame. Mirrors `FrameCompressor::compress` and keeps both
-        // entry points byte-equivalent at the gate level.
-        self.state.strategy_tag =
-            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level);
+        // entry points byte-equivalent at the gate level. A public-parameter
+        // strategy override (#27) wins over the level's derived tag so the
+        // gates see the strategy the matcher actually runs.
+        self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
+            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
+        });
         #[cfg(feature = "hash")]
         {
             self.hasher = XxHash64::with_seed(0);
@@ -436,7 +462,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         // pushes referenceable history before the content, so the frame needs
         // an explicit window descriptor); gate it off when a dict is attached,
         // mirroring `FrameCompressor`'s `!use_dictionary_state` guard.
-        let single_segment = !use_dictionary
+        let single_segment = !use_dictionary_state
             && self
                 .pledged_content_size
                 .map(|size| (512..=(1 << 14)).contains(&size) && size <= window_size)
@@ -446,7 +472,11 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             frame_content_size: self.pledged_content_size,
             single_segment,
             content_checksum: cfg!(feature = "hash") && self.content_checksum,
-            dictionary_id: self.dictionary.as_ref().map(|dict| dict.inner.id as u64),
+            dictionary_id: if use_dictionary_state {
+                self.dictionary.as_ref().map(|dict| dict.inner.id as u64)
+            } else {
+                None
+            },
             window_size: if single_segment {
                 None
             } else {
@@ -577,17 +607,21 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                 | CompressionLevel::Level(_) => {
                     let block = raw_block.take().expect("raw block missing");
                     debug_assert!(!block.is_empty(), "empty blocks handled above");
+                    // A primed dictionary makes "incompressible-looking" blocks
+                    // matchable, so the raw-fast-path must NOT fire. But a dict is
+                    // only PRIMED when the matcher supports priming — a non-priming
+                    // matcher ignores the attached dictionary, so the raw-fast-path
+                    // must stay enabled for it. (This arm is already non-Uncompressed.)
+                    // Mirrors `FrameCompressor`'s `dict_active`.
+                    let dict_active = self.dictionary.is_some()
+                        && self.state.matcher.supports_dictionary_priming();
                     compress_block_encoded(
                         &mut self.state,
                         self.compression_level,
                         last_block,
                         block,
                         &mut encoded,
-                        // When a dictionary is attached, the raw-fast-path must
-                        // NOT fire (an incompressible-looking block can still
-                        // match the dictionary); disable it so the dict is
-                        // always searched, mirroring `FrameCompressor`.
-                        self.dictionary.is_some(),
+                        dict_active,
                         // No FrameEmitInfo on the streaming encoder path — it
                         // does not surface per-block layout, so no sidecar.
                         #[cfg(feature = "lsm")]
@@ -1657,5 +1691,73 @@ mod tests {
             compressed.len(),
             nodict_frame.len()
         );
+    }
+
+    #[test]
+    fn streaming_encoder_strategy_override_survives_frame_start() {
+        // A `.strategy(...)` override must drive BOTH the matcher and the
+        // literal-compression gates (`state.strategy_tag`) once the frame
+        // starts. `ensure_frame_started` re-syncs the tag, so without persisting
+        // the override it would silently fall back to the level's strategy and
+        // diverge from `FrameCompressor` for the same parameters.
+        use crate::encoding::{CompressionParameters, Strategy};
+        let level = CompressionLevel::Fastest;
+        let level_tag = crate::encoding::strategy::StrategyTag::for_compression_level(level);
+        let override_tag = Strategy::Greedy.tag();
+        assert_ne!(
+            level_tag, override_tag,
+            "test needs an override that changes the derived tag"
+        );
+
+        let params = CompressionParameters::builder(level)
+            .strategy(Strategy::Greedy)
+            .build()
+            .unwrap();
+        let payload = b"override must outlive the frame header";
+        let mut encoder = StreamingEncoder::new(Vec::new(), level);
+        encoder.set_parameters(&params).unwrap();
+        encoder.write_all(payload).unwrap();
+        assert_eq!(
+            encoder.state.strategy_tag, override_tag,
+            "strategy override was discarded when the frame started"
+        );
+
+        let compressed = encoder.finish().unwrap();
+        let mut decoder = StreamingDecoder::new(compressed.as_slice()).unwrap();
+        let mut decoded = Vec::new();
+        decoder.read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn streaming_encoder_uncompressed_with_dictionary_omits_dict_id() {
+        // At `Uncompressed` the matcher cannot prime a dictionary, so an
+        // attached dictionary must NOT be reflected in the frame: advertising a
+        // `Dictionary_ID` would force a dictionary at decode time for a frame
+        // that does not actually depend on one. Mirrors `FrameCompressor`'s
+        // `use_dictionary_state` gate.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"tenant=demo table=orders region=eu payload=aaaaabbbbbccccc";
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Uncompressed);
+        encoder
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("attach dictionary");
+        encoder.write_all(payload).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let header = crate::decoding::frame::read_frame_header(compressed.as_slice())
+            .unwrap()
+            .0;
+        assert_eq!(
+            header.dictionary_id(),
+            None,
+            "uncompressed frame must not require a dictionary at decode time"
+        );
+
+        // Decodes WITHOUT any dictionary.
+        let mut decoder = StreamingDecoder::new(compressed.as_slice()).unwrap();
+        let mut decoded = Vec::new();
+        decoder.read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, payload);
     }
 }

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -65,6 +65,32 @@ impl<W: Write> StreamingEncoder<W, MatchGeneratorDriver> {
             compression_level,
         )
     }
+
+    /// Configure fine-grained compression parameters (#27): resets the level to
+    /// the parameters' level and installs the per-knob overrides (window / hash
+    /// / chain / search logs, strategy, long-distance matching) applied at the
+    /// next frame. Mirrors [`FrameCompressor::set_parameters`]. Must be called
+    /// before the first [`write`](Write::write). Only the built-in
+    /// `MatchGeneratorDriver` exposes the override knobs, so this lives on the
+    /// default-matcher impl.
+    pub fn set_parameters(
+        &mut self,
+        params: &crate::encoding::CompressionParameters,
+    ) -> Result<(), Error> {
+        self.ensure_open()?;
+        if self.frame_started {
+            return Err(invalid_input_error(
+                "compression parameters must be set before the first write",
+            ));
+        }
+        self.compression_level = params.level();
+        let overrides = params.overrides();
+        self.state.strategy_tag = overrides.strategy.map(|s| s.tag()).unwrap_or_else(|| {
+            crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
+        });
+        self.state.matcher.set_param_overrides(Some(overrides));
+        Ok(())
+    }
 }
 
 impl<W: Write, M: Matcher> StreamingEncoder<W, M> {

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -11,8 +11,9 @@ use twox_hash::XxHash64;
 
 use crate::encoding::levels::compress_block_encoded;
 use crate::encoding::{
-    CompressionLevel, MatchGeneratorDriver, Matcher, block_header::BlockHeader,
-    frame_compressor::CompressState, frame_compressor::FseTables, frame_header::FrameHeader,
+    CompressionLevel, EncoderDictionary, MatchGeneratorDriver, Matcher, block_header::BlockHeader,
+    frame_compressor::CachedDictionaryEntropy, frame_compressor::CompressState,
+    frame_compressor::FseTables, frame_compressor::PreviousFseTable, frame_header::FrameHeader,
 };
 use crate::io::{Error, ErrorKind, Write};
 
@@ -41,6 +42,13 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     /// Default `true`; combined with the `hash` feature, so without `hash`
     /// no checksum is emitted regardless. See [`Self::set_content_checksum`].
     content_checksum: bool,
+    /// Dictionary applied to the frame (donor `ZSTD_CCtx_loadDictionary` on a
+    /// streaming context). `None` = no dictionary. Set before the first write.
+    dictionary: Option<EncoderDictionary>,
+    /// Encoder entropy tables (literals Huffman + LL/ML/OF FSE "previous"
+    /// tables) the dictionary seeds into the first block, derived once when the
+    /// dictionary is attached so each frame start is a cheap clone.
+    dictionary_entropy_cache: Option<CachedDictionaryEntropy>,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
 }
@@ -88,6 +96,8 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             bytes_consumed: 0,
             magicless: false,
             content_checksum: true,
+            dictionary: None,
+            dictionary_entropy_cache: None,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
         }
@@ -167,6 +177,42 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             ));
         }
         self.state.matcher.set_source_size_hint(size);
+        Ok(())
+    }
+
+    /// Attach a serialized dictionary blob to the frame (donor
+    /// `ZSTD_CCtx_loadDictionary` on a streaming context). The dictionary primes
+    /// the match-finder and seeds the first block's entropy tables + repeat
+    /// offsets, and its ID is written into the frame header. Must be called
+    /// before the first [`write`](Write::write); the parsed dictionary must have
+    /// a non-zero ID and non-zero repeat offsets.
+    pub fn set_dictionary_from_bytes(&mut self, raw_dictionary: &[u8]) -> Result<(), Error> {
+        let dict = EncoderDictionary::from_bytes(raw_dictionary)
+            .map_err(|err| invalid_input_error(&alloc::format!("invalid dictionary: {err:?}")))?;
+        self.set_encoder_dictionary(dict)
+    }
+
+    /// Attach an already-parsed [`EncoderDictionary`] to the frame. See
+    /// [`set_dictionary_from_bytes`](Self::set_dictionary_from_bytes); must be
+    /// called before the first write.
+    pub fn set_encoder_dictionary(&mut self, dict: EncoderDictionary) -> Result<(), Error> {
+        self.ensure_open()?;
+        if self.frame_started {
+            return Err(invalid_input_error(
+                "dictionary must be attached before the first write",
+            ));
+        }
+        let inner = &dict.inner;
+        if inner.id == 0 {
+            return Err(invalid_input_error("dictionary has a zero ID"));
+        }
+        if inner.offset_hist.contains(&0) {
+            return Err(invalid_input_error(
+                "dictionary carries a zero repeat offset",
+            ));
+        }
+        self.dictionary_entropy_cache = Some(CachedDictionaryEntropy::from_dictionary(inner));
+        self.dictionary = Some(dict);
         Ok(())
     }
 
@@ -275,12 +321,72 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         }
 
         self.ensure_level_supported()?;
+        let use_dictionary = self.dictionary.is_some();
+        // The dictionary content size drives dict-tier match-finder sizing
+        // (consumed inside `reset`), so hand it over BEFORE reset.
+        if let Some(dict) = self.dictionary.as_ref() {
+            self.state
+                .matcher
+                .set_dictionary_size_hint(dict.inner.dict_content.len());
+        }
         self.state.matcher.reset(self.compression_level);
-        self.state.offset_hist = [1, 4, 8];
-        self.state.last_huff_table = None;
-        self.state.fse_tables.ll_previous = None;
-        self.state.fse_tables.ml_previous = None;
-        self.state.fse_tables.of_previous = None;
+        // Seed the repeat-offset history from the dictionary (donor
+        // `ZSTD_compress_insertDictionary`), or the default rep codes otherwise.
+        self.state.offset_hist = self
+            .dictionary
+            .as_ref()
+            .map(|dict| dict.inner.offset_hist)
+            .unwrap_or([1, 4, 8]);
+        // Prime the match-finder with the dictionary content + offsets.
+        // `dict` borrows `self.dictionary`; `self.state.matcher` is a disjoint
+        // field, so the immutable dict borrow and the mutable matcher borrow
+        // coexist (field-level borrow splitting) with no conflict.
+        if let Some(dict) = self.dictionary.as_ref() {
+            let offset_hist = dict.inner.offset_hist;
+            self.state
+                .matcher
+                .prime_with_dictionary(dict.inner.dict_content.as_slice(), offset_hist);
+        }
+        // Seed the first block's entropy from the dictionary's cached encoder
+        // tables (donor `cdict->cBlockState`), or clear to defaults.
+        if let Some(cache) = self.dictionary_entropy_cache.as_ref() {
+            self.state.last_huff_table.clone_from(&cache.huff);
+            self.state
+                .fse_tables
+                .ll_previous
+                .clone_from(&cache.ll_previous);
+            self.state
+                .fse_tables
+                .ml_previous
+                .clone_from(&cache.ml_previous);
+            self.state
+                .fse_tables
+                .of_previous
+                .clone_from(&cache.of_previous);
+            let ll_entropy = match cache.ll_previous.as_ref() {
+                Some(PreviousFseTable::Custom(table)) => Some(table.as_ref()),
+                _ => None,
+            };
+            let ml_entropy = match cache.ml_previous.as_ref() {
+                Some(PreviousFseTable::Custom(table)) => Some(table.as_ref()),
+                _ => None,
+            };
+            let of_entropy = match cache.of_previous.as_ref() {
+                Some(PreviousFseTable::Custom(table)) => Some(table.as_ref()),
+                _ => None,
+            };
+            self.state.matcher.seed_dictionary_entropy(
+                self.state.last_huff_table.as_ref(),
+                ll_entropy,
+                ml_entropy,
+                of_entropy,
+            );
+        } else {
+            self.state.last_huff_table = None;
+            self.state.fse_tables.ll_previous = None;
+            self.state.fse_tables.ml_previous = None;
+            self.state.fse_tables.of_previous = None;
+        }
         // Sync `state.strategy_tag` from the active compression level so the
         // literal-compression gates (`min_literals_to_compress`, `min_gain`
         // in `encoding::blocks::compressed`) see the correct strategy for
@@ -300,21 +406,21 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             ));
         }
 
-        // FrameCompressor gates single-segment on dictionary usage state; the
-        // streaming encoder currently has no dictionary API/state, so we only
-        // gate on pledged size and window reach here.
-        // TODO: if streaming dictionary support is added, mirror the
-        // !use_dictionary_state guard from FrameCompressor.
-        let single_segment = self
-            .pledged_content_size
-            .map(|size| (512..=(1 << 14)).contains(&size) && size <= window_size)
-            .unwrap_or(false);
+        // Single-segment is incompatible with a dictionary (the dictionary
+        // pushes referenceable history before the content, so the frame needs
+        // an explicit window descriptor); gate it off when a dict is attached,
+        // mirroring `FrameCompressor`'s `!use_dictionary_state` guard.
+        let single_segment = !use_dictionary
+            && self
+                .pledged_content_size
+                .map(|size| (512..=(1 << 14)).contains(&size) && size <= window_size)
+                .unwrap_or(false);
 
         let header = FrameHeader {
             frame_content_size: self.pledged_content_size,
             single_segment,
             content_checksum: cfg!(feature = "hash") && self.content_checksum,
-            dictionary_id: None,
+            dictionary_id: self.dictionary.as_ref().map(|dict| dict.inner.id as u64),
             window_size: if single_segment {
                 None
             } else {
@@ -451,9 +557,11 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                         last_block,
                         block,
                         &mut encoded,
-                        // The streaming encoder has no dictionary state, so the
-                        // raw-fast-path stays enabled (no dict to match against).
-                        false,
+                        // When a dictionary is attached, the raw-fast-path must
+                        // NOT fire (an incompressible-looking block can still
+                        // match the dictionary); disable it so the dict is
+                        // always searched, mirroring `FrameCompressor`.
+                        self.dictionary.is_some(),
                         // No FrameEmitInfo on the streaming encoder path — it
                         // does not surface per-block layout, so no sidecar.
                         #[cfg(feature = "lsm")]
@@ -1465,5 +1573,63 @@ mod tests {
         // Verify the descriptor confirms FCS field is truly absent (0 bytes),
         // not just FCS present with value 0.
         assert_eq!(header.descriptor.frame_content_size_bytes().unwrap(), 0);
+    }
+
+    #[test]
+    fn streaming_encoder_with_dictionary_roundtrips_and_carries_dict_id() {
+        use alloc::format;
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let dict_id = crate::decoding::Dictionary::decode_dict(dict_raw)
+            .unwrap()
+            .id;
+
+        // Dictionary-resembling payload (the dict was trained on similar lines),
+        // fed in many small writes so the dict + cross-block matching are both
+        // exercised by the streaming path.
+        let mut payload = Vec::new();
+        for i in 0..400u32 {
+            payload.extend_from_slice(
+                format!("tenant=demo table=orders key={i} region=eu payload=aaaaabbbbbccccc\n")
+                    .as_bytes(),
+            );
+        }
+
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Level(19));
+        encoder
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("attach dictionary");
+        for chunk in payload.chunks(777) {
+            encoder.write_all(chunk).unwrap();
+        }
+        let compressed = encoder.finish().unwrap();
+
+        // The frame header advertises the dictionary ID (single-segment is
+        // disabled for dictionary frames, so an explicit window is present).
+        let header = crate::decoding::frame::read_frame_header(compressed.as_slice())
+            .unwrap()
+            .0;
+        assert_eq!(header.dictionary_id(), Some(dict_id));
+
+        // Round-trip through a decoder primed with the SAME dictionary.
+        let mut decoder =
+            StreamingDecoder::new_with_dictionary_bytes(compressed.as_slice(), dict_raw).unwrap();
+        let mut decoded = Vec::new();
+        decoder.read_to_end(&mut decoded).unwrap();
+        assert_eq!(decoded, payload);
+
+        // The dictionary is actually used: the dict frame is no larger than the
+        // no-dictionary frame on this dict-resembling payload (a dict that was
+        // ignored could only ever make the frame the same size or bigger).
+        let mut nodict = StreamingEncoder::new(Vec::new(), CompressionLevel::Level(19));
+        for chunk in payload.chunks(777) {
+            nodict.write_all(chunk).unwrap();
+        }
+        let nodict_frame = nodict.finish().unwrap();
+        assert!(
+            compressed.len() <= nodict_frame.len(),
+            "dict frame {} should not exceed no-dict frame {}",
+            compressed.len(),
+            nodict_frame.len()
+        );
     }
 }

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -172,6 +172,13 @@ pub struct FSETable {
 }
 
 impl FSETable {
+    /// Heap bytes this table holds beyond its inline struct: the flat
+    /// state-transition array (`Box<[u16]>`). The `states` / `symbol_tt`
+    /// arrays are fixed-size and inline (accounted by the owner's `size_of`).
+    pub(crate) fn heap_size(&self) -> usize {
+        self.state_table_flat.len() * core::mem::size_of::<u16>()
+    }
+
     /// O(1) next-state lookup mirroring upstream `FSE_encodeSymbol`
     /// (`lib/compress/fse_compress.c`). Was a linear scan over a
     /// `Vec<State>` per symbol; the flat tables that drive the donor

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -476,6 +476,14 @@ pub struct HuffmanTable {
 }
 
 impl HuffmanTable {
+    /// Heap bytes this table holds: the per-symbol code table and the packed
+    /// dual-container codes. The lazily-built weight-description cache is a
+    /// transient and not counted.
+    pub fn heap_size(&self) -> usize {
+        self.codes.capacity() * core::mem::size_of::<(u32, u8)>()
+            + self.packed_codes.capacity() * core::mem::size_of::<u64>()
+    }
+
     pub fn build_from_data(data: &[u8]) -> Self {
         let mut counts = [0; 256];
         let (max_symbol, _) = histogram::count_bytes(data, &mut counts);


### PR DESCRIPTION
## Summary

Closes the compress-dict L22 peak-memory dashboard alert and builds out the
encoder-side dictionary surface across the whole stack: the pure-Rust codec,
the C ABI, the wasm/npm bindings, and the `zstd` CLI (#128).

## 1. Memory: L22 `_ldm_dict` compress peak 39.7 MB -> 5.47 MB (8.2x -> 1.13x)

The dashboard alert was `decodecorpus-z000033 stage=compress
level=level_22_btultra2_ldm_dict` at 8.21x C zstd. Root cause: with a
dictionary loaded we sized the match-finder tables from the SOURCE window and
kept a second full-table snapshot. C applies CDict economics (the dictionary
supplies the long matches, so the live tables shrink to the dict's cParams
tier; the retained CDict holds no hash3 / opt / LDM). We now match that, all
byte-identical (guarded by a floor-safe reuse test + an LDM-on reuse test):

- size dict match-finder tables from the dictionary, not the source
- match donor `ZSTD_createCDict` table geometry exactly
- drop the (empty) live hash/chain/hash3 tables from the BT dict snapshot
- decouple the (empty) LDM producer from the snapshot
- pre-size the history mirror to the known total (no Vec doubling overshoot)

## 2. Codec: dictionary support for streaming + wasm

- `StreamingEncoder` gained dictionary support (`set_dictionary_from_bytes` /
  `set_encoder_dictionary`) and `set_parameters` (LDM etc.); the non-dictionary
  path stays byte-identical. `CachedDictionaryEntropy::from_dictionary` is
  shared with `FrameCompressor` so both seed identically.
- wasm/npm: `ZstdCompressStream.withDictionary` / `ZstdDecompressStream.withDictionary`
  plus `createCompressStreamWithDictionary` / `createDecompressStreamWithDictionary`.

## 3. C ABI: CDict / DDict

`ZSTD_createCDict[_byReference]` / `freeCDict` / `sizeof_CDict` /
`getDictID_fromCDict` / `compress_usingCDict`, and the symmetric DDict set.
The CCtx caches a dictionary-attached compressor keyed by the CDict pointer.

## 4. CLI: upstream-compatible `zstd` (#128)

Replaces the subcommand CLI with upstream v1.5.7's flag model:
`argv[0]` dispatch (`unzstd` / `zstdcat` / `zcat`), `-z`/`-d`/`-t`/`-l`,
`--train` (`--maxdict`/`--dictID`), `-b`/`-e`/`-i`/`-B`/`-S` benchmark, bare
`-N` levels + `--fast`/`--ultra`/`--long`, `-c`/`-o`/`-f`/`-k`/`--rm`/`-D`,
stdin/stdout, `--version`/`--help`. Manual argv parser (clap derive can't
model bare `-N`). zstdgrep/zstdless remain upstream shell wrappers.

## 5. CI

`ci(release-plz)`: the `structured-zstd-c` crate (added after the shared
v0.0.33 tag) crashed `release-pr` with "Failed to find package"; a private
tag namespace skips the broken baseline diff (same fix as the wasm crate).

## Testing

- 822 codec lib tests, 17 C ABI tests, 19 CLI parse tests, workspace clippy clean.
- Memory + ratio measured via `compare_ffi_memory` / `compare_ffi`
  (deterministic): dict-compress 5.47 MB vs C 4.83 MB; ratio neutral
  (rust_with_dict 421132 vs C 420424, within noise).
- CLI validated end-to-end: file roundtrip, stdin|stdout pipe, `-D` dict
  roundtrip, `unzstd` argv0, `-t`, `-l`, `--train` then use, `-b`, `--long`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * C API: prepared-dictionary support with dictionary-aware compress/decompress entry points and context caching.
  * CLI: revamped entrypoint with new modes (test, list, train, benchmark), improved streaming I/O, atomic outputs, and dictionary options.
  * WASM/npm: streaming compressor/decompressor constructors and helpers that accept raw dictionaries.
  * Streaming: encoder/decoder can attach/reuse dictionaries and emit dictionary IDs in headers.
  * Memory reporting: heap-size reporting across compressors, matchers, and contexts.

* **Tests**
  * Added dictionary round‑trip, reuse, size-accounting, and CLI parsing tests.

* **Chores**
  * Release tooling: registered new package entry without automatic releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

