### PR TITLE
perf(encode): close the level-4 dfast speed outlier (donor greedy double-fast)

### DIFF
--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -25,8 +25,7 @@ use super::match_generator::{
     DFAST_SHORT_HASH_LOOKAHEAD, DFAST_SKIP_STEP_GROWTH_INTERVAL, DFAST_TARGET_LEN, MIN_WINDOW_LOG,
 };
 use super::match_table::helpers::{
-    LazyMatchConfig, best_len_offset_candidate, common_prefix_len_with_kernel,
-    extend_backwards_shared, pick_lazy_match_shared,
+    best_len_offset_candidate, common_prefix_len_with_kernel, extend_backwards_shared,
 };
 use super::match_table::storage::{REBASE_RESET_FLOOR_CEILING, check_stream_abs_headroom};
 use super::opt::types::MatchCandidate;
@@ -393,26 +392,44 @@ macro_rules! dfast_start_matching_general_body {
             let best = best_len_offset_candidate(unsafe { $self.$rep(abs_pos, lit_len) }, unsafe {
                 $self.$hash(abs_pos, lit_len)
             });
-            // Inlined `pick_lazy_match`: the lookahead closure re-probes the
-            // same tier's repcode/hash (one umbrella-boundary hop per deferral,
-            // a cold path versus the per-position search above).
-            let picked = pick_lazy_match_shared(
-                abs_pos,
-                lit_len,
-                best,
-                LazyMatchConfig {
-                    target_len: DFAST_TARGET_LEN,
-                    min_match_len: DFAST_MIN_MATCH_LEN,
-                    lazy_depth: $self.lazy_depth,
-                    history_abs_end: $self.history_abs_end(),
-                },
-                |next_pos, next_lit_len| {
-                    best_len_offset_candidate(
-                        unsafe { $self.$rep(next_pos, next_lit_len) },
-                        unsafe { $self.$hash(next_pos, next_lit_len) },
-                    )
-                },
-            );
+            // Inlined `pick_lazy_match` (donor lazy/lazy2 lookahead): re-probe
+            // the same tier's repcode/hash at `abs_pos + 1` (and `+ 2` for
+            // lazy2) DIRECTLY under this umbrella so the lookahead `$cpl` scans
+            // inline too — no closure (a closure body is a separate
+            // non-`target_feature` MIR body, so its `$rep` / `$hash` calls would
+            // cross the ABI barrier on every deferral). Logic byte-identical to
+            // `pick_lazy_match_shared`.
+            let picked = 'pick: {
+                let Some(b) = best else { break 'pick None };
+                let history_abs_end = $self.history_abs_end();
+                if b.match_len >= DFAST_TARGET_LEN
+                    || abs_pos + 1 + DFAST_MIN_MATCH_LEN > history_abs_end
+                {
+                    break 'pick Some(b);
+                }
+                let next = best_len_offset_candidate(
+                    unsafe { $self.$rep(abs_pos + 1, lit_len + 1) },
+                    unsafe { $self.$hash(abs_pos + 1, lit_len + 1) },
+                );
+                if let Some(n) = next
+                    && (n.match_len > b.match_len
+                        || (n.match_len == b.match_len && n.offset < b.offset))
+                {
+                    break 'pick None;
+                }
+                if $self.lazy_depth >= 2 && abs_pos + 2 + DFAST_MIN_MATCH_LEN <= history_abs_end {
+                    let next2 = best_len_offset_candidate(
+                        unsafe { $self.$rep(abs_pos + 2, lit_len + 2) },
+                        unsafe { $self.$hash(abs_pos + 2, lit_len + 2) },
+                    );
+                    if let Some(n2) = next2
+                        && n2.match_len > b.match_len + 1
+                    {
+                        break 'pick None;
+                    }
+                }
+                Some(b)
+            };
             if let Some(candidate) = picked {
                 let start = $self.emit_candidate(
                     $current_abs_start,

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -26,7 +26,7 @@ use super::match_generator::{
 };
 use super::match_table::helpers::{
     LazyMatchConfig, best_len_offset_candidate, common_prefix_len_with_kernel,
-    extend_backwards_shared, pick_lazy_match_shared, repcode_candidate_shared,
+    extend_backwards_shared, pick_lazy_match_shared,
 };
 use super::match_table::storage::{REBASE_RESET_FLOOR_CEILING, check_stream_abs_headroom};
 use super::opt::types::MatchCandidate;
@@ -180,6 +180,280 @@ macro_rules! dfast_probe_slot_match_body {
             return None;
         }
         Some($self.extend_backwards(candidate_pos, $abs_pos, match_len, $lit_len))
+    }};
+}
+
+/// Per-kernel body of [`DfastMatchGenerator::repcode_candidate`]. Mirrors
+/// `repcode_candidate_shared` but with the tier's `common_prefix_len_ptr`
+/// (`$cpl`) inlined directly on raw pointers (no `match kernel` dispatch, no
+/// ABI-crossing call), so the 3-rep probe runs straight-line under the
+/// wrapper's `#[target_feature]` umbrella. The 3 probes are hand-unrolled (not
+/// a nested `macro_rules!`) because macro hygiene forbids referencing the outer
+/// macro's `$cpl` metavar from a nested macro body.
+macro_rules! dfast_repcode_candidate_body {
+    ($self:ident, $abs_pos:ident, $lit_len:ident, $cpl:path) => {{
+        let concat = $self.live_history();
+        let history_abs_start = $self.history_abs_start;
+        let offset_hist = $self.offset_hist;
+        let current_idx = $abs_pos - history_abs_start;
+        if current_idx + DFAST_MIN_MATCH_LEN > concat.len() {
+            return None;
+        }
+        let (rep0, rep1, rep2_opt) = if $lit_len == 0 {
+            let r2 = if offset_hist[0] > 1 {
+                Some(offset_hist[0] as usize - 1)
+            } else {
+                None
+            };
+            (offset_hist[1] as usize, offset_hist[2] as usize, r2)
+        } else {
+            (
+                offset_hist[0] as usize,
+                offset_hist[1] as usize,
+                Some(offset_hist[2] as usize),
+            )
+        };
+        let mut best: Option<MatchCandidate> = None;
+        // Hand-unrolled inline probes (NOT a closure: a closure body is a
+        // separate non-`target_feature` MIR body, so calling `$cpl` from it
+        // would cross the ABI barrier and defeat the inline). Each call to the
+        // tier's `$cpl` runs directly in this wrapper's umbrella scope (the
+        // `for` loop body and the `if` block are in-fn, not a closure).
+        for &rep in &[rep0, rep1] {
+            if rep != 0 && rep <= $abs_pos {
+                let candidate_pos = $abs_pos - rep;
+                if candidate_pos >= history_abs_start {
+                    let candidate_idx = candidate_pos - history_abs_start;
+                    let a = &concat[candidate_idx..];
+                    let b = &concat[current_idx..];
+                    let max = a.len().min(b.len());
+                    // SAFETY: `a` / `b` each hold at least `len()` initialized
+                    // bytes; `max` is the minimum so both pointers are valid for
+                    // `max` bytes. `$cpl` is the tier kernel this umbrella enables.
+                    let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
+                    if match_len >= DFAST_MIN_MATCH_LEN {
+                        let candidate = extend_backwards_shared(
+                            concat,
+                            history_abs_start,
+                            candidate_pos,
+                            $abs_pos,
+                            match_len,
+                            $lit_len,
+                        );
+                        best = best_len_offset_candidate(best, Some(candidate));
+                    }
+                }
+            }
+        }
+        if let Some(rep) = rep2_opt
+            && rep != 0
+            && rep <= $abs_pos
+        {
+            let candidate_pos = $abs_pos - rep;
+            if candidate_pos >= history_abs_start {
+                let candidate_idx = candidate_pos - history_abs_start;
+                let a = &concat[candidate_idx..];
+                let b = &concat[current_idx..];
+                let max = a.len().min(b.len());
+                // SAFETY: as above.
+                let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
+                if match_len >= DFAST_MIN_MATCH_LEN {
+                    let candidate = extend_backwards_shared(
+                        concat,
+                        history_abs_start,
+                        candidate_pos,
+                        $abs_pos,
+                        match_len,
+                        $lit_len,
+                    );
+                    best = best_len_offset_candidate(best, Some(candidate));
+                }
+            }
+        }
+        best
+    }};
+}
+
+/// Per-kernel body of [`DfastMatchGenerator::hash_candidate`]. `$probe` is the
+/// tier's `probe_slot_match_<kernel>` method; calling it from this wrapper's
+/// matching `#[target_feature]` umbrella inlines the whole long/short probe +
+/// `_search_next_long` retry (and the `$cpl` scan inside each probe) with no
+/// `match kernel` dispatch and no ABI-crossing call per slot.
+macro_rules! dfast_hash_candidate_body {
+    ($self:ident, $abs_pos:ident, $lit_len:ident, $probe:ident) => {{
+        let concat = $self.live_history();
+        let current_idx = $abs_pos - $self.history_abs_start;
+        let history_abs_start = $self.history_abs_start;
+        let position_base = $self.position_base;
+        let mut best = None;
+
+        let long_hit = if current_idx + 8 <= concat.len() {
+            let long_hash = $self.long_hash_index(&concat[current_idx..]);
+            debug_assert!(long_hash < $self.long_hash.len());
+            // SAFETY: `long_hash_index` masks to `long_hash_bits` and
+            // `long_hash.len() == 1 << long_hash_bits` (`ensure_hash_tables`).
+            let slot = unsafe { *$self.long_hash.get_unchecked(long_hash) };
+            unsafe {
+                $self.$probe(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    $abs_pos,
+                    current_idx,
+                    concat,
+                    $lit_len,
+                    8,
+                )
+            }
+        } else {
+            None
+        };
+        if let Some(cand) = long_hit {
+            best = best_len_offset_candidate(best, Some(cand));
+            if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
+                return best;
+            }
+        }
+
+        if current_idx + 4 <= concat.len() {
+            let short_hash = $self.short_hash_index(&concat[current_idx..]);
+            debug_assert!(short_hash < $self.short_hash.len());
+            let slot = unsafe { *$self.short_hash.get_unchecked(short_hash) };
+            if let Some(short_cand) = unsafe {
+                $self.$probe(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    $abs_pos,
+                    current_idx,
+                    concat,
+                    $lit_len,
+                    4,
+                )
+            } {
+                best = best_len_offset_candidate(best, Some(short_cand));
+                if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
+                    return best;
+                }
+                let next_idx = current_idx + 1;
+                if best.is_none_or(|b| b.match_len < DFAST_TARGET_LEN)
+                    && next_idx + 8 <= concat.len()
+                {
+                    let next_long_hash = $self.long_hash_index(&concat[next_idx..]);
+                    debug_assert!(next_long_hash < $self.long_hash.len());
+                    let next_slot = unsafe { *$self.long_hash.get_unchecked(next_long_hash) };
+                    if let Some(retry) = unsafe {
+                        $self.$probe(
+                            next_slot,
+                            position_base,
+                            history_abs_start,
+                            $abs_pos + 1,
+                            next_idx,
+                            concat,
+                            $lit_len.saturating_add(1),
+                            8,
+                        )
+                    } && retry.match_len > short_cand.match_len
+                    {
+                        best = best_len_offset_candidate(best, Some(retry));
+                    }
+                }
+            }
+        }
+        best
+    }};
+}
+
+/// Per-kernel body of the lazy `start_matching_general` loop. `$rep` / `$hash`
+/// are the tier's `repcode_candidate_<kernel>` / `hash_candidate_<kernel>`
+/// methods; calling them from this wrapper's `#[target_feature]` umbrella
+/// inlines the whole per-position match search (repcode 3-probe + hash
+/// long/short probe + every `$cpl` scan) with NO per-position `match kernel`
+/// dispatch and NO ABI-crossing call. The kernel is resolved ONCE per block at
+/// the `start_matching_general` dispatcher, mirroring `start_matching_fast_loop`.
+/// Bookkeeping (`emit_candidate`, `insert_position`,
+/// `extend_with_repcode_after_match`, seeding) stays plain method calls — no
+/// SIMD on those paths.
+macro_rules! dfast_start_matching_general_body {
+    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident,
+     $rep:ident, $hash:ident) => {{
+        let use_adaptive_skip =
+            $self.block_looks_incompressible($current_abs_start, $current_abs_start + $current_len);
+        let mut pos = 1usize;
+        let mut literals_start = 0usize;
+        let mut skip_step = 1usize;
+        let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
+        let mut miss_run = 0usize;
+        while pos + DFAST_MIN_MATCH_LEN <= $current_len {
+            let abs_pos = $current_abs_start + pos;
+            let lit_len = pos - literals_start;
+
+            // Inlined `best_match`: repcode + hash candidate, both under this
+            // tier's umbrella so the `$cpl` scans inline.
+            let best = best_len_offset_candidate(unsafe { $self.$rep(abs_pos, lit_len) }, unsafe {
+                $self.$hash(abs_pos, lit_len)
+            });
+            // Inlined `pick_lazy_match`: the lookahead closure re-probes the
+            // same tier's repcode/hash (one umbrella-boundary hop per deferral,
+            // a cold path versus the per-position search above).
+            let picked = pick_lazy_match_shared(
+                abs_pos,
+                lit_len,
+                best,
+                LazyMatchConfig {
+                    target_len: DFAST_TARGET_LEN,
+                    min_match_len: DFAST_MIN_MATCH_LEN,
+                    lazy_depth: $self.lazy_depth,
+                    history_abs_end: $self.history_abs_end(),
+                },
+                |next_pos, next_lit_len| {
+                    best_len_offset_candidate(
+                        unsafe { $self.$rep(next_pos, next_lit_len) },
+                        unsafe { $self.$hash(next_pos, next_lit_len) },
+                    )
+                },
+            );
+            if let Some(candidate) = picked {
+                let start = $self.emit_candidate(
+                    $current_abs_start,
+                    &mut literals_start,
+                    candidate,
+                    $handle_sequence,
+                );
+                pos = start + candidate.match_len;
+                pos = $self.extend_with_repcode_after_match(
+                    $current_abs_start,
+                    $current_len,
+                    pos,
+                    &mut literals_start,
+                    $handle_sequence,
+                );
+                skip_step = 1;
+                next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
+                miss_run = 0;
+            } else {
+                $self.insert_position(abs_pos);
+                miss_run += 1;
+                let use_local_adaptive_skip = miss_run >= DFAST_LOCAL_SKIP_TRIGGER;
+                if use_adaptive_skip || use_local_adaptive_skip {
+                    let skip_cap = if use_adaptive_skip {
+                        DFAST_MAX_SKIP_STEP
+                    } else {
+                        2
+                    };
+                    if pos >= next_skip_growth_pos {
+                        skip_step = (skip_step + 1).min(skip_cap);
+                        next_skip_growth_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
+                    }
+                    pos += skip_step;
+                } else {
+                    pos += 1;
+                }
+            }
+        }
+
+        $self.seed_remaining_hashable_starts($current_abs_start, $current_len, pos);
+        $self.emit_trailing_literals(literals_start, $handle_sequence);
     }};
 }
 
@@ -723,99 +997,173 @@ impl DfastMatchGenerator {
         self.start_matching_general(current_abs_start, current_len, &mut handle_sequence);
     }
 
+    /// Dispatcher for the per-kernel lazy `start_matching_general` loop:
+    /// resolve the tier ONCE per block via `select_kernel()` and call the
+    /// matching `start_matching_general_<kernel>` wrapper, so the entire
+    /// per-position match search (repcode + hash probe + every
+    /// `common_prefix_len_ptr` scan) inlines under one `#[target_feature]`
+    /// umbrella with no per-position dispatch or ABI-crossing call. Mirrors
+    /// `start_matching_fast_loop`. The loop's safety invariants (block-local
+    /// arithmetic bounded by `current_len`; absolute-position arithmetic gated
+    /// upstream by `check_stream_abs_headroom`) are documented on the body
+    /// macro `dfast_start_matching_general_body!` callers below.
     fn start_matching_general(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
-        let use_adaptive_skip =
-            self.block_looks_incompressible(current_abs_start, current_abs_start + current_len);
-        let mut pos = 1usize;
-        let mut literals_start = 0usize;
-        let mut skip_step = 1usize;
-        let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
-        let mut miss_run = 0usize;
-        // Loop invariants:
-        //
-        // 1. Block-local arithmetic (`pos`, `skip_step`, `start +
-        //    candidate.match_len`, `DFAST_SKIP_STEP_GROWTH_INTERVAL`):
-        //    the dynamic bound is `current_len` itself — the `while
-        //    pos + DFAST_MIN_MATCH_LEN <= current_len` guard keeps
-        //    every offset within that bound regardless of how the
-        //    caller sized `max_window_size`. The general path's
-        //    `best_match` → `hash_candidate` chain uses SAFE slicing
-        //    (`data[..8].try_into()`) which panics on a short slice
-        //    rather than reading uninitialised bytes — UB-free even
-        //    when this guard lets `pos` land within 3 bytes of the
-        //    block tail. The fast loop has stricter `+ HASH_READ_SIZE`
-        //    guards because it does raw-pointer `read_unaligned` for
-        //    speed; see `start_matching_fast_loop`. In production this
-        //    also happens to be `≤ HC_BLOCKSIZE_MAX (128 KiB)` because
-        //    the frame compressor never hands out larger blocks, but
-        //    the safety argument above does not rely on that limit.
-        // 2. Absolute-position arithmetic (`current_abs_start + pos`):
-        //    `current_abs_start` is the frame-lifetime cursor and
-        //    advances with total bytes processed, NOT with the
-        //    retained window size. A long streaming encode on i686
-        //    can therefore push `current_abs_start + pos` past
-        //    `usize::MAX` even though memory usage stays bounded by
-        //    `window_size`. The runtime enforcement lives in
-        //    `DfastMatchGenerator::add_data`, which routes through
-        //    `check_stream_abs_headroom` (the same gate used by
-        //    `MatchTable::add_data`): every ingest fails fast with a
-        //    clear panic if cumulative input would push the cursor
-        //    within `STREAM_ABS_HEADROOM` (`= HC_OPT_NUM + 16`) of
-        //    `usize::MAX`. Raw `+` here is donor parity and is
-        //    correct precisely because that upstream gate runs before
-        //    this loop sees any new bytes.
-        while pos + DFAST_MIN_MATCH_LEN <= current_len {
-            let abs_pos = current_abs_start + pos;
-            let lit_len = pos - literals_start;
-
-            let best = self.best_match(abs_pos, lit_len);
-            if let Some(candidate) = self.pick_lazy_match(abs_pos, lit_len, best) {
-                let start = self.emit_candidate(
-                    current_abs_start,
-                    &mut literals_start,
-                    candidate,
-                    handle_sequence,
-                );
-                pos = start + candidate.match_len;
-                // Donor's opportunistic rep-0 extension after every emit.
-                pos = self.extend_with_repcode_after_match(
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        unsafe {
+            self.start_matching_general_neon(current_abs_start, current_len, handle_sequence)
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
+            match select_kernel() {
+                FastpathKernel::Avx2Bmi2 => unsafe {
+                    self.start_matching_general_avx2_bmi2(
+                        current_abs_start,
+                        current_len,
+                        handle_sequence,
+                    )
+                },
+                FastpathKernel::Sse42 => unsafe {
+                    self.start_matching_general_sse42(
+                        current_abs_start,
+                        current_len,
+                        handle_sequence,
+                    )
+                },
+                FastpathKernel::Scalar => self.start_matching_general_scalar(
                     current_abs_start,
                     current_len,
-                    pos,
-                    &mut literals_start,
                     handle_sequence,
-                );
-                skip_step = 1;
-                next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
-                miss_run = 0;
-            } else {
-                self.insert_position(abs_pos);
-                miss_run += 1;
-                let use_local_adaptive_skip = miss_run >= DFAST_LOCAL_SKIP_TRIGGER;
-                if use_adaptive_skip || use_local_adaptive_skip {
-                    let skip_cap = if use_adaptive_skip {
-                        DFAST_MAX_SKIP_STEP
-                    } else {
-                        2
-                    };
-                    if pos >= next_skip_growth_pos {
-                        skip_step = (skip_step + 1).min(skip_cap);
-                        next_skip_growth_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
-                    }
-                    pos += skip_step;
-                } else {
-                    pos += 1;
-                }
+                ),
             }
         }
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        unsafe {
+            self.start_matching_general_simd128(current_abs_start, current_len, handle_sequence)
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            )
+        )))]
+        {
+            self.start_matching_general_scalar(current_abs_start, current_len, handle_sequence)
+        }
+    }
 
-        self.seed_remaining_hashable_starts(current_abs_start, current_len, pos);
-        self.emit_trailing_literals(literals_start, handle_sequence);
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    unsafe fn start_matching_general_neon(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dfast_start_matching_general_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            repcode_candidate_neon,
+            hash_candidate_neon
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn start_matching_general_sse42(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dfast_start_matching_general_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            repcode_candidate_sse42,
+            hash_candidate_sse42
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    unsafe fn start_matching_general_avx2_bmi2(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dfast_start_matching_general_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            repcode_candidate_avx2_bmi2,
+            hash_candidate_avx2_bmi2
+        )
+    }
+
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    unsafe fn start_matching_general_simd128(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dfast_start_matching_general_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            repcode_candidate_simd128,
+            hash_candidate_simd128
+        )
+    }
+
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
+    #[allow(unused_unsafe)]
+    fn start_matching_general_scalar(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        dfast_start_matching_general_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            repcode_candidate_scalar,
+            hash_candidate_scalar
+        )
     }
 
     /// Single-cursor probe at the last hashable position in the
@@ -1248,149 +1596,154 @@ impl DfastMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
-    #[inline(always)]
-    pub(crate) fn best_match(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
-        let rep = self.repcode_candidate(abs_pos, lit_len);
-        let hash = self.hash_candidate(abs_pos, lit_len);
-        best_len_offset_candidate(rep, hash)
-    }
-
-    pub(crate) fn pick_lazy_match(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-        best: Option<MatchCandidate>,
-    ) -> Option<MatchCandidate> {
-        pick_lazy_match_shared(
-            abs_pos,
-            lit_len,
-            best,
-            LazyMatchConfig {
-                target_len: DFAST_TARGET_LEN,
-                min_match_len: DFAST_MIN_MATCH_LEN,
-                lazy_depth: self.lazy_depth,
-                history_abs_end: self.history_abs_end(),
-            },
-            |next_pos, next_lit_len| self.best_match(next_pos, next_lit_len),
-        )
-    }
-
-    #[inline(always)]
-    pub(crate) fn repcode_candidate(
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    unsafe fn repcode_candidate_avx2_bmi2(
         &self,
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
-        repcode_candidate_shared(
-            self.kernel,
-            self.live_history(),
-            self.history_abs_start,
-            self.offset_hist,
+        dfast_repcode_candidate_body!(
+            self,
             abs_pos,
             lit_len,
-            DFAST_MIN_MATCH_LEN,
+            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
         )
     }
 
-    #[inline(always)]
-    pub(crate) fn hash_candidate(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
-        // Hoist all the per-loop invariants out of the combinator chains.
-        // `short_candidates`/`long_candidates` each re-fetch `live_history`
-        // and recompute `idx` from scratch inside their Option/flatten/filter
-        // adapters; on a per-byte hot path (32% exclusive on default-level
-        // profile) that's measurable Option/Iterator scaffolding the
-        // compiler can't always erase.
-        let concat = self.live_history();
-        let current_idx = abs_pos - self.history_abs_start;
-        let history_abs_start = self.history_abs_start;
-        // Hoist the rebase base out of the bucket-walk loop so each
-        // slot-to-absolute conversion is a single add instead of a
-        // `&self` dereference per iteration. The base only changes
-        // via `reduce`, which is called between match-finding calls.
-        let position_base = self.position_base;
-        let mut best = None;
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn repcode_candidate_sse42(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_repcode_candidate_body!(
+            self,
+            abs_pos,
+            lit_len,
+            crate::encoding::fastpath::sse42::common_prefix_len_ptr
+        )
+    }
 
-        // Long-hash probe first (8-byte hash → longer matches more
-        // likely). Single-slot per bucket — donor parity, no chain
-        // walking. The retry policy below mirrors donor
-        // `_search_next_long`: if the long-hash misses but the
-        // short-hash hits, peek the long-hash at `abs_pos + 1` and
-        // pick the longer of the two matches.
-        let long_hit = if current_idx + 8 <= concat.len() {
-            let long_hash = self.long_hash_index(&concat[current_idx..]);
-            // SAFETY: `long_hash_index` masks to `long_hash_bits` and
-            // `long_hash.len() == 1 << long_hash_bits` (`ensure_hash_tables`).
-            debug_assert!(long_hash < self.long_hash.len());
-            let slot = unsafe { *self.long_hash.get_unchecked(long_hash) };
-            self.probe_slot_match(
-                slot,
-                position_base,
-                history_abs_start,
-                abs_pos,
-                current_idx,
-                concat,
-                lit_len,
-                8, // long-hash equality gate
-            )
-        } else {
-            None
-        };
-        if let Some(cand) = long_hit {
-            best = best_len_offset_candidate(best, Some(cand));
-            if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
-                return best;
-            }
-        }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    unsafe fn repcode_candidate_neon(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_repcode_candidate_body!(
+            self,
+            abs_pos,
+            lit_len,
+            crate::encoding::fastpath::neon::common_prefix_len_ptr
+        )
+    }
 
-        if current_idx + 4 <= concat.len() {
-            let short_hash = self.short_hash_index(&concat[current_idx..]);
-            debug_assert!(short_hash < self.short_hash.len());
-            let slot = unsafe { *self.short_hash.get_unchecked(short_hash) };
-            if let Some(short_cand) = self.probe_slot_match(
-                slot,
-                position_base,
-                history_abs_start,
-                abs_pos,
-                current_idx,
-                concat,
-                lit_len,
-                4, // short-hash equality gate
-            ) {
-                best = best_len_offset_candidate(best, Some(short_cand));
-                if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
-                    return best;
-                }
-                // Donor `_search_next_long` retry: short hit landed but
-                // a long hit at `abs_pos + 1` could be even longer. The
-                // donor inner loop precomputes `hashLong[hl1]` for
-                // exactly this case (line 213 in `zstd_double_fast.c`);
-                // we lift it inline here so the single-slot table
-                // retains the compression-quality donor gets from its
-                // overlapping probe pattern.
-                let next_idx = current_idx + 1;
-                if best.is_none_or(|b| b.match_len < DFAST_TARGET_LEN)
-                    && next_idx + 8 <= concat.len()
-                {
-                    let next_long_hash = self.long_hash_index(&concat[next_idx..]);
-                    debug_assert!(next_long_hash < self.long_hash.len());
-                    let next_slot = unsafe { *self.long_hash.get_unchecked(next_long_hash) };
-                    if let Some(retry) = self.probe_slot_match(
-                        next_slot,
-                        position_base,
-                        history_abs_start,
-                        abs_pos + 1,
-                        next_idx,
-                        concat,
-                        lit_len.saturating_add(1),
-                        8, // long-hash equality gate, `_search_next_long` retry
-                    ) && retry.match_len > short_cand.match_len
-                    {
-                        best = best_len_offset_candidate(best, Some(retry));
-                    }
-                }
-            }
-        }
-        best
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    unsafe fn repcode_candidate_simd128(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_repcode_candidate_body!(
+            self,
+            abs_pos,
+            lit_len,
+            crate::encoding::fastpath::simd128::common_prefix_len_ptr
+        )
+    }
+
+    // Scalar tier: no target feature, so `unsafe` here is only the inner SIMD-
+    // free `$cpl` (scalar `common_prefix_len_ptr`); the `unsafe fn` keeps a
+    // uniform call shape across tiers for the `start_matching_general` body.
+    // Gated like `start_matching_general_scalar` (its only caller): on aarch64
+    // the lazy loop always dispatches to the neon tier, and on wasm+simd128 to
+    // the simd128 tier, so the scalar candidates would be dead there.
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
+    #[allow(unused_unsafe)]
+    unsafe fn repcode_candidate_scalar(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_repcode_candidate_body!(
+            self,
+            abs_pos,
+            lit_len,
+            crate::encoding::fastpath::scalar::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    unsafe fn hash_candidate_avx2_bmi2(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_avx2_bmi2)
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    unsafe fn hash_candidate_sse42(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_sse42)
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    unsafe fn hash_candidate_neon(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
+        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_neon)
+    }
+
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    unsafe fn hash_candidate_simd128(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_simd128)
+    }
+
+    // Gated like `repcode_candidate_scalar` — see that fn's note.
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
+    #[allow(unused_unsafe)]
+    unsafe fn hash_candidate_scalar(
+        &self,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_scalar)
     }
 
     /// Resolve a single packed-slot value against the live history and
@@ -1400,95 +1753,6 @@ impl DfastMatchGenerator {
     /// primary probe, the short-hash primary probe, and the
     /// `_search_next_long` retry — keeps the bounds-checking logic in
     /// one place so the three call sites can't drift.
-    #[inline(always)]
-    #[allow(clippy::too_many_arguments)]
-    fn probe_slot_match(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        // Dispatch on the cached kernel to the matching `#[target_feature]`
-        // variant so the forward match-length scan inlines under that umbrella.
-        // The previous `common_prefix_len_with_kernel` call crossed the
-        // target_feature ABI boundary and left the SIMD body as a non-inlinable
-        // call (`#[inline]` cannot cross it); the probe-width gate / bounds
-        // checks are scalar and identical across tiers.
-        match self.kernel {
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            FastpathKernel::Avx2Bmi2 => unsafe {
-                self.probe_slot_match_avx2_bmi2(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    abs_pos,
-                    current_idx,
-                    concat,
-                    lit_len,
-                    gate_len,
-                )
-            },
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            FastpathKernel::Sse42 => unsafe {
-                self.probe_slot_match_sse42(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    abs_pos,
-                    current_idx,
-                    concat,
-                    lit_len,
-                    gate_len,
-                )
-            },
-            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-            FastpathKernel::Neon => unsafe {
-                self.probe_slot_match_neon(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    abs_pos,
-                    current_idx,
-                    concat,
-                    lit_len,
-                    gate_len,
-                )
-            },
-            #[cfg(all(
-                target_arch = "wasm32",
-                target_feature = "simd128",
-                feature = "kernel_simd128"
-            ))]
-            FastpathKernel::Simd128 => unsafe {
-                self.probe_slot_match_simd128(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    abs_pos,
-                    current_idx,
-                    concat,
-                    lit_len,
-                    gate_len,
-                )
-            },
-            FastpathKernel::Scalar => self.probe_slot_match_scalar(
-                slot,
-                position_base,
-                history_abs_start,
-                abs_pos,
-                current_idx,
-                concat,
-                lit_len,
-                gate_len,
-            ),
-        }
-    }
-
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
     #[allow(clippy::too_many_arguments)]
@@ -1605,6 +1869,17 @@ impl DfastMatchGenerator {
         )
     }
 
+    // Only `hash_candidate_scalar` calls this, and that wrapper is gated out on
+    // aarch64 (neon tier) and wasm+simd128 (simd128 tier), so the scalar probe
+    // would be dead there too.
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
     #[allow(clippy::too_many_arguments)]
     fn probe_slot_match_scalar(
         &self,

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -163,9 +163,23 @@ macro_rules! dfast_probe_slot_match_body {
         if candidate_idx + $gate_len > $concat.len() || $current_idx + $gate_len > $concat.len() {
             return None;
         }
-        if $concat[candidate_idx..candidate_idx + $gate_len]
-            != $concat[$current_idx..$current_idx + $gate_len]
-        {
+        // Fixed-width equality gate. `$gate_len` is 4 (short hash) or 8 (long
+        // hash / `_search_next_long` retry); a slice `!=` here lowers to a libc
+        // `__memcmp` CALL (~14% self-time on the dfast L4 profile) instead of a
+        // single load + compare. Read the gate as one unaligned u32/u64 — the
+        // bounds were verified just above (`candidate_idx + $gate_len <= len`
+        // and `$current_idx + $gate_len <= len`).
+        debug_assert!($gate_len == 4 || $gate_len == 8);
+        let gate_eq = unsafe {
+            let cand = $concat.as_ptr().add(candidate_idx);
+            let cur = $concat.as_ptr().add($current_idx);
+            if $gate_len == 8 {
+                cand.cast::<u64>().read_unaligned() == cur.cast::<u64>().read_unaligned()
+            } else {
+                cand.cast::<u32>().read_unaligned() == cur.cast::<u32>().read_unaligned()
+            }
+        };
+        if !gate_eq {
             return None;
         }
         let a = &$concat[candidate_idx..];
@@ -1408,8 +1422,16 @@ impl DfastMatchGenerator {
             if cur_idx + DFAST_REP_MIN_MATCH_LEN > concat.len() {
                 break;
             }
-            // Cheap 4-byte gate before the SIMD `common_prefix_len`.
-            if concat[cur_idx..cur_idx + 4] != concat[cand_idx..cand_idx + 4] {
+            // Cheap 4-byte gate before the SIMD `common_prefix_len`. Read it as
+            // one unaligned u32 rather than a slice `!=` (which lowers to a libc
+            // `memcmp` CALL). Bounds: `cur_idx + 4 <= len` from the
+            // `DFAST_REP_MIN_MATCH_LEN` (= 4) check above, and
+            // `cand_idx = cur_idx - rep < cur_idx` so `cand_idx + 4 <= len` too.
+            let gate_eq = unsafe {
+                concat.as_ptr().add(cur_idx).cast::<u32>().read_unaligned()
+                    == concat.as_ptr().add(cand_idx).cast::<u32>().read_unaligned()
+            };
+            if !gate_eq {
                 break;
             }
             let match_len =

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -143,6 +143,46 @@ pub(crate) struct DfastDictTables {
     pub(crate) short: alloc::vec::Vec<u32>,
 }
 
+/// Per-kernel body of [`DfastMatchGenerator::probe_slot_match`]. The wrapper
+/// carries the `#[target_feature]` umbrella and passes its tier's
+/// `common_prefix_len_ptr` as `$cpl`, so the forward match-length scan inlines
+/// under that umbrella instead of crossing the target_feature ABI boundary as
+/// a non-inlinable call (`#[inline]` cannot cross it). Mirrors
+/// `start_matching_fast_loop_body!`.
+macro_rules! dfast_probe_slot_match_body {
+    ($self:ident, $slot:ident, $position_base:ident, $history_abs_start:ident,
+     $abs_pos:ident, $current_idx:ident, $concat:ident, $lit_len:ident,
+     $gate_len:ident, $cpl:path) => {{
+        if $slot == DFAST_EMPTY_SLOT {
+            return None;
+        }
+        let candidate_pos = $position_base + ($slot as usize) - 1;
+        if candidate_pos < $history_abs_start || candidate_pos >= $abs_pos {
+            return None;
+        }
+        let candidate_idx = candidate_pos - $history_abs_start;
+        if candidate_idx + $gate_len > $concat.len() || $current_idx + $gate_len > $concat.len() {
+            return None;
+        }
+        if $concat[candidate_idx..candidate_idx + $gate_len]
+            != $concat[$current_idx..$current_idx + $gate_len]
+        {
+            return None;
+        }
+        let a = &$concat[candidate_idx..];
+        let b = &$concat[$current_idx..];
+        let max = a.len().min(b.len());
+        // SAFETY: `a` / `b` each have at least `len()` initialized bytes; `max`
+        // is the minimum, so both pointers are valid for `max` bytes. `$cpl` is
+        // the current tier's kernel, whose target feature this wrapper enables.
+        let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
+        if match_len < DFAST_MIN_MATCH_LEN {
+            return None;
+        }
+        Some($self.extend_backwards(candidate_pos, $abs_pos, match_len, $lit_len))
+    }};
+}
+
 impl DfastMatchGenerator {
     // Keep a short dense tail at block boundaries for two related reasons:
     // 1) insert_position() needs short (4-byte) and long (8-byte) lookahead,
@@ -1373,41 +1413,222 @@ impl DfastMatchGenerator {
         lit_len: usize,
         gate_len: usize,
     ) -> Option<MatchCandidate> {
-        if slot == DFAST_EMPTY_SLOT {
-            return None;
+        // Dispatch on the cached kernel to the matching `#[target_feature]`
+        // variant so the forward match-length scan inlines under that umbrella.
+        // The previous `common_prefix_len_with_kernel` call crossed the
+        // target_feature ABI boundary and left the SIMD body as a non-inlinable
+        // call (`#[inline]` cannot cross it); the probe-width gate / bounds
+        // checks are scalar and identical across tiers.
+        match self.kernel {
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            FastpathKernel::Avx2Bmi2 => unsafe {
+                self.probe_slot_match_avx2_bmi2(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    abs_pos,
+                    current_idx,
+                    concat,
+                    lit_len,
+                    gate_len,
+                )
+            },
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            FastpathKernel::Sse42 => unsafe {
+                self.probe_slot_match_sse42(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    abs_pos,
+                    current_idx,
+                    concat,
+                    lit_len,
+                    gate_len,
+                )
+            },
+            #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+            FastpathKernel::Neon => unsafe {
+                self.probe_slot_match_neon(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    abs_pos,
+                    current_idx,
+                    concat,
+                    lit_len,
+                    gate_len,
+                )
+            },
+            #[cfg(all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ))]
+            FastpathKernel::Simd128 => unsafe {
+                self.probe_slot_match_simd128(
+                    slot,
+                    position_base,
+                    history_abs_start,
+                    abs_pos,
+                    current_idx,
+                    concat,
+                    lit_len,
+                    gate_len,
+                )
+            },
+            FastpathKernel::Scalar => self.probe_slot_match_scalar(
+                slot,
+                position_base,
+                history_abs_start,
+                abs_pos,
+                current_idx,
+                concat,
+                lit_len,
+                gate_len,
+            ),
         }
-        let candidate_pos = position_base + (slot as usize) - 1;
-        if candidate_pos < history_abs_start || candidate_pos >= abs_pos {
-            return None;
-        }
-        let candidate_idx = candidate_pos - history_abs_start;
-        // Probe-width equality gate before the SIMD walk. The long-hash
-        // callers pass `gate_len = 8` (matches an `MEM_read64`-style
-        // probe in the upstream reference); the short-hash caller
-        // passes `gate_len = 4` (`MEM_read32`-style). A 1-byte
-        // precheck would accept hash collisions whose actual common
-        // prefix runs from 1 byte up to less than the probe width,
-        // paying the full `common_prefix_len` walk for them on every
-        // iteration. The wider gate rejects those collisions early
-        // and matches what the upstream `_search_next_long` path does
-        // after a hit.
-        if candidate_idx + gate_len > concat.len() || current_idx + gate_len > concat.len() {
-            return None;
-        }
-        if concat[candidate_idx..candidate_idx + gate_len]
-            != concat[current_idx..current_idx + gate_len]
-        {
-            return None;
-        }
-        let match_len = common_prefix_len_with_kernel(
-            self.kernel,
-            &concat[candidate_idx..],
-            &concat[current_idx..],
-        );
-        if match_len < DFAST_MIN_MATCH_LEN {
-            return None;
-        }
-        Some(self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len))
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn probe_slot_match_avx2_bmi2(
+        &self,
+        slot: u32,
+        position_base: usize,
+        history_abs_start: usize,
+        abs_pos: usize,
+        current_idx: usize,
+        concat: &[u8],
+        lit_len: usize,
+        gate_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_probe_slot_match_body!(
+            self,
+            slot,
+            position_base,
+            history_abs_start,
+            abs_pos,
+            current_idx,
+            concat,
+            lit_len,
+            gate_len,
+            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn probe_slot_match_sse42(
+        &self,
+        slot: u32,
+        position_base: usize,
+        history_abs_start: usize,
+        abs_pos: usize,
+        current_idx: usize,
+        concat: &[u8],
+        lit_len: usize,
+        gate_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_probe_slot_match_body!(
+            self,
+            slot,
+            position_base,
+            history_abs_start,
+            abs_pos,
+            current_idx,
+            concat,
+            lit_len,
+            gate_len,
+            crate::encoding::fastpath::sse42::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn probe_slot_match_neon(
+        &self,
+        slot: u32,
+        position_base: usize,
+        history_abs_start: usize,
+        abs_pos: usize,
+        current_idx: usize,
+        concat: &[u8],
+        lit_len: usize,
+        gate_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_probe_slot_match_body!(
+            self,
+            slot,
+            position_base,
+            history_abs_start,
+            abs_pos,
+            current_idx,
+            concat,
+            lit_len,
+            gate_len,
+            crate::encoding::fastpath::neon::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn probe_slot_match_simd128(
+        &self,
+        slot: u32,
+        position_base: usize,
+        history_abs_start: usize,
+        abs_pos: usize,
+        current_idx: usize,
+        concat: &[u8],
+        lit_len: usize,
+        gate_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_probe_slot_match_body!(
+            self,
+            slot,
+            position_base,
+            history_abs_start,
+            abs_pos,
+            current_idx,
+            concat,
+            lit_len,
+            gate_len,
+            crate::encoding::fastpath::simd128::common_prefix_len_ptr
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn probe_slot_match_scalar(
+        &self,
+        slot: u32,
+        position_base: usize,
+        history_abs_start: usize,
+        abs_pos: usize,
+        current_idx: usize,
+        concat: &[u8],
+        lit_len: usize,
+        gate_len: usize,
+    ) -> Option<MatchCandidate> {
+        dfast_probe_slot_match_body!(
+            self,
+            slot,
+            position_base,
+            history_abs_start,
+            abs_pos,
+            current_idx,
+            concat,
+            lit_len,
+            gate_len,
+            crate::encoding::fastpath::scalar::common_prefix_len_ptr
+        )
     }
 
     #[inline(always)]
@@ -2438,10 +2659,23 @@ impl DfastMatchGenerator {
                 ),
             }
         }
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        unsafe {
+            self.start_matching_fast_loop_simd128(current_abs_start, current_len, handle_sequence)
+        }
         #[cfg(not(any(
             all(target_arch = "aarch64", target_endian = "little"),
             target_arch = "x86",
-            target_arch = "x86_64"
+            target_arch = "x86_64",
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            )
         )))]
         {
             self.start_matching_fast_loop_scalar(current_abs_start, current_len, handle_sequence)
@@ -2499,7 +2733,35 @@ impl DfastMatchGenerator {
         )
     }
 
-    #[cfg(not(all(target_arch = "aarch64", target_endian = "little")))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    unsafe fn start_matching_fast_loop_simd128(
+        &mut self,
+        current_abs_start: usize,
+        current_len: usize,
+        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        start_matching_fast_loop_body!(
+            self,
+            current_abs_start,
+            current_len,
+            handle_sequence,
+            crate::encoding::fastpath::simd128::common_prefix_len_ptr
+        )
+    }
+
+    #[cfg(not(any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
     #[allow(unused_unsafe)]
     fn start_matching_fast_loop_scalar(
         &mut self,

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -992,8 +992,9 @@ impl DfastMatchGenerator {
             unsafe {
                 let load_ptr = base.add(history_start + pos);
                 let v8 = (load_ptr as *const u64).read_unaligned();
-                let v4 = v8 & 0xFFFF_FFFF;
-                let short_idx = (v4.wrapping_mul(PRIME) >> short_shift) as usize;
+                // Donor 5-byte short hash (ZSTD_hash5 shape): low 5 bytes in
+                // the high 40 bits (`v8 << 24`), matching `short_hash_index`.
+                let short_idx = ((v8 << 24).wrapping_mul(PRIME) >> short_shift) as usize;
                 let long_idx = (v8.wrapping_mul(PRIME) >> long_shift) as usize;
                 let packed = (pos as u32) + 1;
                 *short_ptr.add(short_idx) = packed;
@@ -1246,9 +1247,11 @@ impl DfastMatchGenerator {
             (history_base_ptr.add(history_start_offset + concat_idx0) as *const u64)
                 .read_unaligned()
         };
+        // `v4_0` (low 4 bytes) is the 4-byte equality-gate key below; the short
+        // HASH keys on the donor 5-byte window (`v8_0 << 24`, ZSTD_hash5 shape).
         let v4_0 = v8_0 & 0xFFFF_FFFF;
         let hl0_idx = (v8_0.wrapping_mul(PRIME) >> long_shift) as usize;
-        let hs0_idx = (v4_0.wrapping_mul(PRIME) >> short_shift) as usize;
+        let hs0_idx = ((v8_0 << 24).wrapping_mul(PRIME) >> short_shift) as usize;
 
         // Read-only on the hash tables here — unlike the inner loop's
         // "update-before-check" pattern, the writes at `hl0_idx` /
@@ -2026,12 +2029,12 @@ impl DfastMatchGenerator {
                 let packed = ((pos - position_base) as u32) + 1;
                 let load_ptr = history_base_ptr.add(history_start + idx);
                 let v8 = (load_ptr as *const u64).read_unaligned();
-                let v4 = v8 & 0xFFFF_FFFF;
                 // Donor parity (`zstd_compress_internal.h:923-924`):
                 // scalar `* prime8bytes` then shift to high bits. Drops
                 // the CRC32d-based kernel dispatch (3-4 instructions) for
-                // a single mul on the per-byte insert path.
-                let mixed_short = v4.wrapping_mul(0xCF1BBCDCB7A56463_u64);
+                // a single mul on the per-byte insert path. Short hash keys
+                // on the donor 5-byte window (`v8 << 24`, ZSTD_hash5 shape).
+                let mixed_short = (v8 << 24).wrapping_mul(0xCF1BBCDCB7A56463_u64);
                 let mixed_long = v8.wrapping_mul(0xCF1BBCDCB7A56463_u64);
                 let short_idx = (mixed_short >> short_shift) as usize;
                 let long_idx = (mixed_long >> long_shift) as usize;
@@ -2130,7 +2133,18 @@ impl DfastMatchGenerator {
 
     #[inline(always)]
     pub(crate) fn short_hash_index(&self, data: &[u8]) -> usize {
-        let value = u32::from_le_bytes(data[..4].try_into().unwrap()) as u64;
+        // Donor `ZSTD_dfast` keys the short table on a 5-byte hash
+        // (`ZSTD_hashPtr(ip, hBitsS, mls)` with `mls = cParams.minMatch = 5`
+        // for L3/L4), NOT 4 bytes. A 4-byte key collides more on
+        // repetitive/log-stream data, so the single-slot table overwrites
+        // useful positions the donor's 5-byte key keeps. Mirror the donor:
+        // take the low 5 bytes (shifted high like `ZSTD_hash5`) into the
+        // shared multiply-shift mixer. `min(5)` keeps short tail slices
+        // panic-free (zero-padded) without a per-call-site bound change.
+        let mut buf = [0u8; 8];
+        let n = data.len().min(5);
+        buf[..n].copy_from_slice(&data[..n]);
+        let value = u64::from_le_bytes(buf) << 24;
         self.hash_index_with_bits(value, self.short_hash_bits)
     }
 
@@ -2449,8 +2463,11 @@ macro_rules! start_matching_fast_loop_body {
                     (history_base_ptr.add(history_start_offset + concat_idx0) as *const u64)
                         .read_unaligned()
                 };
+                // `v4_0` (low 4 bytes) is the cheap 4-byte equality-gate key
+                // below; the short HASH keys on the donor 5-byte window
+                // (`v8_0 << 24`, ZSTD_hash5 shape) to match `short_hash_index`.
                 let v4_0 = v8_0 & 0xFFFF_FFFF;
-                let hs0_idx = (v4_0.wrapping_mul(PRIME) >> short_shift) as usize;
+                let hs0_idx = ((v8_0 << 24).wrapping_mul(PRIME) >> short_shift) as usize;
                 let idxs0 = unsafe { *short_hash_ptr.add(hs0_idx) };
 
                 // Donor parity (`zstd_double_fast.c:187`): update BOTH

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -602,8 +602,10 @@ impl DfastMatchGenerator {
         let long_ptr = dict.long.as_mut_ptr();
         let short_ptr = dict.short.as_mut_ptr();
         // SAFETY: `base.add(history_start + pos)` is in-bounds for
-        // `pos + 8 <= concat_len` (long) / `pos + 4 <= concat_len` (short),
-        // enforced by the `*_safe_end` cutoffs. `*_idx = mixed >> (64 - bits)`
+        // `pos + 8 <= concat_len` (long) / `pos + 5 <= concat_len` (short, the
+        // donor 5-byte key), enforced by the `*_safe_end` cutoffs (the short
+        // loop reads a 4-byte word + 1 byte, never past `concat_len`).
+        // `*_idx = mixed >> (64 - bits)`
         // has at most `bits` bits set, in-bounds for the `1 << bits` tables.
         // `pos + 1` fits u32: concat indices are bounded by the u32 history
         // gate upstream (`check_stream_abs_headroom`).

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -583,7 +583,13 @@ impl DfastMatchGenerator {
         // bytes, short needs 5 (donor `mls = 5` for the short hash).
         let long_safe_end = concat_len.saturating_sub(7).min(end_concat);
         let short_safe_end = concat_len.saturating_sub(4).min(end_concat);
-        if start_concat >= short_safe_end {
+        // The seam window `[backfill_floor, start_concat)` holds positions that
+        // only became hashable when THIS chunk extended history (e.g. a `4+1`
+        // or `7+1` dict chunking), so gate the early return on `backfill_floor`,
+        // not `start_concat` — otherwise those seam inserts are dropped and the
+        // attached dict tables stay incomplete.
+        let backfill_floor = start_concat.saturating_sub(Self::BOUNDARY_DENSE_TAIL_LEN);
+        if backfill_floor >= short_safe_end {
             return;
         }
         let dict = self.dict.table_mut_or_init(|| DfastDictTables {
@@ -612,7 +618,6 @@ impl DfastMatchGenerator {
         // concat index, and the seam window `[start_concat - tail, start_concat)`
         // is clamped at 0 because there are no dict bytes before the front.
         // The first chunk (`start_concat == 0`) clamps to 0 → no seam, no-op.
-        let backfill_floor = start_concat.saturating_sub(Self::BOUNDARY_DENSE_TAIL_LEN);
         let mut pos = backfill_floor;
         while pos < long_safe_end {
             unsafe {
@@ -2120,8 +2125,11 @@ impl DfastMatchGenerator {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            // Use the matcher-level cached kernel (resolved once in `new()`),
+            // not a per-block `select_kernel()` — the cache only helps if the
+            // hot path actually reads it. Mirrors the Row backend.
+            match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.start_matching_fast_loop_avx2_bmi2(
                         current_abs_start,

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1265,7 +1265,11 @@ impl DfastMatchGenerator {
         // hash position and relies on the dense `_search_next_long`
         // retry in `hash_candidate` (via `best_match`) to preserve
         // compression ratio.
-        if idx + 4 <= concat_len {
+        // Short key needs 5 readable bytes (donor `mls = 5`). A position
+        // within 4 bytes of the current history end is not inserted here; the
+        // `start_matching` seam re-seed picks it up once the next block extends
+        // history far enough to form its full 5-byte key.
+        if idx + 5 <= concat_len {
             let concat = &self.history[self.history_start..];
             let short = self.short_hash_index(&concat[idx..]);
             debug_assert!(short < self.short_hash.len());
@@ -1280,20 +1284,20 @@ impl DfastMatchGenerator {
         }
     }
 
+    /// 5-byte short-hash index (donor `ZSTD_hashPtr(ip, hBitsS, mls=5)`). A
+    /// 4-byte key collides more on repetitive / log-stream data, so the
+    /// single-slot table overwrites useful positions the donor's 5-byte key
+    /// keeps. `data` MUST hold at least 5 bytes — every call site gates on a
+    /// 5-byte lookahead, so no zero-padded synthetic key is ever formed (a
+    /// padded short key would populate buckets for starts the donor skips).
     #[inline(always)]
     pub(crate) fn short_hash_index(&self, data: &[u8]) -> usize {
-        // Donor `ZSTD_dfast` keys the short table on a 5-byte hash
-        // (`ZSTD_hashPtr(ip, hBitsS, mls)` with `mls = cParams.minMatch = 5`
-        // for L3/L4), NOT 4 bytes. A 4-byte key collides more on
-        // repetitive/log-stream data, so the single-slot table overwrites
-        // useful positions the donor's 5-byte key keeps. Mirror the donor:
-        // take the low 5 bytes (shifted high like `ZSTD_hash5`) into the
-        // shared multiply-shift mixer. `min(5)` keeps short tail slices
-        // panic-free (zero-padded) without a per-call-site bound change.
-        let mut buf = [0u8; 8];
-        let n = data.len().min(5);
-        buf[..n].copy_from_slice(&data[..n]);
-        let value = u64::from_le_bytes(buf) << 24;
+        debug_assert!(data.len() >= 5, "short hash needs a full 5-byte key");
+        // Low 5 bytes (ZSTD_hash5 shape) shifted into bits 24..63, matching the
+        // raw `v8 << 24` form used by the fast-loop probe / insert sites.
+        let lo4 = u32::from_le_bytes(data[..4].try_into().unwrap()) as u64;
+        let b5 = data[4] as u64;
+        let value = (lo4 | (b5 << 32)) << 24;
         self.hash_index_with_bits(value, self.short_hash_bits)
     }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -17,6 +17,7 @@ use core::convert::TryInto;
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
 use super::dict_attach::DictAttach;
+use super::fastpath::{FastpathKernel, select_kernel};
 use super::incompressible::block_looks_incompressible;
 use super::match_generator::{
     DFAST_EMPTY_SLOT, DFAST_HASH_BITS, DFAST_INCOMPRESSIBLE_SKIP_STEP, DFAST_LOCAL_SKIP_TRIGGER,
@@ -24,8 +25,8 @@ use super::match_generator::{
     DFAST_SHORT_HASH_LOOKAHEAD, DFAST_SKIP_STEP_GROWTH_INTERVAL, DFAST_TARGET_LEN, MIN_WINDOW_LOG,
 };
 use super::match_table::helpers::{
-    LazyMatchConfig, best_len_offset_candidate, common_prefix_len, extend_backwards_shared,
-    pick_lazy_match_shared, repcode_candidate_shared,
+    LazyMatchConfig, best_len_offset_candidate, common_prefix_len_with_kernel,
+    extend_backwards_shared, pick_lazy_match_shared, repcode_candidate_shared,
 };
 use super::match_table::storage::{REBASE_RESET_FLOOR_CEILING, check_stream_abs_headroom};
 use super::opt::types::MatchCandidate;
@@ -124,6 +125,10 @@ pub(crate) struct DfastMatchGenerator {
     /// `is_attached()` activates the dual-probe kernel; `region_len()` is the
     /// dict/input boundary (`dict_end`, a concat index).
     pub(crate) dict: DictAttach<DfastDictTables>,
+    /// CPU kernel for the `common_prefix_len` / repcode byte-compares,
+    /// resolved once at construction so the per-byte match-finder scans skip
+    /// the `select_kernel()` `OnceLock` atomic on every call.
+    pub(crate) kernel: FastpathKernel,
 }
 
 /// The dfast backend's immutable dictionary tables — a long+short pair mirroring
@@ -164,6 +169,7 @@ impl DfastMatchGenerator {
             use_fast_loop: false,
             lazy_depth: 1,
             dict: DictAttach::new(),
+            kernel: select_kernel(),
         }
     }
 
@@ -1001,7 +1007,8 @@ impl DfastMatchGenerator {
             if concat[cur_idx..cur_idx + 4] != concat[cand_idx..cand_idx + 4] {
                 break;
             }
-            let match_len = common_prefix_len(&concat[cand_idx..], &concat[cur_idx..]);
+            let match_len =
+                common_prefix_len_with_kernel(self.kernel, &concat[cand_idx..], &concat[cur_idx..]);
             if match_len < DFAST_REP_MIN_MATCH_LEN {
                 break;
             }
@@ -1235,6 +1242,7 @@ impl DfastMatchGenerator {
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         repcode_candidate_shared(
+            self.kernel,
             self.live_history(),
             self.history_abs_start,
             self.offset_hist,
@@ -1391,7 +1399,11 @@ impl DfastMatchGenerator {
         {
             return None;
         }
-        let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
+        let match_len = common_prefix_len_with_kernel(
+            self.kernel,
+            &concat[candidate_idx..],
+            &concat[current_idx..],
+        );
         if match_len < DFAST_MIN_MATCH_LEN {
             return None;
         }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -20,13 +20,11 @@ use super::dict_attach::DictAttach;
 use super::fastpath::{FastpathKernel, select_kernel};
 use super::incompressible::block_looks_incompressible;
 use super::match_generator::{
-    DFAST_EMPTY_SLOT, DFAST_HASH_BITS, DFAST_INCOMPRESSIBLE_SKIP_STEP, DFAST_LOCAL_SKIP_TRIGGER,
-    DFAST_MAX_SKIP_STEP, DFAST_MIN_MATCH_LEN, DFAST_REBASE_GUARD_BAND, DFAST_SHORT_HASH_BITS_DELTA,
-    DFAST_SHORT_HASH_LOOKAHEAD, DFAST_SKIP_STEP_GROWTH_INTERVAL, DFAST_TARGET_LEN, MIN_WINDOW_LOG,
+    DFAST_EMPTY_SLOT, DFAST_HASH_BITS, DFAST_INCOMPRESSIBLE_SKIP_STEP, DFAST_MAX_SKIP_STEP,
+    DFAST_MIN_MATCH_LEN, DFAST_REBASE_GUARD_BAND, DFAST_SHORT_HASH_BITS_DELTA,
+    DFAST_SHORT_HASH_LOOKAHEAD, DFAST_SKIP_STEP_GROWTH_INTERVAL, MIN_WINDOW_LOG,
 };
-use super::match_table::helpers::{
-    best_len_offset_candidate, common_prefix_len_with_kernel, extend_backwards_shared,
-};
+use super::match_table::helpers::{common_prefix_len_with_kernel, extend_backwards_shared};
 use super::match_table::storage::{REBASE_RESET_FLOOR_CEILING, check_stream_abs_headroom};
 use super::opt::types::MatchCandidate;
 
@@ -107,9 +105,6 @@ pub(crate) struct DfastMatchGenerator {
     /// frequently than the 8-byte long hash on average, so the
     /// smaller bucket count is the donor-correct sizing.
     pub(crate) short_hash_bits: usize,
-    pub(crate) use_fast_loop: bool,
-    // Lazy match lookahead depth (internal tuning parameter).
-    pub(crate) lazy_depth: u8,
     /// Immutable dictionary long+short hash tables (donor `dictMatchState`)
     /// plus the CDict cache lifecycle, via the shared [`DictAttach`] level-1
     /// scaffolding. Built once over the dictionary region at the front of the
@@ -142,352 +137,6 @@ pub(crate) struct DfastDictTables {
     pub(crate) short: alloc::vec::Vec<u32>,
 }
 
-/// Per-kernel body of [`DfastMatchGenerator::probe_slot_match`]. The wrapper
-/// carries the `#[target_feature]` umbrella and passes its tier's
-/// `common_prefix_len_ptr` as `$cpl`, so the forward match-length scan inlines
-/// under that umbrella instead of crossing the target_feature ABI boundary as
-/// a non-inlinable call (`#[inline]` cannot cross it). Mirrors
-/// `start_matching_fast_loop_body!`.
-macro_rules! dfast_probe_slot_match_body {
-    ($self:ident, $slot:ident, $position_base:ident, $history_abs_start:ident,
-     $abs_pos:ident, $current_idx:ident, $concat:ident, $lit_len:ident,
-     $gate_len:ident, $cpl:path) => {{
-        if $slot == DFAST_EMPTY_SLOT {
-            return None;
-        }
-        let candidate_pos = $position_base + ($slot as usize) - 1;
-        if candidate_pos < $history_abs_start || candidate_pos >= $abs_pos {
-            return None;
-        }
-        let candidate_idx = candidate_pos - $history_abs_start;
-        if candidate_idx + $gate_len > $concat.len() || $current_idx + $gate_len > $concat.len() {
-            return None;
-        }
-        // Fixed-width equality gate. `$gate_len` is 4 (short hash) or 8 (long
-        // hash / `_search_next_long` retry); a slice `!=` here lowers to a libc
-        // `__memcmp` CALL (~14% self-time on the dfast L4 profile) instead of a
-        // single load + compare. Read the gate as one unaligned u32/u64 — the
-        // bounds were verified just above (`candidate_idx + $gate_len <= len`
-        // and `$current_idx + $gate_len <= len`).
-        debug_assert!($gate_len == 4 || $gate_len == 8);
-        let gate_eq = unsafe {
-            let cand = $concat.as_ptr().add(candidate_idx);
-            let cur = $concat.as_ptr().add($current_idx);
-            if $gate_len == 8 {
-                cand.cast::<u64>().read_unaligned() == cur.cast::<u64>().read_unaligned()
-            } else {
-                cand.cast::<u32>().read_unaligned() == cur.cast::<u32>().read_unaligned()
-            }
-        };
-        if !gate_eq {
-            return None;
-        }
-        let a = &$concat[candidate_idx..];
-        let b = &$concat[$current_idx..];
-        let max = a.len().min(b.len());
-        // SAFETY: `a` / `b` each have at least `len()` initialized bytes; `max`
-        // is the minimum, so both pointers are valid for `max` bytes. `$cpl` is
-        // the current tier's kernel, whose target feature this wrapper enables.
-        let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
-        if match_len < DFAST_MIN_MATCH_LEN {
-            return None;
-        }
-        Some($self.extend_backwards(candidate_pos, $abs_pos, match_len, $lit_len))
-    }};
-}
-
-/// Per-kernel body of [`DfastMatchGenerator::repcode_candidate`]. Mirrors
-/// `repcode_candidate_shared` but with the tier's `common_prefix_len_ptr`
-/// (`$cpl`) inlined directly on raw pointers (no `match kernel` dispatch, no
-/// ABI-crossing call), so the 3-rep probe runs straight-line under the
-/// wrapper's `#[target_feature]` umbrella. The 3 probes are hand-unrolled (not
-/// a nested `macro_rules!`) because macro hygiene forbids referencing the outer
-/// macro's `$cpl` metavar from a nested macro body.
-macro_rules! dfast_repcode_candidate_body {
-    ($self:ident, $abs_pos:ident, $lit_len:ident, $cpl:path) => {{
-        let concat = $self.live_history();
-        let history_abs_start = $self.history_abs_start;
-        let offset_hist = $self.offset_hist;
-        let current_idx = $abs_pos - history_abs_start;
-        if current_idx + DFAST_MIN_MATCH_LEN > concat.len() {
-            return None;
-        }
-        let (rep0, rep1, rep2_opt) = if $lit_len == 0 {
-            let r2 = if offset_hist[0] > 1 {
-                Some(offset_hist[0] as usize - 1)
-            } else {
-                None
-            };
-            (offset_hist[1] as usize, offset_hist[2] as usize, r2)
-        } else {
-            (
-                offset_hist[0] as usize,
-                offset_hist[1] as usize,
-                Some(offset_hist[2] as usize),
-            )
-        };
-        let mut best: Option<MatchCandidate> = None;
-        // Hand-unrolled inline probes (NOT a closure: a closure body is a
-        // separate non-`target_feature` MIR body, so calling `$cpl` from it
-        // would cross the ABI barrier and defeat the inline). Each call to the
-        // tier's `$cpl` runs directly in this wrapper's umbrella scope (the
-        // `for` loop body and the `if` block are in-fn, not a closure).
-        for &rep in &[rep0, rep1] {
-            if rep != 0 && rep <= $abs_pos {
-                let candidate_pos = $abs_pos - rep;
-                if candidate_pos >= history_abs_start {
-                    let candidate_idx = candidate_pos - history_abs_start;
-                    let a = &concat[candidate_idx..];
-                    let b = &concat[current_idx..];
-                    let max = a.len().min(b.len());
-                    // SAFETY: `a` / `b` each hold at least `len()` initialized
-                    // bytes; `max` is the minimum so both pointers are valid for
-                    // `max` bytes. `$cpl` is the tier kernel this umbrella enables.
-                    let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
-                    if match_len >= DFAST_MIN_MATCH_LEN {
-                        let candidate = extend_backwards_shared(
-                            concat,
-                            history_abs_start,
-                            candidate_pos,
-                            $abs_pos,
-                            match_len,
-                            $lit_len,
-                        );
-                        best = best_len_offset_candidate(best, Some(candidate));
-                    }
-                }
-            }
-        }
-        if let Some(rep) = rep2_opt
-            && rep != 0
-            && rep <= $abs_pos
-        {
-            let candidate_pos = $abs_pos - rep;
-            if candidate_pos >= history_abs_start {
-                let candidate_idx = candidate_pos - history_abs_start;
-                let a = &concat[candidate_idx..];
-                let b = &concat[current_idx..];
-                let max = a.len().min(b.len());
-                // SAFETY: as above.
-                let match_len = unsafe { $cpl(a.as_ptr(), b.as_ptr(), max) };
-                if match_len >= DFAST_MIN_MATCH_LEN {
-                    let candidate = extend_backwards_shared(
-                        concat,
-                        history_abs_start,
-                        candidate_pos,
-                        $abs_pos,
-                        match_len,
-                        $lit_len,
-                    );
-                    best = best_len_offset_candidate(best, Some(candidate));
-                }
-            }
-        }
-        best
-    }};
-}
-
-/// Per-kernel body of [`DfastMatchGenerator::hash_candidate`]. `$probe` is the
-/// tier's `probe_slot_match_<kernel>` method; calling it from this wrapper's
-/// matching `#[target_feature]` umbrella inlines the whole long/short probe +
-/// `_search_next_long` retry (and the `$cpl` scan inside each probe) with no
-/// `match kernel` dispatch and no ABI-crossing call per slot.
-macro_rules! dfast_hash_candidate_body {
-    ($self:ident, $abs_pos:ident, $lit_len:ident, $probe:ident) => {{
-        let concat = $self.live_history();
-        let current_idx = $abs_pos - $self.history_abs_start;
-        let history_abs_start = $self.history_abs_start;
-        let position_base = $self.position_base;
-        let mut best = None;
-
-        let long_hit = if current_idx + 8 <= concat.len() {
-            let long_hash = $self.long_hash_index(&concat[current_idx..]);
-            debug_assert!(long_hash < $self.long_hash.len());
-            // SAFETY: `long_hash_index` masks to `long_hash_bits` and
-            // `long_hash.len() == 1 << long_hash_bits` (`ensure_hash_tables`).
-            let slot = unsafe { *$self.long_hash.get_unchecked(long_hash) };
-            unsafe {
-                $self.$probe(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    $abs_pos,
-                    current_idx,
-                    concat,
-                    $lit_len,
-                    8,
-                )
-            }
-        } else {
-            None
-        };
-        if let Some(cand) = long_hit {
-            best = best_len_offset_candidate(best, Some(cand));
-            if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
-                return best;
-            }
-        }
-
-        if current_idx + 4 <= concat.len() {
-            let short_hash = $self.short_hash_index(&concat[current_idx..]);
-            debug_assert!(short_hash < $self.short_hash.len());
-            let slot = unsafe { *$self.short_hash.get_unchecked(short_hash) };
-            if let Some(short_cand) = unsafe {
-                $self.$probe(
-                    slot,
-                    position_base,
-                    history_abs_start,
-                    $abs_pos,
-                    current_idx,
-                    concat,
-                    $lit_len,
-                    4,
-                )
-            } {
-                best = best_len_offset_candidate(best, Some(short_cand));
-                if best.is_some_and(|b| b.match_len >= DFAST_TARGET_LEN) {
-                    return best;
-                }
-                let next_idx = current_idx + 1;
-                if best.is_none_or(|b| b.match_len < DFAST_TARGET_LEN)
-                    && next_idx + 8 <= concat.len()
-                {
-                    let next_long_hash = $self.long_hash_index(&concat[next_idx..]);
-                    debug_assert!(next_long_hash < $self.long_hash.len());
-                    let next_slot = unsafe { *$self.long_hash.get_unchecked(next_long_hash) };
-                    if let Some(retry) = unsafe {
-                        $self.$probe(
-                            next_slot,
-                            position_base,
-                            history_abs_start,
-                            $abs_pos + 1,
-                            next_idx,
-                            concat,
-                            $lit_len.saturating_add(1),
-                            8,
-                        )
-                    } && retry.match_len > short_cand.match_len
-                    {
-                        best = best_len_offset_candidate(best, Some(retry));
-                    }
-                }
-            }
-        }
-        best
-    }};
-}
-
-/// Per-kernel body of the lazy `start_matching_general` loop. `$rep` / `$hash`
-/// are the tier's `repcode_candidate_<kernel>` / `hash_candidate_<kernel>`
-/// methods; calling them from this wrapper's `#[target_feature]` umbrella
-/// inlines the whole per-position match search (repcode 3-probe + hash
-/// long/short probe + every `$cpl` scan) with NO per-position `match kernel`
-/// dispatch and NO ABI-crossing call. The kernel is resolved ONCE per block at
-/// the `start_matching_general` dispatcher, mirroring `start_matching_fast_loop`.
-/// Bookkeeping (`emit_candidate`, `insert_position`,
-/// `extend_with_repcode_after_match`, seeding) stays plain method calls — no
-/// SIMD on those paths.
-macro_rules! dfast_start_matching_general_body {
-    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident,
-     $rep:ident, $hash:ident) => {{
-        let use_adaptive_skip =
-            $self.block_looks_incompressible($current_abs_start, $current_abs_start + $current_len);
-        let mut pos = 1usize;
-        let mut literals_start = 0usize;
-        let mut skip_step = 1usize;
-        let mut next_skip_growth_pos = DFAST_SKIP_STEP_GROWTH_INTERVAL;
-        let mut miss_run = 0usize;
-        while pos + DFAST_MIN_MATCH_LEN <= $current_len {
-            let abs_pos = $current_abs_start + pos;
-            let lit_len = pos - literals_start;
-
-            // Inlined `best_match`: repcode + hash candidate, both under this
-            // tier's umbrella so the `$cpl` scans inline.
-            let best = best_len_offset_candidate(unsafe { $self.$rep(abs_pos, lit_len) }, unsafe {
-                $self.$hash(abs_pos, lit_len)
-            });
-            // Inlined `pick_lazy_match` (donor lazy/lazy2 lookahead): re-probe
-            // the same tier's repcode/hash at `abs_pos + 1` (and `+ 2` for
-            // lazy2) DIRECTLY under this umbrella so the lookahead `$cpl` scans
-            // inline too — no closure (a closure body is a separate
-            // non-`target_feature` MIR body, so its `$rep` / `$hash` calls would
-            // cross the ABI barrier on every deferral). Logic byte-identical to
-            // `pick_lazy_match_shared`.
-            let picked = 'pick: {
-                let Some(b) = best else { break 'pick None };
-                let history_abs_end = $self.history_abs_end();
-                if b.match_len >= DFAST_TARGET_LEN
-                    || abs_pos + 1 + DFAST_MIN_MATCH_LEN > history_abs_end
-                {
-                    break 'pick Some(b);
-                }
-                let next = best_len_offset_candidate(
-                    unsafe { $self.$rep(abs_pos + 1, lit_len + 1) },
-                    unsafe { $self.$hash(abs_pos + 1, lit_len + 1) },
-                );
-                if let Some(n) = next
-                    && (n.match_len > b.match_len
-                        || (n.match_len == b.match_len && n.offset < b.offset))
-                {
-                    break 'pick None;
-                }
-                if $self.lazy_depth >= 2 && abs_pos + 2 + DFAST_MIN_MATCH_LEN <= history_abs_end {
-                    let next2 = best_len_offset_candidate(
-                        unsafe { $self.$rep(abs_pos + 2, lit_len + 2) },
-                        unsafe { $self.$hash(abs_pos + 2, lit_len + 2) },
-                    );
-                    if let Some(n2) = next2
-                        && n2.match_len > b.match_len + 1
-                    {
-                        break 'pick None;
-                    }
-                }
-                Some(b)
-            };
-            if let Some(candidate) = picked {
-                let start = $self.emit_candidate(
-                    $current_abs_start,
-                    &mut literals_start,
-                    candidate,
-                    $handle_sequence,
-                );
-                pos = start + candidate.match_len;
-                pos = $self.extend_with_repcode_after_match(
-                    $current_abs_start,
-                    $current_len,
-                    pos,
-                    &mut literals_start,
-                    $handle_sequence,
-                );
-                skip_step = 1;
-                next_skip_growth_pos = pos + DFAST_SKIP_STEP_GROWTH_INTERVAL;
-                miss_run = 0;
-            } else {
-                $self.insert_position(abs_pos);
-                miss_run += 1;
-                let use_local_adaptive_skip = miss_run >= DFAST_LOCAL_SKIP_TRIGGER;
-                if use_adaptive_skip || use_local_adaptive_skip {
-                    let skip_cap = if use_adaptive_skip {
-                        DFAST_MAX_SKIP_STEP
-                    } else {
-                        2
-                    };
-                    if pos >= next_skip_growth_pos {
-                        skip_step = (skip_step + 1).min(skip_cap);
-                        next_skip_growth_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
-                    }
-                    pos += skip_step;
-                } else {
-                    pos += 1;
-                }
-            }
-        }
-
-        $self.seed_remaining_hashable_starts($current_abs_start, $current_len, pos);
-        $self.emit_trailing_literals(literals_start, $handle_sequence);
-    }};
-}
-
 impl DfastMatchGenerator {
     // Keep a short dense tail at block boundaries for two related reasons:
     // 1) insert_position() needs short (4-byte) and long (8-byte) lookahead,
@@ -511,8 +160,6 @@ impl DfastMatchGenerator {
             position_base: 0,
             long_hash_bits: DFAST_HASH_BITS,
             short_hash_bits: DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA,
-            use_fast_loop: false,
-            lazy_depth: 1,
             dict: DictAttach::new(),
             kernel: select_kernel(),
         }
@@ -887,16 +534,6 @@ impl DfastMatchGenerator {
     /// without per-frame dict cost. Cached via the `DictAttach` primed flag.
     pub(crate) fn skip_matching_for_dict_attach(&mut self) {
         self.ensure_hash_tables();
-        // The dual-probe lives only in `start_matching_fast_loop`. The general
-        // path (L1/L2/L4) has no dict probe, so for those levels prime the dict
-        // into the LIVE tables (`skip_matching_dense`), where the dense scan
-        // finds it — keeping the attach win to the fast-loop levels (L3 /
-        // Default / L0) without regressing general-path dict ratio.
-        if !self.use_fast_loop {
-            self.dict.invalidate();
-            self.skip_matching_dense();
-            return;
-        }
         let current_len = self.window_blocks.back().copied().unwrap_or(0);
         if current_len == 0 {
             return;
@@ -913,19 +550,8 @@ impl DfastMatchGenerator {
     /// Mark the dict tables fully built (CDict cache). The driver calls this
     /// after the final dictionary chunk so the next frame skips the re-hash.
     ///
-    /// Only the fast-loop path builds the immutable dict tables; the
-    /// general-path levels (L1/L2/L4) prime the dict into the LIVE tables and
-    /// `invalidate()` the attach cache (see [`Self::skip_matching_for_dict_attach`]),
-    /// leaving `self.dict.table()` empty. Gate on `use_fast_loop` so a
-    /// general-path frame can never flip the primed flag, which would let a
-    /// later fast-loop frame short-circuit [`Self::prime_dict_tables_for_range`]
-    /// with no dict tables built. ([`DictAttach::mark_primed`] also self-guards
-    /// on `table.is_some()`, so this is belt-and-suspenders making the
-    /// precondition explicit at the call site.)
     pub(crate) fn mark_dict_primed(&mut self) {
-        if self.use_fast_loop {
-            self.dict.mark_primed();
-        }
+        self.dict.mark_primed();
     }
 
     /// Drop the cached dict tables (next frame carries no dict, or eviction /
@@ -954,9 +580,9 @@ impl DfastMatchGenerator {
         let long_bits = self.long_hash_bits;
         let short_bits = self.short_hash_bits;
         // Lookahead-safe cutoffs within the concat: long needs 8 readable
-        // bytes, short needs 4 (donor parity with `insert_positions`).
+        // bytes, short needs 5 (donor `mls = 5` for the short hash).
         let long_safe_end = concat_len.saturating_sub(7).min(end_concat);
-        let short_safe_end = concat_len.saturating_sub(3).min(end_concat);
+        let short_safe_end = concat_len.saturating_sub(4).min(end_concat);
         if start_concat >= short_safe_end {
             return;
         }
@@ -1005,8 +631,13 @@ impl DfastMatchGenerator {
         while pos < short_safe_end {
             unsafe {
                 let load_ptr = base.add(history_start + pos);
-                let v4 = (load_ptr as *const u32).read_unaligned() as u64;
-                let short_idx = (v4.wrapping_mul(PRIME) >> short_shift) as usize;
+                // 5-byte short key (donor `mls = 5`), assembled from a 4-byte
+                // load + 1 byte so it never over-reads the <8-byte tail; the
+                // low 5 bytes land in bits 24..63, matching `v8 << 24`.
+                let lo4 = (load_ptr as *const u32).read_unaligned() as u64;
+                let b5 = *load_ptr.add(4) as u64;
+                let v5 = (lo4 | (b5 << 32)) << 24;
+                let short_idx = (v5.wrapping_mul(PRIME) >> short_shift) as usize;
                 *short_ptr.add(short_idx) = (pos as u32) + 1;
             }
             pos += 1;
@@ -1022,180 +653,22 @@ impl DfastMatchGenerator {
         }
 
         let current_abs_start = self.history_abs_start + self.window_size - current_len;
-        if self.use_fast_loop {
-            self.start_matching_fast_loop(current_abs_start, current_len, &mut handle_sequence);
-            return;
+        // Re-seed the previous block's seam. With the donor 5-byte short hash,
+        // a position within `mls - 1` bytes of the prior block end could not
+        // form its full key when that block was processed (the trailing bytes
+        // arrived with THIS block); re-hash that tail now that history spans
+        // it, so cross-block matches anchored in the seam are found. Mirrors
+        // `skip_matching_dense`'s backfill.
+        let backfill_start = current_abs_start
+            .saturating_sub(Self::BOUNDARY_DENSE_TAIL_LEN)
+            .max(self.history_abs_start);
+        if backfill_start < current_abs_start {
+            self.insert_positions(backfill_start, current_abs_start);
         }
-        self.start_matching_general(current_abs_start, current_len, &mut handle_sequence);
-    }
-
-    /// Dispatcher for the per-kernel lazy `start_matching_general` loop:
-    /// resolve the tier ONCE per block via `select_kernel()` and call the
-    /// matching `start_matching_general_<kernel>` wrapper, so the entire
-    /// per-position match search (repcode + hash probe + every
-    /// `common_prefix_len_ptr` scan) inlines under one `#[target_feature]`
-    /// umbrella with no per-position dispatch or ABI-crossing call. Mirrors
-    /// `start_matching_fast_loop`. The loop's safety invariants (block-local
-    /// arithmetic bounded by `current_len`; absolute-position arithmetic gated
-    /// upstream by `check_stream_abs_headroom`) are documented on the body
-    /// macro `dfast_start_matching_general_body!` callers below.
-    fn start_matching_general(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-        unsafe {
-            self.start_matching_general_neon(current_abs_start, current_len, handle_sequence)
-        }
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
-                FastpathKernel::Avx2Bmi2 => unsafe {
-                    self.start_matching_general_avx2_bmi2(
-                        current_abs_start,
-                        current_len,
-                        handle_sequence,
-                    )
-                },
-                FastpathKernel::Sse42 => unsafe {
-                    self.start_matching_general_sse42(
-                        current_abs_start,
-                        current_len,
-                        handle_sequence,
-                    )
-                },
-                FastpathKernel::Scalar => self.start_matching_general_scalar(
-                    current_abs_start,
-                    current_len,
-                    handle_sequence,
-                ),
-            }
-        }
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        ))]
-        unsafe {
-            self.start_matching_general_simd128(current_abs_start, current_len, handle_sequence)
-        }
-        #[cfg(not(any(
-            all(target_arch = "aarch64", target_endian = "little"),
-            target_arch = "x86",
-            target_arch = "x86_64",
-            all(
-                target_arch = "wasm32",
-                target_feature = "simd128",
-                feature = "kernel_simd128"
-            )
-        )))]
-        {
-            self.start_matching_general_scalar(current_abs_start, current_len, handle_sequence)
-        }
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[target_feature(enable = "neon")]
-    unsafe fn start_matching_general_neon(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dfast_start_matching_general_body!(
-            self,
-            current_abs_start,
-            current_len,
-            handle_sequence,
-            repcode_candidate_neon,
-            hash_candidate_neon
-        )
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "sse4.2")]
-    unsafe fn start_matching_general_sse42(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dfast_start_matching_general_body!(
-            self,
-            current_abs_start,
-            current_len,
-            handle_sequence,
-            repcode_candidate_sse42,
-            hash_candidate_sse42
-        )
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn start_matching_general_avx2_bmi2(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dfast_start_matching_general_body!(
-            self,
-            current_abs_start,
-            current_len,
-            handle_sequence,
-            repcode_candidate_avx2_bmi2,
-            hash_candidate_avx2_bmi2
-        )
-    }
-
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    #[target_feature(enable = "simd128")]
-    unsafe fn start_matching_general_simd128(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dfast_start_matching_general_body!(
-            self,
-            current_abs_start,
-            current_len,
-            handle_sequence,
-            repcode_candidate_simd128,
-            hash_candidate_simd128
-        )
-    }
-
-    #[cfg(not(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        )
-    )))]
-    #[allow(unused_unsafe)]
-    fn start_matching_general_scalar(
-        &mut self,
-        current_abs_start: usize,
-        current_len: usize,
-        handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dfast_start_matching_general_body!(
-            self,
-            current_abs_start,
-            current_len,
-            handle_sequence,
-            repcode_candidate_scalar,
-            hash_candidate_scalar
-        )
+        // dfast is the donor's greedy double-fast at every level (no lazy
+        // variant exists — lazy parsing is the separate `ZSTD_lazy`/`lazy2`
+        // strategy), so there is a single match path.
+        self.start_matching_fast_loop(current_abs_start, current_len, &mut handle_sequence);
     }
 
     /// Single-cursor probe at the last hashable position in the
@@ -1638,334 +1111,6 @@ impl DfastMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn repcode_candidate_avx2_bmi2(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_repcode_candidate_body!(
-            self,
-            abs_pos,
-            lit_len,
-            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "sse4.2")]
-    unsafe fn repcode_candidate_sse42(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_repcode_candidate_body!(
-            self,
-            abs_pos,
-            lit_len,
-            crate::encoding::fastpath::sse42::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[target_feature(enable = "neon")]
-    unsafe fn repcode_candidate_neon(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_repcode_candidate_body!(
-            self,
-            abs_pos,
-            lit_len,
-            crate::encoding::fastpath::neon::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    #[target_feature(enable = "simd128")]
-    unsafe fn repcode_candidate_simd128(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_repcode_candidate_body!(
-            self,
-            abs_pos,
-            lit_len,
-            crate::encoding::fastpath::simd128::common_prefix_len_ptr
-        )
-    }
-
-    // Scalar tier: no target feature, so `unsafe` here is only the inner SIMD-
-    // free `$cpl` (scalar `common_prefix_len_ptr`); the `unsafe fn` keeps a
-    // uniform call shape across tiers for the `start_matching_general` body.
-    // Gated like `start_matching_general_scalar` (its only caller): on aarch64
-    // the lazy loop always dispatches to the neon tier, and on wasm+simd128 to
-    // the simd128 tier, so the scalar candidates would be dead there.
-    #[cfg(not(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        )
-    )))]
-    #[allow(unused_unsafe)]
-    unsafe fn repcode_candidate_scalar(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_repcode_candidate_body!(
-            self,
-            abs_pos,
-            lit_len,
-            crate::encoding::fastpath::scalar::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn hash_candidate_avx2_bmi2(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_avx2_bmi2)
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "sse4.2")]
-    unsafe fn hash_candidate_sse42(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_sse42)
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[target_feature(enable = "neon")]
-    unsafe fn hash_candidate_neon(&self, abs_pos: usize, lit_len: usize) -> Option<MatchCandidate> {
-        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_neon)
-    }
-
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    #[target_feature(enable = "simd128")]
-    unsafe fn hash_candidate_simd128(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_simd128)
-    }
-
-    // Gated like `repcode_candidate_scalar` — see that fn's note.
-    #[cfg(not(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        )
-    )))]
-    #[allow(unused_unsafe)]
-    unsafe fn hash_candidate_scalar(
-        &self,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_hash_candidate_body!(self, abs_pos, lit_len, probe_slot_match_scalar)
-    }
-
-    /// Resolve a single packed-slot value against the live history and
-    /// return a backward-extended `MatchCandidate` if the bucket holds
-    /// a valid in-range position whose forward extension reaches at
-    /// least `DFAST_MIN_MATCH_LEN` bytes. Shared between the long-hash
-    /// primary probe, the short-hash primary probe, and the
-    /// `_search_next_long` retry — keeps the bounds-checking logic in
-    /// one place so the three call sites can't drift.
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "avx2,bmi2")]
-    #[allow(clippy::too_many_arguments)]
-    unsafe fn probe_slot_match_avx2_bmi2(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_probe_slot_match_body!(
-            self,
-            slot,
-            position_base,
-            history_abs_start,
-            abs_pos,
-            current_idx,
-            concat,
-            lit_len,
-            gate_len,
-            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    #[target_feature(enable = "sse4.2")]
-    #[allow(clippy::too_many_arguments)]
-    unsafe fn probe_slot_match_sse42(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_probe_slot_match_body!(
-            self,
-            slot,
-            position_base,
-            history_abs_start,
-            abs_pos,
-            current_idx,
-            concat,
-            lit_len,
-            gate_len,
-            crate::encoding::fastpath::sse42::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    #[target_feature(enable = "neon")]
-    #[allow(clippy::too_many_arguments)]
-    unsafe fn probe_slot_match_neon(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_probe_slot_match_body!(
-            self,
-            slot,
-            position_base,
-            history_abs_start,
-            abs_pos,
-            current_idx,
-            concat,
-            lit_len,
-            gate_len,
-            crate::encoding::fastpath::neon::common_prefix_len_ptr
-        )
-    }
-
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    #[target_feature(enable = "simd128")]
-    #[allow(clippy::too_many_arguments)]
-    unsafe fn probe_slot_match_simd128(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_probe_slot_match_body!(
-            self,
-            slot,
-            position_base,
-            history_abs_start,
-            abs_pos,
-            current_idx,
-            concat,
-            lit_len,
-            gate_len,
-            crate::encoding::fastpath::simd128::common_prefix_len_ptr
-        )
-    }
-
-    // Only `hash_candidate_scalar` calls this, and that wrapper is gated out on
-    // aarch64 (neon tier) and wasm+simd128 (simd128 tier), so the scalar probe
-    // would be dead there too.
-    #[cfg(not(any(
-        all(target_arch = "aarch64", target_endian = "little"),
-        all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        )
-    )))]
-    #[allow(clippy::too_many_arguments)]
-    fn probe_slot_match_scalar(
-        &self,
-        slot: u32,
-        position_base: usize,
-        history_abs_start: usize,
-        abs_pos: usize,
-        current_idx: usize,
-        concat: &[u8],
-        lit_len: usize,
-        gate_len: usize,
-    ) -> Option<MatchCandidate> {
-        dfast_probe_slot_match_body!(
-            self,
-            slot,
-            position_base,
-            history_abs_start,
-            abs_pos,
-            current_idx,
-            concat,
-            lit_len,
-            gate_len,
-            crate::encoding::fastpath::scalar::common_prefix_len_ptr
-        )
-    }
-
-    #[inline(always)]
-    fn extend_backwards(
-        &self,
-        candidate_pos: usize,
-        abs_pos: usize,
-        match_len: usize,
-        lit_len: usize,
-    ) -> MatchCandidate {
-        extend_backwards_shared(
-            self.live_history(),
-            self.history_abs_start,
-            candidate_pos,
-            abs_pos,
-            match_len,
-            lit_len,
-        )
-    }
-
     pub(crate) fn insert_positions(&mut self, start: usize, end: usize) {
         let start = start.max(self.history_abs_start);
         let end = end.min(self.history_abs_end());
@@ -2011,7 +1156,7 @@ impl DfastMatchGenerator {
         // donor parity is "no insert" — skip entirely.
         let abs_concat_end = history_abs_start + concat_len;
         let long_safe_end = abs_concat_end.saturating_sub(7).min(end);
-        let short_safe_end = abs_concat_end.saturating_sub(3).min(end);
+        let short_safe_end = abs_concat_end.saturating_sub(4).min(end);
 
         // SAFETY: `history_base_ptr.add(history_start + idx)` is
         // in-bounds for `idx + 8 <= concat_len`, which the two
@@ -2048,8 +1193,12 @@ impl DfastMatchGenerator {
                 let idx = pos - history_abs_start;
                 let packed = ((pos - position_base) as u32) + 1;
                 let load_ptr = history_base_ptr.add(history_start + idx);
-                let v4 = (load_ptr as *const u32).read_unaligned() as u64;
-                let mixed_short = v4.wrapping_mul(0xCF1BBCDCB7A56463_u64);
+                // 5-byte short key (donor `mls = 5`): 4-byte load + 1 byte so
+                // the <8-byte tail is never over-read; low 5 bytes in bits
+                // 24..63 to match `v8 << 24`.
+                let lo4 = (load_ptr as *const u32).read_unaligned() as u64;
+                let b5 = *load_ptr.add(4) as u64;
+                let mixed_short = ((lo4 | (b5 << 32)) << 24).wrapping_mul(0xCF1BBCDCB7A56463_u64);
                 let short_idx = (mixed_short >> short_shift) as usize;
                 *short_hash_ptr.add(short_idx) = packed;
             }
@@ -3163,7 +2312,6 @@ mod extend_with_repcode_tests {
         // Window sized to the block so the matcher does not start
         // trimming history mid-test.
         let mut dfast = DfastMatchGenerator::new(data.len().next_power_of_two().max(64));
-        dfast.use_fast_loop = false; // exercise `start_matching_general`
         dfast.ensure_hash_tables();
         dfast.add_data(data.to_vec(), |_| {});
         dfast
@@ -3257,7 +2405,6 @@ mod extend_with_repcode_tests {
         let block_a: Vec<u8> = vec![b'C'; 64];
         let block_b: Vec<u8> = vec![b'C'; 32];
         let mut dfast = DfastMatchGenerator::new(256);
-        dfast.use_fast_loop = false;
         dfast.ensure_hash_tables();
         dfast.add_data(block_a, |_| {});
         dfast.add_data(block_b.clone(), |_| {});
@@ -3335,7 +2482,6 @@ mod extend_with_repcode_tests {
         let data: Vec<u8> = b"ABCD????ABCD!??????????ABCDX????".to_vec();
         assert_eq!(data.len(), 32, "fixture invariant: 32 bytes");
         let mut dfast = DfastMatchGenerator::new(64);
-        dfast.use_fast_loop = false;
         dfast.ensure_hash_tables();
         dfast.add_data(data.clone(), |_| {});
 

--- a/zstd/src/encoding/fastpath/mod.rs
+++ b/zstd/src/encoding/fastpath/mod.rs
@@ -270,7 +270,26 @@ pub(crate) unsafe fn dispatch_common_prefix_len_ptr(
     rhs: *const u8,
     max: usize,
 ) -> usize {
-    match select_kernel() {
+    // Cold-path shim: resolves the kernel via `select_kernel()` on every call.
+    // Hot match-finder loops resolve the kernel once per block and call
+    // [`dispatch_common_prefix_len_ptr_with_kernel`] directly.
+    unsafe { dispatch_common_prefix_len_ptr_with_kernel(select_kernel(), lhs, rhs, max) }
+}
+
+/// Prefix-length scan against an already-resolved [`FastpathKernel`], so a hot
+/// loop pays the kernel-select once per block (caller-cached) instead of the
+/// `OnceLock` atomic + branch on every byte-compare.
+///
+/// # Safety
+/// `lhs` / `rhs` must each point to at least `max` initialized bytes.
+#[inline(always)]
+pub(crate) unsafe fn dispatch_common_prefix_len_ptr_with_kernel(
+    kernel: FastpathKernel,
+    lhs: *const u8,
+    rhs: *const u8,
+    max: usize,
+) -> usize {
+    match kernel {
         FastpathKernel::Scalar => unsafe { scalar::common_prefix_len_ptr(lhs, rhs, max) },
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         FastpathKernel::Neon => unsafe { neon::common_prefix_len_ptr(lhs, rhs, max) },

--- a/zstd/src/encoding/fastpath/mod.rs
+++ b/zstd/src/encoding/fastpath/mod.rs
@@ -77,6 +77,13 @@ pub(crate) mod sse42;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub(crate) mod avx2_bmi2;
 
+#[cfg(all(
+    target_arch = "wasm32",
+    target_feature = "simd128",
+    feature = "kernel_simd128"
+))]
+pub(crate) mod simd128;
+
 /// Runtime-selected variant tag. Picked once per process by [`select_kernel`].
 ///
 /// Each variant corresponds to one of the submodules above and dictates which
@@ -90,6 +97,12 @@ pub(crate) enum FastpathKernel {
     Sse42,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     Avx2Bmi2,
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    Simd128,
 }
 
 /// Select the best supported variant for the running CPU. Cached after first
@@ -111,6 +124,17 @@ pub(crate) fn select_kernel() -> FastpathKernel {
 }
 
 #[inline]
+// On wasm32+simd128 the tier is resolved unconditionally to `Simd128` (no
+// runtime CPUID), so the trailing `Scalar` fallback is statically unreachable
+// there; it stays the reachable fallback on every other target.
+#[cfg_attr(
+    all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ),
+    allow(unreachable_code)
+)]
 fn detect_kernel_uncached() -> FastpathKernel {
     // Each kernel's `hash_mix_u64` uses a hardware CRC instruction
     // (`_mm_crc32_u64` on x86, `__crc32d` on AArch64) for the donor-style
@@ -175,6 +199,19 @@ fn detect_kernel_uncached() -> FastpathKernel {
         }
     }
 
+    // wasm SIMD is a compile-time feature (no runtime detection), so the
+    // `+simd128` payload selects the SIMD kernel and the scalar payload never
+    // compiles the variant. `hash_mix_u64` routes through the scalar mixer
+    // (wasm has no CRC), so there's no extra feature to gate on here.
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    {
+        return FastpathKernel::Simd128;
+    }
+
     FastpathKernel::Scalar
 }
 
@@ -225,6 +262,20 @@ pub(crate) fn dispatch_count_match_from_indices(
                 seed_len,
             )
         },
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        FastpathKernel::Simd128 => unsafe {
+            simd128::count_match_from_indices(
+                concat,
+                current_idx,
+                candidate_idx,
+                tail_limit,
+                seed_len,
+            )
+        },
     }
 }
 
@@ -246,6 +297,12 @@ pub(crate) fn hash_mix_u64_with_kernel(kernel: FastpathKernel, value: u64) -> u6
         FastpathKernel::Sse42 => unsafe { sse42::hash_mix_u64(value) },
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         FastpathKernel::Avx2Bmi2 => unsafe { avx2_bmi2::hash_mix_u64(value) },
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        FastpathKernel::Simd128 => simd128::hash_mix_u64(value),
     }
 }
 
@@ -297,6 +354,12 @@ pub(crate) unsafe fn dispatch_common_prefix_len_ptr_with_kernel(
         FastpathKernel::Sse42 => unsafe { sse42::common_prefix_len_ptr(lhs, rhs, max) },
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         FastpathKernel::Avx2Bmi2 => unsafe { avx2_bmi2::common_prefix_len_ptr(lhs, rhs, max) },
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        FastpathKernel::Simd128 => unsafe { simd128::common_prefix_len_ptr(lhs, rhs, max) },
     }
 }
 
@@ -319,6 +382,12 @@ mod tests {
             FastpathKernel::Sse42 => {}
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             FastpathKernel::Avx2Bmi2 => {}
+            #[cfg(all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ))]
+            FastpathKernel::Simd128 => {}
         }
     }
 

--- a/zstd/src/encoding/fastpath/simd128.rs
+++ b/zstd/src/encoding/fastpath/simd128.rs
@@ -1,0 +1,128 @@
+//! WebAssembly `simd128` fastpath variant. Mirrors [`super::neon`] (the other
+//! 128-bit-SIMD tier) but on `core::arch::wasm32` `v128` intrinsics. Every
+//! hot-path function carries `#[target_feature(enable = "simd128")]` so the
+//! intrinsics inline into the caller's loop instead of crossing the
+//! target_feature ABI barrier as a non-inlinable call.
+//!
+//! wasm has no CRC instruction, so `hash_mix_u64` falls back to the portable
+//! scalar mixer (a single 64-bit mix has no SIMD speedup anyway); the win here
+//! is the vectorized `common_prefix_len` match-length scan.
+
+#![cfg(all(
+    target_arch = "wasm32",
+    target_feature = "simd128",
+    feature = "kernel_simd128"
+))]
+#![allow(dead_code)]
+
+use core::arch::wasm32::{i8x16_bitmask, u8x16_eq, v128, v128_load};
+
+use super::scalar;
+
+pub(crate) const KERNEL_TAG: &str = "simd128";
+
+/// wasm has no CRC unit; route the single-lane mix through the portable scalar
+/// mixer so it stays bit-identical with every other tier's `hash_mix_u64`.
+#[inline]
+pub(crate) fn hash_mix_u64(value: u64) -> u64 {
+    scalar::hash_mix_u64(value)
+}
+
+/// 16-byte `v128` prefix-length probe. Returns the number of leading equal
+/// bytes in whole 16-byte chunks; the caller handles the scalar tail.
+///
+/// # Safety
+/// `lhs` / `rhs` must point to at least `max` initialized bytes. `simd128` must
+/// be available — enforced by the `target_feature` attribute (and, on wasm, by
+/// the compile-time `+simd128` payload the dispatcher selects).
+#[target_feature(enable = "simd128")]
+#[inline]
+pub(crate) unsafe fn prefix_len_simd(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+    let mut off = 0usize;
+    while off + 16 <= max {
+        // SAFETY: `off + 16 <= max` and the caller guarantees `max` initialized
+        // bytes behind each pointer, so both 16-byte loads stay in bounds.
+        let a: v128 = unsafe { v128_load(lhs.add(off) as *const v128) };
+        let b: v128 = unsafe { v128_load(rhs.add(off) as *const v128) };
+        // `u8x16_eq` sets each lane to 0xFF on equality, 0x00 otherwise;
+        // `i8x16_bitmask` then folds the per-lane high bit into a u16, so bit
+        // `i` is set iff byte `i` matched. All 16 equal => 0xFFFF.
+        let mask = i8x16_bitmask(u8x16_eq(a, b));
+        if mask != 0xFFFF {
+            // First mismatching byte = first cleared bit = trailing zeros of
+            // the inverted mask.
+            return off + (!mask).trailing_zeros() as usize;
+        }
+        off += 16;
+    }
+    off
+}
+
+/// `simd128` variant of `common_prefix_len_ptr`: vector loop then the shared
+/// scalar tail. `target_feature(enable = "simd128")` so same-umbrella callers
+/// inline it without an ABI barrier.
+///
+/// # Safety
+/// `lhs` / `rhs` must point to at least `max` initialized bytes.
+#[target_feature(enable = "simd128")]
+#[inline]
+pub(crate) unsafe fn common_prefix_len_ptr(lhs: *const u8, rhs: *const u8, max: usize) -> usize {
+    let off = unsafe { prefix_len_simd(lhs, rhs, max) };
+    unsafe { scalar::common_prefix_len_scalar_ptr(lhs, rhs, off, max) }
+}
+
+/// `simd128` variant of `count_match_from_indices` — the BT-walk match-length
+/// probe entry point. Same invariants as the scalar variant, under the
+/// `simd128` umbrella.
+///
+/// # Safety
+/// BT walk invariants: `candidate_idx + tail_limit <= concat.len()` and
+/// `current_idx + tail_limit <= concat.len()`.
+#[target_feature(enable = "simd128")]
+#[inline]
+pub(crate) unsafe fn count_match_from_indices(
+    concat: &[u8],
+    current_idx: usize,
+    candidate_idx: usize,
+    tail_limit: usize,
+    seed_len: usize,
+) -> usize {
+    let seed = seed_len.min(tail_limit);
+    if seed == tail_limit {
+        return seed;
+    }
+    let remaining = tail_limit - seed;
+    let base = concat.as_ptr();
+    let lhs = unsafe { base.add(candidate_idx + seed) };
+    let rhs = unsafe { base.add(current_idx + seed) };
+    let extra = unsafe { common_prefix_len_ptr(lhs, rhs, remaining) };
+    seed + extra
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec::Vec;
+
+    #[test]
+    fn simd128_prefix_len_matches_scalar_on_long_run() {
+        let a = b"abcdefghijklmnopqrstuvwxyz0123456789-+=*";
+        let mut b: Vec<u8> = a.to_vec();
+        b[25] = b'!';
+        let max = a.len();
+        let got = unsafe { common_prefix_len_ptr(a.as_ptr(), b.as_ptr(), max) };
+        let scl = unsafe { scalar::common_prefix_len_ptr(a.as_ptr(), b.as_ptr(), max) };
+        assert_eq!(got, scl);
+        assert_eq!(got, 25);
+    }
+
+    #[test]
+    fn simd128_handles_short_input() {
+        let a = b"abc";
+        let b = b"abc";
+        assert_eq!(
+            unsafe { common_prefix_len_ptr(a.as_ptr(), b.as_ptr(), a.len()) },
+            3
+        );
+    }
+}

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -5993,6 +5993,10 @@ fn config_override_is_consumed_by_reset() {
     );
 }
 
+// Level 4 maps to the greedy Dfast (double-fast) backend — "greedy" here is the
+// parse discipline (no lazy lookahead, donor `ZSTD_dfast`), NOT the Row/Greedy
+// strategy (which is Level 5). This roundtrip is intentional Dfast L4 coverage;
+// the Row backend is exercised by the `Level(5)` fixtures elsewhere in this file.
 #[cfg(test)]
 fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (usize, usize) {
     let mut driver = MatchGeneratorDriver::new(slice_size, max_slices);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8180,11 +8180,12 @@ fn dfast_prime_with_dictionary_counts_four_byte_tail_budget() {
 #[test]
 fn row_prime_with_dictionary_preserves_history_for_first_full_block() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    // Level(4) is greedy Dfast (donor parity: clevels.h L3/L4 = `ZSTD_dfast`,
-    // no lazy). The greedy fast loop needs `HASH_READ_SIZE` (8) bytes ahead, so
-    // use a 16-byte dict + 16-byte block (whole block matches the dict, offset
-    // = dict length = 16).
-    driver.reset(CompressionLevel::Level(4));
+    // Level(5) is the greedy Row backend (LEVEL_TABLE row 5: Greedy / RowHash).
+    // Level(4) now routes to Dfast, so this test must use Level(5) to actually
+    // exercise `RowMatchGenerator`'s dictionary priming. The 16-byte dict +
+    // 16-byte block lets the whole block match the primed dict (offset = dict
+    // length = 16).
+    driver.reset(CompressionLevel::Level(5));
 
     let payload = b"abcdefghijklmnop";
     driver.prime_with_dictionary(payload, [1, 4, 8]);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1776,13 +1776,13 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::Dfast(dfast) => {
                 dfast.max_window_size = max_window_size;
                 dfast.lazy_depth = params.lazy_depth;
-                dfast.use_fast_loop = matches!(
-                    level,
-                    CompressionLevel::Default
-                        | CompressionLevel::Level(0)
-                        | CompressionLevel::Level(3)
-                        | CompressionLevel::Level(4)
-                );
+                // Donor `ZSTD_dfast` is ALWAYS the greedy double-fast
+                // (`zstd_double_fast.c`, no lazy lookahead); lazy parsing is a
+                // separate strategy (`ZSTD_lazy`/`lazy2`). Keying the greedy
+                // loop on the Dfast backend (not the numeric level) keeps a
+                // custom `Strategy::Dfast` set via the parameter API greedy at
+                // every level, matching the donor.
+                dfast.use_fast_loop = true;
                 let dcfg = params
                     .dfast
                     .expect("Dfast level row must carry a DfastConfig");

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1781,6 +1781,7 @@ impl Matcher for MatchGeneratorDriver {
                     CompressionLevel::Default
                         | CompressionLevel::Level(0)
                         | CompressionLevel::Level(3)
+                        | CompressionLevel::Level(4)
                 );
                 let dcfg = params
                     .dfast
@@ -7894,17 +7895,19 @@ fn hc_prime_with_dictionary_disables_btultra2_seed_pass() {
 #[test]
 fn dfast_prime_with_dictionary_preserves_history_for_first_full_block() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    // Use Level(4) — Dfast with `use_fast_loop=false`. Level(3) is
-    // also Dfast but flips `use_fast_loop=true`, which routes through
-    // a different scan path that bails early on the tiny 8-byte
-    // dict + 8-byte block scenario this test exercises.
+    // Level(4) is Dfast with the greedy double-fast loop (donor parity:
+    // clevels.h L3/L4 are both `ZSTD_dfast`, which has no lazy lookahead).
+    // The fast loop needs at least `HASH_READ_SIZE` (8) bytes ahead of the
+    // probe cursor, so this exercises a 16-byte dict + 16-byte block (the
+    // whole block matches the dict, offset = dict length = 16).
     driver.reset(CompressionLevel::Level(4));
 
-    driver.prime_with_dictionary(b"abcdefgh", [1, 4, 8]);
+    let payload = b"abcdefghijklmnop";
+    driver.prime_with_dictionary(payload, [1, 4, 8]);
 
     let mut space = driver.get_next_space();
     space.clear();
-    space.extend_from_slice(b"abcdefgh");
+    space.extend_from_slice(payload);
     driver.commit_space(space);
 
     let mut saw_match = false;
@@ -7915,7 +7918,7 @@ fn dfast_prime_with_dictionary_preserves_history_for_first_full_block() {
             match_len,
         } = seq
             && literals.is_empty()
-            && offset == 8
+            && offset == payload.len()
             && match_len >= DFAST_MIN_MATCH_LEN
         {
             saw_match = true;
@@ -8182,13 +8185,18 @@ fn dfast_prime_with_dictionary_counts_four_byte_tail_budget() {
 #[test]
 fn row_prime_with_dictionary_preserves_history_for_first_full_block() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
+    // Level(4) is greedy Dfast (donor parity: clevels.h L3/L4 = `ZSTD_dfast`,
+    // no lazy). The greedy fast loop needs `HASH_READ_SIZE` (8) bytes ahead, so
+    // use a 16-byte dict + 16-byte block (whole block matches the dict, offset
+    // = dict length = 16).
     driver.reset(CompressionLevel::Level(4));
 
-    driver.prime_with_dictionary(b"abcdefgh", [1, 4, 8]);
+    let payload = b"abcdefghijklmnop";
+    driver.prime_with_dictionary(payload, [1, 4, 8]);
 
     let mut space = driver.get_next_space();
     space.clear();
-    space.extend_from_slice(b"abcdefgh");
+    space.extend_from_slice(payload);
     driver.commit_space(space);
 
     let mut saw_match = false;
@@ -8199,7 +8207,7 @@ fn row_prime_with_dictionary_preserves_history_for_first_full_block() {
             match_len,
         } = seq
             && literals.is_empty()
-            && offset == 8
+            && offset == payload.len()
             && match_len >= ROW_MIN_MATCH_LEN
         {
             saw_match = true;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -55,7 +55,6 @@ use std::arch::is_x86_feature_detected;
 pub(crate) const DFAST_MIN_MATCH_LEN: usize = 5;
 pub(crate) const DFAST_SHORT_HASH_LOOKAHEAD: usize = 4;
 pub(crate) const ROW_MIN_MATCH_LEN: usize = 5;
-pub(crate) const DFAST_TARGET_LEN: usize = 48;
 // Donor `clevels.h:31` at level 3 large-input bucket sets
 // `hashLog = 17` (the long-hash table) and `chainLog = 16` (the
 // short-hash table — donor names this `chainTable` even though for
@@ -103,7 +102,6 @@ pub(crate) const DFAST_EMPTY_SLOT: u32 = 0;
 pub(crate) const DFAST_REBASE_GUARD_BAND: u32 = 1u32 << 30;
 pub(crate) const DFAST_SKIP_SEARCH_STRENGTH: usize = 6;
 pub(crate) const DFAST_SKIP_STEP_GROWTH_INTERVAL: usize = 1 << DFAST_SKIP_SEARCH_STRENGTH;
-pub(crate) const DFAST_LOCAL_SKIP_TRIGGER: usize = 256;
 pub(crate) const DFAST_MAX_SKIP_STEP: usize = 8;
 pub(crate) const DFAST_INCOMPRESSIBLE_SKIP_STEP: usize = 16;
 pub(crate) const ROW_HASH_BITS: usize = 20;
@@ -1775,14 +1773,6 @@ impl Matcher for MatchGeneratorDriver {
             }
             MatcherStorage::Dfast(dfast) => {
                 dfast.max_window_size = max_window_size;
-                dfast.lazy_depth = params.lazy_depth;
-                // Donor `ZSTD_dfast` is ALWAYS the greedy double-fast
-                // (`zstd_double_fast.c`, no lazy lookahead); lazy parsing is a
-                // separate strategy (`ZSTD_lazy`/`lazy2`). Keying the greedy
-                // loop on the Dfast backend (not the numeric level) keeps a
-                // custom `Strategy::Dfast` set via the parameter API greedy at
-                // every level, matching the donor.
-                dfast.use_fast_loop = true;
                 let dcfg = params
                     .dfast
                     .expect("Dfast level row must carry a DfastConfig");
@@ -5585,7 +5575,12 @@ fn dfast_accepts_exact_five_byte_match() {
     data.extend_from_slice(b"!!!!!!!!!!!!!!!!!!!!!!!"); // 5..28 (23 bytes)
     data.extend_from_slice(b"ABCDE"); // 28..33
     data.push(b'F'); // 33: forces forward extension to stop at length 5
-    assert_eq!(data.len(), 34);
+    // Trailing filler so the match site (28) sits at least HASH_READ_SIZE (8)
+    // bytes before the block end. The greedy double-fast — like the donor —
+    // stops probing at `ilimit = iend - HASH_READ_SIZE`, so a match in the
+    // final 8 bytes is never searched (donor parity, not a regression).
+    data.extend_from_slice(b"GHIJKLMNOPQRSTUVWXYZ"); // 34..54
+    assert_eq!(data.len(), 54);
 
     let mut matcher = DfastMatchGenerator::new(1 << 22);
     matcher.add_data(data.clone(), |_| {});

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -5660,20 +5660,22 @@ fn driver_level5_selects_row_backend() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(5));
     assert_eq!(driver.active_backend(), super::strategy::BackendTag::Row);
-    // Greedy-specific routing assertion: the `BackendTag::Row` arm of
-    // `MatchGeneratorDriver::compress_block` has a
-    // `debug_assert_eq!(matcher.lazy_depth, 0)` invariant that
-    // dispatches L5 unconditionally into `start_matching_greedy`.
-    // If a future change rerouted L5 through the
-    // `RowMatchGenerator::start_matching` (depth >= 1) path, this
-    // assertion would catch it before the round-trip tests below —
-    // round-trip alone passes on the lazy parser too. Together with
-    // the round-trip suite this pins the greedy-vs-lazy routing
-    // decision at the level table layer.
+    // Greedy-specific routing assertion: `MatchGeneratorDriver::start_matching`
+    // dispatches the Row backend into `start_matching_greedy` iff
+    // `self.parse == ParseMode::Greedy`, so assert that actual selector —
+    // round-trip alone passes on the lazy parser too. `row_matcher().lazy_depth`
+    // is a secondary corroboration of the same routing decision (a mirror of
+    // the parse mode); checking `parse` directly catches a regression even if
+    // the two ever drift apart.
+    assert_eq!(
+        driver.parse,
+        super::strategy::ParseMode::Greedy,
+        "L5 must route to start_matching_greedy (parse == Greedy)",
+    );
     assert_eq!(
         driver.row_matcher().lazy_depth,
         0,
-        "L5 must route to start_matching_greedy (lazy_depth == 0)",
+        "row matcher lazy_depth must mirror the greedy parse mode",
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -53,7 +53,10 @@ use std::arch::is_aarch64_feature_detected;
 use std::arch::is_x86_feature_detected;
 
 pub(crate) const DFAST_MIN_MATCH_LEN: usize = 5;
-pub(crate) const DFAST_SHORT_HASH_LOOKAHEAD: usize = 4;
+// Bytes the dfast short hash reads (donor `mls = 5`). Seeding / lookahead
+// guards use it so a position is only short-hashed once its full 5-byte key
+// is in range.
+pub(crate) const DFAST_SHORT_HASH_LOOKAHEAD: usize = 5;
 pub(crate) const ROW_MIN_MATCH_LEN: usize = 5;
 // Donor `clevels.h:31` at level 3 large-input bucket sets
 // `hashLog = 17` (the long-hash table) and `chainLog = 16` (the
@@ -10202,11 +10205,11 @@ fn dfast_seed_remaining_hashable_starts_seeds_last_short_hash_positions() {
     let seed_start = current_len - DFAST_MIN_MATCH_LEN;
     matcher.seed_remaining_hashable_starts(current_abs_start, current_len, seed_start);
 
-    let target_abs_pos = current_abs_start + current_len - 4;
+    let target_abs_pos = current_abs_start + current_len - 5;
     let target_rel = target_abs_pos - matcher.history_abs_start;
     let live = matcher.live_history();
     assert!(
-        target_rel + 4 <= live.len(),
+        target_rel + 5 <= live.len(),
         "fixture must leave the last short-hash start valid"
     );
     let short_hash = matcher.short_hash_index(&live[target_rel..]);
@@ -10217,7 +10220,7 @@ fn dfast_seed_remaining_hashable_starts_seeds_last_short_hash_positions() {
     );
     assert_eq!(
         matcher.short_hash[short_hash], target_slot,
-        "tail seeding must include the last 4-byte-hashable start"
+        "tail seeding must include the last 5-byte-hashable start"
     );
 }
 
@@ -10232,11 +10235,11 @@ fn dfast_seed_remaining_hashable_starts_handles_pos_at_block_end() {
     let current_abs_start = matcher.history_abs_start + matcher.window_size - current_len;
     matcher.seed_remaining_hashable_starts(current_abs_start, current_len, current_len);
 
-    let target_abs_pos = current_abs_start + current_len - 4;
+    let target_abs_pos = current_abs_start + current_len - 5;
     let target_rel = target_abs_pos - matcher.history_abs_start;
     let live = matcher.live_history();
     assert!(
-        target_rel + 4 <= live.len(),
+        target_rel + 5 <= live.len(),
         "fixture must leave the last short-hash start valid"
     );
     let short_hash = matcher.short_hash_index(&live[target_rel..]);
@@ -10247,7 +10250,7 @@ fn dfast_seed_remaining_hashable_starts_handles_pos_at_block_end() {
     );
     assert_eq!(
         matcher.short_hash[short_hash], target_slot,
-        "tail seeding must still include the last 4-byte-hashable start when pos is at block end"
+        "tail seeding must still include the last 5-byte-hashable start when pos is at block end"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -5663,8 +5663,8 @@ fn driver_level5_selects_row_backend() {
     // Greedy-specific routing assertion: the `BackendTag::Row` arm of
     // `MatchGeneratorDriver::compress_block` has a
     // `debug_assert_eq!(matcher.lazy_depth, 0)` invariant that
-    // dispatches L4 unconditionally into `start_matching_greedy`.
-    // If a future change rerouted L4 through the
+    // dispatches L5 unconditionally into `start_matching_greedy`.
+    // If a future change rerouted L5 through the
     // `RowMatchGenerator::start_matching` (depth >= 1) path, this
     // assertion would catch it before the round-trip tests below —
     // round-trip alone passes on the lazy parser too. Together with
@@ -5673,20 +5673,17 @@ fn driver_level5_selects_row_backend() {
     assert_eq!(
         driver.row_matcher().lazy_depth,
         0,
-        "L4 must route to start_matching_greedy (lazy_depth == 0)",
+        "L5 must route to start_matching_greedy (lazy_depth == 0)",
     );
 }
 
-/// Level 4 maps to `StrategyTag::Greedy` which dispatches into
-/// [`super::row::RowMatchGenerator::start_matching_greedy`]. Round-trip
-/// alone doesn't pin the greedy-vs-lazy choice (a lazy parser would
-/// also reconstruct the input correctly) — that piece is locked down
-/// by the `lazy_depth == 0` assertion in
-/// [`driver_level4_selects_row_backend`]. This test guards the parse
-/// output itself: a small repeating pattern must produce at least one
-/// `Sequence::Triple`, so a future regression that emits literals-only
-/// (e.g. a `min_match` or rep-probe guard regression) is caught
-/// independently of routing.
+/// Level 4 maps to `StrategyTag::Dfast` (the greedy double-fast, donor
+/// `ZSTD_dfast` — "greedy" is the parse discipline, not the Row/Greedy
+/// strategy at Level 5). Round-trip alone doesn't pin match quality (a lazy
+/// parser would also reconstruct the input correctly), so this test guards the
+/// parse output itself: a small repeating pattern must produce at least one
+/// `Sequence::Triple`, so a future regression that emits literals-only (e.g. a
+/// `min_match` or rep-probe guard regression) is caught.
 #[test]
 fn driver_level4_greedy_round_trip_single_slice() {
     let mut driver = MatchGeneratorDriver::new(64, 2);

--- a/zstd/src/encoding/match_table/helpers.rs
+++ b/zstd/src/encoding/match_table/helpers.rs
@@ -15,6 +15,7 @@
 //! change is `pub(crate)` visibility on the moved items.
 
 use super::super::opt::types::MatchCandidate;
+use crate::encoding::fastpath::FastpathKernel;
 
 /// Minimum match length emitted by the Simple / level-1 matcher (and the
 /// donor `ZSTD_fast.c` baseline). Lives here so every matcher and the
@@ -43,6 +44,23 @@ pub(crate) fn common_prefix_len(a: &[u8], b: &[u8]) -> usize {
     // bytes.
     unsafe {
         crate::encoding::fastpath::dispatch_common_prefix_len_ptr(a.as_ptr(), b.as_ptr(), max)
+    }
+}
+
+/// As [`common_prefix_len`] but against an already-resolved [`FastpathKernel`].
+/// Hot match-finder loops resolve the kernel once per block and pass it in,
+/// so each byte-compare skips the per-call `select_kernel()` `OnceLock` atomic.
+#[inline(always)]
+pub(crate) fn common_prefix_len_with_kernel(kernel: FastpathKernel, a: &[u8], b: &[u8]) -> usize {
+    let max = a.len().min(b.len());
+    // SAFETY: as `common_prefix_len` — both pointers are valid for `max` bytes.
+    unsafe {
+        crate::encoding::fastpath::dispatch_common_prefix_len_ptr_with_kernel(
+            kernel,
+            a.as_ptr(),
+            b.as_ptr(),
+            max,
+        )
     }
 }
 
@@ -114,6 +132,7 @@ pub(crate) fn extend_backwards_shared(
 /// (~10% exclusive on the default-level profile).
 #[inline]
 pub(crate) fn repcode_candidate_shared(
+    kernel: FastpathKernel,
     concat: &[u8],
     history_abs_start: usize,
     offset_hist: [u32; 3],
@@ -156,8 +175,11 @@ pub(crate) fn repcode_candidate_shared(
                 let candidate_pos = abs_pos - rep;
                 if candidate_pos >= history_abs_start {
                     let candidate_idx = candidate_pos - history_abs_start;
-                    let match_len =
-                        common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
+                    let match_len = common_prefix_len_with_kernel(
+                        kernel,
+                        &concat[candidate_idx..],
+                        &concat[current_idx..],
+                    );
                     if match_len >= min_match_len {
                         let candidate = extend_backwards_shared(
                             concat,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1090,6 +1090,7 @@ impl RowMatchGenerator {
             let rep_probe_lit_len = lit_len + 1;
             let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= self.history_abs_end() {
                 repcode_candidate_shared(
+                    self.hash_kernel,
                     self.live_history(),
                     self.history_abs_start,
                     self.offset_hist,
@@ -1305,6 +1306,7 @@ impl RowMatchGenerator {
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         repcode_candidate_shared(
+            self.hash_kernel,
             self.live_history(),
             self.history_abs_start,
             self.offset_hist,


### PR DESCRIPTION
## Summary

The dashboard's worst compress outlier was `decodecorpus-z000033` at level 4
(dfast): the encoder ran ~8.4x slower than the C reference even though it
already beat the reference on ratio. Root cause: level 4 was routed through a
lazy `start_matching_general` path that has no counterpart in the reference.
The reference's `ZSTD_dfast` is the greedy double-fast at every level (lazy
parsing is the separate `lazy`/`lazy2` strategy). Routing level 4 through the
greedy double-fast loop closes most of the gap.

Result on the i9 bench host (`compress/level_4_dfast/decodecorpus-z000033`):
pure-Rust **~43.4 ms -> ~19.6 ms (2.2x faster)**; rust/ffi gap **8.4x -> ~3.9x**.
Ratio stays in our favour (`rust_bytes 493671 < ffi_bytes 526163`).

## Changes

- **Greedy double-fast for dfast (level 3/4).** Key `use_fast_loop` on the
  Dfast backend, not the numeric level, so a parameter-API `Strategy::Dfast`
  stays greedy at every level (reference parity). Then remove the unreachable
  lazy `start_matching_general` path entirely (~900 lines: per-kernel wrappers,
  general-only candidate/probe helpers + body macros, the `use_fast_loop` /
  `lazy_depth` fields and dead constants).
- **5-byte short hash** keyed on `mls = 5` (reference `ZSTD_hashPtr`), applied
  consistently across build / insert / probe / dict-probe, with a block-seam
  re-seed so cross-block matches anchored in the boundary tail are still found.
- **Inline fixed-width equality gates** (4/8-byte) as `u32`/`u64` loads instead
  of slice `!=`, which lowered to a libc `memcmp` CALL (~14% self-time, ~-4% on
  glibc builds; neutral on musl, which already inlines it).
- **wasm `simd128` encoder kernel** (`fastpath/simd128.rs`): v128
  common-prefix-len / count-match, wired through `FastpathKernel::Simd128` and
  the dfast/row hot paths.
- Cache the fastpath kernel once per matcher (drops a per-scan `OnceLock`
  atomic); per-kernel `#[target_feature]` monolith for the dfast greedy loop so
  the SIMD scan inlines under one umbrella.

## Testing

819 lib tests pass byte-identical-roundtrip; aarch64 / x86_64 / wasm32 (with
and without the `simd128` payload) build clean. Bench numbers measured on the
i9 host with a flat FFI control arm.

## Follow-up (parity, not this PR)

Residual ~3.9x vs the reference on z000033 and the `large-log-stream` ratio gap
are the reference greedy double-fast's remaining quality/throughput edge over
ours; tracked as parity work.

Part of #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Single fast-loop match path with a cached kernel and a new SIMD-accelerated fastpath for WebAssembly, reducing per-match overhead.

* **Behavior Changes**
  * Dictionary priming now occurs unconditionally; short-hash/lookahead moved to 5-byte semantics, altering tail/safe-end and match-boundary behavior.

* **Refactor**
  * Match-generation and prefix-matching consolidated around kernel-driven helpers to ensure consistent, lower-overhead matching.

* **Tests**
  * Unit tests and fixtures updated to reflect new matching semantics and short-hash boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->