### PR TITLE
perf(encode): reshape dfast match-find toward donor structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ CLAUDE.md
 .claude/
 .local/
 **/__pycache__/
+dhat-heap.json

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -58,6 +58,10 @@ alloc = { version = "1.0.0", optional = true, package = "rustc-std-workspace-all
 criterion = "0.8"
 rand = "0.10"
 zstd = { version = "0.13.3", features = ["zdict_builder", "experimental"] }
+# Heap profiler for per-allocation-site attribution (the `dhat-heap`
+# feature swaps it in as the global allocator in the reuse profiling
+# example). Dev-only; never linked into the library.
+dhat = "0.3"
 
 [features]
 default = [
@@ -112,6 +116,14 @@ critical-section = ["dep:critical-section"]
 bench_internals = []
 fuzz_exports = []
 std = []
+# Dev-only: route the `encode_loop_reuse_z000033` profiling example through
+# the `dhat` heap profiler (per-allocation-site call-stack attribution) so a
+# reused-compressor run shows which Rust sites allocate, and how many times —
+# the per-frame allocation churn that libc-frame-pointer-broken flamegraphs
+# can't attribute. Off by default (the profiler adds large overhead); enable
+# only for the example. Writes `dhat-heap.json` (view at the dhat viewer or
+# parse for `total_blocks` per site).
+dhat-heap = []
 # Diagnostic-only: atomic histograms of the match/literal copy shape on the
 # decode path (call counts + size buckets + requested-vs-overshoot byte
 # totals). Off in every shipping / bench build (zero codegen impact). Enabled

--- a/zstd/examples/encode_loop_reuse_z000033.rs
+++ b/zstd/examples/encode_loop_reuse_z000033.rs
@@ -85,14 +85,4 @@ fn main() {
         level,
         sink
     );
-    #[cfg(feature = "dhat-heap")]
-    {
-        let calls = structured_zstd::huff0::huff0_encoder::BUILD_FROM_COUNTS_CALLS
-            .load(core::sync::atomic::Ordering::Relaxed);
-        eprintln!(
-            "build_from_counts calls: {} total = {:.1} per frame",
-            calls,
-            calls as f64 / iters as f64
-        );
-    }
 }

--- a/zstd/examples/encode_loop_reuse_z000033.rs
+++ b/zstd/examples/encode_loop_reuse_z000033.rs
@@ -85,4 +85,14 @@ fn main() {
         level,
         sink
     );
+    #[cfg(feature = "dhat-heap")]
+    {
+        let calls = structured_zstd::huff0::huff0_encoder::BUILD_FROM_COUNTS_CALLS
+            .load(core::sync::atomic::Ordering::Relaxed);
+        eprintln!(
+            "build_from_counts calls: {} total = {:.1} per frame",
+            calls,
+            calls as f64 / iters as f64
+        );
+    }
 }

--- a/zstd/examples/encode_loop_reuse_z000033.rs
+++ b/zstd/examples/encode_loop_reuse_z000033.rs
@@ -22,7 +22,18 @@ use std::env;
 
 use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
 
+// With `--features dhat-heap`, route every allocation through the dhat heap
+// profiler so the run records per-call-site allocation counts + bytes (the
+// reused-compressor churn that broken-unwind flamegraphs can't attribute).
+// Writes `dhat-heap.json` on `Profiler` drop.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let args: Vec<String> = env::args().collect();
     let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
     let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2000);

--- a/zstd/examples/encode_loop_reuse_z000033.rs
+++ b/zstd/examples/encode_loop_reuse_z000033.rs
@@ -1,0 +1,77 @@
+//! Reused-compressor encode-loop for profiling the ENCODER COMPUTE in
+//! isolation from per-frame allocation.
+//!
+//! Unlike [`encode_loop_z000033`] (which constructs a fresh
+//! `FrameCompressor` every iteration so the profile INCLUDES the matcher
+//! table allocation + memset + first-touch page faults), this binary
+//! constructs ONE `FrameCompressor` outside the loop and drives
+//! `compress_independent_frame_into` — the CCtx-equivalent reuse path that
+//! resets per-frame state but keeps every allocation. After the first
+//! iteration the hash tables, history, entropy scratch and output buffer
+//! are all warm, so steady-state samples land on the real compute hot
+//! path (match-find + sequence emit + entropy encode), letting a
+//! flamegraph reveal where the encoder spends CPU once allocation is
+//! amortized (the shape a real caller that reuses one compressor sees).
+//!
+//! Build: `cargo build --profile flamegraph -p structured-zstd
+//!          --example encode_loop_reuse_z000033 --features dict_builder`
+//! Run:   `cargo flamegraph --example encode_loop_reuse_z000033 --features dict_builder
+//!          --profile flamegraph -- <level> <iters> <corpus_path>`
+
+use std::env;
+
+use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(3);
+    let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2000);
+    let corpus_path: Option<&str> = args.get(3).map(|s| s.as_str());
+
+    let src: Vec<u8> = if let Some(path) = corpus_path {
+        std::fs::read(path).expect("read corpus file")
+    } else {
+        let n = 1_048_576usize;
+        let mut src = Vec::with_capacity(n);
+        let mut state: u64 = 0x517cc1b727220a95;
+        while src.len() < n {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            src.push((state >> 56) as u8);
+        }
+        src
+    };
+
+    let cap = src
+        .len()
+        .checked_add(src.len() >> 3)
+        .and_then(|v| v.checked_add(4096))
+        .expect("corpus too large: output-capacity bound overflows usize");
+    let mut out: Vec<u8> = Vec::with_capacity(cap);
+
+    let compressor_level = CompressionLevel::from_level(level);
+
+    // ONE compressor, reused across every iteration: allocations happen on
+    // the first frame and amortize to zero for the rest, so the profile is
+    // dominated by compute, not table alloc / memset / page faults.
+    let mut frame_enc: FrameCompressor = FrameCompressor::new(compressor_level);
+    frame_enc.set_source_size_hint(src.len() as u64);
+
+    let mut sink: usize = 0;
+    for _ in 0..iters {
+        // `_into` replaces `out`'s contents and reuses its capacity; the
+        // compressor resets per-frame state but keeps its heavy allocations.
+        frame_enc.compress_independent_frame_into(src.as_slice(), &mut out);
+        sink = sink.wrapping_add(out.len());
+        core::hint::black_box(&out);
+    }
+
+    eprintln!(
+        "encoded {} bytes × {} iters at level {} (reused compressor); last-out-sum={}",
+        src.len(),
+        iters,
+        level,
+        sink
+    );
+}

--- a/zstd/src/decoding/prefetch.rs
+++ b/zstd/src/decoding/prefetch.rs
@@ -27,16 +27,6 @@ pub(crate) fn prefetch_slice_t1(slice: &[u8]) {
     prefetch_slice_impl_t1(slice);
 }
 
-/// Issue one L1 prefetch hint at `ptr`. The encoder match-finder uses this
-/// to warm the input lines a few positions ahead (donor `PREFETCH_L1(ip +
-/// 256)` in `ZSTD_compressBlock_doubleFast`). `ptr` need not be in bounds —
-/// prefetching an invalid address is a no-op by the ISA spec, not UB — so the
-/// caller may aim slightly past the buffer end without a bounds check.
-#[inline(always)]
-pub(crate) fn prefetch_l1_at(ptr: *const u8) {
-    prefetch_first_line_l1_impl(ptr);
-}
-
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn prefetch_slice_impl_l1(slice: &[u8]) {

--- a/zstd/src/decoding/prefetch.rs
+++ b/zstd/src/decoding/prefetch.rs
@@ -27,6 +27,16 @@ pub(crate) fn prefetch_slice_t1(slice: &[u8]) {
     prefetch_slice_impl_t1(slice);
 }
 
+/// Issue one L1 prefetch hint at `ptr`. The encoder match-finder uses this
+/// to warm the input lines a few positions ahead (donor `PREFETCH_L1(ip +
+/// 256)` in `ZSTD_compressBlock_doubleFast`). `ptr` need not be in bounds —
+/// prefetching an invalid address is a no-op by the ISA spec, not UB — so the
+/// caller may aim slightly past the buffer end without a bounds check.
+#[inline(always)]
+pub(crate) fn prefetch_l1_at(ptr: *const u8) {
+    prefetch_first_line_l1_impl(ptr);
+}
+
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn prefetch_slice_impl_l1(slice: &[u8]) {

--- a/zstd/src/encoding/block_header.rs
+++ b/zstd/src/encoding/block_header.rs
@@ -23,8 +23,17 @@ impl BlockHeader {
     /// Write encoded binary representation of this header into the provided buffer.
     pub fn serialize(self, output: &mut Vec<u8>) {
         vprintln!("Serializing block with the header: {self:?}");
+        output.extend_from_slice(&self.to_le_bytes());
+    }
+
+    /// The fixed 3-byte little-endian block header. Block headers are always
+    /// exactly 3 bytes (RFC 8878 §3.1.1.2), so callers that reserved space
+    /// up front can backfill the header in place via this array without a
+    /// `Vec` round-trip (the compress-into-output emit path relies on this).
+    #[inline]
+    pub fn to_le_bytes(&self) -> [u8; 3] {
         let encoded_block_type = match self.block_type {
-            BlockType::Raw => 0,
+            BlockType::Raw => 0u32,
             BlockType::RLE => 1,
             BlockType::Compressed => 2,
             BlockType::Reserved => panic!("You cannot use a reserved block type"),
@@ -32,7 +41,8 @@ impl BlockHeader {
         let mut block_header = self.block_size << 3;
         block_header |= encoded_block_type << 1;
         block_header |= self.last_block as u32;
-        output.extend_from_slice(&block_header.to_le_bytes()[0..3]);
+        let le = block_header.to_le_bytes();
+        [le[0], le[1], le[2]]
     }
 }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1298,45 +1298,53 @@ impl DfastMatchGenerator {
 
     #[inline]
     pub(crate) fn insert_position(&mut self, pos: usize) {
-        let idx = pos.wrapping_sub(self.history_abs_start);
-        let concat_len = self.history.len() - self.history_start;
-        // Pre-rebase guard. The producer that walks `insert_positions*`
-        // can sweep an arbitrary number of positions per block; running
-        // `pack_slot` per-position would call `ensure_room_for` from a
-        // tight inner loop. Hoisting the rebase trigger to the start of
-        // `insert_position` keeps the per-byte hot path branch-free
-        // when the relative window has plenty of headroom (the common
-        // case) while still guaranteeing the slot value below fits in
-        // `u32`. `ensure_room_for` is a single u32 comparison when no
-        // rebase is needed.
-        self.ensure_room_for(pos);
-        let packed = self.pack_slot(pos);
-        // SAFETY: the `*_hash_index` helpers mask the mixed hash to
-        // `long_hash_bits` / `short_hash_bits`, and `ensure_hash_tables`
-        // sizes the two tables to `1 << long_hash_bits` /
-        // `1 << short_hash_bits` respectively, so every produced index
-        // is provably below the table length. Eliding the bounds check
-        // on this per-byte hot path saves ~4 instructions per call.
+        // Source the bytes + rebase coordinates through `scan_source()` so a
+        // borrowed window's seam / tail re-seeds hash the in-place input
+        // exactly as the owned path hashes its `history` concat.
+        let (base_ptr, start_offset, abs_start, _position_base, concat_len) = self.scan_source();
+        let idx = pos.wrapping_sub(abs_start);
+        // Pre-rebase guard (owned only). The producer that walks
+        // `insert_positions*` can sweep an arbitrary number of positions
+        // per block; running `pack_slot` per-position would call
+        // `ensure_room_for` from a tight inner loop. Hoisting the rebase
+        // trigger here keeps the per-byte hot path branch-free when the
+        // relative window has headroom (the common case) while still
+        // guaranteeing the slot value below fits in `u32`. The borrowed
+        // window never rebases (`position_base == 0`, no eviction), so it
+        // packs the absolute position directly with the same +1 bias.
+        let packed = if self.borrowed.is_some() {
+            (pos as u32).wrapping_add(1)
+        } else {
+            self.ensure_room_for(pos);
+            self.pack_slot(pos)
+        };
+        // SAFETY: `base_ptr + start_offset` is the live source start (owned
+        // `history[history_start..]` or the borrowed input slice) and
+        // `concat_len` its readable byte count; the `idx + 5` / `idx + 8`
+        // gates keep both keyed reads in range. The slice is raw-pointer
+        // backed (holds no borrow on `self`), so the `&mut self.short_hash`
+        // / `&mut self.long_hash` writes below stay sound. The `*_hash_index`
+        // helpers mask to `long_hash_bits` / `short_hash_bits` and
+        // `ensure_hash_tables` sizes both tables to `1 << bits`, so every
+        // index is below the table length — eliding the bounds check on this
+        // per-byte hot path saves ~4 instructions per call.
         //
-        // Single-slot overwrite (upstream parity): the previous 4-slot
-        // bucket shift (`copy_within(..)`) is gone — upstream
-        // `ZSTD_compressBlock_doubleFast_*` writes a single `U32` per
-        // hash position and relies on the dense `_search_next_long`
-        // retry in `hash_candidate` (via `best_match`) to preserve
-        // compression ratio.
+        // Single-slot overwrite (upstream parity): upstream
+        // `ZSTD_compressBlock_doubleFast_*` writes a single `U32` per hash
+        // position and relies on the dense `_search_next_long` retry in
+        // `hash_candidate` (via `best_match`) to preserve compression ratio.
         // Short key needs 5 readable bytes (donor `mls = 5`). A position
-        // within 4 bytes of the current history end is not inserted here; the
-        // `start_matching` seam re-seed picks it up once the next block extends
-        // history far enough to form its full 5-byte key.
+        // within 4 bytes of the source end is not inserted here; the
+        // `start_matching` seam re-seed picks it up once the next block
+        // extends the source far enough to form its full 5-byte key.
+        let concat = unsafe { core::slice::from_raw_parts(base_ptr.add(start_offset), concat_len) };
         if idx + 5 <= concat_len {
-            let concat = &self.history[self.history_start..];
             let short = self.short_hash_index(&concat[idx..]);
             debug_assert!(short < self.short_hash.len());
             unsafe { *self.short_hash.get_unchecked_mut(short) = packed };
         }
 
         if idx + 8 <= concat_len {
-            let concat = &self.history[self.history_start..];
             let long = self.long_hash_index(&concat[idx..]);
             debug_assert!(long < self.long_hash.len());
             unsafe { *self.long_hash.get_unchecked_mut(long) = packed };

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1014,6 +1014,28 @@ impl DfastMatchGenerator {
         }
     }
 
+    /// Per-outer-iteration byte-source descriptor for the fast loop:
+    /// `(base_ptr, start_offset, abs_start, position_base, concat_len)`.
+    ///
+    /// Read once at the top of every outer iteration so the kernel body
+    /// is agnostic to where its bytes live: the owned path returns the
+    /// `history` concat's (rebased) fields, and a future borrowed
+    /// one-shot window will return its own constant descriptor without
+    /// the kernel body changing. Returns raw pointer + offsets (no borrow
+    /// held), so the subsequent `&mut self` hash-table pointer snapshot in
+    /// the loop stays sound.
+    #[inline(always)]
+    fn scan_source(&self) -> (*const u8, usize, usize, usize, usize) {
+        let start_offset = self.history_start;
+        (
+            self.history.as_ptr(),
+            start_offset,
+            self.history_abs_start,
+            self.position_base,
+            self.history.len() - start_offset,
+        )
+    }
+
     fn emit_candidate(
         &mut self,
         current_abs_start: usize,
@@ -1543,13 +1565,16 @@ macro_rules! start_matching_fast_loop_body {
 
             // Re-read every per-frame-mutable cursor here — `emit_candidate`
             // in the previous outer iteration may have triggered a rebase.
-            let history_abs_start = $self.history_abs_start;
-            let position_base = $self.position_base;
-            let history_start_offset = $self.history_start;
-            let history_base_ptr = $self.history.as_ptr();
+            // The byte-source quintet comes through `scan_source()` so a
+            // borrowed one-shot window can substitute the owned `history`
+            // concat without touching this kernel body: the owned path
+            // returns its rebased fields, a borrowed window its constant
+            // descriptor. The hash-table pointers are mode-invariant (the
+            // tables persist across owned/borrowed) so they stay direct.
+            let (history_base_ptr, history_start_offset, history_abs_start, position_base, concat_len) =
+                $self.scan_source();
             let short_hash_ptr = $self.short_hash.as_mut_ptr();
             let long_hash_ptr = $self.long_hash.as_mut_ptr();
-            let concat_len = $self.history.len() - history_start_offset;
 
             // Pre-compute long hash at ip0 ONCE per outer iter.
             // `concat_idx = ($current_abs_start + ip0) - history_abs_start`

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -724,6 +724,97 @@ impl DfastMatchGenerator {
         self.start_matching_fast_loop(current_abs_start, current_len, &mut handle_sequence);
     }
 
+    /// Register the caller's in-place input buffer for the borrowed one-shot
+    /// path (donor `ZSTD_CCtx` in-place input). The dfast analog of
+    /// [`super::simple::fast_matcher::FastKernelMatcher::set_borrowed_window`]:
+    /// subsequent blocks scan ranges of `buffer` directly instead of copying
+    /// each into the owned `history` concat.
+    ///
+    /// # Safety
+    /// `buffer` must stay live and unmodified until [`Self::clear_borrowed_window`]
+    /// (or [`Self::reset`]) — the matcher stores a raw pointer into it and
+    /// dereferences it during every staged block scan.
+    pub(crate) unsafe fn set_borrowed_window(&mut self, buffer: &[u8]) {
+        self.borrowed_input = Some((buffer.as_ptr(), buffer.len()));
+        self.borrowed_block = None;
+    }
+
+    /// Drop the borrowed input window (the caller's slice no longer lives).
+    pub(crate) fn clear_borrowed_window(&mut self) {
+        self.borrowed_input = None;
+        self.borrowed_block = None;
+    }
+
+    /// Make `[block_start, block_end)` the active borrowed block BEFORE the
+    /// scan, so the emit pipeline's pre-scan `get_last_space().len()` reserve
+    /// reports this block (not a stale or whole-input range).
+    pub(crate) fn stage_borrowed_block(&mut self, block_start: usize, block_end: usize) {
+        let (_ptr, total) = self
+            .borrowed_input
+            .expect("stage_borrowed_block requires a registered borrowed window");
+        // Always-on (not debug_assert): the range feeds the unsafe slice
+        // builders in `scan_source` / `get_last_space`, so an out-of-range or
+        // inverted range must fault here, not deep in the kernel.
+        assert!(
+            block_start <= block_end && block_end <= total,
+            "borrowed block bounds out of range: start={block_start} end={block_end} total={total}",
+        );
+        self.borrowed_block = Some((block_start, block_end));
+    }
+
+    /// Borrowed one-shot equivalent of [`Self::start_matching`]: scan
+    /// `[block_start, block_end)` of the registered borrowed window in place
+    /// (no `commit_space` copy). Produces a byte-identical sequence stream to
+    /// the owned path for in-window inputs — positions are absolute input
+    /// offsets, candidate reads land in the same buffer, and the seam re-seed
+    /// re-hashes the prior block's short-key tail exactly as the owned loop
+    /// does once `history` spans it.
+    pub(crate) fn start_matching_borrowed(
+        &mut self,
+        block_start: usize,
+        block_end: usize,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        self.stage_borrowed_block(block_start, block_end);
+        self.ensure_hash_tables();
+        let current_len = block_end - block_start;
+        if current_len == 0 {
+            return;
+        }
+        let current_abs_start = block_start;
+        // Seam re-seed (mirror `start_matching`): re-hash the prior block's
+        // trailing `BOUNDARY_DENSE_TAIL_LEN` bytes now that the readable
+        // length spans them so a position whose 5-byte key could not form at
+        // the prior block end becomes matchable. The borrowed floor is the
+        // input start (0), so the first block (block_start == 0) backfills
+        // nothing.
+        let backfill_start = current_abs_start.saturating_sub(Self::BOUNDARY_DENSE_TAIL_LEN);
+        if backfill_start < current_abs_start {
+            self.insert_positions(backfill_start, current_abs_start);
+        }
+        self.start_matching_fast_loop(current_abs_start, current_len, &mut handle_sequence);
+    }
+
+    /// Borrowed one-shot equivalent of [`Self::skip_matching`]: stage the
+    /// block (so `get_last_space` reports it for the RLE/Raw emit) without
+    /// scanning. The block's bytes already sit in the borrowed buffer at
+    /// their absolute offsets, so a future block reaches them by offset just
+    /// as the owned skip's `history` append makes them reachable; the
+    /// `Some(false)` dictionary-priming case hashes every position so future
+    /// blocks can MATCH them, mirroring the owned skip's prime path.
+    pub(crate) fn skip_matching_borrowed(
+        &mut self,
+        block_start: usize,
+        block_end: usize,
+        incompressible_hint: Option<bool>,
+    ) {
+        self.stage_borrowed_block(block_start, block_end);
+        if incompressible_hint == Some(false) {
+            self.ensure_hash_tables();
+            self.insert_positions(block_start, block_end);
+        }
+    }
+
     /// Single-cursor probe at the last hashable position in the
     /// current block. Called from `start_matching_fast_loop` only when
     /// the outer iteration sees `ip0` still hashable but `ip1` past
@@ -2865,6 +2956,65 @@ mod extend_with_repcode_tests {
              got {} → {} bytes",
             data.len(),
             compressed.len()
+        );
+    }
+
+    /// The borrowed one-shot scan (no per-block `commit_space` copy) must
+    /// emit the byte-identical sequence stream as the owned `history`-copying
+    /// path for an in-window input: the window far exceeds the input so the
+    /// owned path never evicts, making its accumulated `history` identical to
+    /// the borrowed buffer, and the borrowed scan's absolute positions /
+    /// seam re-seed reproduce the same match decisions. This is the
+    /// correctness contract behind routing dfast through `borrowed_eligible`.
+    #[test]
+    fn dfast_borrowed_window_matches_owned_sequence_stream() {
+        // Repeating pattern (period 64) so the matcher emits real matches,
+        // split across two blocks.
+        let mut whole: Vec<u8> = Vec::with_capacity(512);
+        for i in 0..512usize {
+            whole.push((i % 64) as u8);
+        }
+        let split = 300usize;
+        let window = 1usize << 16; // 64 KiB >> 512-byte input: no eviction.
+
+        // Owned: commit each block, then scan.
+        let mut owned = DfastMatchGenerator::new(window);
+        owned.ensure_hash_tables();
+        let mut owned_seqs: Vec<CapturedSeq> = Vec::new();
+        owned.add_data(whole[..split].to_vec(), |_| {});
+        {
+            let mut rec = record_seq(&mut owned_seqs);
+            owned.start_matching(&mut rec);
+        }
+        owned.add_data(whole[split..].to_vec(), |_| {});
+        {
+            let mut rec = record_seq(&mut owned_seqs);
+            owned.start_matching(&mut rec);
+        }
+
+        // Borrowed: same bytes, scanned in place by absolute block range.
+        let mut borrowed = DfastMatchGenerator::new(window);
+        borrowed.ensure_hash_tables();
+        let mut borrowed_seqs: Vec<CapturedSeq> = Vec::new();
+        // SAFETY: `whole` outlives both scans; `borrowed` is dropped at end
+        // of scope before `whole`, so the window never dangles.
+        unsafe { borrowed.set_borrowed_window(&whole) };
+        {
+            let mut rec = record_seq(&mut borrowed_seqs);
+            borrowed.start_matching_borrowed(0, split, &mut rec);
+        }
+        {
+            let mut rec = record_seq(&mut borrowed_seqs);
+            borrowed.start_matching_borrowed(split, whole.len(), &mut rec);
+        }
+
+        assert_eq!(
+            owned_seqs, borrowed_seqs,
+            "dfast borrowed window must emit the identical sequence stream as the owned path",
+        );
+        assert_eq!(
+            owned.offset_hist, borrowed.offset_hist,
+            "rep state must match after both scans",
         );
     }
 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1189,6 +1189,40 @@ impl DfastMatchGenerator {
         )
     }
 
+    /// Byte-source descriptor for the BORROWED kernel: `(input_ptr,
+    /// block_end)`. The borrowed window packs absolute input offsets, so the
+    /// owned rebase coordinates (`start_offset`, `abs_start`, `position_base`)
+    /// are constant `0` and the hot loop supplies them as literals — folding
+    /// every per-position `abs - abs_start` / `>= abs_start` term to the bare
+    /// absolute position (donor `base + index` shape). Split out from
+    /// [`Self::scan_source`] so the `BORROWED` const kernel never materialises
+    /// the owned-path arithmetic.
+    #[inline(always)]
+    fn borrowed_scan_descriptor(&self) -> (*const u8, usize) {
+        let (ptr, _total) = self
+            .borrowed_input
+            .expect("BORROWED kernel dispatched without a borrowed window");
+        let (_block_start, block_end) = self
+            .borrowed_block
+            .expect("BORROWED kernel dispatched without a staged block");
+        (ptr, block_end)
+    }
+
+    /// Byte-source descriptor for the owned (history-concat) kernel. Mirrors
+    /// the owned arm of [`Self::scan_source`] without the borrowed branch, so
+    /// the `!BORROWED` const kernel reads the rebased fields directly.
+    #[inline(always)]
+    fn owned_scan_descriptor(&self) -> (*const u8, usize, usize, usize, usize) {
+        let start_offset = self.history_start;
+        (
+            self.history.as_ptr(),
+            start_offset,
+            self.history_abs_start,
+            self.position_base,
+            self.history.len() - start_offset,
+        )
+    }
+
     /// `(ptr, len)` of the block currently being emitted, for the literal
     /// slices in `emit_candidate` / `emit_trailing_literals`. Owned: the
     /// `history` concat tail (`last_len` bytes). Borrowed: the in-place
@@ -1568,7 +1602,7 @@ impl DfastMatchGenerator {
 /// cpl calls inline under one umbrella and `select_kernel()` is resolved ONCE
 /// per block in the bare dispatcher, never per cpl call.
 macro_rules! start_matching_fast_loop_body {
-    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident, $cpl:path, $use_dict:expr) => {{
+    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident, $cpl:path, $use_dict:expr, $borrowed:expr) => {{
         // Behaviour change vs the pre-refactor `start_matching_general`:
         // this fast loop deliberately drops the strict-incompressible
         // early-skip path (the `block_looks_incompressible_strict` short
@@ -1659,7 +1693,7 @@ macro_rules! start_matching_fast_loop_body {
         // 0` (the eligibility gate caps `input_len <= u32::MAX`, so every
         // `abs + 1` slot fits without a reduce), and a `reduce()` here would
         // subtract from every live slot and corrupt that absolute encoding.
-        if $self.borrowed_block.is_none() {
+        if !$borrowed {
             $self.ensure_room_for($current_abs_start + $current_len - 1);
         }
         const PRIME: u64 = 0xCF1BBCDCB7A56463_u64;
@@ -1776,8 +1810,19 @@ macro_rules! start_matching_fast_loop_body {
             // returns its rebased fields, a borrowed window its constant
             // descriptor. The hash-table pointers are mode-invariant (the
             // tables persist across owned/borrowed) so they stay direct.
+            // `$borrowed` is a compile-time const (the kernel is monomorphised
+            // per borrowed/owned), so only one arm survives. On the borrowed
+            // kernel `history_start_offset / history_abs_start / position_base`
+            // are LITERAL `0`, collapsing every per-position `abs - abs_start`
+            // term and the always-true `cand_pos >= abs_start` lower-bound
+            // check to the bare absolute position (donor `base + index` shape).
             let (history_base_ptr, history_start_offset, history_abs_start, position_base, concat_len) =
-                $self.scan_source();
+                if $borrowed {
+                    let (ptr, block_end) = $self.borrowed_scan_descriptor();
+                    (ptr, 0usize, 0usize, 0usize, block_end)
+                } else {
+                    $self.owned_scan_descriptor()
+                };
             let short_hash_ptr = $self.short_hash.as_mut_ptr();
             let long_hash_ptr = $self.long_hash.as_mut_ptr();
 
@@ -2480,13 +2525,27 @@ impl DfastMatchGenerator {
         // loop-invariant runtime check inside the scan. The no-dict kernel
         // carries zero dict code (donor keeps the noDict / dictMatchState loops
         // as separate functions for exactly this reason).
+        // Two orthogonal axes resolved ONCE here, off the hot path, into a
+        // const-monomorphised kernel:
+        //   * `USE_DICT` — dict probe compiled in or out (donor keeps noDict /
+        //     dictMatchState as separate functions for the same reason).
+        //   * `BORROWED` — borrowed-window scan vs owned history concat. The
+        //     borrowed kernel folds the rebase coordinates to literal `0`,
+        //     erasing the per-position abstraction arithmetic the owned path
+        //     needs (donor `base + index` shape).
+        // A borrowed block never carries a dict (`borrowed_eligible` rejects
+        // `use_dictionary_state`), so only three of the four combinations are
+        // ever instantiated; the `<true, true>` arm is unreachable.
         let use_dict = self.dict.table().is_some();
+        let borrowed = self.borrowed_block.is_some();
         macro_rules! dispatch_dict {
             ($kernel:ident) => {
-                if use_dict {
-                    self.$kernel::<true>(current_abs_start, current_len, handle_sequence)
+                if borrowed {
+                    self.$kernel::<false, true>(current_abs_start, current_len, handle_sequence)
+                } else if use_dict {
+                    self.$kernel::<true, false>(current_abs_start, current_len, handle_sequence)
                 } else {
-                    self.$kernel::<false>(current_abs_start, current_len, handle_sequence)
+                    self.$kernel::<false, false>(current_abs_start, current_len, handle_sequence)
                 }
             };
         }
@@ -2533,7 +2592,7 @@ impl DfastMatchGenerator {
 
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
-    unsafe fn start_matching_fast_loop_neon<const USE_DICT: bool>(
+    unsafe fn start_matching_fast_loop_neon<const USE_DICT: bool, const BORROWED: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2545,13 +2604,14 @@ impl DfastMatchGenerator {
             current_len,
             handle_sequence,
             crate::encoding::fastpath::neon::common_prefix_len_ptr,
-            USE_DICT
+            USE_DICT,
+            BORROWED
         )
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "sse4.2")]
-    unsafe fn start_matching_fast_loop_sse42<const USE_DICT: bool>(
+    unsafe fn start_matching_fast_loop_sse42<const USE_DICT: bool, const BORROWED: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2563,13 +2623,14 @@ impl DfastMatchGenerator {
             current_len,
             handle_sequence,
             crate::encoding::fastpath::sse42::common_prefix_len_ptr,
-            USE_DICT
+            USE_DICT,
+            BORROWED
         )
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn start_matching_fast_loop_avx2_bmi2<const USE_DICT: bool>(
+    unsafe fn start_matching_fast_loop_avx2_bmi2<const USE_DICT: bool, const BORROWED: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2581,7 +2642,8 @@ impl DfastMatchGenerator {
             current_len,
             handle_sequence,
             crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
-            USE_DICT
+            USE_DICT,
+            BORROWED
         )
     }
 
@@ -2591,7 +2653,7 @@ impl DfastMatchGenerator {
         feature = "kernel_simd128"
     ))]
     #[target_feature(enable = "simd128")]
-    unsafe fn start_matching_fast_loop_simd128<const USE_DICT: bool>(
+    unsafe fn start_matching_fast_loop_simd128<const USE_DICT: bool, const BORROWED: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2603,7 +2665,8 @@ impl DfastMatchGenerator {
             current_len,
             handle_sequence,
             crate::encoding::fastpath::simd128::common_prefix_len_ptr,
-            USE_DICT
+            USE_DICT,
+            BORROWED
         )
     }
 
@@ -2616,7 +2679,7 @@ impl DfastMatchGenerator {
         )
     )))]
     #[allow(unused_unsafe)]
-    fn start_matching_fast_loop_scalar<const USE_DICT: bool>(
+    fn start_matching_fast_loop_scalar<const USE_DICT: bool, const BORROWED: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2628,7 +2691,8 @@ impl DfastMatchGenerator {
             current_len,
             handle_sequence,
             crate::encoding::fastpath::scalar::common_prefix_len_ptr,
-            USE_DICT
+            USE_DICT,
+            BORROWED
         )
     }
 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1844,6 +1844,20 @@ macro_rules! start_matching_fast_loop_body {
                 let concat_idx0 = abs_ip0 - history_abs_start;
                 let concat_idx1 = abs_ip1 - history_abs_start;
 
+                // Donor `PREFETCH_L1(ip + 256)` (zstd_double_fast.c:237): warm
+                // the input line the match-finder will hash/verify a few
+                // positions ahead. The match-find loop is memory-latency bound
+                // (hash-table + candidate-verify loads dominate its self-time),
+                // and the step-accelerated cursor skips past the sequential
+                // stride the hardware prefetcher tracks, so an explicit hint
+                // covers what the HW prefetcher misses. An out-of-bounds
+                // prefetch is an ISA no-op, so no end-of-buffer guard is needed.
+                unsafe {
+                    crate::decoding::prefetch::prefetch_l1_at(
+                        history_base_ptr.add(history_start_offset + concat_idx0 + 256),
+                    );
+                }
+
                 // Load 8 bytes at ip0 for both short (low 4) and long
                 // probe equality checks. We already used `v8_at_ip0` to
                 // compute hl0/idxl0 in the outer init / previous iter's
@@ -2387,6 +2401,14 @@ macro_rules! start_matching_fast_loop_body {
 
                 // Step bump on distance (donor `zstd_double_fast.c:224-228`).
                 if ip1 >= next_step_pos {
+                    // Donor (zstd_double_fast.c:225-226): on a skip-step bump
+                    // the cursor is about to jump well past `ip1`, so warm the
+                    // two cache lines just beyond it. OOB prefetch is a no-op.
+                    unsafe {
+                        let base = history_base_ptr.add(history_start_offset + concat_idx1);
+                        crate::decoding::prefetch::prefetch_l1_at(base.add(64));
+                        crate::decoding::prefetch::prefetch_l1_at(base.add(128));
+                    }
                     step = (step + 1).min(DFAST_MAX_SKIP_STEP);
                     next_step_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
                 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -123,17 +123,20 @@ pub(crate) struct DfastMatchGenerator {
     /// resolved once at construction so the per-byte match-finder scans skip
     /// the `select_kernel()` `OnceLock` atomic on every call.
     pub(crate) kernel: FastpathKernel,
-    /// Borrowed one-shot scan window: `(input_base_ptr, block_start,
-    /// block_end)`. When `Some`, the fast loop sources bytes from the
-    /// caller's in-place input slice with absolute input positions
-    /// (`abs_start = position_base = start_offset = 0`, readable length =
-    /// `block_end`) instead of copying each block into the owned `history`
-    /// concat — the dfast analog of the Fast backend's borrowed window. The
-    /// pointer is the input start (constant for the frame); `block_start..
-    /// block_end` is the active block's absolute range, re-staged before each
-    /// block scan (so `get_last_space` reports the borrowed block to the emit
-    /// pipeline). `None` = owned (history-copying) path. Cleared on `reset()`.
-    pub(crate) borrowed: Option<(*const u8, usize, usize)>,
+    /// Borrowed one-shot input window, registered once per frame:
+    /// `(input_base_ptr, total_len)`. When `Some`, the fast loop sources
+    /// bytes from the caller's in-place input slice with absolute input
+    /// positions (`abs_start = position_base = start_offset = 0`) instead of
+    /// copying each block into the owned `history` concat — the dfast analog
+    /// of the Fast backend's borrowed window. `None` = owned (history-copying)
+    /// path. Cleared on `reset()`.
+    pub(crate) borrowed_input: Option<(*const u8, usize)>,
+    /// Active borrowed block range `[block_start, block_end)` (absolute input
+    /// offsets), re-staged before each block scan so `scan_source` bounds the
+    /// readable length to `block_end` (byte-identical match window to the
+    /// owned evicting path) and `get_last_space` reports the borrowed block
+    /// to the emit pipeline. Only meaningful while `borrowed_input` is `Some`.
+    pub(crate) borrowed_block: Option<(usize, usize)>,
 }
 
 /// The dfast backend's immutable dictionary tables — a long+short pair mirroring
@@ -173,7 +176,8 @@ impl DfastMatchGenerator {
             short_hash_bits: DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA,
             dict: DictAttach::new(),
             kernel: select_kernel(),
-            borrowed: None,
+            borrowed_input: None,
+            borrowed_block: None,
         }
     }
 
@@ -332,7 +336,8 @@ impl DfastMatchGenerator {
         // Drop any borrowed window: the input slice it pointed at does not
         // outlive the frame, and the next frame re-stages its own (or runs
         // the owned path). A stale pointer must never survive a reset.
-        self.borrowed = None;
+        self.borrowed_input = None;
+        self.borrowed_block = None;
     }
 
     /// Slice of bytes from the most recently appended block. Returns
@@ -351,7 +356,9 @@ impl DfastMatchGenerator {
     /// usage and avoids a panic-vs-gate divergence that would
     /// surprise a future refactor consolidating the call sites.
     pub(crate) fn get_last_space(&self) -> &[u8] {
-        if let Some((ptr, block_start, block_end)) = self.borrowed {
+        if let (Some((ptr, _total)), Some((block_start, block_end))) =
+            (self.borrowed_input, self.borrowed_block)
+        {
             // Borrowed window: the active block is the in-place input range
             // `[block_start, block_end)`, staged before the scan so the emit
             // pipeline's pre-scan `get_last_space().len()` reserve is correct.
@@ -1070,7 +1077,9 @@ impl DfastMatchGenerator {
     /// the loop stays sound.
     #[inline(always)]
     fn scan_source(&self) -> (*const u8, usize, usize, usize, usize) {
-        if let Some((ptr, _block_start, block_end)) = self.borrowed {
+        if let (Some((ptr, _total)), Some((_block_start, block_end))) =
+            (self.borrowed_input, self.borrowed_block)
+        {
             // Borrowed one-shot window: positions are absolute input
             // offsets, so the rebase coordinates collapse to zero
             // (`start_offset = abs_start = position_base = 0`) and the
@@ -1097,7 +1106,9 @@ impl DfastMatchGenerator {
     /// the slice locally and still take `&mut self` for `offset_hist`.
     #[inline]
     fn current_block_ptr_len(&self, current_abs_start: usize) -> (*const u8, usize) {
-        if let Some((ptr, _block_start, block_end)) = self.borrowed {
+        if let (Some((ptr, _total)), Some((_block_start, block_end))) =
+            (self.borrowed_input, self.borrowed_block)
+        {
             // SAFETY: borrowed liveness contract; `current_abs_start` =
             // block_start <= block_end <= buffer len (entry-validated).
             (
@@ -1226,32 +1237,36 @@ impl DfastMatchGenerator {
     }
 
     pub(crate) fn insert_positions(&mut self, start: usize, end: usize) {
-        let start = start.max(self.history_abs_start);
-        let end = end.min(self.history_abs_end());
+        // Source the byte buffer + rebase coordinates through `scan_source()`
+        // so a borrowed window's batch re-seed hashes the in-place input
+        // (owned returns its `history` fields, byte-identical).
+        let (history_base_ptr, history_start, history_abs_start, _pb0, concat_len) =
+            self.scan_source();
+        let start = start.max(history_abs_start);
+        let end = end.min(history_abs_start + concat_len);
         if start >= end {
             return;
         }
-        // Hoist the rebase trigger out of the inner loop: a single
-        // `ensure_room_for(end - 1)` covers every `pack_slot` in the
-        // range. The per-position `ensure_room_for` call inside
-        // `insert_position` would re-check on every byte and the
-        // compiler cannot prove the call is idempotent through
-        // `&mut self`.
-        self.ensure_room_for(end - 1);
+        // Owned: hoist the rebase trigger out of the inner loop (a single
+        // `ensure_room_for(end - 1)` covers every `pack_slot` in the range);
+        // it may advance `position_base`, so read that AFTER the call. The
+        // borrowed window packs absolute input offsets with `position_base ==
+        // 0` and never rebases (the eligibility gate caps `input_len <=
+        // u32::MAX`), so a `reduce()` here would corrupt the absolute slots.
+        let position_base = if self.borrowed_block.is_none() {
+            self.ensure_room_for(end - 1);
+            self.position_base
+        } else {
+            0
+        };
 
-        // Snapshot every per-call invariant. `&mut self` blocks the
-        // optimiser from hoisting these loads across the inner loop —
-        // the bodies of `short_hash` / `long_hash` writes mutate
-        // through `self`, so each iteration would otherwise reload
-        // `history.len()`, `history_start`, `position_base`,
-        // `*_hash_bits`. With ~1 input byte per
-        // call on the dfast hot path that re-load shape was the
-        // dominant cost in the per-position cluster.
-        let history_abs_start = self.history_abs_start;
-        let position_base = self.position_base;
-        let history_start = self.history_start;
-        let concat_len = self.history.len() - history_start;
-        let history_base_ptr = self.history.as_ptr();
+        // Snapshot the remaining per-call invariants. `&mut self` blocks the
+        // optimiser from hoisting these loads across the inner loop — the
+        // bodies of `short_hash` / `long_hash` writes mutate through `self`,
+        // so each iteration would otherwise reload `*_hash_bits`. With ~1
+        // input byte per call on the dfast hot path that re-load shape was
+        // the dominant cost in the per-position cluster. `history_base_ptr`
+        // stays valid across `ensure_room_for` (it never reallocs `history`).
         let short_hash_bits = self.short_hash_bits;
         let long_hash_bits = self.long_hash_bits;
         let short_hash_ptr = self.short_hash.as_mut_ptr();
@@ -1367,7 +1382,7 @@ impl DfastMatchGenerator {
         // guaranteeing the slot value below fits in `u32`. The borrowed
         // window never rebases (`position_base == 0`, no eviction), so it
         // packs the absolute position directly with the same +1 bias.
-        let packed = if self.borrowed.is_some() {
+        let packed = if self.borrowed_block.is_some() {
             (pos as u32).wrapping_add(1)
         } else {
             self.ensure_room_for(pos);
@@ -1548,7 +1563,14 @@ macro_rules! start_matching_fast_loop_body {
         // rebase is unconditional in release builds since the
         // precondition holds.
         debug_assert!($current_len > 0, "fast_loop precondition: $current_len > 0");
-        $self.ensure_room_for($current_abs_start + $current_len - 1);
+        // Owned only: advance the u32 packing rebase past this block. A
+        // borrowed window packs absolute input offsets with `position_base ==
+        // 0` (the eligibility gate caps `input_len <= u32::MAX`, so every
+        // `abs + 1` slot fits without a reduce), and a `reduce()` here would
+        // subtract from every live slot and corrupt that absolute encoding.
+        if $self.borrowed_block.is_none() {
+            $self.ensure_room_for($current_abs_start + $current_len - 1);
+        }
         const PRIME: u64 = 0xCF1BBCDCB7A56463_u64;
         let short_shift = 64 - $self.short_hash_bits;
         let long_shift = 64 - $self.long_hash_bits;

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1844,20 +1844,6 @@ macro_rules! start_matching_fast_loop_body {
                 let concat_idx0 = abs_ip0 - history_abs_start;
                 let concat_idx1 = abs_ip1 - history_abs_start;
 
-                // Donor `PREFETCH_L1(ip + 256)` (zstd_double_fast.c:237): warm
-                // the input line the match-finder will hash/verify a few
-                // positions ahead. The match-find loop is memory-latency bound
-                // (hash-table + candidate-verify loads dominate its self-time),
-                // and the step-accelerated cursor skips past the sequential
-                // stride the hardware prefetcher tracks, so an explicit hint
-                // covers what the HW prefetcher misses. An out-of-bounds
-                // prefetch is an ISA no-op, so no end-of-buffer guard is needed.
-                unsafe {
-                    crate::decoding::prefetch::prefetch_l1_at(
-                        history_base_ptr.add(history_start_offset + concat_idx0 + 256),
-                    );
-                }
-
                 // Load 8 bytes at ip0 for both short (low 4) and long
                 // probe equality checks. We already used `v8_at_ip0` to
                 // compute hl0/idxl0 in the outer init / previous iter's
@@ -2401,14 +2387,6 @@ macro_rules! start_matching_fast_loop_body {
 
                 // Step bump on distance (donor `zstd_double_fast.c:224-228`).
                 if ip1 >= next_step_pos {
-                    // Donor (zstd_double_fast.c:225-226): on a skip-step bump
-                    // the cursor is about to jump well past `ip1`, so warm the
-                    // two cache lines just beyond it. OOB prefetch is a no-op.
-                    unsafe {
-                        let base = history_base_ptr.add(history_start_offset + concat_idx1);
-                        crate::decoding::prefetch::prefetch_l1_at(base.add(64));
-                        crate::decoding::prefetch::prefetch_l1_at(base.add(128));
-                    }
                     step = (step + 1).min(DFAST_MAX_SKIP_STEP);
                     next_step_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
                 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1727,16 +1727,30 @@ macro_rules! start_matching_fast_loop_body {
 
                 // Long match check at ip0 with idxl0. 8-byte equality
                 // gate (`MEM_read64`) — if it passes, candidate is real.
-                if idxl0 != DFAST_EMPTY_SLOT {
-                    let cand_pos = position_base + (idxl0 as usize) - 1;
-                    if cand_pos >= history_abs_start && cand_pos < abs_ip0 {
-                        let cand_idx = cand_pos - history_abs_start;
-                        // SAFETY: same buffer/length bounds as v8_0 above.
-                        let cand_v8 = unsafe {
-                            (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
-                                .read_unaligned()
-                        };
-                        if cand_v8 == v8_0 {
+                {
+                    // Branchless validity (donor `ZSTD_selectAddr`/cmov): fold
+                    // the slot-empty / out-of-window / past-cursor checks into a
+                    // bitwise `in_long` mask, then mask the candidate index to 0
+                    // (history start, always readable) when invalid so the 8-byte
+                    // load never faults and is never a real candidate. The only
+                    // remaining branch is the rare actual-match `& in_long`,
+                    // which is predictable — this removes the per-position
+                    // validity mispredict that dominated the hot loop.
+                    let cand_pos = position_base.wrapping_add((idxl0 as usize).wrapping_sub(1));
+                    let in_long = (idxl0 != DFAST_EMPTY_SLOT)
+                        & (cand_pos >= history_abs_start)
+                        & (cand_pos < abs_ip0);
+                    let cand_idx =
+                        cand_pos.wrapping_sub(history_abs_start) & (in_long as usize).wrapping_neg();
+                    // SAFETY: `cand_idx` is either a valid in-window concat index
+                    // (when `in_long`) or 0; both leave the 8-byte load inside
+                    // live history (same buffer/length bounds as `v8_0`).
+                    let cand_v8 = unsafe {
+                        (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
+                            .read_unaligned()
+                    };
+                    if cand_v8 == v8_0 && in_long {
+                        {
                             // 8 bytes match; count forward + extend back.
                             let mut match_len = 8usize;
                             let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
@@ -1829,15 +1843,23 @@ macro_rules! start_matching_fast_loop_body {
                 // Short match check at ip0 with idxs0 — 4-byte gate
                 // ONLY (donor `zstd_double_fast.c:220`). Forward count
                 // and `_search_next_long` retry happen ONLY on hit.
-                if idxs0 != DFAST_EMPTY_SLOT {
-                    let cand_pos_s = position_base + (idxs0 as usize) - 1;
-                    if cand_pos_s >= history_abs_start && cand_pos_s < abs_ip0 {
-                        let cand_idx_s = cand_pos_s - history_abs_start;
-                        let cand4 = unsafe {
-                            (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
-                                .read_unaligned()
-                        };
-                        if cand4 == v4_0 as u32 {
+                {
+                    // Branchless validity (same `ZSTD_selectAddr`/cmov shape as
+                    // the long check above): fold into `in_short`, mask the index
+                    // to 0 when invalid so the 4-byte load never faults, reject
+                    // the dummy read with `& in_short`.
+                    let cand_pos_s = position_base.wrapping_add((idxs0 as usize).wrapping_sub(1));
+                    let in_short = (idxs0 != DFAST_EMPTY_SLOT)
+                        & (cand_pos_s >= history_abs_start)
+                        & (cand_pos_s < abs_ip0);
+                    let cand_idx_s = cand_pos_s.wrapping_sub(history_abs_start)
+                        & (in_short as usize).wrapping_neg();
+                    let cand4 = unsafe {
+                        (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
+                            .read_unaligned()
+                    };
+                    if cand4 == v4_0 as u32 && in_short {
+                        {
                             // Short hit: count forward from byte 4 onwards.
                             let mut s_match_len = 4usize;
                             let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1568,7 +1568,7 @@ impl DfastMatchGenerator {
 /// cpl calls inline under one umbrella and `select_kernel()` is resolved ONCE
 /// per block in the bare dispatcher, never per cpl call.
 macro_rules! start_matching_fast_loop_body {
-    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident, $cpl:path) => {{
+    ($self:ident, $current_abs_start:ident, $current_len:ident, $handle_sequence:ident, $cpl:path, $use_dict:expr) => {{
         // Behaviour change vs the pre-refactor `start_matching_general`:
         // this fast loop deliberately drops the strict-incompressible
         // early-skip path (the `block_looks_incompressible_strict` short
@@ -1685,20 +1685,25 @@ macro_rules! start_matching_fast_loop_body {
         // lookahead. Gating on `table().is_some()` keeps the null dict
         // pointers out of the probe below, which dereferences them before
         // the `dict_end` bound is consulted.
-        let (use_dict, dict_long_ptr, dict_short_ptr, dict_end): (
-            bool,
-            *const u32,
-            *const u32,
-            usize,
-        ) = match $self.dict.table() {
-            Some(d) => (
-                true,
-                d.long.as_ptr(),
-                d.short.as_ptr(),
-                $self.dict.region_len(),
-            ),
-            None => (false, core::ptr::null(), core::ptr::null(), 0),
-        };
+        // Dict probe pointers are materialised ONLY on the `USE_DICT` kernel.
+        // The dispatcher monomorphises a separate no-dict kernel
+        // (`$use_dict == false`, a compile-time const) in which this block and
+        // every `if $use_dict` probe below const-fold away — so the hot no-dict
+        // loop carries zero dict code and zero per-position dict check, instead
+        // of branching on a loop-invariant flag every position (donor keeps the
+        // no-dict and dictMatchState loops as separate functions for the same
+        // reason). `$use_dict == true` is dispatched only when the table is
+        // present, so the `expect` never fires.
+        let (dict_long_ptr, dict_short_ptr, dict_end): (*const u32, *const u32, usize) =
+            if $use_dict {
+                let d = $self
+                    .dict
+                    .table()
+                    .expect("USE_DICT kernel dispatched without a dict table");
+                (d.long.as_ptr(), d.short.as_ptr(), $self.dict.region_len())
+            } else {
+                (core::ptr::null(), core::ptr::null(), 0)
+            };
 
         'outer: loop {
             // Outer-iter precondition: at least `HASH_READ_SIZE = 8` bytes
@@ -2054,7 +2059,7 @@ macro_rules! start_matching_fast_loop_body {
                 // a dict match is `offset = abs_ip0 - dict_abs` and the forward
                 // count crosses the dict→input boundary like any in-window
                 // match (no `dictBase`/`count_2segments`).
-                if use_dict {
+                if $use_dict {
                     // SAFETY: when `use_dict`, `dict_long_ptr` is non-null and
                     // sized `1 << long_hash_bits`; `hl0_idx < 1 << long_hash_bits`.
                     let dl = unsafe { *dict_long_ptr.add(hl0_idx) };
@@ -2258,7 +2263,7 @@ macro_rules! start_matching_fast_loop_body {
                             // dict-long upgrade the old dense-reprime path got
                             // for free (dict positions lived in the live table)
                             // is lost and the loop emits the shorter short match.
-                            if !live_l1_hit && use_dict {
+                            if !live_l1_hit && $use_dict {
                                 // SAFETY: `use_dict` ⇒ `dict_long_ptr` non-null,
                                 // sized `1 << long_hash_bits`; `hl1_idx` is in range.
                                 let dl1 = unsafe { *dict_long_ptr.add(hl1_idx) };
@@ -2346,7 +2351,7 @@ macro_rules! start_matching_fast_loop_body {
                 // costs more than emitting the bytes as literals). No
                 // `_search_next_long` retry: the dict long fallback already
                 // covers the long-upgrade case at `ip0`.
-                if use_dict {
+                if $use_dict {
                     // SAFETY: `use_dict` ⇒ `dict_short_ptr` non-null, sized
                     // `1 << short_hash_bits`; `hs0_idx < 1 << short_hash_bits`.
                     let ds = unsafe { *dict_short_ptr.add(hs0_idx) };
@@ -2471,9 +2476,25 @@ impl DfastMatchGenerator {
         current_len: usize,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
+        // Resolve dict presence ONCE here, off the hot path, and select a
+        // const-monomorphised kernel (`USE_DICT` true/false) so the per-position
+        // dict probe is compiled in or out at the call shape — never a
+        // loop-invariant runtime check inside the scan. The no-dict kernel
+        // carries zero dict code (donor keeps the noDict / dictMatchState loops
+        // as separate functions for exactly this reason).
+        let use_dict = self.dict.table().is_some();
+        macro_rules! dispatch_dict {
+            ($kernel:ident) => {
+                if use_dict {
+                    self.$kernel::<true>(current_abs_start, current_len, handle_sequence)
+                } else {
+                    self.$kernel::<false>(current_abs_start, current_len, handle_sequence)
+                }
+            };
+        }
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         unsafe {
-            self.start_matching_fast_loop_neon(current_abs_start, current_len, handle_sequence)
+            dispatch_dict!(start_matching_fast_loop_neon)
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
@@ -2483,24 +2504,10 @@ impl DfastMatchGenerator {
             // hot path actually reads it. Mirrors the Row backend.
             match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
-                    self.start_matching_fast_loop_avx2_bmi2(
-                        current_abs_start,
-                        current_len,
-                        handle_sequence,
-                    )
+                    dispatch_dict!(start_matching_fast_loop_avx2_bmi2)
                 },
-                FastpathKernel::Sse42 => unsafe {
-                    self.start_matching_fast_loop_sse42(
-                        current_abs_start,
-                        current_len,
-                        handle_sequence,
-                    )
-                },
-                FastpathKernel::Scalar => self.start_matching_fast_loop_scalar(
-                    current_abs_start,
-                    current_len,
-                    handle_sequence,
-                ),
+                FastpathKernel::Sse42 => unsafe { dispatch_dict!(start_matching_fast_loop_sse42) },
+                FastpathKernel::Scalar => dispatch_dict!(start_matching_fast_loop_scalar),
             }
         }
         #[cfg(all(
@@ -2509,7 +2516,7 @@ impl DfastMatchGenerator {
             feature = "kernel_simd128"
         ))]
         unsafe {
-            self.start_matching_fast_loop_simd128(current_abs_start, current_len, handle_sequence)
+            dispatch_dict!(start_matching_fast_loop_simd128)
         }
         #[cfg(not(any(
             all(target_arch = "aarch64", target_endian = "little"),
@@ -2522,13 +2529,13 @@ impl DfastMatchGenerator {
             )
         )))]
         {
-            self.start_matching_fast_loop_scalar(current_abs_start, current_len, handle_sequence)
+            dispatch_dict!(start_matching_fast_loop_scalar)
         }
     }
 
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
-    unsafe fn start_matching_fast_loop_neon(
+    unsafe fn start_matching_fast_loop_neon<const USE_DICT: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2539,13 +2546,14 @@ impl DfastMatchGenerator {
             current_abs_start,
             current_len,
             handle_sequence,
-            crate::encoding::fastpath::neon::common_prefix_len_ptr
+            crate::encoding::fastpath::neon::common_prefix_len_ptr,
+            USE_DICT
         )
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "sse4.2")]
-    unsafe fn start_matching_fast_loop_sse42(
+    unsafe fn start_matching_fast_loop_sse42<const USE_DICT: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2556,13 +2564,14 @@ impl DfastMatchGenerator {
             current_abs_start,
             current_len,
             handle_sequence,
-            crate::encoding::fastpath::sse42::common_prefix_len_ptr
+            crate::encoding::fastpath::sse42::common_prefix_len_ptr,
+            USE_DICT
         )
     }
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
-    unsafe fn start_matching_fast_loop_avx2_bmi2(
+    unsafe fn start_matching_fast_loop_avx2_bmi2<const USE_DICT: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2573,7 +2582,8 @@ impl DfastMatchGenerator {
             current_abs_start,
             current_len,
             handle_sequence,
-            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
+            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
+            USE_DICT
         )
     }
 
@@ -2583,7 +2593,7 @@ impl DfastMatchGenerator {
         feature = "kernel_simd128"
     ))]
     #[target_feature(enable = "simd128")]
-    unsafe fn start_matching_fast_loop_simd128(
+    unsafe fn start_matching_fast_loop_simd128<const USE_DICT: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2594,7 +2604,8 @@ impl DfastMatchGenerator {
             current_abs_start,
             current_len,
             handle_sequence,
-            crate::encoding::fastpath::simd128::common_prefix_len_ptr
+            crate::encoding::fastpath::simd128::common_prefix_len_ptr,
+            USE_DICT
         )
     }
 
@@ -2607,7 +2618,7 @@ impl DfastMatchGenerator {
         )
     )))]
     #[allow(unused_unsafe)]
-    fn start_matching_fast_loop_scalar(
+    fn start_matching_fast_loop_scalar<const USE_DICT: bool>(
         &mut self,
         current_abs_start: usize,
         current_len: usize,
@@ -2618,7 +2629,8 @@ impl DfastMatchGenerator {
             current_abs_start,
             current_len,
             handle_sequence,
-            crate::encoding::fastpath::scalar::common_prefix_len_ptr
+            crate::encoding::fastpath::scalar::common_prefix_len_ptr,
+            USE_DICT
         )
     }
 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1844,20 +1844,6 @@ macro_rules! start_matching_fast_loop_body {
                 let concat_idx0 = abs_ip0 - history_abs_start;
                 let concat_idx1 = abs_ip1 - history_abs_start;
 
-                // Donor `PREFETCH_L1(ip + 256)` (zstd_double_fast.c:237): warm
-                // the input line the match-finder will hash/verify a few
-                // positions ahead. The match-find loop is memory-latency bound
-                // (hash-table + candidate-verify loads dominate its self-time),
-                // and the step-accelerated cursor skips past the sequential
-                // stride the hardware prefetcher tracks, so an explicit hint
-                // covers what the HW prefetcher misses. An out-of-bounds
-                // prefetch is an ISA no-op, so no end-of-buffer guard is needed.
-                unsafe {
-                    crate::decoding::prefetch::prefetch_l1_at(
-                        history_base_ptr.add(history_start_offset + concat_idx0 + 256),
-                    );
-                }
-
                 // Load 8 bytes at ip0 for both short (low 4) and long
                 // probe equality checks. We already used `v8_at_ip0` to
                 // compute hl0/idxl0 in the outer init / previous iter's
@@ -1974,6 +1960,26 @@ macro_rules! start_matching_fast_loop_body {
                         .read_unaligned()
                 };
                 let hl1_idx = (v8_1.wrapping_mul(PRIME) >> long_shift) as usize;
+
+                // Prefetch the RANDOM-ACCESS hash-table slots the loop is about
+                // to read, while there is work to hide the latency behind. The
+                // match-find loop is memory-latency bound on these table loads
+                // (perf --call-graph dwarf annotate: ~21% self-time across the
+                // long/short slot reads), and the hardware prefetcher cannot
+                // predict a hash-indexed address. `hl1_idx`'s slot is loaded
+                // ~100 instructions below (the `_search_next_long` retry at
+                // `ip1`); the next inner iteration's short-hash slot is keyed on
+                // these same `v8_1` bytes (this `ip1` becomes the next `ip0`).
+                // Unlike the donor's input `PREFETCH_L1(ip + 256)` — which only
+                // warms the sequential input the HW prefetcher already covers —
+                // these target the loads that actually stall.
+                unsafe {
+                    let hs1_idx = ((v8_1 << 24).wrapping_mul(PRIME) >> short_shift) as usize;
+                    crate::decoding::prefetch::prefetch_l1_at(long_hash_ptr.add(hl1_idx) as *const u8);
+                    crate::decoding::prefetch::prefetch_l1_at(
+                        short_hash_ptr.add(hs1_idx) as *const u8,
+                    );
+                }
 
                 // Long match check at ip0 with idxl0. 8-byte equality
                 // gate (`MEM_read64`) — if it passes, candidate is real.
@@ -2401,14 +2407,6 @@ macro_rules! start_matching_fast_loop_body {
 
                 // Step bump on distance (donor `zstd_double_fast.c:224-228`).
                 if ip1 >= next_step_pos {
-                    // Donor (zstd_double_fast.c:225-226): on a skip-step bump
-                    // the cursor is about to jump well past `ip1`, so warm the
-                    // two cache lines just beyond it. OOB prefetch is a no-op.
-                    unsafe {
-                        let base = history_base_ptr.add(history_start_offset + concat_idx1);
-                        crate::decoding::prefetch::prefetch_l1_at(base.add(64));
-                        crate::decoding::prefetch::prefetch_l1_at(base.add(128));
-                    }
                     step = (step + 1).min(DFAST_MAX_SKIP_STEP);
                     next_step_pos += DFAST_SKIP_STEP_GROWTH_INTERVAL;
                 }

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1988,30 +1988,28 @@ macro_rules! start_matching_fast_loop_body {
 
                 // Long match check at ip0 with idxl0. 8-byte equality
                 // gate (`MEM_read64`) — if it passes, candidate is real.
-                {
-                    // Branchless validity (donor `ZSTD_selectAddr`/cmov): fold
-                    // the slot-empty / out-of-window / past-cursor checks into a
-                    // bitwise `in_long` mask, then mask the candidate index to 0
-                    // (history start, always readable) when invalid so the 8-byte
-                    // load never faults and is never a real candidate. The only
-                    // remaining branch is the rare actual-match `& in_long`,
-                    // which is predictable — this removes the per-position
-                    // validity mispredict that dominated the hot loop.
-                    let cand_pos = position_base.wrapping_add((idxl0 as usize).wrapping_sub(1));
-                    let in_long = (idxl0 != DFAST_EMPTY_SLOT)
-                        & (cand_pos >= history_abs_start)
-                        & (cand_pos < abs_ip0);
-                    let cand_idx =
-                        cand_pos.wrapping_sub(history_abs_start) & (in_long as usize).wrapping_neg();
-                    // SAFETY: `cand_idx` is either a valid in-window concat index
-                    // (when `in_long`) or 0; both leave the 8-byte load inside
-                    // live history (same buffer/length bounds as `v8_0`).
-                    let cand_v8 = unsafe {
-                        (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
-                            .read_unaligned()
-                    };
-                    if cand_v8 == v8_0 && in_long {
-                        {
+                //
+                // Branchy validity rather than a branchless `in_long` mask: the
+                // slot-populated / in-window / before-cursor checks are highly
+                // predictable once the table is warm, so the branch predictor
+                // speculates the hot 8-byte candidate load past them. A
+                // branchless mask instead makes the load ADDRESS depend on the
+                // mask (`cand_idx &= -(in_long)`), serialising the loop's single
+                // hottest instruction (~13% self-time on z000033) behind the
+                // mask — a stall the predictor cannot hide.
+                if idxl0 != DFAST_EMPTY_SLOT {
+                    let cand_pos = position_base + ((idxl0 as usize) - 1);
+                    if cand_pos >= history_abs_start && cand_pos < abs_ip0 {
+                        let cand_idx = cand_pos - history_abs_start;
+                        // SAFETY: the bounds above make `cand_idx` a valid
+                        // in-window concat index, so the 8-byte load stays in
+                        // live history (same buffer/length bounds as `v8_0`).
+                        let cand_v8 = unsafe {
+                            (history_base_ptr.add(history_start_offset + cand_idx) as *const u64)
+                                .read_unaligned()
+                        };
+                        if cand_v8 == v8_0 {
+                            {
                             // 8 bytes match; count forward + extend back.
                             let mut match_len = 8usize;
                             let max_fwd = concat_len.saturating_sub(concat_idx0 + 8);
@@ -2049,6 +2047,7 @@ macro_rules! start_matching_fast_loop_body {
                             );
                             break 'inner InnerExit::Committed(cand);
                         }
+                    }
                     }
                 }
 
@@ -2126,23 +2125,21 @@ macro_rules! start_matching_fast_loop_body {
                 // Short match check at ip0 with idxs0 — 4-byte gate
                 // ONLY (donor `zstd_double_fast.c:220`). Forward count
                 // and `_search_next_long` retry happen ONLY on hit.
-                {
-                    // Branchless validity (same `ZSTD_selectAddr`/cmov shape as
-                    // the long check above): fold into `in_short`, mask the index
-                    // to 0 when invalid so the 4-byte load never faults, reject
-                    // the dummy read with `& in_short`.
-                    let cand_pos_s = position_base.wrapping_add((idxs0 as usize).wrapping_sub(1));
-                    let in_short = (idxs0 != DFAST_EMPTY_SLOT)
-                        & (cand_pos_s >= history_abs_start)
-                        & (cand_pos_s < abs_ip0);
-                    let cand_idx_s = cand_pos_s.wrapping_sub(history_abs_start)
-                        & (in_short as usize).wrapping_neg();
-                    let cand4 = unsafe {
-                        (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
-                            .read_unaligned()
-                    };
-                    if cand4 == v4_0 as u32 && in_short {
-                        {
+                // Branchy validity, same shape as the ip1 long retry below:
+                // the slot-populated / in-window / before-cursor checks are
+                // predictable after warmup, so the predictor speculates the
+                // 4-byte candidate load past them. A branchless mask would tie
+                // the load address to the mask, serialising it.
+                if idxs0 != DFAST_EMPTY_SLOT {
+                    let cand_pos_s = position_base + ((idxs0 as usize) - 1);
+                    if cand_pos_s >= history_abs_start && cand_pos_s < abs_ip0 {
+                        let cand_idx_s = cand_pos_s - history_abs_start;
+                        let cand4 = unsafe {
+                            (history_base_ptr.add(history_start_offset + cand_idx_s) as *const u32)
+                                .read_unaligned()
+                        };
+                        if cand4 == v4_0 as u32 {
+                            {
                             // Short hit: count forward from byte 4 onwards.
                             let mut s_match_len = 4usize;
                             let max_fwd = concat_len.saturating_sub(concat_idx0 + 4);
@@ -2340,6 +2337,7 @@ macro_rules! start_matching_fast_loop_body {
                             // worse than emitting the 4 bytes as
                             // literals).
                         }
+                    }
                     }
                 }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1021,23 +1021,16 @@ impl DfastMatchGenerator {
         candidate: MatchCandidate,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) -> usize {
-        // Insert the LITERAL region densely, the MATCH INTERIOR sparsely
-        // (upstream `zstd_double_fast.c` parity). The literal positions
-        // `[literals_start, match_start)` are load-bearing: the producer
-        // loop starts at `pos = 1` and only hashes positions it actually
-        // probes, so the block anchor (position 0) and any stepped-over
-        // literal byte is hashed ONLY here — dropping it loses real match
-        // sources for later positions (and later blocks). The match
-        // interior, by contrast, is never re-probed within the block;
-        // upstream fills only `curr+2` and `ip-2` there, so inserting the
-        // full `[match_start, match_end)` span was ~match_len wasted
-        // single-slot overwrites — the dominant self-time on
-        // dict-heavy / highly-matchable blocks. Mirror the rep-extension
-        // path's audited 3-target set (`curr+2`, `ip-2`, `ip-1`), each
-        // clamped to the open match interval.
+        // Donor `zstd_double_fast.c` parity: the inner search loop already
+        // inserts every position it VISITS (step-accelerated), so the literal
+        // run is hashed exactly as densely as the donor's cursor swept it —
+        // stepped-over and block-anchor (position 0) positions are NOT
+        // re-inserted here (the donor skips them too via `ip += (ip ==
+        // prefixStart)` + the growing `step`). Match interior: donor fills only
+        // the sparse 3-target set (`curr+2`, `ip-2`, `ip-1`), each clamped to
+        // the open match interval.
         let match_start = candidate.start;
         let post_match_end = candidate.start + candidate.match_len;
-        self.insert_positions(current_abs_start + *literals_start, match_start);
         let insert_targets = [
             match_start + 2,                  // curr + 2
             post_match_end.saturating_sub(2), // ip - 2 (post-match cursor)

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1760,7 +1760,18 @@ macro_rules! start_matching_fast_loop_body {
                             // `extend_with_repcode_after_match` chain
                             // (which uses 4) inconsistent with the peek.
                             if match_len >= DFAST_REP_MIN_MATCH_LEN {
-                                let concat = &$self.history[history_start_offset..];
+                                // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                                 let rep_cand = extend_backwards_shared(
                                     concat,
                                     history_abs_start,
@@ -1823,7 +1834,18 @@ macro_rules! start_matching_fast_loop_body {
                                 );
                                 match_len += ext;
                             }
-                            let concat = &$self.history[history_start_offset..];
+                            // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                             let cand = extend_backwards_shared(
                                 concat,
                                 history_abs_start,
@@ -1880,7 +1902,18 @@ macro_rules! start_matching_fast_loop_body {
                                     match_len += ext;
                                 }
                                 let cand_pos = history_abs_start + dp;
-                                let concat = &$self.history[history_start_offset..];
+                                // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                                 let cand = extend_backwards_shared(
                                     concat,
                                     history_abs_start,
@@ -1930,7 +1963,18 @@ macro_rules! start_matching_fast_loop_body {
                                 );
                                 s_match_len += ext;
                             }
-                            let concat = &$self.history[history_start_offset..];
+                            // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                             let short_cand = extend_backwards_shared(
                                 concat,
                                 history_abs_start,
@@ -1984,7 +2028,18 @@ macro_rules! start_matching_fast_loop_body {
                                             l1_match_len += ext;
                                         }
                                         if l1_match_len > short_cand.match_len {
-                                            let concat = &$self.history[history_start_offset..];
+                                            // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                                             chosen = extend_backwards_shared(
                                                 concat,
                                                 history_abs_start,
@@ -2051,7 +2106,18 @@ macro_rules! start_matching_fast_loop_body {
                                             }
                                             if dl1_match_len > short_cand.match_len {
                                                 let cand_pos = history_abs_start + dp1;
-                                                let concat = &$self.history[history_start_offset..];
+                                                // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                                                 chosen = extend_backwards_shared(
                                                     concat,
                                                     history_abs_start,
@@ -2123,7 +2189,18 @@ macro_rules! start_matching_fast_loop_body {
                                     s_match_len += ext;
                                 }
                                 let cand_pos = history_abs_start + dp;
-                                let concat = &$self.history[history_start_offset..];
+                                // SAFETY: `history_base_ptr + history_start_offset` is the live
+                                // source start (owned `history[history_start..]` or the
+                                // borrowed input slice) and `concat_len` its readable byte
+                                // count, both from `scan_source()` at the top of this outer
+                                // iter; `extend_backwards_shared` only indexes within the
+                                // candidate/cursor range it is handed, all `< concat_len`.
+                                let concat = unsafe {
+                                    core::slice::from_raw_parts(
+                                        history_base_ptr.add(history_start_offset),
+                                        concat_len,
+                                    )
+                                };
                                 let dcand = extend_backwards_shared(
                                     concat,
                                     history_abs_start,

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -123,16 +123,17 @@ pub(crate) struct DfastMatchGenerator {
     /// resolved once at construction so the per-byte match-finder scans skip
     /// the `select_kernel()` `OnceLock` atomic on every call.
     pub(crate) kernel: FastpathKernel,
-    /// Borrowed one-shot scan window: `(input_base_ptr, current_block_end)`.
-    /// When `Some`, the fast loop sources bytes from the caller's in-place
-    /// input slice with absolute input positions (`abs_start = position_base
-    /// = start_offset = 0`, readable length = `current_block_end`) instead of
-    /// copying each block into the owned `history` concat — the dfast analog
-    /// of the Fast backend's borrowed window. The pointer is the input start
-    /// (constant for the frame); the second field is updated to the active
-    /// block's end before each block scan. `None` = owned (history-copying)
-    /// path. Cleared on `reset()`.
-    pub(crate) borrowed: Option<(*const u8, usize)>,
+    /// Borrowed one-shot scan window: `(input_base_ptr, block_start,
+    /// block_end)`. When `Some`, the fast loop sources bytes from the
+    /// caller's in-place input slice with absolute input positions
+    /// (`abs_start = position_base = start_offset = 0`, readable length =
+    /// `block_end`) instead of copying each block into the owned `history`
+    /// concat — the dfast analog of the Fast backend's borrowed window. The
+    /// pointer is the input start (constant for the frame); `block_start..
+    /// block_end` is the active block's absolute range, re-staged before each
+    /// block scan (so `get_last_space` reports the borrowed block to the emit
+    /// pipeline). `None` = owned (history-copying) path. Cleared on `reset()`.
+    pub(crate) borrowed: Option<(*const u8, usize, usize)>,
 }
 
 /// The dfast backend's immutable dictionary tables — a long+short pair mirroring
@@ -350,6 +351,16 @@ impl DfastMatchGenerator {
     /// usage and avoids a panic-vs-gate divergence that would
     /// surprise a future refactor consolidating the call sites.
     pub(crate) fn get_last_space(&self) -> &[u8] {
+        if let Some((ptr, block_start, block_end)) = self.borrowed {
+            // Borrowed window: the active block is the in-place input range
+            // `[block_start, block_end)`, staged before the scan so the emit
+            // pipeline's pre-scan `get_last_space().len()` reserve is correct.
+            // SAFETY: borrowed liveness contract; `block_start <= block_end <=
+            // buffer len` (validated when staged).
+            return unsafe {
+                core::slice::from_raw_parts(ptr.add(block_start), block_end - block_start)
+            };
+        }
         let last_len = self.window_blocks.back().copied().unwrap_or(0);
         &self.history[self.history.len() - last_len..]
     }
@@ -740,11 +751,10 @@ impl DfastMatchGenerator {
 
         let abs_ip0 = current_abs_start + ip0;
         let lit_len_ip0 = ip0 - literals_start;
-        let history_abs_start = self.history_abs_start;
-        let position_base = self.position_base;
-        let history_start_offset = self.history_start;
-        let concat_len = self.history.len() - history_start_offset;
-        let history_base_ptr = self.history.as_ptr();
+        // Byte source through `scan_source()` so the tail probe reads the
+        // borrowed input in place when a borrowed window is active.
+        let (history_base_ptr, history_start_offset, history_abs_start, position_base, concat_len) =
+            self.scan_source();
 
         let concat_idx0 = abs_ip0 - history_abs_start;
 
@@ -818,7 +828,12 @@ impl DfastMatchGenerator {
                         );
                         match_len += ext;
                     }
-                    let concat = &self.history[history_start_offset..];
+                    let concat = unsafe {
+                        core::slice::from_raw_parts(
+                            history_base_ptr.add(history_start_offset),
+                            concat_len,
+                        )
+                    };
                     return Some(extend_backwards_shared(
                         concat,
                         history_abs_start,
@@ -853,7 +868,12 @@ impl DfastMatchGenerator {
                         );
                         s_match_len += ext;
                     }
-                    let concat = &self.history[history_start_offset..];
+                    let concat = unsafe {
+                        core::slice::from_raw_parts(
+                            history_base_ptr.add(history_start_offset),
+                            concat_len,
+                        )
+                    };
                     let short_cand = extend_backwards_shared(
                         concat,
                         history_abs_start,
@@ -913,8 +933,12 @@ impl DfastMatchGenerator {
             if rep == 0 {
                 break;
             }
+            // Source bytes + rebase coordinate through `scan_source()` so a
+            // borrowed window's rep-extension reads the in-place input.
+            let (base_ptr, start_offset, abs_start, _position_base, concat_len) =
+                self.scan_source();
             let abs_pos = current_abs_start + pos;
-            let cur_idx = abs_pos - self.history_abs_start;
+            let cur_idx = abs_pos - abs_start;
             // `checked_sub` is the authoritative bound here: a valid rep
             // can reach beyond the current block into retained history
             // (the contiguous `live_history()` buffer covers
@@ -929,7 +953,12 @@ impl DfastMatchGenerator {
                 Some(idx) => idx,
                 None => break,
             };
-            let concat = &self.history[self.history_start..];
+            // SAFETY: `base_ptr + start_offset` is the live source start and
+            // `concat_len` its readable length (owned history or borrowed
+            // input); the `cur_idx` / `cand_idx` reads below are gated `<
+            // concat.len()`. Raw-ptr backed, no borrow on `self`.
+            let concat =
+                unsafe { core::slice::from_raw_parts(base_ptr.add(start_offset), concat_len) };
             if cur_idx + DFAST_REP_MIN_MATCH_LEN > concat.len() {
                 break;
             }
@@ -1041,7 +1070,7 @@ impl DfastMatchGenerator {
     /// the loop stays sound.
     #[inline(always)]
     fn scan_source(&self) -> (*const u8, usize, usize, usize, usize) {
-        if let Some((ptr, block_end)) = self.borrowed {
+        if let Some((ptr, _block_start, block_end)) = self.borrowed {
             // Borrowed one-shot window: positions are absolute input
             // offsets, so the rebase coordinates collapse to zero
             // (`start_offset = abs_start = position_base = 0`) and the
@@ -1058,6 +1087,29 @@ impl DfastMatchGenerator {
             self.position_base,
             self.history.len() - start_offset,
         )
+    }
+
+    /// `(ptr, len)` of the block currently being emitted, for the literal
+    /// slices in `emit_candidate` / `emit_trailing_literals`. Owned: the
+    /// `history` concat tail (`last_len` bytes). Borrowed: the in-place
+    /// input sub-slice `[current_abs_start, block_end)`. Returns a raw
+    /// pointer (not a `&[u8]` tied to `&self`) so the caller can rebuild
+    /// the slice locally and still take `&mut self` for `offset_hist`.
+    #[inline]
+    fn current_block_ptr_len(&self, current_abs_start: usize) -> (*const u8, usize) {
+        if let Some((ptr, _block_start, block_end)) = self.borrowed {
+            // SAFETY: borrowed liveness contract; `current_abs_start` =
+            // block_start <= block_end <= buffer len (entry-validated).
+            (
+                unsafe { ptr.add(current_abs_start) },
+                block_end - current_abs_start,
+            )
+        } else {
+            let last_len = self.window_blocks.back().copied().unwrap_or(0);
+            let off = self.history.len() - last_len;
+            // SAFETY: `off + last_len == history.len()`, in bounds.
+            (unsafe { self.history.as_ptr().add(off) }, last_len)
+        }
     }
 
     fn emit_candidate(
@@ -1096,12 +1148,15 @@ impl DfastMatchGenerator {
         // `debug_assert!` makes that precondition fail at the source
         // in tests rather than silently produce an empty slice and
         // panic on the literals subslice below.
-        let last_len = self.window_blocks.back().copied().unwrap_or(0);
+        let (cur_ptr, cur_len) = self.current_block_ptr_len(current_abs_start);
         debug_assert!(
-            last_len > 0,
+            cur_len > 0,
             "emit_candidate precondition: active block must be non-empty"
         );
-        let current = &self.history[self.history.len() - last_len..];
+        // SAFETY: raw-ptr backed (no borrow on `self`), so the
+        // `&mut self.offset_hist` below coexists. Bytes are the active block
+        // (owned history tail or borrowed input sub-slice).
+        let current = unsafe { core::slice::from_raw_parts(cur_ptr, cur_len) };
         let start = candidate.start - current_abs_start;
         let literals = &current[*literals_start..start];
         handle_sequence(Sequence::Triple {
@@ -1120,16 +1175,16 @@ impl DfastMatchGenerator {
 
     fn emit_trailing_literals(
         &self,
+        current_abs_start: usize,
         literals_start: usize,
         handle_sequence: &mut impl for<'a> FnMut(Sequence<'a>),
     ) {
-        let last_len = self.window_blocks.back().copied().unwrap_or(0);
-        if literals_start < last_len {
-            // Inline rather than calling `get_last_space()` so the gate
-            // pattern matches `skip_matching` / `start_matching` /
-            // `emit_candidate`. `last_len > 0` is already established by
-            // the `literals_start < last_len` check above.
-            let current = &self.history[self.history.len() - last_len..];
+        let (cur_ptr, cur_len) = self.current_block_ptr_len(current_abs_start);
+        if literals_start < cur_len {
+            // SAFETY: raw-ptr backed active-block slice (owned history tail
+            // or borrowed input sub-slice); `literals_start < cur_len` gated
+            // above keeps the subslice in range.
+            let current = unsafe { core::slice::from_raw_parts(cur_ptr, cur_len) };
             handle_sequence(Sequence::Literals {
                 literals: &current[literals_start..],
             });
@@ -2266,7 +2321,7 @@ macro_rules! start_matching_fast_loop_body {
         }
 
         $self.seed_remaining_hashable_starts($current_abs_start, $current_len, pos);
-        $self.emit_trailing_literals(literals_start, $handle_sequence);
+        $self.emit_trailing_literals($current_abs_start, literals_start, $handle_sequence);
     }};
 }
 

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -123,6 +123,16 @@ pub(crate) struct DfastMatchGenerator {
     /// resolved once at construction so the per-byte match-finder scans skip
     /// the `select_kernel()` `OnceLock` atomic on every call.
     pub(crate) kernel: FastpathKernel,
+    /// Borrowed one-shot scan window: `(input_base_ptr, current_block_end)`.
+    /// When `Some`, the fast loop sources bytes from the caller's in-place
+    /// input slice with absolute input positions (`abs_start = position_base
+    /// = start_offset = 0`, readable length = `current_block_end`) instead of
+    /// copying each block into the owned `history` concat — the dfast analog
+    /// of the Fast backend's borrowed window. The pointer is the input start
+    /// (constant for the frame); the second field is updated to the active
+    /// block's end before each block scan. `None` = owned (history-copying)
+    /// path. Cleared on `reset()`.
+    pub(crate) borrowed: Option<(*const u8, usize)>,
 }
 
 /// The dfast backend's immutable dictionary tables — a long+short pair mirroring
@@ -162,6 +172,7 @@ impl DfastMatchGenerator {
             short_hash_bits: DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA,
             dict: DictAttach::new(),
             kernel: select_kernel(),
+            borrowed: None,
         }
     }
 
@@ -317,6 +328,10 @@ impl DfastMatchGenerator {
         // per-block input Vecs internally; the dispatcher in
         // `match_generator.rs` resolves the per-backend shape).
         self.window_blocks.clear();
+        // Drop any borrowed window: the input slice it pointed at does not
+        // outlive the frame, and the next frame re-stages its own (or runs
+        // the owned path). A stale pointer must never survive a reset.
+        self.borrowed = None;
     }
 
     /// Slice of bytes from the most recently appended block. Returns
@@ -1026,6 +1041,15 @@ impl DfastMatchGenerator {
     /// the loop stays sound.
     #[inline(always)]
     fn scan_source(&self) -> (*const u8, usize, usize, usize, usize) {
+        if let Some((ptr, block_end)) = self.borrowed {
+            // Borrowed one-shot window: positions are absolute input
+            // offsets, so the rebase coordinates collapse to zero
+            // (`start_offset = abs_start = position_base = 0`) and the
+            // readable length is the active block's end. No history concat,
+            // no `commit_space` copy. Candidate reads from earlier blocks
+            // land at `ptr + earlier_abs_pos` (< block_end), in range.
+            return (ptr, 0, 0, 0, block_end);
+        }
         let start_offset = self.history_start;
         (
             self.history.as_ptr(),

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -725,10 +725,25 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
     /// stay small), so >4 GiB inputs fall back to it.
     fn borrowed_eligible(&self, input_len: usize, prep: &FramePrep) -> bool {
         use crate::encoding::strategy::StrategyTag;
-        !prep.use_dictionary_state
-            && !matches!(self.compression_level, CompressionLevel::Uncompressed)
-            && self.state.strategy_tag == StrategyTag::Fast
-            && input_len <= u32::MAX as usize
+        if prep.use_dictionary_state
+            || matches!(self.compression_level, CompressionLevel::Uncompressed)
+            || input_len > u32::MAX as usize
+        {
+            return false;
+        }
+        match self.state.strategy_tag {
+            // Fast handles over-window inputs in the borrowed scan via an
+            // explicit `window_low = block_end - advertised_window` bound.
+            StrategyTag::Fast => true,
+            // The Dfast borrowed scan uses `history_abs_start` (== 0 in
+            // borrowed mode) as the candidate lower bound, not `window_low`,
+            // so it reproduces the owned (evicting) path only when the whole
+            // input fits the window — then neither side evicts, so neither
+            // rejects an in-window candidate and the sequence streams match.
+            // Over-window inputs fall back to the owned path.
+            StrategyTag::Dfast => input_len <= self.state.matcher.window_size() as usize,
+            _ => false,
+        }
     }
 
     /// Compress `input` as one frame's worth of blocks: the borrowed

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -746,18 +746,18 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
         }
     }
 
-    /// Compress `input` as one frame's worth of blocks: the borrowed
-    /// in-place loop when [`Self::borrowed_eligible`], else the owned
-    /// (history-copying) loop fed an in-place `&[u8]` cursor. Returns
-    /// `(all_blocks, total_uncompressed)`; the caller emits the frame tail
-    /// (`finish_frame` for a configured drain, `write_frame_to_vec` for a
-    /// returned buffer).
-    fn run_one_frame(&mut self, input: &[u8], prep: &FramePrep) -> (Vec<u8>, u64) {
+    /// Compress `input` as one frame's worth of blocks into `out` (appended
+    /// from its current end): the borrowed in-place loop when
+    /// [`Self::borrowed_eligible`], else the owned (history-copying) loop fed
+    /// an in-place `&[u8]` cursor. Returns `total_uncompressed`; the caller
+    /// emits the frame header (before this call, when the content size is
+    /// known) or the drain tail.
+    fn run_one_frame(&mut self, input: &[u8], prep: &FramePrep, out: &mut Vec<u8>) -> u64 {
         if self.borrowed_eligible(input.len(), prep) {
-            self.run_borrowed_block_loop(input, prep.initial_size_hint)
+            self.run_borrowed_block_loop(input, out)
         } else {
             let mut cursor: &[u8] = input;
-            self.run_owned_block_loop(&mut cursor, prep.initial_size_hint)
+            self.run_owned_block_loop(&mut cursor, prep.initial_size_hint, out)
         }
     }
 
@@ -810,8 +810,34 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
         // resolved window/header and could flip borrowed eligibility).
         self.source_size_hint = Some(input.len() as u64);
         let prep = self.prepare_frame();
-        let (all_blocks, total_uncompressed) = self.run_one_frame(input, &prep);
-        self.write_frame_to_vec(out, all_blocks, total_uncompressed, &prep);
+        // Content size is known up front (one-shot), so write the frame
+        // header FIRST and emit blocks STRAIGHT into `out` — no separate
+        // `all_blocks` accumulator and no header+blocks copy (which was the
+        // dominant per-frame memmove + the only un-amortized per-frame alloc
+        // even when the compressor is reused).
+        let total_uncompressed = input.len() as u64;
+        let header_buf = self.build_frame_header(total_uncompressed, &prep);
+        let emit_checksum = cfg!(feature = "hash") && self.content_checksum;
+        let checksum_len = if emit_checksum { 4 } else { 0 };
+        out.clear();
+        // Reserve the worst-case compressed size ONCE so the block appends
+        // below never realloc; the caller reuses `out` across frames, so the
+        // reservation is paid on the first frame and amortizes to zero.
+        out.reserve(header_buf.len() + crate::encoding::compress_bound(input.len()) + checksum_len);
+        out.extend_from_slice(&header_buf);
+        let header_len = out.len();
+        let _ = self.run_one_frame(input, &prep, out);
+        #[cfg(feature = "hash")]
+        if self.content_checksum {
+            out.extend_from_slice(&(self.hasher.finish() as u32).to_le_bytes());
+        }
+        #[cfg(feature = "lsm")]
+        {
+            let blocks_end = out.len() - checksum_len;
+            self.populate_frame_emit_info(header_len, &out[header_len..blocks_end], emit_checksum);
+        }
+        #[cfg(not(feature = "lsm"))]
+        let _ = header_len;
     }
 
     /// Convenience wrapper over [`Self::compress_independent_frame_into`]
@@ -841,12 +867,15 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
     /// total_uncompressed)`. Caller guarantees Fast backend + no
     /// dictionary; over-window inputs are fine (matches are bounded by
     /// `window_low` exactly as the owned evicting path).
-    fn run_borrowed_block_loop(
-        &mut self,
-        input: &[u8],
-        initial_size_hint: Option<u64>,
-    ) -> (Vec<u8>, u64) {
-        let mut all_blocks: Vec<u8> = Vec::with_capacity(initial_all_blocks_cap(initial_size_hint));
+    fn run_borrowed_block_loop(&mut self, input: &[u8], out: &mut Vec<u8>) -> u64 {
+        // Blocks are appended to `out` starting here. `out` may already hold
+        // the frame header (the one-shot compress-into-Vec path writes it
+        // first, since the content size is known up front, and the loop
+        // emits blocks straight after it — no separate `all_blocks` Vec and
+        // no header+blocks copy). Output-size reads below are taken RELATIVE
+        // to `blocks_start` so a header prefix never skews the donor split
+        // `savings` gate (which would change block boundaries / wire output).
+        let blocks_start = out.len();
         let total_uncompressed = input.len() as u64;
         // Empty input: emit a single empty last Raw block (mirrors the
         // owned loop's empty-file special case).
@@ -856,14 +885,14 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 block_type: crate::blocks::block::BlockType::Raw,
                 block_size: 0,
             };
-            header.serialize(&mut all_blocks);
+            header.serialize(out);
             #[cfg(feature = "lsm")]
             self.block_decompressed_sizes.push(0);
             #[cfg(all(feature = "lsm", feature = "hash"))]
             if let Some(checksums) = self.block_checksums.as_mut() {
                 checksums.push(xxh64_block_low32(&[]));
             }
-            return (all_blocks, total_uncompressed);
+            return total_uncompressed;
         }
         // SAFETY: `input` outlives this call (held by the caller across
         // the call) and is not mutated. Only the Simple backend is active
@@ -898,7 +927,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             // incompressible input keep the full 128 KiB). The borrowed window
             // already spans the whole input, so a smaller block is just a
             // narrower `(block_start, block_end)` range into it.
-            let savings = start as i64 - all_blocks.len() as i64;
+            let savings = start as i64 - (out.len() - blocks_start) as i64;
             let block_len = optimal_block_size(
                 self.compression_level,
                 &input[start..],
@@ -920,7 +949,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 block,
                 start,
                 end,
-                &mut all_blocks,
+                out,
                 #[cfg(feature = "lsm")]
                 Some(&mut self.block_decompressed_sizes),
                 #[cfg(all(feature = "lsm", feature = "hash"))]
@@ -929,7 +958,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             start = end;
         }
         // `_clear_guard` drops here, clearing the borrowed window.
-        (all_blocks, total_uncompressed)
+        total_uncompressed
     }
 }
 
@@ -1072,8 +1101,13 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             .uncompressed_data
             .take()
             .expect("source must be set via set_source before compress()");
-        let (all_blocks, total_uncompressed) =
-            self.run_owned_block_loop(&mut source, prep.initial_size_hint);
+        // Streaming drain: the content size is only known at EOF, so the
+        // frame header can't precede the blocks — accumulate them in a local
+        // buffer and let `finish_frame` write header + blocks to the drain.
+        let mut all_blocks: Vec<u8> =
+            Vec::with_capacity(initial_all_blocks_cap(prep.initial_size_hint));
+        let total_uncompressed =
+            self.run_owned_block_loop(&mut source, prep.initial_size_hint, &mut all_blocks);
         self.uncompressed_data = Some(source);
         self.finish_frame(all_blocks, total_uncompressed, &prep);
     }
@@ -1268,11 +1302,15 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         &mut self,
         source: &mut Rd,
         initial_size_hint: Option<u64>,
-    ) -> (Vec<u8>, u64) {
-        // Accumulate all compressed blocks; the frame header is written
-        // after all input has been read so Frame_Content_Size is known.
-        // Seed capacity by source-size hint — see `initial_all_blocks_cap`.
-        let mut all_blocks: Vec<u8> = Vec::with_capacity(initial_all_blocks_cap(initial_size_hint));
+        out: &mut Vec<u8>,
+    ) -> u64 {
+        // Compressed blocks are appended to `out` from its current end. The
+        // streaming drain path passes a fresh buffer (the frame header is
+        // written to the drain afterward, since Frame_Content_Size is only
+        // known once the reader hits EOF); the one-shot compress-into-Vec
+        // path passes `out` already holding the header. The donor split
+        // `savings` gate below accumulates block-relative (`before_len`)
+        // output deltas, so a header prefix never skews it.
         let mut total_uncompressed: u64 = 0;
         let mut pending_input: Vec<u8> = Vec::new();
         let mut reached_eof = false;
@@ -1397,7 +1435,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     block_type: crate::blocks::block::BlockType::Raw,
                     block_size: 0,
                 };
-                header.serialize(&mut all_blocks);
+                header.serialize(out);
                 #[cfg(feature = "lsm")]
                 self.block_decompressed_sizes.push(0);
                 #[cfg(all(feature = "lsm", feature = "hash"))]
@@ -1414,7 +1452,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                         block_type: crate::blocks::block::BlockType::Raw,
                         block_size: uncompressed_data.len().try_into().unwrap(),
                     };
-                    header.serialize(&mut all_blocks);
+                    header.serialize(out);
                     #[cfg(feature = "lsm")]
                     self.block_decompressed_sizes
                         .push(uncompressed_data.len() as u32);
@@ -1422,7 +1460,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                     if let Some(checksums) = self.block_checksums.as_mut() {
                         checksums.push(xxh64_block_low32(&uncompressed_data));
                     }
-                    all_blocks.extend_from_slice(&uncompressed_data);
+                    out.extend_from_slice(&uncompressed_data);
                     savings +=
                         uncompressed_data.len() as i64 - (3 + uncompressed_data.len()) as i64;
                 }
@@ -1431,7 +1469,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | CompressionLevel::Better
                 | CompressionLevel::Best
                 | CompressionLevel::Level(_) => {
-                    let before_len = all_blocks.len();
+                    let before_len = out.len();
                     let block_len = uncompressed_data.len();
                     // A primed dictionary makes "incompressible-looking"
                     // blocks matchable against the dict, so the raw-fast-
@@ -1448,21 +1486,21 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                         self.compression_level,
                         last_block,
                         uncompressed_data,
-                        &mut all_blocks,
+                        out,
                         dict_active,
                         #[cfg(feature = "lsm")]
                         Some(&mut self.block_decompressed_sizes),
                         #[cfg(all(feature = "lsm", feature = "hash"))]
                         self.block_checksums.as_mut(),
                     );
-                    savings += block_len as i64 - (all_blocks.len() - before_len) as i64;
+                    savings += block_len as i64 - (out.len() - before_len) as i64;
                 }
             }
             if last_block && pending_input.is_empty() {
                 break;
             }
         }
-        (all_blocks, total_uncompressed)
+        total_uncompressed
     }
 
     /// Build the frame header bytes once the total payload size is known
@@ -1537,28 +1575,6 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// `out` is the same one copy `finish_frame` performs writing
     /// `all_blocks` into a `Vec` drain, no extra buffering vs the drain
     /// path.
-    fn write_frame_to_vec(
-        &mut self,
-        out: &mut Vec<u8>,
-        all_blocks: Vec<u8>,
-        total_uncompressed: u64,
-        prep: &FramePrep,
-    ) {
-        let header_buf = self.build_frame_header(total_uncompressed, prep);
-        let emit_checksum = cfg!(feature = "hash") && self.content_checksum;
-        let checksum_len = if emit_checksum { 4 } else { 0 };
-        out.clear();
-        out.reserve(header_buf.len() + all_blocks.len() + checksum_len);
-        out.extend_from_slice(&header_buf);
-        out.extend_from_slice(&all_blocks);
-        #[cfg(feature = "hash")]
-        if self.content_checksum {
-            out.extend_from_slice(&(self.hasher.finish() as u32).to_le_bytes());
-        }
-        #[cfg(feature = "lsm")]
-        self.populate_frame_emit_info(header_buf.len(), &all_blocks, emit_checksum);
-    }
-
     /// Walk `all_blocks` to recover per-block layout and store it in
     /// `frame_emit_info`. Each Block_Header is 3 bytes LE packing
     /// `(block_size << 3) | (block_type << 1) | last_block`. Physical body

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -110,7 +110,6 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         BlockType::Raw
     } else {
         // Compress as a standard compressed block
-        let mut compressed = Vec::new();
         let uncompressed_len = uncompressed_data.len();
         state.matcher.commit_space(uncompressed_data);
         if matches!(compression_level, CompressionLevel::Level(16..=22))
@@ -160,19 +159,28 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         let saved_ll_previous = state.fse_tables.ll_previous.clone();
         let saved_ml_previous = state.fse_tables.ml_previous.clone();
         let saved_of_previous = state.fse_tables.of_previous.clone();
-        compress_block(state, &mut compressed);
+        // Compress directly into `output`: reserve the fixed 3-byte block
+        // header, append the payload after it, then backfill the header in
+        // place once its length is known — no temp `Vec`, no extend-copy.
+        let hdr_off = output.len();
+        output.extend_from_slice(&[0u8; 3]);
+        let payload_off = output.len();
+        compress_block(state, output);
+        let payload_len = output.len() - payload_off;
         // If the compressed data is larger than the maximum allowable
         // block size, store uncompressed. When a dictionary is active we
         // ALSO fall back to raw whenever compression did not actually
-        // shrink the block (`compressed >= block_size`): the raw-fast-path
+        // shrink the block (`payload >= block_size`): the raw-fast-path
         // was bypassed to give dictionary matching a chance, so a block
         // that turns out incompressible-even-with-the-dict must still be
         // emitted raw instead of as a (larger) compressed block. Mirrors
         // the reference's post-hoc raw fallback; gated on `dict_active` so
         // the non-dictionary wire output is byte-identical to before.
-        if compressed.len() >= MAX_BLOCK_SIZE as usize
-            || (dict_active && compressed.len() >= block_size as usize)
+        if payload_len >= MAX_BLOCK_SIZE as usize
+            || (dict_active && payload_len >= block_size as usize)
         {
+            // Roll back the payload + reserved header and the entropy state.
+            output.truncate(hdr_off);
             state.offset_hist = saved_offset_hist;
             state.last_huff_table = saved_huff_table;
             state.fse_tables.ll_previous = saved_ll_previous;
@@ -191,11 +199,10 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
             let header = BlockHeader {
                 last_block,
                 block_type: BlockType::Compressed,
-                block_size: compressed.len() as u32,
+                block_size: payload_len as u32,
             };
-            // Write the header, then the block
-            header.serialize(output);
-            output.extend(compressed);
+            // Backfill the reserved 3-byte header in place.
+            output[hdr_off..hdr_off + 3].copy_from_slice(&header.to_le_bytes());
             BlockType::Compressed
         }
     }
@@ -271,7 +278,6 @@ pub(crate) fn compress_block_encoded_borrowed(
             !matches!(compression_level, CompressionLevel::Level(16..=22)),
             "borrowed one-shot path is gated to Fast levels; post-split is unreachable",
         );
-        let mut compressed = Vec::new();
         // Stage the borrowed range so `compress_block`'s internal
         // `start_matching` scans it in place (no `commit_space` copy).
         state.matcher.set_borrowed_block(block_start, block_end);
@@ -291,8 +297,20 @@ pub(crate) fn compress_block_encoded_borrowed(
         let saved_ll_previous = state.fse_tables.ll_previous.clone();
         let saved_ml_previous = state.fse_tables.ml_previous.clone();
         let saved_of_previous = state.fse_tables.of_previous.clone();
-        compress_block(state, &mut compressed);
-        if compressed.len() >= MAX_BLOCK_SIZE as usize {
+        // Compress directly into `output`: reserve the fixed 3-byte block
+        // header, append the payload after it, then backfill the header in
+        // place once its length is known. Avoids the per-block temp `Vec`
+        // plus the `output.extend(compressed)` copy (the dominant per-frame
+        // memmove on this hot path).
+        let hdr_off = output.len();
+        output.extend_from_slice(&[0u8; 3]);
+        let payload_off = output.len();
+        compress_block(state, output);
+        let payload_len = output.len() - payload_off;
+        if payload_len >= MAX_BLOCK_SIZE as usize {
+            // Incompressible: roll back the payload + reserved header and the
+            // entropy state, then emit a stored Raw block.
+            output.truncate(hdr_off);
             state.offset_hist = saved_offset_hist;
             state.last_huff_table = saved_huff_table;
             state.fse_tables.ll_previous = saved_ll_previous;
@@ -310,10 +328,9 @@ pub(crate) fn compress_block_encoded_borrowed(
             let header = BlockHeader {
                 last_block,
                 block_type: BlockType::Compressed,
-                block_size: compressed.len() as u32,
+                block_size: payload_len as u32,
             };
-            header.serialize(output);
-            output.extend(compressed);
+            output[hdr_off..hdr_off + 3].copy_from_slice(&header.to_le_bytes());
             BlockType::Compressed
         }
     }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -5836,24 +5836,30 @@ fn dfast_matches_roundtrip_multi_block_pattern() {
 #[test]
 fn dfast_accepts_exact_five_byte_match() {
     // Layout the input so that:
-    //   bytes 0..5   = "ABCDE"        (the match source)
-    //   bytes 5..28  = 23 filler bytes that do NOT start with 'A'
-    //   bytes 28..33 = "ABCDE"        (the 5-byte match site)
-    //   byte  33     = 'F'            (differs from byte 5 = '!')
-    // The longest available copy at position 28 is exactly 5 bytes:
-    // the byte at position 33 ('F') differs from the byte at position 5
+    //   byte  0      = 'Z'            (lead byte — keeps the match SOURCE off
+    //                                  position 0, which the greedy loop never
+    //                                  inserts: like the donor it starts the
+    //                                  cursor at ip+1 and hashes only visited
+    //                                  positions)
+    //   bytes 1..6   = "ABCDE"        (the match source — position 1 IS visited)
+    //   bytes 6..29  = 23 filler bytes that do NOT start with 'A'
+    //   bytes 29..34 = "ABCDE"        (the 5-byte match site)
+    //   byte  34     = 'F'            (differs from byte 6 = '!')
+    // The longest available copy at position 29 is exactly 5 bytes:
+    // the byte at position 34 ('F') differs from the byte at position 6
     // ('!'), so the forward extension stops at length 5.
     let mut data = Vec::new();
-    data.extend_from_slice(b"ABCDE"); // 0..5
-    data.extend_from_slice(b"!!!!!!!!!!!!!!!!!!!!!!!"); // 5..28 (23 bytes)
-    data.extend_from_slice(b"ABCDE"); // 28..33
-    data.push(b'F'); // 33: forces forward extension to stop at length 5
-    // Trailing filler so the match site (28) sits at least HASH_READ_SIZE (8)
+    data.push(b'Z'); // 0
+    data.extend_from_slice(b"ABCDE"); // 1..6
+    data.extend_from_slice(b"!!!!!!!!!!!!!!!!!!!!!!!"); // 6..29 (23 bytes)
+    data.extend_from_slice(b"ABCDE"); // 29..34
+    data.push(b'F'); // 34: forces forward extension to stop at length 5
+    // Trailing filler so the match site (29) sits at least HASH_READ_SIZE (8)
     // bytes before the block end. The greedy double-fast — like the donor —
     // stops probing at `ilimit = iend - HASH_READ_SIZE`, so a match in the
     // final 8 bytes is never searched (donor parity, not a regression).
-    data.extend_from_slice(b"GHIJKLMNOPQRSTUVWXYZ"); // 34..54
-    assert_eq!(data.len(), 54);
+    data.extend_from_slice(b"GHIJKLMNOPQRSTUVWXYZ"); // 35..55
+    assert_eq!(data.len(), 55);
 
     let mut matcher = DfastMatchGenerator::new(1 << 22);
     matcher.add_data(data.clone(), |_| {});

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1360,13 +1360,25 @@ impl MatchGeneratorDriver {
     /// reused for another frame.
     pub(crate) unsafe fn set_borrowed_window(&mut self, buffer: &[u8]) {
         // SAFETY: forwarded contract — caller upholds liveness/clear.
-        unsafe { self.simple_mut().set_borrowed_window(buffer) };
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => unsafe {
+                self.simple_mut().set_borrowed_window(buffer)
+            },
+            super::strategy::BackendTag::Dfast => unsafe {
+                self.dfast_matcher_mut().set_borrowed_window(buffer)
+            },
+            other => unreachable!("borrowed window only for Simple/Dfast backends, got {other:?}"),
+        }
     }
 
-    /// Clear the borrowed one-shot window, returning the Simple backend
+    /// Clear the borrowed one-shot window, returning the active backend
     /// to the owned `history` path.
     pub(crate) fn clear_borrowed_window(&mut self) {
-        self.simple_mut().clear_borrowed_window();
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => self.simple_mut().clear_borrowed_window(),
+            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().clear_borrowed_window(),
+            _ => {}
+        }
         self.borrowed_pending = None;
     }
 
@@ -1378,10 +1390,12 @@ impl MatchGeneratorDriver {
     /// block. See [`Matcher::start_matching`] /
     /// [`Matcher::skip_matching_with_hint`] on this type.
     pub(crate) fn set_borrowed_block(&mut self, block_start: usize, block_end: usize) {
-        assert_eq!(
-            self.active_backend(),
-            super::strategy::BackendTag::Simple,
-            "borrowed block staging is only valid for the Simple (Fast) backend",
+        assert!(
+            matches!(
+                self.active_backend(),
+                super::strategy::BackendTag::Simple | super::strategy::BackendTag::Dfast
+            ),
+            "borrowed block staging is only valid for the Simple (Fast) / Dfast backends",
         );
         assert!(
             block_start <= block_end,
@@ -1393,8 +1407,15 @@ impl MatchGeneratorDriver {
         // `collect_block_parts` BEFORE `start_matching` consumes the
         // stage, so the staged block (not the whole borrowed window) must
         // be reported now to keep the literal-buffer reservation right.
-        self.simple_mut()
-            .stage_borrowed_block(block_start, block_end);
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => self
+                .simple_mut()
+                .stage_borrowed_block(block_start, block_end),
+            super::strategy::BackendTag::Dfast => self
+                .dfast_matcher_mut()
+                .stage_borrowed_block(block_start, block_end),
+            _ => unreachable!(),
+        }
     }
 
     #[cfg(test)]
@@ -2573,8 +2594,17 @@ impl Matcher for MatchGeneratorDriver {
         // the Simple backend is instrumented (the gate guarantees it),
         // and the stage is consumed so the next block re-stages.
         if let Some((block_start, block_end)) = self.borrowed_pending.take() {
-            self.simple_mut()
-                .start_matching_borrowed(block_start, block_end, &mut handle_sequence);
+            match self.active_backend() {
+                super::strategy::BackendTag::Simple => self.simple_mut().start_matching_borrowed(
+                    block_start,
+                    block_end,
+                    &mut handle_sequence,
+                ),
+                super::strategy::BackendTag::Dfast => self
+                    .dfast_matcher_mut()
+                    .start_matching_borrowed(block_start, block_end, &mut handle_sequence),
+                other => unreachable!("borrowed scan only for Simple/Dfast, got {other:?}"),
+            }
             return;
         }
         // Decoupled parse×search dispatch (fires once per block). The
@@ -2643,8 +2673,17 @@ impl Matcher for MatchGeneratorDriver {
         // hashes on the dict-priming hint) with no owned-history append
         // and nothing to recycle. Stage is consumed.
         if let Some((block_start, block_end)) = self.borrowed_pending.take() {
-            self.simple_mut()
-                .skip_matching_borrowed(block_start, block_end, incompressible_hint);
+            match self.active_backend() {
+                super::strategy::BackendTag::Simple => self.simple_mut().skip_matching_borrowed(
+                    block_start,
+                    block_end,
+                    incompressible_hint,
+                ),
+                super::strategy::BackendTag::Dfast => self
+                    .dfast_matcher_mut()
+                    .skip_matching_borrowed(block_start, block_end, incompressible_hint),
+                other => unreachable!("borrowed skip only for Simple/Dfast, got {other:?}"),
+            }
             return;
         }
         match self.active_backend() {

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -475,14 +475,6 @@ pub struct HuffmanTable {
     cached_encoded_weight_description: CachedDescription,
 }
 
-/// Diagnostic call counter for `build_from_counts` (the Huffman tree builder),
-/// active only under the `dhat-heap` profiling feature. Lets the reuse
-/// profiling example report builds-per-frame so over-build / over-split churn
-/// can be confirmed without guessing from a flamegraph.
-#[cfg(feature = "dhat-heap")]
-pub static BUILD_FROM_COUNTS_CALLS: core::sync::atomic::AtomicUsize =
-    core::sync::atomic::AtomicUsize::new(0);
-
 impl HuffmanTable {
     /// Heap bytes this table holds: the per-symbol code table and the packed
     /// dual-container codes. The lazily-built weight-description cache is a
@@ -500,8 +492,6 @@ impl HuffmanTable {
     }
 
     pub fn build_from_counts(counts: &[usize]) -> Self {
-        #[cfg(feature = "dhat-heap")]
-        BUILD_FROM_COUNTS_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         assert!(counts.len() <= 256);
         let symbol_cardinality = counts.iter().filter(|&&count| count > 0).count();
         if symbol_cardinality <= 1 {
@@ -510,7 +500,7 @@ impl HuffmanTable {
 
         let min_table_log = symbol_cardinality.ilog2() as usize + 1;
         let mut best_size = usize::MAX - 1;
-        let mut best_weights: Option<alloc::vec::Vec<usize>> = None;
+        let mut best_table = None;
 
         // Outer-loop scoring uses [`cheap_desc_size_proxy`] — an integer
         // entropy estimate of the weight description, no FSE encode.
@@ -540,15 +530,13 @@ impl HuffmanTable {
             if !huffman_weight_sum_is_power_of_two(&weights) {
                 continue;
             }
-            // Derive `max_bits` and the would-be compressed size directly from
-            // the weights instead of materialising a full `HuffmanTable`
-            // (codes + packed_codes Vecs) for every candidate table_log — only
-            // the winning table_log is built, after the loop. The per-symbol
-            // code length is `table_log + 1 - weight[s]` (see
-            // `build_from_weights`), so the maximum is `table_log + 1 -
-            // min_nonzero_weight`. This drops ~8 of every ~9 per-build
-            // HuffmanTable allocations on the entropy hot path.
-            let max_bits = max_bits_from_weights(table_log, &weights);
+            let table = Self::build_from_weights(&weights);
+            let max_bits = table
+                .codes
+                .iter()
+                .map(|&(_, bits)| bits)
+                .max()
+                .unwrap_or_default() as usize;
             if max_bits < table_log && table_log > min_table_log {
                 break;
             }
@@ -570,23 +558,20 @@ impl HuffmanTable {
             let Some(desc_size) = cheap_desc_size_proxy(trimmed) else {
                 continue;
             };
-            let new_size = estimate_compressed_size_from_weights(&weights, counts, table_log)
+            let new_size = table
+                .estimate_compressed_size_from_counts(counts)
                 .saturating_add(desc_size);
             if new_size > best_size + 1 {
                 break;
             }
             if new_size < best_size {
                 best_size = new_size;
-                best_weights = Some(weights);
+                best_table = Some(table);
             }
         }
 
-        // Build the selected table exactly once (winner's weights, or the
-        // donor 11-bit fallback when no candidate scored).
-        match best_weights {
-            Some(weights) => Self::build_from_weights(&weights),
-            None => Self::build_from_weights(&build_donor_limited_weights(counts, 11)),
-        }
+        best_table
+            .unwrap_or_else(|| Self::build_from_weights(&build_donor_limited_weights(counts, 11)))
     }
 
     /// Estimates encoded payload size in bytes for `data` using this table.
@@ -1006,45 +991,6 @@ fn build_huffman_leaf_depths(counts: &[usize]) -> Vec<HuffNode> {
     // changes their `count` / `symbol`. Return just the leaves (with depths).
     nodes.truncate(leaf_count);
     nodes
-}
-
-/// Maximum Huffman code length implied by `weights` at `table_log`, without
-/// materialising the code table. Mirrors `build_from_weights`'s assignment
-/// `nb_bits = table_log + 1 - weight` for every non-zero weight, so the
-/// maximum is `table_log + 1 - min_nonzero_weight` (zero-weight symbols carry
-/// `nb_bits = 0` and never raise the max). Returns `0` when no weight is
-/// non-zero (matching the old `max().unwrap_or_default()` over an all-zero
-/// code table).
-fn max_bits_from_weights(table_log: usize, weights: &[usize]) -> usize {
-    match weights.iter().copied().filter(|&w| w > 0).min() {
-        Some(min_w) => table_log + 1 - min_w,
-        None => 0,
-    }
-}
-
-/// Would-be compressed payload size (bytes) for `counts` under `weights` at
-/// `table_log`, computed straight from the weights instead of building the
-/// table. Byte-for-byte identical to
-/// [`HuffmanTable::estimate_compressed_size_from_counts`]: the per-symbol code
-/// length is `table_log + 1 - weight` for non-zero weights (and `0`
-/// otherwise), and the byte formula is the same `div_ceil(8) + is_multiple_of(8)`.
-fn estimate_compressed_size_from_weights(
-    weights: &[usize],
-    counts: &[usize],
-    table_log: usize,
-) -> usize {
-    let bits: usize = weights
-        .iter()
-        .zip(counts.iter())
-        .map(|(&weight, &count)| {
-            if weight > 0 {
-                (table_log + 1 - weight) * count
-            } else {
-                0
-            }
-        })
-        .sum();
-    bits.div_ceil(8) + usize::from(bits.is_multiple_of(8))
 }
 
 /// Limit the natural Huffman depths in `leaves` (from

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -475,6 +475,14 @@ pub struct HuffmanTable {
     cached_encoded_weight_description: CachedDescription,
 }
 
+/// Diagnostic call counter for `build_from_counts` (the Huffman tree builder),
+/// active only under the `dhat-heap` profiling feature. Lets the reuse
+/// profiling example report builds-per-frame so over-build / over-split churn
+/// can be confirmed without guessing from a flamegraph.
+#[cfg(feature = "dhat-heap")]
+pub static BUILD_FROM_COUNTS_CALLS: core::sync::atomic::AtomicUsize =
+    core::sync::atomic::AtomicUsize::new(0);
+
 impl HuffmanTable {
     /// Heap bytes this table holds: the per-symbol code table and the packed
     /// dual-container codes. The lazily-built weight-description cache is a
@@ -492,6 +500,8 @@ impl HuffmanTable {
     }
 
     pub fn build_from_counts(counts: &[usize]) -> Self {
+        #[cfg(feature = "dhat-heap")]
+        BUILD_FROM_COUNTS_CALLS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         assert!(counts.len() <= 256);
         let symbol_cardinality = counts.iter().filter(|&&count| count > 0).count();
         if symbol_cardinality <= 1 {
@@ -500,7 +510,7 @@ impl HuffmanTable {
 
         let min_table_log = symbol_cardinality.ilog2() as usize + 1;
         let mut best_size = usize::MAX - 1;
-        let mut best_table = None;
+        let mut best_weights: Option<alloc::vec::Vec<usize>> = None;
 
         // Outer-loop scoring uses [`cheap_desc_size_proxy`] — an integer
         // entropy estimate of the weight description, no FSE encode.
@@ -530,13 +540,15 @@ impl HuffmanTable {
             if !huffman_weight_sum_is_power_of_two(&weights) {
                 continue;
             }
-            let table = Self::build_from_weights(&weights);
-            let max_bits = table
-                .codes
-                .iter()
-                .map(|&(_, bits)| bits)
-                .max()
-                .unwrap_or_default() as usize;
+            // Derive `max_bits` and the would-be compressed size directly from
+            // the weights instead of materialising a full `HuffmanTable`
+            // (codes + packed_codes Vecs) for every candidate table_log — only
+            // the winning table_log is built, after the loop. The per-symbol
+            // code length is `table_log + 1 - weight[s]` (see
+            // `build_from_weights`), so the maximum is `table_log + 1 -
+            // min_nonzero_weight`. This drops ~8 of every ~9 per-build
+            // HuffmanTable allocations on the entropy hot path.
+            let max_bits = max_bits_from_weights(table_log, &weights);
             if max_bits < table_log && table_log > min_table_log {
                 break;
             }
@@ -558,20 +570,23 @@ impl HuffmanTable {
             let Some(desc_size) = cheap_desc_size_proxy(trimmed) else {
                 continue;
             };
-            let new_size = table
-                .estimate_compressed_size_from_counts(counts)
+            let new_size = estimate_compressed_size_from_weights(&weights, counts, table_log)
                 .saturating_add(desc_size);
             if new_size > best_size + 1 {
                 break;
             }
             if new_size < best_size {
                 best_size = new_size;
-                best_table = Some(table);
+                best_weights = Some(weights);
             }
         }
 
-        best_table
-            .unwrap_or_else(|| Self::build_from_weights(&build_donor_limited_weights(counts, 11)))
+        // Build the selected table exactly once (winner's weights, or the
+        // donor 11-bit fallback when no candidate scored).
+        match best_weights {
+            Some(weights) => Self::build_from_weights(&weights),
+            None => Self::build_from_weights(&build_donor_limited_weights(counts, 11)),
+        }
     }
 
     /// Estimates encoded payload size in bytes for `data` using this table.
@@ -991,6 +1006,45 @@ fn build_huffman_leaf_depths(counts: &[usize]) -> Vec<HuffNode> {
     // changes their `count` / `symbol`. Return just the leaves (with depths).
     nodes.truncate(leaf_count);
     nodes
+}
+
+/// Maximum Huffman code length implied by `weights` at `table_log`, without
+/// materialising the code table. Mirrors `build_from_weights`'s assignment
+/// `nb_bits = table_log + 1 - weight` for every non-zero weight, so the
+/// maximum is `table_log + 1 - min_nonzero_weight` (zero-weight symbols carry
+/// `nb_bits = 0` and never raise the max). Returns `0` when no weight is
+/// non-zero (matching the old `max().unwrap_or_default()` over an all-zero
+/// code table).
+fn max_bits_from_weights(table_log: usize, weights: &[usize]) -> usize {
+    match weights.iter().copied().filter(|&w| w > 0).min() {
+        Some(min_w) => table_log + 1 - min_w,
+        None => 0,
+    }
+}
+
+/// Would-be compressed payload size (bytes) for `counts` under `weights` at
+/// `table_log`, computed straight from the weights instead of building the
+/// table. Byte-for-byte identical to
+/// [`HuffmanTable::estimate_compressed_size_from_counts`]: the per-symbol code
+/// length is `table_log + 1 - weight` for non-zero weights (and `0`
+/// otherwise), and the byte formula is the same `div_ceil(8) + is_multiple_of(8)`.
+fn estimate_compressed_size_from_weights(
+    weights: &[usize],
+    counts: &[usize],
+    table_log: usize,
+) -> usize {
+    let bits: usize = weights
+        .iter()
+        .zip(counts.iter())
+        .map(|(&weight, &count)| {
+            if weight > 0 {
+                (table_log + 1 - weight) * count
+            } else {
+                0
+            }
+        })
+        .sum();
+    bits.div_ceil(8) + usize::from(bits.is_multiple_of(8))
 }
 
 /// Limit the natural Huffman depths in `leaves` (from


### PR DESCRIPTION
## Summary

Reshapes the dfast (L3/L4 greedy double-fast) match-find path toward the
reference implementation's structure, cutting the encode-speed gap vs the C
library while keeping output byte-identical.

Three layered changes:

- **Borrowed one-shot in-place scan.** When the whole input fits the window
  and no dictionary is in play, dfast now scans the caller's `&[u8]` directly
  instead of copying it into the history concat first. Positions become bare
  absolute input offsets (`position_base == 0`), and candidate reads from
  earlier blocks land in the same buffer. The byte source flows through a
  single `scan_source()` seam so the owned (history-copying) path and the
  borrowed path share one kernel body.

- **Const-monomorphised kernels (`USE_DICT` x `BORROWED`).** The dispatcher
  resolves dict-presence and borrowed-vs-owned once per block and selects a
  monomorphised kernel, so the hot loop carries neither a per-position dict
  check nor the owned-path rebase arithmetic when they don't apply (the
  reference keeps noDict / dictMatchState as separate functions for the same
  reason). The borrowed kernel supplies the rebase coordinates as literal `0`,
  folding every `abs - abs_start` term and the always-true lower-bound compare
  to the bare position (reference `base + index` shape). A borrowed block never
  carries a dict, so only three of four combinations instantiate.

- **Branchy match-validity.** The candidate validity check (slot populated /
  in-window / before-cursor) is branchy rather than a branchless select-address
  mask. The mask tied the candidate load's ADDRESS to the mask computation,
  serialising the loop's hottest instruction; the checks are highly predictable
  after table warmup, so the branchy form lets the out-of-order engine
  speculate the load past them (the reference's `ip+1` long retry is branchy
  for exactly this reason).

## Performance (i9-9900K, BMI2+AVX2)

Measured on `compare_ffi` decodecorpus-z000033, flat C-FFI control arm:

- Borrowed reshape: L3 dfast ~-16%, L4 ~-11% vs the pre-reshape baseline.
- Branchy validity: L4 dfast -2.58% (flat control).
- Borrowed/owned monomorphisation: L4 dfast -5.54% (flat control); the borrowed
  AVX2 kernel drops from 1388 to 765 instructions (objdump) as the abstraction
  arithmetic folds.

Output stays smaller than the C donor on this fixture (ratio unaffected, the
changes are speed-only).

## Testing

- 825 library tests pass (`--features dict_builder`), including the
  cross-validation suite (Rust-compress / C-decompress round trips) and the
  `borrowed_oneshot_matches_owned_and_roundtrips` byte-identity test that pins
  the borrowed path to the owned path's exact output.
- Clippy clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional heap profiling capability (`dhat-heap` feature) for performance analysis
  * Added new encoder profiling example for loop optimization analysis

* **Refactor**
  * Optimized encoder memory allocation patterns and block serialization efficiency
  * Enhanced encoder matcher to support direct input scanning
  * Improved frame compression output streaming to reduce intermediate buffering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->