### PR TITLE
perf(encode): 4-byte gate before HC chain common_prefix_len

### DIFF
--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -353,7 +353,22 @@ impl HcMatcher {
                     }
                 }
 
-                if !skip {
+                // Cheap 4-byte equality gate before the wider SIMD count
+                // (donor `MEM_read32` gate in `ZSTD_HcFindBestMatch`).
+                // `HC_MIN_MATCH_LEN == 4`, so a first-4-byte mismatch can never
+                // reach the match floor — reject without the vector
+                // load+count+tzcnt. On dict-primed chains over low-match
+                // (random) input, where `best` stays `None` so the speculative
+                // tail gate above never fires, this rejects the bulk of chain
+                // candidates on a scalar compare instead of a full
+                // `common_prefix_len`. Falls through to the full count when
+                // either side lacks a 4-byte lookahead (the count handles short
+                // tails), so the accepted set is byte-identical.
+                let four_byte_ok = candidate_idx + 4 > history_tail
+                    || current_idx + 4 > history_tail
+                    || concat[candidate_idx..candidate_idx + 4]
+                        == concat[current_idx..current_idx + 4];
+                if !skip && four_byte_ok {
                     let match_len =
                         common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
                     if match_len >= HC_MIN_MATCH_LEN {


### PR DESCRIPTION
## Summary

Adds a cheap 4-byte equality gate before the full SIMD `common_prefix_len` in
the lazy / hash-chain match walk.

The walk ran a full vector `common_prefix_len` (load + count + tzcnt) on every
chain candidate. The existing speculative tail gate only fires once a best
match exists; on dictionary-primed chains over low-match (e.g. random) input
`best` stays `None`, so every candidate paid the wider vector path even though
almost none reach the match floor. `HC_MIN_MATCH_LEN == 4`, so a first-4-byte
mismatch can never reach the floor — reject it on a scalar compare instead.

It falls through to the full count when either side lacks a 4-byte lookahead
(the count handles short tails), so the **accepted match set is byte-identical**.

## Performance

i9-9900K, `compare_ffi` `compress-dict/level_7_lazy/small-10k-random`:

- **~-9%** on the dictionary-lazy compress path (the gate skips the vector
  `common_prefix_len` for the non-matching dict candidates the random input
  walks). The donor (`ZSTD_HcFindBestMatch`) does the same `MEM_read32` gate.

## Testing

- Byte-identical output: 197 cross-validation (Rust-compress / C-decompress) +
  hc + dict tests pass. The gate only skips candidates that could not have
  reached `HC_MIN_MATCH_LEN`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal matching algorithm for improved compression performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->