### PR TITLE
perf(decode): hash each block while cache-hot on the direct path

### DIFF
--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -2647,6 +2647,23 @@ impl FrameDecoder {
         // post-loop hashing loop are both gated by the same flag.
         #[cfg(all(feature = "lsm", feature = "hash"))]
         let mut block_ranges: alloc::vec::Vec<(usize, usize)> = alloc::vec::Vec::new();
+        // Frame-level XXH64, accumulated PER BLOCK right after each block
+        // decodes — the bytes are still cache-resident then. The previous
+        // shape hashed the whole output once after the loop, which re-read
+        // the entire frame cold: a full extra memory pass that the
+        // reference implementation does not make (it hashes incrementally
+        // per block). Invisible on outputs that fit L3, ~1.14x wall on a
+        // 100 MiB all-raw decode and the dominant CI gap on
+        // bandwidth-limited hosts.
+        #[cfg(feature = "hash")]
+        let mut running_hash: Option<twox_hash::XxHash64> =
+            if state.frame_header.descriptor.content_checksum_flag()
+                && self.content_checksum != ContentChecksum::None
+            {
+                Some(twox_hash::XxHash64::with_seed(0))
+            } else {
+                None
+            };
         loop {
             #[cfg(all(feature = "lsm", feature = "hash"))]
             let produced_before: Option<usize> = if self.per_block_checksums_enabled {
@@ -2741,6 +2758,15 @@ impl FrameDecoder {
                     ));
                 }
             };
+            // Hash this block's freshly-written bytes while they are hot
+            // (see `running_hash` above). `tail()` is the physical write
+            // cursor: `drop_to_window_size` below only advances the head,
+            // so `[prev_tail, tail)` is exactly this block's output.
+            #[cfg(feature = "hash")]
+            if let Some(hasher) = running_hash.as_mut() {
+                use core::hash::Hasher;
+                hasher.write(direct.buffer.buffer_ref().written_since(produced as usize));
+            }
             produced = direct.buffer.buffer_ref().tail() as u64;
             // Post-decode FCS overflow check.
             if produced > content_size {
@@ -2801,25 +2827,13 @@ impl FrameDecoder {
             }
         }
         #[cfg(feature = "hash")]
-        if state.frame_header.descriptor.content_checksum_flag()
-            && self.content_checksum != ContentChecksum::None
-        {
-            // Direct path bypasses the per-write hash accounting
-            // (DecodeBuffer hashes during drain; the direct path
-            // never drains because the user slice IS the buffer).
-            // Walk the decoded output once and propagate the
-            // resulting hasher state so the frame-tail XXH64 check
-            // (in the block loop above) can verify the digest.
-            //
-            // Gated on `content_checksum_flag`: frames without a
-            // trailing checksum byte have nothing to verify, and the
-            // 1 MiB+ second-pass scan dominated decode wall time
-            // (63 % of total on z000033 L-3 in the standalone perf
-            // loop). `get_calculated_checksum()` now returns `None`
-            // for flag-off frames, matching this skip.
-            use core::hash::Hasher;
-            let mut hasher = twox_hash::XxHash64::with_seed(0);
-            hasher.write(&output[..written]);
+        if let Some(hasher) = running_hash {
+            // Propagate the per-block-accumulated hasher state (see the
+            // `running_hash` rationale above the loop) so the frame-tail
+            // XXH64 check and `get_calculated_checksum()` read the digest.
+            // `running_hash` is `None` for flag-off frames or
+            // `ContentChecksum::None` — nothing to verify there, and
+            // `get_calculated_checksum()` returns `None`, matching the skip.
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => s.buffer.hash = hasher,
                 DecoderScratchKind::Ring(s) => s.buffer.hash = hasher,

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -159,7 +159,9 @@ impl<'a> UserSliceBackend<'a> {
     /// path hashes each block's output through this right after the
     /// block decodes, while the bytes are still cache-resident; a
     /// post-decode whole-output hash walk re-reads the entire frame
-    /// cold (a full extra memory pass on large outputs).
+    /// cold (a full extra memory pass on large outputs). Only the
+    /// XXH64 accumulation reads it, hence the `hash` gate.
+    #[cfg(feature = "hash")]
     pub(crate) fn written_since(&self, from: usize) -> &[u8] {
         &self.slice[from..self.tail]
     }

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -23,10 +23,13 @@
 //!   builds; dict frames stay on the regular path).
 //!
 //! `content_checksum_flag` is NOT a precondition: when set, the
-//! direct-decode caller walks `output[..content_size]` once at end
-//! of decode (single sequential xxhash pass over cache-hot data)
-//! and stores the digest into the persistent scratch's hasher so
-//! `get_calculated_checksum()` reads the right value.
+//! direct-decode caller accumulates the frame XXH64 incrementally —
+//! after each block it hashes that block's freshly-written bytes via
+//! [`UserSliceBackend::written_since`] while they are still
+//! cache-resident — and stores the final digest into the persistent
+//! scratch's hasher so `get_calculated_checksum()` reads the right
+//! value. (A single end-of-frame walk re-read the whole output cold:
+//! one full extra memory pass on large frames.)
 //!
 //! Multi-segment frames work via the caller's per-block
 //! `DecodeBuffer::drop_to_window_size` invocation — bytes drop

--- a/zstd/src/decoding/user_slice_buf.rs
+++ b/zstd/src/decoding/user_slice_buf.rs
@@ -154,6 +154,16 @@ impl<'a> UserSliceBackend<'a> {
         }
     }
 
+    /// Physical bytes `slice[from..tail]` — the output written since a
+    /// previously-observed [`BufferBackend::tail`]. The direct decode
+    /// path hashes each block's output through this right after the
+    /// block decodes, while the bytes are still cache-resident; a
+    /// post-decode whole-output hash walk re-reads the entire frame
+    /// cold (a full extra memory pass on large outputs).
+    pub(crate) fn written_since(&self, from: usize) -> &[u8] {
+        &self.slice[from..self.tail]
+    }
+
     /// Exact, non-overshooting copy for the trailing sequence(s) when the
     /// remaining slice capacity is too tight for the SIMD wildcopy
     /// overshoot of the fast path. Lets the direct-decode gate require


### PR DESCRIPTION
## Summary

The direct decode path computed the frame XXH64 as one whole-output walk after the block loop — a full extra memory pass re-reading the entire frame cold. Invisible when the output fits L3 (the 1 MiB bench fixtures decode at parity), but dominant on bandwidth-limited hosts: the dashboard decompress outsider (`high-entropy-1m`, `level_12_lazy`, `rust_stream`, −72%) showed the FFI side at full speed (9.6 GB/s) while ours dropped to 2.7 GB/s — the reference implementation hashes incrementally per block while the bytes are still cache-resident.

The frame hasher now accumulates inside the block loop from the backend's physical `[prev_tail, tail)` range right after each block decodes (`drop_to_window_size` only moves the head, so the range is exactly the block's output); the post-loop cold pass is gone. Flag-off frames and `ContentChecksum::None` skip everything, unchanged.

## Measurements (bench host, 100 MiB random = all-raw blocks, L12, checksummed frames)

| arm | before | after |
|---|---|---|
| rust | 17.27 ms/iter, 203M LLC misses | **15.14 ms/iter, 147.5M misses** |
| ffi  | 15.15 ms/iter, 146M misses | 15.52 ms/iter, 146M misses |

The +57M-miss delta (exactly one extra 100 MiB pass per iteration) collapses to parity; rust edges out the FFI arm by ~2.4%. Without checksums the two sides were already byte-parity (8.86 vs 8.91 ms/iter) — the entire gap was the cold hash walk. The 1 MiB criterion fixtures decode at parity before and after (L3-resident output masked the extra pass there).

## Testing

- 826 lib/integration tests pass (`cargo nextest run --features dict_builder`), including the stored-vs-calculated checksum propagation and corrupted-checksum rejection tests; clippy clean on default and no-hash feature combos.
- Verified on the bench host with perf counters (table above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized checksum computation during decompression to accumulate validation data incrementally, improving efficiency when content checksums are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->