### PR TITLE
perf(encode): monolithize dfast per-match helpers into the kernel

### DIFF
--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1248,6 +1248,7 @@ impl DfastMatchGenerator {
         }
     }
 
+    #[inline(always)]
     fn emit_candidate(
         &mut self,
         current_abs_start: usize,
@@ -1361,6 +1362,7 @@ impl DfastMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
+    #[inline(always)]
     pub(crate) fn insert_positions(&mut self, start: usize, end: usize) {
         // Source the byte buffer + rebase coordinates through `scan_source()`
         // so a borrowed window's batch re-seed hashes the in-place input

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -1248,7 +1248,11 @@ impl DfastMatchGenerator {
         }
     }
 
-    #[inline(always)]
+    // Force-inline on native (the dfast monolithization speedup) but NOT on
+    // wasm32, where inlining these per-match helpers into every call site
+    // bloats the module past the .wasm size budget; wasm is size-, not
+    // speed-sensitive, so let LLVM keep them out-of-line there.
+    #[cfg_attr(not(target_arch = "wasm32"), inline(always))]
     fn emit_candidate(
         &mut self,
         current_abs_start: usize,
@@ -1362,7 +1366,7 @@ impl DfastMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
-    #[inline(always)]
+    #[cfg_attr(not(target_arch = "wasm32"), inline(always))]
     pub(crate) fn insert_positions(&mut self, start: usize, end: usize) {
         // Source the byte buffer + rebase coordinates through `scan_source()`
         // so a borrowed window's batch re-seed hashes the in-place input


### PR DESCRIPTION
## Summary

Force-inlines the two per-match dfast helpers (`emit_candidate`,
`insert_positions`) into the match-find kernel, monolithizing the dfast (L3/L4)
hot path.

A 3-way bench (ours / a literal C-to-Rust transliteration / the C library)
showed the literal port does all dfast work inside one function, while ours
split the per-match emit + position-insert into separate methods called from
the loop. Our dfast hot path therefore paid call-boundary overhead (call/ret,
no cross-inlining optimisation, register spills across the boundary) that the
monolithic shape folds away. The reference function is *larger* yet faster, so
the monolith size is not a concern.

## Performance

Measured on i9-9900K (BMI2+AVX2), `compare_ffi` decodecorpus-z000033:

- dfast L3/L4 encode hot path: **~30% faster** (the matcher's per-position cost
  drops once the per-match helpers fold in, eliminating the call boundaries).

## Testing

- Byte-identical output: 140 cross-validation (Rust-compress / C-decompress
  round trips) + dfast + roundtrip tests pass. `#[inline(always)]` is a codegen
  hint only; it cannot change the emitted bytes.
- Two-line diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved encoding performance on native (non-wasm32) platforms via internal inlining optimizations. Users may observe faster encoding speeds and reduced latency when compressing data in relevant environments. No functional or behavioral changes exposed to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->