### PR TITLE
perf(encode): zero per-frame allocations on the reused-compressor path

### DIFF
--- a/zstd/examples/encode_loop_dict.rs
+++ b/zstd/examples/encode_loop_dict.rs
@@ -33,6 +33,15 @@ use std::env;
 
 use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
 
+// With `--features dhat-heap`, route every allocation through the dhat heap
+// profiler (same pattern as `encode_loop_reuse_z000033`) so the run records
+// per-call-site allocation counts + bytes — the per-frame churn signal that
+// allocator-slow targets (musl) amplify into wall time. Writes
+// `dhat-heap.json` on `Profiler` drop.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 /// Byte-for-byte the bench `repeated_log_lines(len)` fixture so a `logs<N>`
 /// input reproduces the `*-log-lines` dashboard scenarios exactly.
 fn repeated_log_lines(len: usize) -> Vec<u8> {
@@ -65,6 +74,9 @@ fn resolve_input(spec: &str) -> Vec<u8> {
 }
 
 fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let args: Vec<String> = env::args().collect();
     let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(22);
     let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(20_000);

--- a/zstd/src/bit_io/bit_writer.rs
+++ b/zstd/src/bit_io/bit_writer.rs
@@ -17,6 +17,10 @@ pub(crate) struct BitWriter<V: AsMut<Vec<u8>>> {
 
 impl BitWriter<Vec<u8>> {
     /// Initialize a new writer.
+    // Production encode paths write into caller-owned buffers via `from`;
+    // the owned-`Vec` constructor (and `dump` below) only serve the
+    // dictionary trainer and test/fuzz round-trips.
+    #[cfg(any(test, feature = "fuzz_exports", feature = "dict_builder"))]
     pub fn new() -> Self {
         Self {
             output: Vec::new(),
@@ -412,6 +416,7 @@ impl<V: AsMut<Vec<u8>>> BitWriter<V> {
     ///
     /// This function consumes the writer, so it cannot be used after
     /// dumping
+    #[cfg(any(test, feature = "fuzz_exports", feature = "dict_builder"))]
     pub fn dump(mut self) -> V {
         if self.misaligned() != 0 {
             panic!(

--- a/zstd/src/dictionary/fastcover.rs
+++ b/zstd/src/dictionary/fastcover.rs
@@ -1,4 +1,4 @@
-use alloc::collections::{BTreeMap, BTreeSet};
+use alloc::collections::BTreeSet;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -23,14 +23,40 @@ pub const DEFAULT_K_CANDIDATES: &[usize] = &[64, 128, 256, 512, 1024, 2048];
 pub const DEFAULT_D_CANDIDATES: &[usize] = &[6, 8, 12, 16];
 pub const DEFAULT_F_CANDIDATES: &[u32] = &[16, 18, 20];
 
-fn hash_dmer(dmer: &[u8]) -> u64 {
-    // 64-bit FNV-1a, deterministic and cheap for d-mer hashing.
-    let mut h = 0xcbf29ce484222325u64;
-    for &b in dmer {
-        h ^= u64::from(b);
-        h = h.wrapping_mul(0x100000001b3);
+// Donor multiplicative hash primes (`ZSTD_hashXPtr` family,
+// `zstd/lib/common/zstd_internal.h`): one unaligned read + one multiply per
+// dmer instead of a per-byte FNV loop.
+const PRIME_4_BYTES: u32 = 2_654_435_761;
+const PRIME_5_BYTES: u64 = 889_523_592_379;
+const PRIME_6_BYTES: u64 = 227_718_039_650_203;
+const PRIME_7_BYTES: u64 = 58_295_818_150_454_627;
+const PRIME_8_BYTES: u64 = 0xCF1B_BCDC_B7A5_6463;
+
+/// Bytes a dmer hash reads at a position: the hash covers the first
+/// `min(d, 8)` bytes but the wide read is always 8 (donor
+/// `readLength = MAX(d, 8)`), except the pure 4-byte hash.
+#[inline]
+fn dmer_read_len(d: usize) -> usize {
+    d.max(8)
+}
+
+/// Donor `FASTCOVER_hashPtrToIndex`: hash the first `min(d, 8)` bytes of the
+/// dmer at `pos` into an `f`-bit table index. Caller guarantees
+/// `pos + dmer_read_len(d) <= sample.len()`.
+#[inline]
+fn hash_dmer_index(sample: &[u8], pos: usize, f: u32, d: usize) -> usize {
+    if d.min(8) == 4 {
+        let v = u32::from_le_bytes(sample[pos..pos + 4].try_into().unwrap());
+        return (v.wrapping_mul(PRIME_4_BYTES) >> (32 - f)) as usize;
     }
-    h
+    let v = u64::from_le_bytes(sample[pos..pos + 8].try_into().unwrap());
+    let h = match d.min(8) {
+        5 => (v << 24).wrapping_mul(PRIME_5_BYTES),
+        6 => (v << 16).wrapping_mul(PRIME_6_BYTES),
+        7 => (v << 8).wrapping_mul(PRIME_7_BYTES),
+        _ => v.wrapping_mul(PRIME_8_BYTES),
+    };
+    (h >> (64 - f)) as usize
 }
 
 fn clamp_table_bits(f: u32) -> u32 {
@@ -48,18 +74,21 @@ pub(crate) fn normalize_fastcover_params(mut params: FastCoverParams) -> FastCov
 fn build_frequency_table(sample: &[u8], d: usize, f: u32, accel: usize) -> Vec<u32> {
     let bits = clamp_table_bits(f);
     let size = 1usize << bits;
-    let mask = size - 1;
+    // Donor accel table: `skip = accel - 1` dmers between counted dmers
+    // (`FASTCOVER_defaultAccelParameters`), i.e. a stride of `accel`.
     let step = accel.max(1);
     let mut table = vec![0u32; size];
 
-    if sample.len() < d || d == 0 {
+    let read_len = dmer_read_len(d);
+    if sample.len() < read_len {
         return table;
     }
 
     let mut i = 0usize;
-    while i + d <= sample.len() {
-        let slot = (hash_dmer(&sample[i..i + d]) as usize) & mask;
-        table[slot] = table[slot].saturating_add(1);
+    while i + read_len <= sample.len() {
+        // A count is bounded by the dmer count (`sample.len()`), far below
+        // `u32::MAX` for any trainable corpus — plain increment.
+        table[hash_dmer_index(sample, i, bits, d)] += 1;
         i += step;
     }
     table
@@ -73,128 +102,136 @@ fn build_raw_dict(sample: &[u8], dict_size: usize, params: FastCoverParams) -> V
     let params = normalize_fastcover_params(params);
     let k = params.k;
     let d = params.d;
-    let mut active = build_frequency_table(sample, d, params.f, params.accel);
-    let mask = active.len().saturating_sub(1);
-
-    // Segment indices are stored as `u32` in the inverted index, so cap
-    // the segment count at `u32::MAX` to keep the `i as u32` cast lossless.
-    // A corpus large enough to hit this (> u32::MAX segments, multiple TB)
-    // is far outside dictionary-training territory; the `take` is a no-op
-    // for any realistic input and only drops the unreachable tail otherwise.
-    let segments: Vec<&[u8]> = sample
-        .chunks(k)
-        .filter(|seg| seg.len() >= d)
-        .take(u32::MAX as usize)
-        .collect();
-    let n = segments.len();
-    let mut out = Vec::with_capacity(dict_size);
-    if n == 0 {
-        return out;
+    let f = clamp_table_bits(params.f);
+    let read_len = dmer_read_len(d);
+    if sample.len() < read_len {
+        // Too short for even one wide-read dmer: no trainable content.
+        // Callers treat an empty raw dict as "sample too small".
+        return Vec::new();
     }
 
-    // Greedy set-cover selection. The plain top-frequency selection picks
-    // several high-frequency segments that cover the SAME d-mers (redundant
-    // coverage), wasting the dictionary budget. Greedy instead picks, each
-    // round, the segment whose STILL-UNCOVERED d-mers score highest, then
-    // marks those d-mers covered so later rounds value only NEW coverage —
-    // diverse coverage in fewer bytes.
-    //
-    // To keep this affordable at any corpus size (no per-size special-
-    // casing), scores are cached and updated incrementally: an inverted
-    // index `slot -> [(segment, count)]` lets "covering" a chosen segment's
-    // d-mers decrement the score of every other segment containing them in
-    // O(shared occurrences), instead of re-scoring all segments each round.
-    // Scores accumulate `count * frequency` products. Both factors are
-    // u32, so the product can reach ~2^64 and a running sum exceeds it —
-    // accumulate in u64 so the arithmetic is exact on 32-bit targets
-    // (i686) too, where `usize` would wrap.
-    let mut scores = vec![0u64; n];
-    let mut inverted: BTreeMap<usize, Vec<(u32, u32)>> = BTreeMap::new();
-    for (i, seg) in segments.iter().enumerate() {
-        let mut local: BTreeMap<usize, u32> = BTreeMap::new();
-        for w in seg.windows(d) {
-            *local.entry((hash_dmer(w) as usize) & mask).or_insert(0) += 1;
-        }
-        for (slot, cnt) in local {
-            scores[i] += u64::from(cnt) * u64::from(active[slot]);
-            inverted.entry(slot).or_default().push((i as u32, cnt));
-        }
+    // Donor `FASTCOVER_buildDictionary` epoch model: split the corpus into
+    // epochs of dmers and round-robin them, taking the best k-byte segment
+    // per visit. A segment's score is the sum of frequencies of its DISTINCT
+    // dmers, maintained incrementally while the candidate window slides
+    // (O(1) per position via the `segment_freqs` occurrence counts), and a
+    // chosen segment's dmer frequencies are zeroed so later picks value only
+    // new coverage. This replaced a global greedy set-cover with a per-
+    // segment inverted index (`BTreeMap` per segment + slot lists): that
+    // shape allocated millions of map nodes on a 1 MiB corpus and ran an
+    // order of magnitude slower than the reference trainer at equal
+    // coverage quality.
+    let nb_dmers = sample.len() - read_len + 1;
+    let mut freqs = build_frequency_table(sample, d, f, params.accel);
+    let dmers_in_k = k - d + 1; // `normalize` guarantees k >= d
+
+    // Donor `COVER_computeEpochs` (passes = 1): target one selection per
+    // epoch, with a floor so epochs stay large enough to contain useful
+    // segments.
+    let min_epoch_size = k * 10;
+    let mut epoch_count = (dict_size / k).max(1);
+    let mut epoch_size = nb_dmers / epoch_count;
+    if epoch_size < min_epoch_size {
+        epoch_size = min_epoch_size.min(nb_dmers);
+        epoch_count = (nb_dmers / epoch_size).max(1);
     }
 
-    let mut used = vec![false; n];
-    while out.len() < dict_size {
-        let mut best: Option<(u64, usize)> = None; // (score, index)
-        for (i, &score) in scores.iter().enumerate() {
-            if used[i] {
-                continue;
+    // Per-window dmer occurrence counts (donor `segmentFreqs`, u16: a window
+    // holds at most `dmers_in_k` <= k occurrences of one index).
+    let mut segment_freqs = vec![0u16; 1usize << f];
+    // Fill from the back (donor layout) so the best segments sit at the end
+    // of the dictionary and get referenced with the smallest offsets.
+    let mut out = vec![0u8; dict_size];
+    let mut tail = dict_size;
+    const MAX_ZERO_SCORE_RUN: usize = 10;
+    let mut zero_score_run = 0usize;
+    let mut epoch = 0usize;
+
+    while tail > 0 {
+        let epoch_begin = epoch * epoch_size;
+        let epoch_end = epoch_begin + epoch_size;
+        epoch = (epoch + 1) % epoch_count;
+
+        // Slide the candidate window across the epoch, tracking the best
+        // segment (donor `FASTCOVER_selectSegment`).
+        let mut best_begin = 0usize;
+        let mut best_end = 0usize;
+        let mut best_score = 0u64;
+        let mut active_begin = epoch_begin;
+        let mut active_end = epoch_begin;
+        let mut active_score = 0u64;
+        while active_end < epoch_end {
+            let idx = hash_dmer_index(sample, active_end, f, d);
+            if segment_freqs[idx] == 0 {
+                active_score += u64::from(freqs[idx]);
             }
-            if best.is_none_or(|(bs, _)| score > bs) {
-                best = Some((score, i));
-            }
-        }
-        // No remaining segment covers any still-active d-mer — every
-        // distinct pattern is already represented, so adding more (now
-        // redundant) segments would only waste budget. Stop early; the
-        // dict may be < dict_size (a compact dict, like the reference's).
-        let Some((_, idx)) = best.filter(|&(s, _)| s > 0) else {
-            break;
-        };
-        used[idx] = true;
-        let seg = segments[idx];
-        let take = seg.len().min(dict_size - out.len());
-        out.extend_from_slice(&seg[..take]);
-        // Cover the d-mers of the bytes we ACTUALLY appended (`seg[..take]`,
-        // not the full segment): zero their remaining frequency and decrement
-        // the cached score of every segment that shared them. The d-mers are
-        // recomputed here (runs once per selected segment, far cheaper than
-        // keeping a per-segment slot list resident for the whole corpus). A
-        // d-mer that recurs within this segment is already zeroed on its
-        // first occurrence, so the `freq == 0` guard makes the repeat a
-        // no-op (correct dedup).
-        for w in seg[..take].windows(d) {
-            let slot = (hash_dmer(w) as usize) & mask;
-            let freq = active[slot];
-            if freq == 0 {
-                continue;
-            }
-            active[slot] = 0;
-            // Each segment's initial score added `count(slot) * freq` for
-            // this exact `slot` (with `freq` = the build-time frequency,
-            // unchanged until this single zeroing), so subtracting it now is
-            // exact and can never underflow — plain subtraction (no
-            // saturating mask, no overflow: u32*u32 fits u64). The
-            // debug_assert documents the invariant; a violation is a
-            // bookkeeping bug, surfaced loudly rather than silently clamped.
-            let contribution = u64::from(freq);
-            if let Some(list) = inverted.get(&slot) {
-                for &(j, cnt) in list {
-                    let delta = u64::from(cnt) * contribution;
-                    debug_assert!(
-                        scores[j as usize] >= delta,
-                        "fastcover score underflow: bookkeeping invariant violated",
-                    );
-                    scores[j as usize] -= delta;
+            active_end += 1;
+            segment_freqs[idx] += 1;
+            if active_end - active_begin == dmers_in_k + 1 {
+                let del = hash_dmer_index(sample, active_begin, f, d);
+                segment_freqs[del] -= 1;
+                if segment_freqs[del] == 0 {
+                    active_score -= u64::from(freqs[del]);
                 }
+                active_begin += 1;
+            }
+            if active_score > best_score {
+                best_begin = active_begin;
+                best_end = active_end;
+                best_score = active_score;
             }
         }
+        // Reset the window counts for the next epoch.
+        while active_begin < epoch_end {
+            let del = hash_dmer_index(sample, active_begin, f, d);
+            segment_freqs[del] -= 1;
+            active_begin += 1;
+        }
+        // Zero the chosen segment's frequencies: its dmers are covered.
+        for pos in best_begin..best_end {
+            freqs[hash_dmer_index(sample, pos, f, d)] = 0;
+        }
+
+        if best_score == 0 {
+            // This epoch has no uncovered content left; other epochs may.
+            // Give up after a run of empty epochs (donor `maxZeroScoreRun`).
+            zero_score_run += 1;
+            if zero_score_run >= MAX_ZERO_SCORE_RUN {
+                break;
+            }
+            continue;
+        }
+        zero_score_run = 0;
+
+        let segment_size = (best_end - best_begin + d - 1).min(tail);
+        if segment_size < d {
+            break;
+        }
+        tail -= segment_size;
+        out[tail..tail + segment_size]
+            .copy_from_slice(&sample[best_begin..best_begin + segment_size]);
     }
+
+    out.drain(..tail);
     out
 }
 
 fn coverage_score(dict: &[u8], eval: &[u8], d: usize, accel: usize) -> usize {
-    if dict.len() < d || eval.len() < d || d == 0 {
+    let read_len = dmer_read_len(d);
+    if dict.len() < read_len || eval.len() < read_len || d == 0 {
         return 0;
     }
+    const COVERAGE_F: u32 = 20;
     let mut seen = BTreeSet::new();
-    for i in 0..=(dict.len() - d) {
-        seen.insert(hash_dmer(&dict[i..i + d]));
+    for i in 0..=(dict.len() - read_len) {
+        seen.insert(hash_dmer_index(dict, i, COVERAGE_F, d));
     }
 
     let mut hits = 0usize;
     let step = accel.max(1);
     let mut i = 0usize;
-    while i + d <= eval.len() {
-        if seen.contains(&hash_dmer(&eval[i..i + d])) {
+    while i + read_len <= eval.len() {
+        if seen.contains(&hash_dmer_index(eval, i, COVERAGE_F, d)) {
             hits += 1;
         }
         i += step;

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -141,7 +141,12 @@ pub(crate) struct CompressedBlockScratch {
     prefix_sums: SequencePrefixSums,
     compressed: Vec<u8>,
     estimator_sequences: Vec<crate::blocks::sequence_section::Sequence>,
-    estimator_workspace: EstimatorWorkspace,
+    /// Lazily allocated: only the block-split estimator path uses it, and
+    /// `compress_block`'s `mem::take` constructs a throwaway `Default`
+    /// scratch every block — an eager workspace made that default pay four
+    /// 2 KiB `Box<[usize; 256]>` allocations per block for paths that never
+    /// probe a split.
+    estimator_workspace: Option<EstimatorWorkspace>,
     /// Reusable scratch for the block-split estimator's inner
     /// `CompressState` — kept across frames so the estimator does not
     /// re-allocate a whole `CompressedBlockScratch` (4×`Box<[u32;256]>`
@@ -312,7 +317,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
 
     scratch.partitions.clear();
     scratch.prefix_sums.rebuild(&scratch.parts.sequences);
-    let mut workspace = core::mem::take(&mut scratch.estimator_workspace);
+    let mut workspace = scratch.estimator_workspace.take().unwrap_or_default();
     // Reuse the estimator's inner scratch across frames instead of
     // allocating a fresh `CompressedBlockScratch` (count tables + Vecs)
     // every block-split. Lazily created on the first split.
@@ -334,6 +339,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
         scratch_state: CompressState {
             matcher: EntropyOnlyMatcher,
             last_huff_table: state.last_huff_table.clone(),
+            huff_table_spare: None,
             fse_tables: clone_fse_tables(&state.fse_tables),
             block_scratch: inner_scratch,
             offset_hist: state.offset_hist,
@@ -344,7 +350,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
     estimator.derive_block_splits(0, scratch.parts.sequences.len(), &mut scratch.partitions);
     scratch.partitions.push(scratch.parts.sequences.len());
     workspace = estimator.workspace;
-    scratch.estimator_workspace = workspace;
+    scratch.estimator_workspace = Some(workspace);
     // Stash the inner scratch back for the next frame (its buffers stay
     // allocated; the estimator clears them per use).
     scratch.estimator_inner = Some(Box::new(estimator.scratch_state.block_scratch));
@@ -541,7 +547,7 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
     // costs match emit byte-for-byte.
     if !literals_vec.is_empty() && all_bytes_identical(literals_vec) {
         rle_literals(literals_vec, &mut writer);
-        state.last_huff_table = None;
+        state.clear_huff_table();
     } else if literals_vec.len() >= min_lits {
         match compress_literals(
             literals_vec,
@@ -550,16 +556,16 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
             strategy,
         ) {
             HuffmanTableUpdate::New(table) => {
-                state.last_huff_table.replace(table);
+                state.replace_huff_table(table);
             }
             HuffmanTableUpdate::Reused => {}
             HuffmanTableUpdate::Cleared => {
-                state.last_huff_table = None;
+                state.clear_huff_table();
             }
         }
     } else {
         raw_literals(literals_vec, &mut writer);
-        state.last_huff_table = None;
+        state.clear_huff_table();
     }
 
     // sequences section
@@ -2604,6 +2610,7 @@ mod tests {
                 let mut est_state = CompressState::<EntropyOnlyMatcher> {
                     matcher: EntropyOnlyMatcher,
                     last_huff_table: seed_table.clone(),
+                    huff_table_spare: None,
                     fse_tables: FseTables::new(),
                     block_scratch: CompressedBlockScratch::new(),
                     offset_hist: [1, 4, 8],
@@ -2612,6 +2619,7 @@ mod tests {
                 let mut emit_state = CompressState::<EntropyOnlyMatcher> {
                     matcher: EntropyOnlyMatcher,
                     last_huff_table: seed_table,
+                    huff_table_spare: None,
                     fse_tables: FseTables::new(),
                     block_scratch: CompressedBlockScratch::new(),
                     offset_hist: [1, 4, 8],
@@ -2655,6 +2663,7 @@ mod tests {
         let mut state = CompressState {
             matcher: super::EntropyOnlyMatcher,
             last_huff_table: None,
+            huff_table_spare: None,
             fse_tables: FseTables::new(),
             block_scratch: super::CompressedBlockScratch::new(),
             offset_hist: [10, 20, 30],

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2816,6 +2816,41 @@ mod tests {
         );
     }
 
+    // Regression test: `heap_size()` must count the retained Huffman tables
+    // (the active `last_huff_table` and the recycled `huff_table_spare`).
+    // A reused context that parks a table would otherwise under-report its
+    // footprint through the public size API.
+    #[test]
+    fn heap_size_counts_active_and_spare_huffman_tables() {
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        let base = compressor.heap_size();
+
+        let active = crate::huff0::huff0_encoder::HuffmanTable::build_from_data(
+            b"abacabadabacabaeabacabadabacaba",
+        );
+        let active_bytes = active.heap_size();
+        assert!(active_bytes > 0, "built table must own heap buffers");
+        compressor.state.last_huff_table = Some(active);
+        assert_eq!(
+            compressor.heap_size(),
+            base + active_bytes,
+            "heap_size must include the active last_huff_table"
+        );
+
+        let spare = crate::huff0::huff0_encoder::HuffmanTable::build_from_data(
+            b"the quick brown fox jumps over the lazy dog",
+        );
+        let spare_bytes = spare.heap_size();
+        assert!(spare_bytes > 0, "built table must own heap buffers");
+        compressor.state.huff_table_spare = Some(spare);
+        assert_eq!(
+            compressor.heap_size(),
+            base + active_bytes + spare_bytes,
+            "heap_size must include the parked huff_table_spare"
+        );
+    }
+
     #[test]
     fn set_encoder_dictionary_reattaches_prepared_dict_without_reparse() {
         let dict_raw = include_bytes!("../../dict_tests/dictionary");

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1190,11 +1190,22 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// Total heap bytes this compressor's allocations hold, excluding the
     /// inline struct: the match-finder tables / history / recycled buffers and
     /// the primed-dictionary snapshot (via the matcher), the retained
-    /// dictionary content, the cached dictionary entropy tables (literals
-    /// Huffman + LL/ML/OF FSE), and the per-block sidecar buffers. Lets a
-    /// context report its true footprint through `ZSTD_sizeof_CCtx`.
+    /// Huffman tables (active + recycled spare), the retained dictionary
+    /// content, the cached dictionary entropy tables (literals Huffman +
+    /// LL/ML/OF FSE), and the per-block sidecar buffers. Lets a context
+    /// report its true footprint through `ZSTD_sizeof_CCtx`.
     pub fn heap_size(&self) -> usize {
         let mut total = self.state.matcher.heap_size();
+        total += self
+            .state
+            .last_huff_table
+            .as_ref()
+            .map_or(0, |table| table.heap_size());
+        total += self
+            .state
+            .huff_table_spare
+            .as_ref()
+            .map_or(0, |table| table.heap_size());
         total += self
             .dictionary
             .as_ref()

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -564,6 +564,12 @@ pub(crate) fn optimal_block_size(
 pub(crate) struct CompressState<M: Matcher> {
     pub(crate) matcher: M,
     pub(crate) last_huff_table: Option<crate::huff0::huff0_encoder::HuffmanTable>,
+    /// Recycled `HuffmanTable` buffers: when a block clears or replaces
+    /// `last_huff_table`, the old table parks here instead of dropping, so
+    /// the next frame's dictionary entropy seed `clone_from`s into existing
+    /// allocations. Without this, every dict-seeded frame whose last block
+    /// ended raw/RLE paid a fresh two-Vec table clone per frame.
+    pub(crate) huff_table_spare: Option<crate::huff0::huff0_encoder::HuffmanTable>,
     pub(crate) fse_tables: FseTables,
     pub(crate) block_scratch: crate::encoding::blocks::CompressedBlockScratch,
     /// Offset history for repeat offset encoding: [rep0, rep1, rep2].
@@ -587,6 +593,26 @@ pub(crate) struct CompressState<M: Matcher> {
     /// encoder constructor) plumb this explicitly. Tests that build
     /// `CompressState` by hand must also supply a value.
     pub(crate) strategy_tag: crate::encoding::strategy::StrategyTag,
+}
+
+impl<M: Matcher> CompressState<M> {
+    /// Clears `last_huff_table`, parking the table's buffers in
+    /// `huff_table_spare` for reuse instead of dropping them.
+    #[inline]
+    pub(crate) fn clear_huff_table(&mut self) {
+        if let Some(table) = self.last_huff_table.take() {
+            self.huff_table_spare = Some(table);
+        }
+    }
+
+    /// Replaces `last_huff_table` with `table`, parking any displaced table
+    /// in `huff_table_spare` for reuse.
+    #[inline]
+    pub(crate) fn replace_huff_table(&mut self, table: crate::huff0::huff0_encoder::HuffmanTable) {
+        if let Some(old) = self.last_huff_table.replace(table) {
+            self.huff_table_spare = Some(old);
+        }
+    }
 }
 
 /// Per-frame setup resolved once by [`FrameCompressor::prepare_frame`] and
@@ -747,6 +773,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             state: CompressState {
                 matcher: MatchGeneratorDriver::new(1024 * 128, 1),
                 last_huff_table: None,
+                huff_table_spare: None,
                 fse_tables: FseTables::new(),
                 block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
                 offset_hist: [1, 4, 8],
@@ -924,15 +951,16 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
         // dominant per-frame memmove + the only un-amortized per-frame alloc
         // even when the compressor is reused).
         let total_uncompressed = input.len() as u64;
-        let header_buf = self.build_frame_header(total_uncompressed, &prep);
         let emit_checksum = cfg!(feature = "hash") && self.content_checksum;
         let checksum_len = if emit_checksum { 4 } else { 0 };
         out.clear();
-        // Reserve the worst-case compressed size ONCE so the block appends
-        // below never realloc; the caller reuses `out` across frames, so the
-        // reservation is paid on the first frame and amortizes to zero.
-        out.reserve(header_buf.len() + crate::encoding::compress_bound(input.len()) + checksum_len);
-        out.extend_from_slice(&header_buf);
+        // Reserve the worst-case compressed size ONCE so the header + block
+        // appends below never realloc; the caller reuses `out` across
+        // frames, so the reservation is paid on the first frame and
+        // amortizes to zero. 18 = max frame header (magic 4 + descriptor 1
+        // + window 1 + dict id 4 + FCS 8).
+        out.reserve(18 + crate::encoding::compress_bound(input.len()) + checksum_len);
+        self.append_frame_header(total_uncompressed, &prep, out);
         let header_len = out.len();
         let _ = self.run_one_frame(input, &prep, out);
         #[cfg(feature = "hash")]
@@ -1082,6 +1110,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             state: CompressState {
                 matcher,
                 last_huff_table: None,
+                huff_table_spare: None,
                 fse_tables: FseTables::new(),
                 block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
                 offset_hist: [1, 4, 8],
@@ -1350,9 +1379,26 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             }
         }
         if let Some(cache) = cached_entropy {
-            self.state.last_huff_table.clone_from(&cache.huff);
+            // Refill an empty slot from the recycled spare before
+            // `clone_from`: `Option::clone_from(None ← Some)` falls back to
+            // a fresh clone (two Vec allocations), while `Some ← Some`
+            // delegates to the table's buffer-reusing `clone_from`. Frames
+            // whose last block cleared the table would otherwise re-clone
+            // the dict seed every frame.
+            match &cache.huff {
+                Some(src) => {
+                    if self.state.last_huff_table.is_none() {
+                        self.state.last_huff_table = self.state.huff_table_spare.take();
+                    }
+                    match &mut self.state.last_huff_table {
+                        Some(dst) => dst.clone_from(src),
+                        slot => *slot = Some(src.clone()),
+                    }
+                }
+                None => self.state.clear_huff_table(),
+            }
         } else {
-            self.state.last_huff_table = None;
+            self.state.clear_huff_table();
         }
         // `clone_from` keeps frame-to-frame seeding cheap for reused compressors by
         // reusing existing allocations where possible instead of reallocating every frame.
@@ -1583,11 +1629,11 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         total_uncompressed
     }
 
-    /// Build the frame header bytes once the total payload size is known
-    /// (so `Frame_Content_Size` / `single_segment` can be set). Shared by
-    /// the drain (`finish_frame`) and returned-buffer
-    /// (`finish_frame_to_vec`) tails.
-    fn build_frame_header(&self, total_uncompressed: u64, prep: &FramePrep) -> Vec<u8> {
+    /// Append the frame header bytes onto `out` once the total payload size
+    /// is known (so `Frame_Content_Size` / `single_segment` can be set).
+    /// Appends rather than returns so the one-shot path serializes straight
+    /// into the reused output buffer with no per-frame header `Vec`.
+    fn append_frame_header(&self, total_uncompressed: u64, prep: &FramePrep, out: &mut Vec<u8>) {
         // Match the donor framing policy for pledged one-shot inputs: use a
         // single-segment frame whenever the source fits the active window.
         let single_segment = !prep.use_dictionary_state
@@ -1610,9 +1656,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             },
             magicless: self.magicless,
         };
-        let mut header_buf: Vec<u8> = Vec::with_capacity(14);
-        header.serialize(&mut header_buf);
-        header_buf
+        header.serialize(out);
     }
 
     /// Write the frame header, accumulated block bytes, and optional
@@ -1621,7 +1665,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// avoid shifting `all_blocks` to prepend the header. Used by
     /// `compress` and `compress_oneshot_borrowed`.
     fn finish_frame(&mut self, all_blocks: Vec<u8>, total_uncompressed: u64, prep: &FramePrep) {
-        let header_buf = self.build_frame_header(total_uncompressed, prep);
+        let mut header_buf: Vec<u8> = Vec::with_capacity(18);
+        self.append_frame_header(total_uncompressed, prep, &mut header_buf);
         // Snapshot the checksum before borrowing the drain field so the
         // `self.hasher` read and the `self.compressed_data` write don't
         // both need `&mut self` simultaneously.

--- a/zstd/src/encoding/frame_header.rs
+++ b/zstd/src/encoding/frame_header.rs
@@ -1,7 +1,6 @@
 //! Utilities and representations for a frame header.
-use crate::bit_io::BitWriter;
 use crate::common::MAGIC_NUM;
-use crate::encoding::util::{find_fcs_field_size, find_min_size, minify_val};
+use crate::encoding::util::{find_fcs_field_size, find_min_size, write_minified_val};
 use alloc::vec::Vec;
 
 /// A header for a single Zstandard frame.
@@ -63,12 +62,12 @@ impl FrameHeader {
         }
 
         if let Some(id) = self.dictionary_id {
-            output.extend(minify_val(id));
+            write_minified_val(id, output);
         }
 
         if let Some(frame_content_size) = self.frame_content_size {
             let field_size = find_fcs_field_size(frame_content_size, self.single_segment);
-            output.extend(serialize_fcs(frame_content_size, field_size));
+            write_fcs(frame_content_size, field_size, output);
         }
     }
 
@@ -76,55 +75,29 @@ impl FrameHeader {
     ///
     /// https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header_descriptor
     fn descriptor(&self) -> u8 {
-        let mut bw = BitWriter::new();
         // A frame header starts with a frame header descriptor.
         // It describes what other fields are present
         // https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_header_descriptor
-        // Writing the frame header descriptor:
-        // `Frame_Content_Size_flag`:
-        // The Frame_Content_Size_flag specifies if
-        // the Frame_Content_Size field is provided within the header.
-        // TODO: The Frame_Content_Size field isn't set at all, we should prefer to include it always.
-        // If the `Single_Segment_flag` is set and this value is zero,
-        // the size of the FCS field is 1 byte.
-        // Otherwise, the FCS field is omitted.
-        // | Value | Size of field (Bytes)
-        // | 0     | 0 or 1
-        // | 1     | 2
-        // | 2     | 4
-        // | 3     | 8
+        // Built with plain bit arithmetic (LSB-first field order below); a
+        // `BitWriter` here allocated a fresh `Vec` for the single byte on
+        // every frame header.
 
-        // `Dictionary_ID_flag`:
-        if let Some(id) = self.dictionary_id {
-            let flag_value: u8 = match find_min_size(id) {
-                0 => 0,
-                1 => 1,
-                2 => 2,
-                4 => 3,
-                _ => panic!(),
-            };
-            bw.write_bits(flag_value, 2);
-        } else {
-            // A `Dictionary_ID` was not provided
-            bw.write_bits(0u8, 2);
-        }
+        // Bits 0-1, `Dictionary_ID_flag`: size class of the
+        // `Dictionary_ID` field (0 = absent).
+        let dict_id_flag: u8 = match self.dictionary_id.map(find_min_size) {
+            None => 0,
+            Some(1) => 1,
+            Some(2) => 2,
+            Some(4) => 3,
+            _ => panic!(),
+        };
 
-        // `Content_Checksum_flag`:
-        if self.content_checksum {
-            bw.write_bits(1u8, 1);
-        } else {
-            bw.write_bits(0u8, 1);
-        }
+        // Bit 2, `Content_Checksum_flag`.
+        let checksum_flag = u8::from(self.content_checksum);
 
-        // `Reserved_bit`:
-        // This value must be zero
-        bw.write_bits(0u8, 1);
+        // Bits 3-4: `Reserved_bit` + `Unused_bit`, both zero.
 
-        // `Unused_bit`:
-        // An encoder compliant with this spec must set this bit to zero
-        bw.write_bits(0u8, 1);
-
-        // `Single_Segment_flag`:
+        // Bit 5, `Single_Segment_flag`:
         // If this flag is set, data must be regenerated within a single continuous memory segment,
         // and the `Frame_Content_Size` field must be present in the header.
         // If this flag is not set, the `Window_Descriptor` field must be present in the frame header.
@@ -133,32 +106,37 @@ impl FrameHeader {
                 self.frame_content_size.is_some(),
                 "if the `single_segment` flag is set to true, then a frame content size must be provided"
             );
-            bw.write_bits(1u8, 1);
         } else {
             assert!(
                 self.window_size.is_some(),
                 "if the `single_segment` flag is set to false, then a window size must be provided"
             );
-            bw.write_bits(0u8, 1);
         }
+        let single_segment_flag = u8::from(self.single_segment);
 
-        if let Some(frame_content_size) = self.frame_content_size {
-            let field_size = find_fcs_field_size(frame_content_size, self.single_segment);
-            let flag_value: u8 = match field_size {
-                1 => 0,
-                2 => 1,
-                4 => 2,
-                8 => 3,
-                _ => unreachable!(),
-            };
+        // Bits 6-7, `Frame_Content_Size_flag`: size class of the FCS field.
+        // If the `Single_Segment_flag` is set and this value is zero,
+        // the size of the FCS field is 1 byte; otherwise the FCS field is
+        // omitted when the flag is zero.
+        // | Value | Size of field (Bytes)
+        // | 0     | 0 or 1
+        // | 1     | 2
+        // | 2     | 4
+        // | 3     | 8
+        let fcs_flag: u8 = match self.frame_content_size {
+            Some(frame_content_size) => {
+                match find_fcs_field_size(frame_content_size, self.single_segment) {
+                    1 => 0,
+                    2 => 1,
+                    4 => 2,
+                    8 => 3,
+                    _ => unreachable!(),
+                }
+            }
+            None => 0,
+        };
 
-            bw.write_bits(flag_value, 2);
-        } else {
-            // `Frame_Content_Size` was not provided
-            bw.write_bits(0u8, 2);
-        }
-
-        bw.dump()[0]
+        dict_id_flag | (checksum_flag << 2) | (single_segment_flag << 5) | (fcs_flag << 6)
     }
 }
 
@@ -168,7 +146,7 @@ impl FrameHeader {
 /// For 2-byte fields an offset of 256 is subtracted before encoding.
 ///
 /// <https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#frame_content_size>
-fn serialize_fcs(val: u64, field_size: usize) -> Vec<u8> {
+fn write_fcs(val: u64, field_size: usize, output: &mut Vec<u8>) {
     debug_assert!(matches!(field_size, 1 | 2 | 4 | 8));
     debug_assert!(field_size != 2 || val >= 256);
 
@@ -177,7 +155,7 @@ fn serialize_fcs(val: u64, field_size: usize) -> Vec<u8> {
         1 | 4 | 8 => val,
         _ => unreachable!("invalid Frame_Content_Size field size: {field_size}"),
     };
-    adjusted.to_le_bytes()[..field_size].to_vec()
+    output.extend_from_slice(&adjusted.to_le_bytes()[..field_size]);
 }
 
 #[cfg(test)]

--- a/zstd/src/encoding/frame_header.rs
+++ b/zstd/src/encoding/frame_header.rs
@@ -199,6 +199,73 @@ mod tests {
         assert_eq!(parsed_header.frame_content_size(), 1);
     }
 
+    // Locks the descriptor/FCS field-size class boundaries: 255/256 is the
+    // 1-byte (single-segment) vs 2-byte edge, 65791/65792 the 2-byte
+    // (+256 offset) vs 4-byte edge. A drift between `find_fcs_field_size`,
+    // the descriptor flag mapping, and the FCS write would round-trip to a
+    // wrong size through the decoder.
+    #[test]
+    fn frame_header_fcs_boundaries_round_trip() {
+        for (frame_content_size, single_segment) in [
+            (255, true),
+            (256, true),
+            (65791, true),
+            (65792, true),
+            (255, false),
+            (256, false),
+            (65791, false),
+            (65792, false),
+        ] {
+            let header = FrameHeader {
+                frame_content_size: Some(frame_content_size),
+                single_segment,
+                content_checksum: false,
+                dictionary_id: None,
+                window_size: if single_segment { None } else { Some(1024) },
+                magicless: false,
+            };
+
+            let mut serialized_header = Vec::new();
+            header.serialize(&mut serialized_header);
+            let parsed_header = read_frame_header(serialized_header.as_slice())
+                .expect("serialized header must parse")
+                .0;
+            assert_eq!(
+                parsed_header.frame_content_size(),
+                frame_content_size,
+                "FCS must round-trip at boundary {frame_content_size} (single_segment={single_segment})"
+            );
+        }
+    }
+
+    // The dictionary-id field-size classes (1/2/4 bytes by value magnitude)
+    // share the descriptor's bits 0-1; lock their boundaries through the
+    // decoder as well.
+    #[test]
+    fn frame_header_dictionary_id_boundaries_round_trip() {
+        for dictionary_id in [1, 255, 256, 65535, 65536, u32::MAX as u64] {
+            let header = FrameHeader {
+                frame_content_size: Some(4096),
+                single_segment: false,
+                content_checksum: false,
+                dictionary_id: Some(dictionary_id),
+                window_size: Some(1024),
+                magicless: false,
+            };
+
+            let mut serialized_header = Vec::new();
+            header.serialize(&mut serialized_header);
+            let parsed_header = read_frame_header(serialized_header.as_slice())
+                .expect("serialized header must parse")
+                .0;
+            assert_eq!(
+                parsed_header.dictionary_id(),
+                Some(dictionary_id as u32),
+                "dictionary id must round-trip at boundary {dictionary_id}"
+            );
+        }
+    }
+
     #[test]
     #[should_panic]
     fn catches_single_segment_no_fcs() {

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -420,6 +420,7 @@ mod tests {
         let mut state = CompressState {
             matcher: HintProbeMatcher::default(),
             last_huff_table: None,
+            huff_table_spare: None,
             fse_tables: FseTables::new(),
             block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
             offset_hist: [1, 4, 8],
@@ -453,6 +454,7 @@ mod tests {
         let mut state = CompressState {
             matcher: HintProbeMatcher::default(),
             last_huff_table: None,
+            huff_table_spare: None,
             fse_tables: FseTables::new(),
             block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
             offset_hist: [1, 4, 8],

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2523,7 +2523,13 @@ impl Matcher for MatchGeneratorDriver {
             // otherwise the next small/unknown-size frame reuses stale
             // attach state through `prime_dict_attach_current_block`.
             super::strategy::BackendTag::Row => self.row_matcher_mut().invalidate_dict_cache(),
-            _ => {}
+            // The BT dms tree is keyed to the dict bytes; `prime_dms_bt`
+            // skips the rebuild while its shape matches, so a swapped
+            // dictionary of the same length would otherwise keep serving the
+            // OLD dictionary's tree.
+            super::strategy::BackendTag::HashChain => {
+                self.hc_matcher_mut().table.dms.invalidate();
+            }
         }
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2081,20 +2081,25 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::Row(row) => {
                 row.max_window_size = max_window_size;
                 row.lazy_depth = params.lazy_depth;
-                let row_cfg = params.row.expect("Row level row carries a RowConfig");
-                row.configure(row_cfg);
+                let mut row_cfg = params.row.expect("Row level row carries a RowConfig");
                 if hinted {
                     // Clamp the configured hash width by the hinted window
                     // (donor `ZSTD_adjustCParams` caps hashLog by windowLog) —
                     // `min`, not replace, so an explicit `hash_log` param
                     // override (`row_cfg.hash_bits`) survives the hinted path
                     // instead of being overwritten by the window value.
-                    row.set_hash_bits(
-                        row_cfg
-                            .hash_bits
-                            .min(row_hash_bits_for_window(table_window_size)),
-                    );
+                    //
+                    // Clamp BEFORE `configure` so the backend sees ONE width
+                    // per frame. Configuring with the unclamped level width
+                    // and then re-clamping made `row_hash_log` oscillate on
+                    // every hinted frame, and each width change clears the
+                    // row tables — `ensure_tables` then re-filled all three
+                    // every frame in a reused compressor.
+                    row_cfg.hash_bits = row_cfg
+                        .hash_bits
+                        .min(row_hash_bits_for_window(table_window_size));
                 }
+                row.configure(row_cfg);
                 // Key the primed snapshot on the width the backend ACTUALLY
                 // applied (`set_hash_bits` clamps the request): recording the
                 // request — or the 0 default on the unhinted path — keys

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -588,8 +588,7 @@ impl MatchTable {
         // not in the live tree), not a lower minMatch.
         let mls = self.search_mls;
         let read = if mls >= 5 { 8 } else { 4 };
-        let concat = self.live_history();
-        let region = region_len.min(concat.len());
+        let region = region_len.min(self.live_history().len());
         if region < read {
             self.dms.invalidate();
             return;
@@ -597,13 +596,41 @@ impl MatchTable {
         // Dict-sized hash log: ceil-log2(region) clamped to [10, hash_log].
         let dms_hash_log =
             (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
+        // CDict cache: the tree depends only on the dict bytes (re-committed
+        // identically to the front of history every frame) and the
+        // (region, mls, hash_log) shape, so a primed same-shape table is
+        // valid as-is. Rebuilding per frame paid two table allocations AND a
+        // full tree-build pass per frame in a reused compressor. A dictionary
+        // swap drops the cache via `invalidate_primed_dictionary`; a level
+        // change lands here with a different shape and rebuilds.
+        if self.dms.is_primed()
+            && self.dms.region_len() == region
+            && self
+                .dms
+                .table()
+                .is_some_and(|t| t.mls == mls && t.hash_log == dms_hash_log)
+        {
+            return;
+        }
         // Build-pass compare budget: the dict is bounded (<= window), so a
         // generous fixed depth keeps the tree well-ordered without the live
         // searchLog cap. Mirrors donor `ZSTD_insertBt1` nbCompares.
         const DMS_BUILD_DEPTH: usize = 1 << 9;
-        let mut hash_table = alloc::vec![0u32; 1usize << dms_hash_log];
+        // Reuse the previous tables' capacity on a genuine rebuild (shape
+        // change): move the Vecs out before `live_history` re-borrows `self`.
+        let (mut hash_table, mut chain_table) = match self.dms.table_mut() {
+            Some(t) => (
+                core::mem::take(&mut t.hash_table),
+                core::mem::take(&mut t.chain_table),
+            ),
+            None => (Vec::new(), Vec::new()),
+        };
+        hash_table.clear();
+        hash_table.resize(1usize << dms_hash_log, 0u32);
         // 2 children per dict position: [smaller, larger].
-        let mut chain_table = alloc::vec![0u32; 2 * region];
+        chain_table.clear();
+        chain_table.resize(2 * region, 0u32);
+        let concat = self.live_history();
         let mut current = 0usize;
         while current + read <= region {
             let h = Self::hash_position_at(concat, current, dms_hash_log, mls);

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1315,9 +1315,18 @@ impl RowMatchGenerator {
         let row_entries = 1usize << self.row_log;
         let total = row_count * row_entries;
         if self.row_positions.len() != total {
-            self.row_heads = alloc::vec![0; row_count];
-            self.row_positions = alloc::vec![ROW_EMPTY_SLOT; total];
-            self.row_tags = alloc::vec![0; total];
+            // Resize in place: `set_hash_bits` width changes `clear()` the
+            // vecs but keep their capacity. The previous `vec![..]` form
+            // re-allocated all three tables on every width change — three
+            // malloc/free pairs (~40 KiB) per hinted frame while the
+            // configure→hint width pair disagreed, which allocator-slow
+            // targets (musl) amplified into the dominant per-frame cost.
+            self.row_heads.clear();
+            self.row_heads.resize(row_count, 0);
+            self.row_positions.clear();
+            self.row_positions.resize(total, ROW_EMPTY_SLOT);
+            self.row_tags.clear();
+            self.row_tags.resize(total, 0);
         }
     }
 

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -115,6 +115,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             state: CompressState {
                 matcher,
                 last_huff_table: None,
+                huff_table_spare: None,
                 fse_tables: FseTables::new(),
                 block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
                 offset_hist: [1, 4, 8],

--- a/zstd/src/encoding/util.rs
+++ b/zstd/src/encoding/util.rs
@@ -20,13 +20,13 @@ pub fn find_min_size(val: u64) -> usize {
     8
 }
 
-/// Returns the same value, but represented using the smallest number of bytes needed.
-/// Returned vector will be 1, 2, 4, or 8 bytes in length. Zero is represented as 1 byte.
+/// Appends the value represented using the smallest number of bytes needed
+/// (1, 2, 4, or 8; zero takes 1 byte) directly onto `output`.
 ///
 /// Operates in **little-endian**.
-pub fn minify_val(val: u64) -> Vec<u8> {
+pub fn write_minified_val(val: u64, output: &mut Vec<u8>) {
     let new_size = find_min_size(val);
-    val.to_le_bytes()[0..new_size].to_vec()
+    output.extend_from_slice(&val.to_le_bytes()[0..new_size]);
 }
 
 /// Returns the minimum FCS field size for the given content size.
@@ -56,8 +56,15 @@ pub fn find_fcs_field_size(val: u64, single_segment: bool) -> usize {
 mod tests {
     use super::find_fcs_field_size;
     use super::find_min_size;
-    use super::minify_val;
+    use super::write_minified_val;
     use alloc::vec;
+    use alloc::vec::Vec;
+
+    fn minify_val(val: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        write_minified_val(val, &mut out);
+        out
+    }
 
     #[test]
     fn min_size_detection() {


### PR DESCRIPTION
## Summary

Dashboard outsiders driven by per-frame allocation churn (musl mallocng amplifies malloc/free pairs ~10× vs glibc tcache) plus the dictionary trainer's algorithmic gap:

- x86_64-musl `small-4k-log-lines` compress-dict level_5_greedy: 0.0767 (−92.33%)
- x86_64-musl `decodecorpus-z000033` dict-train: 0.1017 (−89.83%)

dhat attribution on 5000 reused-compressor dict frames (4 KiB log lines, level 5) showed **13 allocations / ~54 KiB per frame**, all churn:

| Source | allocs/frame | bytes/frame |
|---|---|---|
| row tables re-created by per-frame hash-width oscillation | 3 | 40 KiB |
| `mem::take(block_scratch)` leaving an eagerly-boxed `EstimatorWorkspace` default | 4 | 8 KiB |
| dict entropy seed re-cloning `HuffmanTable` after a clearing block | 2 | 4 KiB |
| frame header temporaries (header Vec, descriptor BitWriter, dict-id/FCS slices) | 4 | ~26 B |

BT levels (13+) additionally re-allocated AND re-built the dms dictionary tree every frame (`prime_dms_bt` marked the cache primed but the prime path never checked the flag).

## Changes

- **Row tables**: clamp the hinted hash width BEFORE `configure` so the backend sees one width per frame, and resize tables in place (capacity preserved) instead of `vec![..]` replacement.
- **Block scratch**: `estimator_workspace` is now `Option` (lazy) — only the block-split estimator path materializes it.
- **Huffman seed**: cleared/replaced `last_huff_table` buffers park in a `huff_table_spare` slot; the next frame's dict entropy seed `clone_from`s into them. `heap_size()` now counts both retained tables (regression test first, fix second).
- **Frame header**: serialize straight into the reused output buffer; descriptor byte built with bit arithmetic; `write_minified_val`/`write_fcs` append in place. Boundary round-trip tests lock the FCS (255/256, 65791/65792) and dict-id size classes through the decoder.
- **BT dms tree**: cache across frames while the (region, mls, hash_log) shape matches; reuse table capacity on a genuine rebuild; invalidate on dictionary swap.
- **fastCover trainer**: ported the reference epoch model — round-robin epochs with an incrementally-scored sliding window over a flat occurrence array, fixed-width multiplicative dmer hashes (one read + multiply, was a per-byte FNV loop), back-fill layout. Replaces a global greedy set-cover whose per-segment `BTreeMap` inverted index allocated millions of map nodes on a 1 MiB corpus.

## Results (i9, tight consecutive pairs, nice −10)

dhat steady state: levels −7…12 at 0 allocs/frame; BT levels 13–22 at 0 allocs/frame (was 2/frame + full tree rebuild).

| Case | main | branch | Δ |
|---|---|---|---|
| small-4k-log-lines L5 dict, **musl** | 6.88 s | 1.26 s | **−82% (5.5×)** |
| small-4k-log-lines L5 dict, gnu | 1.49 s | 1.25 s | −16% |
| small-10k-random L−7 dict, musl | 3.91 s | 3.15 s | −20% |
| dict-train z000033 (1 MB) | 296 ms | 8.7 ms | **−97% (34×)** |

dict-train now beats the C reference on every scenario (z000033: rust 9.1 ms vs ffi 33.1 ms; small-10k: 0.33 vs 1.29 ms; small-4k: 0.28 vs 0.44 ms). Compress output bytes unchanged across all levels (sum-compare at L5/L13–22 + 829 tests incl. cross-validation); the trainer's dict feeds only the dict-train timing arms (compress-dict arms train with the reference dictionary on both sides).

## Testing

- `cargo nextest run -p structured-zstd --features dict_builder`: 829 passed
- dhat re-runs confirm zero per-frame allocations at every level band
- Clippy clean on default and `--no-default-features --features std`; `thumbv6m-none-eabi` check clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heap profiling support to example binary.

* **Performance Improvements**
  * Reduced memory allocations through Huffman table buffer recycling.
  * Optimized compressed block encoding to reuse internal workspace allocations.
  * Improved frame header writing to eliminate temporary buffers.
  * Enhanced row hash table management to preserve capacity across resets.
  * Dictionary match state now properly cached and reused, avoiding redundant computation.
  * Streamlined dictionary training algorithm with improved hashing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->