### PR TITLE
feat(c-api): advanced parameter API + streaming surface (compressStream2 / decompressStream)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml/badge.svg)](https://github.com/structured-world/structured-zstd/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/structured-zstd.svg)](https://crates.io/crates/structured-zstd)
 [![docs.rs](https://docs.rs/structured-zstd/badge.svg)](https://docs.rs/structured-zstd)
+[![npm downloads](https://img.shields.io/npm/dw/%40structured-world%2Fstructured-zstd?label=npm%20downloads)](https://www.npmjs.com/package/@structured-world/structured-zstd)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 ## Quick start

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -65,6 +65,9 @@ pub struct ZSTD_CCtx {
     pub(crate) scratch: Vec<u8>,
     /// Sticky advanced parameters (`ZSTD_CCtx_setParameter` family).
     pub(crate) params: crate::params::CCtxParams,
+    /// In-flight streaming frame (`ZSTD_compressStream2`). `None` between
+    /// frames.
+    pub(crate) stream: Option<crate::streaming::CStreamState>,
     /// `FrameCompressor` with a dictionary attached, lazily built by the CDict
     /// path. `None` until the first `ZSTD_compress_usingCDict`.
     pub(crate) dict_compressor: Option<FrameCompressor>,
@@ -84,6 +87,9 @@ pub struct ZSTD_DCtx {
     /// `ZSTD_d_windowLogMax`: streaming window-size acceptance ceiling
     /// (log2). Defaults to `ZSTD_WINDOWLOG_LIMIT_DEFAULT`.
     pub(crate) window_log_max: core::ffi::c_int,
+    /// Whether the streaming decoder sits at a frame boundary (the next
+    /// `ZSTD_decompressStream` input starts a new frame). `true` initially.
+    pub(crate) stream_frame_done: bool,
     /// Identity of the `DDict` whose content was last loaded into `decoder`
     /// (its never-reused serial; `0` = none), so repeated
     /// `ZSTD_decompress_usingDDict` calls with the same DDict skip re-adding it.
@@ -99,6 +105,7 @@ pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     try_box(ZSTD_CCtx {
         scratch: Vec::new(),
         params: crate::params::CCtxParams::default(),
+        stream: None,
         dict_compressor: None,
         dict_serial: 0,
         dict_level: 0,
@@ -107,17 +114,16 @@ pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
 
 impl ZSTD_CCtx {
     /// Whether a streaming frame is currently mid-flight (parameters are
-    /// frozen until it finishes or the session is reset). The streaming
-    /// surface stores its state on the context; until it lands no frame can
-    /// be in flight.
+    /// frozen until it finishes or the session is reset).
     pub(crate) fn stream_in_progress(&self) -> bool {
-        false
+        self.stream.is_some()
     }
 
     /// `ZSTD_reset_session_only`: abandon any in-flight frame and the
     /// pledged size; sticky parameters and dictionary references survive.
     pub(crate) fn reset_session(&mut self) {
         self.scratch.clear();
+        self.stream = None;
         self.params.pledged_src_size = crate::params::CONTENTSIZE_UNKNOWN;
     }
 
@@ -273,6 +279,7 @@ pub extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
     try_box(ZSTD_DCtx {
         decoder: FrameDecoder::new(),
         window_log_max: crate::params::WINDOW_LOG_LIMIT_DEFAULT,
+        stream_frame_done: true,
         ddict_serial: 0,
     })
 }
@@ -283,8 +290,9 @@ impl ZSTD_DCtx {
     /// and parameters are untouched.
     pub(crate) fn reset_session(&mut self) {
         // A frame mid-decode lives inside `decoder`'s internal state and is
-        // re-initialised by the next `init`/`reset` call, so nothing to
-        // abandon eagerly here.
+        // re-initialised by the next `init`/`reset` call; just mark the
+        // stream as sitting at a frame boundary again.
+        self.stream_frame_done = true;
     }
 
     /// `ZSTD_reset_parameters`: restore parameter defaults and drop

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -63,6 +63,8 @@ pub(crate) unsafe fn free_boxed<T>(ptr: *mut T) {
 #[allow(non_camel_case_types)]
 pub struct ZSTD_CCtx {
     pub(crate) scratch: Vec<u8>,
+    /// Sticky advanced parameters (`ZSTD_CCtx_setParameter` family).
+    pub(crate) params: crate::params::CCtxParams,
     /// `FrameCompressor` with a dictionary attached, lazily built by the CDict
     /// path. `None` until the first `ZSTD_compress_usingCDict`.
     pub(crate) dict_compressor: Option<FrameCompressor>,
@@ -79,6 +81,9 @@ pub struct ZSTD_CCtx {
 #[allow(non_camel_case_types)]
 pub struct ZSTD_DCtx {
     pub(crate) decoder: FrameDecoder,
+    /// `ZSTD_d_windowLogMax`: streaming window-size acceptance ceiling
+    /// (log2). Defaults to `ZSTD_WINDOWLOG_LIMIT_DEFAULT`.
+    pub(crate) window_log_max: core::ffi::c_int,
     /// Identity of the `DDict` whose content was last loaded into `decoder`
     /// (its never-reused serial; `0` = none), so repeated
     /// `ZSTD_decompress_usingDDict` calls with the same DDict skip re-adding it.
@@ -93,10 +98,37 @@ pub struct ZSTD_DCtx {
 pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
     try_box(ZSTD_CCtx {
         scratch: Vec::new(),
+        params: crate::params::CCtxParams::default(),
         dict_compressor: None,
         dict_serial: 0,
         dict_level: 0,
     })
+}
+
+impl ZSTD_CCtx {
+    /// Whether a streaming frame is currently mid-flight (parameters are
+    /// frozen until it finishes or the session is reset). The streaming
+    /// surface stores its state on the context; until it lands no frame can
+    /// be in flight.
+    pub(crate) fn stream_in_progress(&self) -> bool {
+        false
+    }
+
+    /// `ZSTD_reset_session_only`: abandon any in-flight frame and the
+    /// pledged size; sticky parameters and dictionary references survive.
+    pub(crate) fn reset_session(&mut self) {
+        self.scratch.clear();
+        self.params.pledged_src_size = crate::params::CONTENTSIZE_UNKNOWN;
+    }
+
+    /// `ZSTD_reset_parameters`: restore parameter defaults and drop
+    /// dictionary references.
+    pub(crate) fn reset_parameters(&mut self) {
+        self.params = crate::params::CCtxParams::default();
+        self.dict_compressor = None;
+        self.dict_serial = 0;
+        self.dict_level = 0;
+    }
 }
 
 /// `size_t ZSTD_freeCCtx(ZSTD_CCtx* cctx)` — frees the context; `NULL` is a
@@ -177,14 +209,93 @@ pub unsafe extern "C" fn ZSTD_compressCCtx(
     len
 }
 
+/// `size_t ZSTD_compress2(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity,
+/// const void* src, size_t srcSize)` — one-shot compression driven entirely
+/// by the sticky advanced parameters (`ZSTD_CCtx_set*`); always starts a new
+/// frame.
+///
+/// # Safety
+/// `cctx` must be live; `dst`/`src` valid for their lengths (or `NULL`+0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compress2(
+    cctx: *mut ZSTD_CCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    let src = unsafe { in_slice(src, src_size) };
+    // The pledge is single-use: consumed by this frame regardless of
+    // outcome. With all input present in one call the actual srcSize drives
+    // the header, but a mismatching explicit pledge is a contract violation
+    // (upstream `srcSizeWrong`).
+    let pledged = core::mem::replace(
+        &mut cctx.params.pledged_src_size,
+        crate::params::CONTENTSIZE_UNKNOWN,
+    );
+    if pledged != crate::params::CONTENTSIZE_UNKNOWN && pledged != src_size as u64 {
+        return encode(ZSTD_ErrorCode::ZSTD_error_srcSize_wrong);
+    }
+    let Some(resolved) = cctx.params.resolve() else {
+        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
+    };
+    let params = cctx.params;
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        cctx.scratch.clear();
+        let mut enc: FrameCompressor =
+            FrameCompressor::new(CompressionLevel::from_level(params.level));
+        enc.set_parameters(&resolved);
+        enc.set_content_checksum(params.checksum_flag);
+        enc.set_content_size_flag(params.content_size_flag);
+        enc.set_dictionary_id_flag(params.dict_id_flag);
+        enc.compress_independent_frame_into(src, &mut cctx.scratch);
+    }));
+    if outcome.is_err() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let len = cctx.scratch.len();
+    if len > dst_capacity {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
+    }
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    dst[..len].copy_from_slice(&cctx.scratch);
+    len
+}
+
 /// `ZSTD_DCtx* ZSTD_createDCtx(void)`. Returns `NULL` on allocation failure
 /// (never aborts), matching upstream.
 #[unsafe(no_mangle)]
 pub extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
     try_box(ZSTD_DCtx {
         decoder: FrameDecoder::new(),
+        window_log_max: crate::params::WINDOW_LOG_LIMIT_DEFAULT,
         ddict_serial: 0,
     })
+}
+
+impl ZSTD_DCtx {
+    /// `ZSTD_reset_session_only`: abandon any in-flight frame. The decoder
+    /// instance (and its reusable workspace) survives; loaded dictionaries
+    /// and parameters are untouched.
+    pub(crate) fn reset_session(&mut self) {
+        // A frame mid-decode lives inside `decoder`'s internal state and is
+        // re-initialised by the next `init`/`reset` call, so nothing to
+        // abandon eagerly here.
+    }
+
+    /// `ZSTD_reset_parameters`: restore parameter defaults and drop
+    /// dictionary references.
+    pub(crate) fn reset_parameters(&mut self) {
+        self.window_log_max = crate::params::WINDOW_LOG_LIMIT_DEFAULT;
+        // Replace the decoder to drop any loaded dictionaries; the
+        // workspace re-grows on the next frame.
+        self.decoder = FrameDecoder::new();
+        self.ddict_serial = 0;
+    }
 }
 
 /// `size_t ZSTD_freeDCtx(ZSTD_DCtx* dctx)` — frees the context; `NULL` is a

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -258,6 +258,9 @@ pub unsafe extern "C" fn ZSTD_compress2(
         enc.set_content_checksum(params.checksum_flag);
         enc.set_content_size_flag(params.content_size_flag);
         enc.set_dictionary_id_flag(params.dict_id_flag);
+        if params.target_cblock_size > 0 {
+            enc.set_target_block_size(Some(params.target_cblock_size as u32));
+        }
         enc.compress_independent_frame_into(src, &mut cctx.scratch);
     }));
     if outcome.is_err() {

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -234,6 +234,12 @@ pub unsafe extern "C" fn ZSTD_compress2(
         return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
     }
     let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        // A one-shot frame would interleave with the unfinished streaming
+        // frame on this context (and consume its pledge); the stream must
+        // be ended or the session reset first.
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
     let src = unsafe { in_slice(src, src_size) };
     // The pledge is single-use: consumed by this frame regardless of
     // outcome. With all input present in one call the actual srcSize drives

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -31,6 +31,7 @@ mod ffi;
 mod frame;
 mod params;
 mod simple;
+mod streaming;
 
 #[cfg(test)]
 mod tests;
@@ -43,3 +44,4 @@ pub use dict::ZDICT_params_t;
 pub use error::ZSTD_ErrorCode;
 pub use frame::{ZSTD_FrameHeader, ZSTD_FrameType_e, ZSTD_format_e};
 pub use params::ZSTD_bounds;
+pub use streaming::{ZSTD_inBuffer, ZSTD_outBuffer};

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -29,6 +29,7 @@ mod dict;
 mod error;
 mod ffi;
 mod frame;
+mod params;
 mod simple;
 
 #[cfg(test)]
@@ -41,3 +42,4 @@ pub use context::{ZSTD_CCtx, ZSTD_DCtx};
 pub use dict::ZDICT_params_t;
 pub use error::ZSTD_ErrorCode;
 pub use frame::{ZSTD_FrameHeader, ZSTD_FrameType_e, ZSTD_format_e};
+pub use params::ZSTD_bounds;

--- a/c-api/src/params.rs
+++ b/c-api/src/params.rs
@@ -55,10 +55,16 @@ const TARGET_CBLOCK_SIZE_MAX: c_int = 131_072;
 /// Upstream `ZSTD_WINDOWLOG_LIMIT_DEFAULT`: the streaming decoder's default
 /// window-size acceptance ceiling, `1 << 27` bytes.
 pub(crate) const WINDOW_LOG_LIMIT_DEFAULT: c_int = 27;
-/// Decoder-side window-log bounds (`ZSTD_WINDOWLOG_ABSOLUTEMIN` .. 64-bit
-/// `ZSTD_WINDOWLOG_MAX`).
+/// Decoder-side window-log bounds (`ZSTD_WINDOWLOG_ABSOLUTEMIN` ..
+/// `ZSTD_WINDOWLOG_MAX`). The ceiling is pointer-width dependent upstream
+/// (`ZSTD_WINDOWLOG_MAX_32` = 30, `ZSTD_WINDOWLOG_MAX_64` = 31 via
+/// `sizeof(size_t)`), so the advertised bounds match the header on 32-bit
+/// builds too.
 const D_WINDOW_LOG_MIN: c_int = 10;
+#[cfg(target_pointer_width = "64")]
 const D_WINDOW_LOG_MAX: c_int = 31;
+#[cfg(not(target_pointer_width = "64"))]
+const D_WINDOW_LOG_MAX: c_int = 30;
 
 /// `ZSTD_bounds` — ABI mirror of the upstream struct: an error slot tested
 /// with `ZSTD_isError` plus an inclusive `[lowerBound, upperBound]` range.
@@ -119,9 +125,10 @@ pub(crate) struct CCtxParams {
     pub(crate) job_size: c_int,
     /// Only meaningful with workers; stored for `getParameter` symmetry.
     pub(crate) overlap_log: c_int,
-    /// Accepted and stored; the encoder's block sizing currently ignores the
-    /// convergence target (upstream documents it as best-effort, not a
-    /// guarantee).
+    /// Applied at frame start: the encoder caps every physical block's
+    /// payload at the target (raw length <= target bounds the compressed
+    /// length too), so blocks land at or under `target + 3` header bytes —
+    /// a strict form of upstream's best-effort convergence target.
     pub(crate) target_cblock_size: c_int,
     /// Pledged size of the next frame (`ZSTD_CCtx_setPledgedSrcSize`).
     /// Consumed by the next frame start, then reset to unknown.
@@ -467,6 +474,12 @@ pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
         return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
     }
     let dctx = unsafe { &mut *dctx };
+    if !dctx.stream_frame_done {
+        // Decoder parameters may only change between frames (upstream
+        // stage contract); mutating the window ceiling mid-frame would
+        // change acceptance rules under the active decode.
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
     match param {
         ZSTD_D_WINDOW_LOG_MAX => {
             if value != 0 && !(D_WINDOW_LOG_MIN..=D_WINDOW_LOG_MAX).contains(&value) {
@@ -521,6 +534,12 @@ pub unsafe extern "C" fn ZSTD_DCtx_reset(dctx: *mut ZSTD_DCtx, reset: c_int) -> 
             0
         }
         ZSTD_RESET_PARAMETERS => {
+            // Parameters can only be reset between frames (upstream stage
+            // contract); a session reset must accompany the request to
+            // abandon an in-flight frame.
+            if !dctx.stream_frame_done {
+                return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+            }
             dctx.reset_parameters();
             0
         }

--- a/c-api/src/params.rs
+++ b/c-api/src/params.rs
@@ -324,7 +324,13 @@ pub unsafe extern "C" fn ZSTD_CCtx_setParameter(
             p.strategy = if value == 0 {
                 None
             } else {
-                Strategy::from_ordinal(value as u32)
+                // Bounds guarantee 1..=9, which from_ordinal fully covers;
+                // error loudly (not silent auto) if that coverage ever
+                // drifts.
+                match Strategy::from_ordinal(value as u32) {
+                    Some(strategy) => Some(strategy),
+                    None => return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound),
+                }
             };
         }
         ZSTD_C_TARGET_CBLOCK_SIZE => p.target_cblock_size = value,

--- a/c-api/src/params.rs
+++ b/c-api/src/params.rs
@@ -1,0 +1,528 @@
+//! Advanced parameter API: `ZSTD_CCtx_setParameter` / `ZSTD_DCtx_setParameter`
+//! families, bounds queries, pledged source size, and context reset.
+//!
+//! Parameters are sticky per context (upstream semantics): they survive
+//! frames and are only cleared by `ZSTD_CCtx_reset` with a parameters
+//! directive. `ZSTD_compress2` and the streaming entry points consume the
+//! stored set when a frame starts.
+
+use core::ffi::c_int;
+
+use codec::encoding::{CParameter, CompressionLevel, CompressionParameters, Strategy};
+
+use crate::context::{ZSTD_CCtx, ZSTD_DCtx};
+use crate::error::{ZSTD_ErrorCode, encode};
+
+/// `ZSTD_CONTENTSIZE_UNKNOWN` (`0ULL - 1`): the pledged-size sentinel for
+/// "unknown", the default for every new frame.
+pub(crate) const CONTENTSIZE_UNKNOWN: u64 = u64::MAX;
+
+// `ZSTD_cParameter` discriminants (vendored `zstd.h` v1.5.7). The C enum
+// arrives over the ABI as a plain `int`; wrappers match on these constants.
+pub(crate) const ZSTD_C_COMPRESSION_LEVEL: c_int = 100;
+pub(crate) const ZSTD_C_WINDOW_LOG: c_int = 101;
+pub(crate) const ZSTD_C_HASH_LOG: c_int = 102;
+pub(crate) const ZSTD_C_CHAIN_LOG: c_int = 103;
+pub(crate) const ZSTD_C_SEARCH_LOG: c_int = 104;
+pub(crate) const ZSTD_C_MIN_MATCH: c_int = 105;
+pub(crate) const ZSTD_C_TARGET_LENGTH: c_int = 106;
+pub(crate) const ZSTD_C_STRATEGY: c_int = 107;
+pub(crate) const ZSTD_C_TARGET_CBLOCK_SIZE: c_int = 130;
+pub(crate) const ZSTD_C_ENABLE_LDM: c_int = 160;
+pub(crate) const ZSTD_C_LDM_HASH_LOG: c_int = 161;
+pub(crate) const ZSTD_C_LDM_MIN_MATCH: c_int = 162;
+pub(crate) const ZSTD_C_LDM_BUCKET_SIZE_LOG: c_int = 163;
+pub(crate) const ZSTD_C_LDM_HASH_RATE_LOG: c_int = 164;
+pub(crate) const ZSTD_C_CONTENT_SIZE_FLAG: c_int = 200;
+pub(crate) const ZSTD_C_CHECKSUM_FLAG: c_int = 201;
+pub(crate) const ZSTD_C_DICT_ID_FLAG: c_int = 202;
+pub(crate) const ZSTD_C_NB_WORKERS: c_int = 400;
+pub(crate) const ZSTD_C_JOB_SIZE: c_int = 401;
+pub(crate) const ZSTD_C_OVERLAP_LOG: c_int = 402;
+
+// `ZSTD_dParameter` discriminants.
+pub(crate) const ZSTD_D_WINDOW_LOG_MAX: c_int = 100;
+
+// `ZSTD_ResetDirective` discriminants.
+pub(crate) const ZSTD_RESET_SESSION_ONLY: c_int = 1;
+pub(crate) const ZSTD_RESET_PARAMETERS: c_int = 2;
+pub(crate) const ZSTD_RESET_SESSION_AND_PARAMETERS: c_int = 3;
+
+/// `ZSTD_TARGETCBLOCKSIZE_MIN` / `_MAX` (vendored header).
+const TARGET_CBLOCK_SIZE_MIN: c_int = 1340;
+const TARGET_CBLOCK_SIZE_MAX: c_int = 131_072;
+
+/// Upstream `ZSTD_WINDOWLOG_LIMIT_DEFAULT`: the streaming decoder's default
+/// window-size acceptance ceiling, `1 << 27` bytes.
+pub(crate) const WINDOW_LOG_LIMIT_DEFAULT: c_int = 27;
+/// Decoder-side window-log bounds (`ZSTD_WINDOWLOG_ABSOLUTEMIN` .. 64-bit
+/// `ZSTD_WINDOWLOG_MAX`).
+const D_WINDOW_LOG_MIN: c_int = 10;
+const D_WINDOW_LOG_MAX: c_int = 31;
+
+/// `ZSTD_bounds` — ABI mirror of the upstream struct: an error slot tested
+/// with `ZSTD_isError` plus an inclusive `[lowerBound, upperBound]` range.
+#[repr(C)]
+#[allow(non_camel_case_types, non_snake_case)]
+#[derive(Copy, Clone, Debug)]
+pub struct ZSTD_bounds {
+    pub error: usize,
+    pub lowerBound: c_int,
+    pub upperBound: c_int,
+}
+
+impl ZSTD_bounds {
+    const fn ok(lower: c_int, upper: c_int) -> Self {
+        Self {
+            error: 0,
+            lowerBound: lower,
+            upperBound: upper,
+        }
+    }
+
+    fn err(code: ZSTD_ErrorCode) -> Self {
+        Self {
+            error: encode(code),
+            lowerBound: 0,
+            upperBound: 0,
+        }
+    }
+}
+
+/// Sticky per-context compression parameters (upstream `ZSTD_CCtx_params`
+/// equivalent). `None` knobs mean "auto" (value 0 in the C API): the level's
+/// resolved defaults apply.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct CCtxParams {
+    pub(crate) level: c_int,
+    pub(crate) window_log: Option<u32>,
+    pub(crate) hash_log: Option<u32>,
+    pub(crate) chain_log: Option<u32>,
+    pub(crate) search_log: Option<u32>,
+    pub(crate) min_match: Option<u32>,
+    pub(crate) target_length: Option<u32>,
+    pub(crate) strategy: Option<Strategy>,
+    pub(crate) enable_ldm: bool,
+    pub(crate) ldm_hash_log: Option<u32>,
+    pub(crate) ldm_min_match: Option<u32>,
+    pub(crate) ldm_bucket_size_log: Option<u32>,
+    pub(crate) ldm_hash_rate_log: Option<u32>,
+    pub(crate) content_size_flag: bool,
+    pub(crate) checksum_flag: bool,
+    pub(crate) dict_id_flag: bool,
+    /// Accepted and stored but single-threaded for now: real worker support
+    /// is the multi-threading milestone; until then every value compresses
+    /// on the calling thread (the blocking mode every consumer must already
+    /// handle, since upstream blocks whenever it lacks worker budget too).
+    pub(crate) nb_workers: c_int,
+    /// Only meaningful with workers; stored for `getParameter` symmetry.
+    pub(crate) job_size: c_int,
+    /// Only meaningful with workers; stored for `getParameter` symmetry.
+    pub(crate) overlap_log: c_int,
+    /// Accepted and stored; the encoder's block sizing currently ignores the
+    /// convergence target (upstream documents it as best-effort, not a
+    /// guarantee).
+    pub(crate) target_cblock_size: c_int,
+    /// Pledged size of the next frame (`ZSTD_CCtx_setPledgedSrcSize`).
+    /// Consumed by the next frame start, then reset to unknown.
+    pub(crate) pledged_src_size: u64,
+}
+
+impl Default for CCtxParams {
+    fn default() -> Self {
+        Self {
+            level: 3, // ZSTD_CLEVEL_DEFAULT
+            window_log: None,
+            hash_log: None,
+            chain_log: None,
+            search_log: None,
+            min_match: None,
+            target_length: None,
+            strategy: None,
+            enable_ldm: false,
+            ldm_hash_log: None,
+            ldm_min_match: None,
+            ldm_bucket_size_log: None,
+            ldm_hash_rate_log: None,
+            content_size_flag: true,
+            checksum_flag: false,
+            dict_id_flag: true,
+            nb_workers: 0,
+            job_size: 0,
+            overlap_log: 0,
+            target_cblock_size: 0,
+            pledged_src_size: CONTENTSIZE_UNKNOWN,
+        }
+    }
+}
+
+impl CCtxParams {
+    /// Resolve the sticky knob set into the codec's validated
+    /// [`CompressionParameters`]. `None` on an internally-inconsistent set
+    /// (should be unreachable: every knob was bounds-checked on entry).
+    pub(crate) fn resolve(&self) -> Option<CompressionParameters> {
+        let mut builder = CompressionParameters::builder(CompressionLevel::from_level(self.level));
+        if let Some(v) = self.window_log {
+            builder = builder.window_log(v);
+        }
+        if let Some(v) = self.hash_log {
+            builder = builder.hash_log(v);
+        }
+        if let Some(v) = self.chain_log {
+            builder = builder.chain_log(v);
+        }
+        if let Some(v) = self.search_log {
+            builder = builder.search_log(v);
+        }
+        if let Some(v) = self.min_match {
+            builder = builder.min_match(v);
+        }
+        if let Some(v) = self.target_length {
+            builder = builder.target_length(v);
+        }
+        if let Some(v) = self.strategy {
+            builder = builder.strategy(v);
+        }
+        if self.enable_ldm {
+            builder = builder.enable_long_distance_matching(true);
+            if let Some(v) = self.ldm_hash_log {
+                builder = builder.ldm_hash_log(v);
+            }
+            if let Some(v) = self.ldm_min_match {
+                builder = builder.ldm_min_match(v);
+            }
+            if let Some(v) = self.ldm_bucket_size_log {
+                builder = builder.ldm_bucket_size_log(v);
+            }
+            if let Some(v) = self.ldm_hash_rate_log {
+                builder = builder.ldm_hash_rate_log(v);
+            }
+        }
+        builder.build().ok()
+    }
+}
+
+/// Bounds for one `ZSTD_cParameter` discriminant, or `None` for an unknown /
+/// unsupported parameter.
+fn c_param_bounds(param: c_int) -> Option<(c_int, c_int)> {
+    let from_codec = |p: CParameter| {
+        let b = p.bounds();
+        (b.lower_bound as c_int, b.upper_bound as c_int)
+    };
+    Some(match param {
+        ZSTD_C_COMPRESSION_LEVEL => (CompressionLevel::MIN_LEVEL, CompressionLevel::MAX_LEVEL),
+        ZSTD_C_WINDOW_LOG => from_codec(CParameter::WindowLog),
+        ZSTD_C_HASH_LOG => from_codec(CParameter::HashLog),
+        ZSTD_C_CHAIN_LOG => from_codec(CParameter::ChainLog),
+        ZSTD_C_SEARCH_LOG => from_codec(CParameter::SearchLog),
+        ZSTD_C_MIN_MATCH => from_codec(CParameter::MinMatch),
+        ZSTD_C_TARGET_LENGTH => from_codec(CParameter::TargetLength),
+        ZSTD_C_STRATEGY => from_codec(CParameter::Strategy),
+        ZSTD_C_TARGET_CBLOCK_SIZE => (TARGET_CBLOCK_SIZE_MIN, TARGET_CBLOCK_SIZE_MAX),
+        ZSTD_C_ENABLE_LDM => (0, 1),
+        ZSTD_C_LDM_HASH_LOG => from_codec(CParameter::LdmHashLog),
+        ZSTD_C_LDM_MIN_MATCH => from_codec(CParameter::LdmMinMatch),
+        ZSTD_C_LDM_BUCKET_SIZE_LOG => from_codec(CParameter::LdmBucketSizeLog),
+        ZSTD_C_LDM_HASH_RATE_LOG => from_codec(CParameter::LdmHashRateLog),
+        ZSTD_C_CONTENT_SIZE_FLAG | ZSTD_C_CHECKSUM_FLAG | ZSTD_C_DICT_ID_FLAG => (0, 1),
+        // Single-threaded build surface: workers are accepted (stored) but
+        // compression runs on the calling thread, so the advertised bounds
+        // mirror upstream's non-multithreaded build.
+        ZSTD_C_NB_WORKERS | ZSTD_C_JOB_SIZE | ZSTD_C_OVERLAP_LOG => (0, 0),
+        _ => return None,
+    })
+}
+
+/// `ZSTD_bounds ZSTD_cParam_getBounds(ZSTD_cParameter cParam)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_cParam_getBounds(param: c_int) -> ZSTD_bounds {
+    match c_param_bounds(param) {
+        Some((lower, upper)) => ZSTD_bounds::ok(lower, upper),
+        None => ZSTD_bounds::err(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}
+
+/// `ZSTD_bounds ZSTD_dParam_getBounds(ZSTD_dParameter dParam)`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_dParam_getBounds(param: c_int) -> ZSTD_bounds {
+    match param {
+        ZSTD_D_WINDOW_LOG_MAX => ZSTD_bounds::ok(D_WINDOW_LOG_MIN, D_WINDOW_LOG_MAX),
+        _ => ZSTD_bounds::err(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}
+
+/// Validate `value` against the parameter's bounds. `0` is the universal
+/// "auto / default" escape for the tunables and is always accepted; the
+/// boolean / worker knobs treat their range literally.
+fn check_bounds(param: c_int, value: c_int) -> Result<(), ZSTD_ErrorCode> {
+    let Some((lower, upper)) = c_param_bounds(param) else {
+        return Err(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported);
+    };
+    let zero_is_auto = !matches!(
+        param,
+        ZSTD_C_CONTENT_SIZE_FLAG
+            | ZSTD_C_CHECKSUM_FLAG
+            | ZSTD_C_DICT_ID_FLAG
+            | ZSTD_C_ENABLE_LDM
+            | ZSTD_C_NB_WORKERS
+            | ZSTD_C_JOB_SIZE
+            | ZSTD_C_OVERLAP_LOG
+            | ZSTD_C_COMPRESSION_LEVEL
+    );
+    if zero_is_auto && value == 0 {
+        return Ok(());
+    }
+    if value < lower || value > upper {
+        return Err(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
+    Ok(())
+}
+
+/// `size_t ZSTD_CCtx_setParameter(ZSTD_CCtx* cctx, ZSTD_cParameter param, int value)`.
+///
+/// Stores one sticky compression parameter. Rejected with
+/// `parameter_outOfBound` / `parameter_unsupported` outside the advertised
+/// bounds; `0` means "back to auto" for the tunables.
+///
+/// # Safety
+/// `cctx` must be a live pointer from `ZSTD_createCCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_setParameter(
+    cctx: *mut ZSTD_CCtx,
+    param: c_int,
+    value: c_int,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        // Upstream forbids parameter changes mid-frame (stage != init).
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    if let Err(code) = check_bounds(param, value) {
+        return encode(code);
+    }
+    let p = &mut cctx.params;
+    let opt = |v: c_int| (v != 0).then_some(v as u32);
+    match param {
+        ZSTD_C_COMPRESSION_LEVEL => {
+            // Value 0 selects the default level, mirroring upstream.
+            p.level = if value == 0 { 3 } else { value };
+        }
+        ZSTD_C_WINDOW_LOG => p.window_log = opt(value),
+        ZSTD_C_HASH_LOG => p.hash_log = opt(value),
+        ZSTD_C_CHAIN_LOG => p.chain_log = opt(value),
+        ZSTD_C_SEARCH_LOG => p.search_log = opt(value),
+        ZSTD_C_MIN_MATCH => p.min_match = opt(value),
+        ZSTD_C_TARGET_LENGTH => {
+            // 0 is both "auto" and a legal literal for targetLength; treat
+            // it as auto like upstream's special-value rule.
+            p.target_length = opt(value);
+        }
+        ZSTD_C_STRATEGY => {
+            p.strategy = if value == 0 {
+                None
+            } else {
+                Strategy::from_ordinal(value as u32)
+            };
+        }
+        ZSTD_C_TARGET_CBLOCK_SIZE => p.target_cblock_size = value,
+        ZSTD_C_ENABLE_LDM => p.enable_ldm = value != 0,
+        ZSTD_C_LDM_HASH_LOG => p.ldm_hash_log = opt(value),
+        ZSTD_C_LDM_MIN_MATCH => p.ldm_min_match = opt(value),
+        ZSTD_C_LDM_BUCKET_SIZE_LOG => p.ldm_bucket_size_log = opt(value),
+        ZSTD_C_LDM_HASH_RATE_LOG => p.ldm_hash_rate_log = opt(value),
+        ZSTD_C_CONTENT_SIZE_FLAG => p.content_size_flag = value != 0,
+        ZSTD_C_CHECKSUM_FLAG => p.checksum_flag = value != 0,
+        ZSTD_C_DICT_ID_FLAG => p.dict_id_flag = value != 0,
+        ZSTD_C_NB_WORKERS => p.nb_workers = value,
+        ZSTD_C_JOB_SIZE => p.job_size = value,
+        ZSTD_C_OVERLAP_LOG => p.overlap_log = value,
+        _ => return encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+    0
+}
+
+/// `size_t ZSTD_CCtx_getParameter(const ZSTD_CCtx* cctx, ZSTD_cParameter param, int* value)`.
+///
+/// Reads back the currently stored value (`0` = auto for unset tunables).
+///
+/// # Safety
+/// `cctx` must be live or `NULL`; `value` must be a valid writable `int`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_getParameter(
+    cctx: *const ZSTD_CCtx,
+    param: c_int,
+    value: *mut c_int,
+) -> usize {
+    if cctx.is_null() || value.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let p = unsafe { &(*cctx).params };
+    let opt = |v: Option<u32>| v.map_or(0, |x| x as c_int);
+    let out = match param {
+        ZSTD_C_COMPRESSION_LEVEL => p.level,
+        ZSTD_C_WINDOW_LOG => opt(p.window_log),
+        ZSTD_C_HASH_LOG => opt(p.hash_log),
+        ZSTD_C_CHAIN_LOG => opt(p.chain_log),
+        ZSTD_C_SEARCH_LOG => opt(p.search_log),
+        ZSTD_C_MIN_MATCH => opt(p.min_match),
+        ZSTD_C_TARGET_LENGTH => opt(p.target_length),
+        ZSTD_C_STRATEGY => p.strategy.map_or(0, |s| s.ordinal() as c_int),
+        ZSTD_C_TARGET_CBLOCK_SIZE => p.target_cblock_size,
+        ZSTD_C_ENABLE_LDM => c_int::from(p.enable_ldm),
+        ZSTD_C_LDM_HASH_LOG => opt(p.ldm_hash_log),
+        ZSTD_C_LDM_MIN_MATCH => opt(p.ldm_min_match),
+        ZSTD_C_LDM_BUCKET_SIZE_LOG => opt(p.ldm_bucket_size_log),
+        ZSTD_C_LDM_HASH_RATE_LOG => opt(p.ldm_hash_rate_log),
+        ZSTD_C_CONTENT_SIZE_FLAG => c_int::from(p.content_size_flag),
+        ZSTD_C_CHECKSUM_FLAG => c_int::from(p.checksum_flag),
+        ZSTD_C_DICT_ID_FLAG => c_int::from(p.dict_id_flag),
+        ZSTD_C_NB_WORKERS => p.nb_workers,
+        ZSTD_C_JOB_SIZE => p.job_size,
+        ZSTD_C_OVERLAP_LOG => p.overlap_log,
+        _ => return encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    };
+    unsafe { value.write(out) };
+    0
+}
+
+/// `size_t ZSTD_CCtx_setPledgedSrcSize(ZSTD_CCtx* cctx, unsigned long long pledgedSrcSize)`.
+///
+/// Records the total size of the NEXT frame (written into its header unless
+/// `ZSTD_c_contentSizeFlag` forbids it, validated at frame end). Consumed by
+/// the next frame start; `ZSTD_CONTENTSIZE_UNKNOWN` restores the default.
+///
+/// # Safety
+/// `cctx` must be a live pointer from `ZSTD_createCCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_setPledgedSrcSize(
+    cctx: *mut ZSTD_CCtx,
+    pledged_src_size: u64,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    cctx.params.pledged_src_size = pledged_src_size;
+    0
+}
+
+/// `size_t ZSTD_CCtx_reset(ZSTD_CCtx* cctx, ZSTD_ResetDirective reset)`.
+///
+/// Session reset abandons any in-flight frame (never fails); parameter reset
+/// restores defaults and drops dictionary references, and is only legal
+/// between frames.
+///
+/// # Safety
+/// `cctx` must be a live pointer from `ZSTD_createCCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_reset(cctx: *mut ZSTD_CCtx, reset: c_int) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    match reset {
+        ZSTD_RESET_SESSION_ONLY => {
+            cctx.reset_session();
+            0
+        }
+        ZSTD_RESET_PARAMETERS => {
+            if cctx.stream_in_progress() {
+                return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+            }
+            cctx.reset_parameters();
+            0
+        }
+        ZSTD_RESET_SESSION_AND_PARAMETERS => {
+            cctx.reset_session();
+            cctx.reset_parameters();
+            0
+        }
+        _ => encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}
+
+/// `size_t ZSTD_DCtx_setParameter(ZSTD_DCtx* dctx, ZSTD_dParameter param, int value)`.
+///
+/// # Safety
+/// `dctx` must be a live pointer from `ZSTD_createDCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
+    dctx: *mut ZSTD_DCtx,
+    param: c_int,
+    value: c_int,
+) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    match param {
+        ZSTD_D_WINDOW_LOG_MAX => {
+            if value != 0 && (value < D_WINDOW_LOG_MIN || value > D_WINDOW_LOG_MAX) {
+                return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+            }
+            dctx.window_log_max = if value == 0 {
+                WINDOW_LOG_LIMIT_DEFAULT
+            } else {
+                value
+            };
+            0
+        }
+        _ => encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}
+
+/// `size_t ZSTD_DCtx_getParameter(const ZSTD_DCtx* dctx, ZSTD_dParameter param, int* value)`.
+///
+/// # Safety
+/// `dctx` must be live or `NULL`; `value` must be a valid writable `int`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_getParameter(
+    dctx: *const ZSTD_DCtx,
+    param: c_int,
+    value: *mut c_int,
+) -> usize {
+    if dctx.is_null() || value.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    match param {
+        ZSTD_D_WINDOW_LOG_MAX => {
+            unsafe { value.write((*dctx).window_log_max) };
+            0
+        }
+        _ => encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}
+
+/// `size_t ZSTD_DCtx_reset(ZSTD_DCtx* dctx, ZSTD_ResetDirective reset)`.
+///
+/// # Safety
+/// `dctx` must be a live pointer from `ZSTD_createDCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_reset(dctx: *mut ZSTD_DCtx, reset: c_int) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    match reset {
+        ZSTD_RESET_SESSION_ONLY => {
+            dctx.reset_session();
+            0
+        }
+        ZSTD_RESET_PARAMETERS => {
+            dctx.reset_parameters();
+            0
+        }
+        ZSTD_RESET_SESSION_AND_PARAMETERS => {
+            dctx.reset_session();
+            dctx.reset_parameters();
+            0
+        }
+        _ => encode(ZSTD_ErrorCode::ZSTD_error_parameter_unsupported),
+    }
+}

--- a/c-api/src/params.rs
+++ b/c-api/src/params.rs
@@ -463,7 +463,7 @@ pub unsafe extern "C" fn ZSTD_DCtx_setParameter(
     let dctx = unsafe { &mut *dctx };
     match param {
         ZSTD_D_WINDOW_LOG_MAX => {
-            if value != 0 && (value < D_WINDOW_LOG_MIN || value > D_WINDOW_LOG_MAX) {
+            if value != 0 && !(D_WINDOW_LOG_MIN..=D_WINDOW_LOG_MAX).contains(&value) {
                 return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
             }
             dctx.window_log_max = if value == 0 {

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -399,7 +399,6 @@ pub unsafe extern "C" fn ZSTD_initDStream(zds: *mut ZSTD_DCtx) -> usize {
     }
     let dctx = unsafe { &mut *zds };
     dctx.reset_session();
-    dctx.stream_frame_done = true;
     ZSTD_DStreamInSize()
 }
 

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -438,6 +438,7 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
             // No active frame and nothing to read: frame-done signal.
             return 0;
         }
+        use codec::decoding::errors::ReadFrameHeaderError;
         match codec::decoding::read_frame_header_info(&src[inp.pos..], false) {
             Ok(info) => {
                 // `ZSTD_d_windowLogMax`: refuse oversized windows before any
@@ -461,9 +462,35 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                     }
                 }
             }
-            // The header is split across input chunks: consume nothing and
-            // ask for more input.
-            Err(_) => return 1,
+            // Skippable frame: consume it whole when fully buffered (magic 4
+            // + length 4 + payload), else ask for more input.
+            Err(ReadFrameHeaderError::SkipFrame { length, .. }) => {
+                let total = 8usize + length as usize;
+                if inp.size - inp.pos < total {
+                    return 1;
+                }
+                inp.pos += total;
+                // Stay at a frame boundary; the caller's loop re-enters for
+                // whatever follows.
+                return 1;
+            }
+            // A truncated header (the reader hit end-of-input mid-field):
+            // consume nothing and ask for more input.
+            Err(
+                ReadFrameHeaderError::MagicNumberReadError(_)
+                | ReadFrameHeaderError::FrameDescriptorReadError(_)
+                | ReadFrameHeaderError::WindowDescriptorReadError(_)
+                | ReadFrameHeaderError::DictionaryIdReadError(_)
+                | ReadFrameHeaderError::FrameContentSizeReadError(_),
+            ) => return 1,
+            // A malformed header (bad magic, invalid descriptor, ...) is a
+            // decode error: the need-more-input hint with nothing consumed
+            // would spin the caller forever.
+            Err(err) => {
+                return encode(code_for_decoder_error(
+                    &codec::decoding::errors::FrameDecoderError::ReadFrameHeaderError(err),
+                ));
+            }
         }
     }
     let outcome = catch_unwind(AssertUnwindSafe(|| {

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -1,0 +1,492 @@
+//! Streaming API: `ZSTD_compressStream2` / `ZSTD_decompressStream` plus the
+//! legacy `ZSTD_initCStream` / `ZSTD_compressStream` / `ZSTD_flushStream` /
+//! `ZSTD_endStream` / `ZSTD_initDStream` entry points and the recommended
+//! buffer-size queries.
+//!
+//! `ZSTD_CStream` / `ZSTD_DStream` are the same objects as `ZSTD_CCtx` /
+//! `ZSTD_DCtx` (upstream v1.3.0+ semantics); the create/free "stream"
+//! functions alias the context ones.
+
+use core::ffi::{c_int, c_void};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use codec::encoding::{CompressionLevel, StreamingEncoder};
+
+use crate::context::{ZSTD_CCtx, ZSTD_DCtx};
+use crate::error::{ZSTD_ErrorCode, code_for_decoder_error, encode};
+use crate::params::CONTENTSIZE_UNKNOWN;
+
+/// `ZSTD_BLOCKSIZE_MAX`: 128 KiB, the recommended streaming input granule.
+const BLOCK_SIZE_MAX: usize = 128 * 1024;
+
+/// `ZSTD_inBuffer` — ABI mirror: `{ const void* src; size_t size; size_t pos }`.
+#[repr(C)]
+#[allow(non_camel_case_types, non_snake_case)]
+#[derive(Copy, Clone, Debug)]
+pub struct ZSTD_inBuffer {
+    pub src: *const c_void,
+    pub size: usize,
+    pub pos: usize,
+}
+
+/// `ZSTD_outBuffer` — ABI mirror: `{ void* dst; size_t size; size_t pos }`.
+#[repr(C)]
+#[allow(non_camel_case_types, non_snake_case)]
+#[derive(Copy, Clone, Debug)]
+pub struct ZSTD_outBuffer {
+    pub dst: *mut c_void,
+    pub size: usize,
+    pub pos: usize,
+}
+
+// `ZSTD_EndDirective` discriminants.
+const ZSTD_E_CONTINUE: c_int = 0;
+const ZSTD_E_FLUSH: c_int = 1;
+const ZSTD_E_END: c_int = 2;
+
+/// Streaming-compression state stored on the `ZSTD_CCtx` between
+/// `ZSTD_compressStream2` calls.
+pub(crate) struct CStreamState {
+    /// Push-side encoder writing compressed bytes into its owned `Vec`
+    /// drain. `None` after `ZSTD_e_end` finished the frame (the epilogue
+    /// then lives in `pending`).
+    encoder: Option<StreamingEncoder<Vec<u8>>>,
+    /// Frame bytes produced but not yet copied out to the caller (the
+    /// finished-frame tail after `ZSTD_e_end`, or `None`-encoder leftovers).
+    pending: Vec<u8>,
+    /// Read offset into `pending`.
+    pending_pos: usize,
+}
+
+impl CStreamState {
+    fn pending_remaining(&self) -> usize {
+        self.pending.len() - self.pending_pos
+    }
+
+    /// Copy as much produced output as fits into `out`, draining the
+    /// encoder's accumulated drain bytes first into `pending`.
+    fn copy_out(&mut self, out: &mut ZSTD_outBuffer, dst: &mut [u8]) {
+        if let Some(enc) = self.encoder.as_mut() {
+            let drain = enc.get_mut();
+            if !drain.is_empty() {
+                if self.pending_pos == self.pending.len() {
+                    self.pending.clear();
+                    self.pending_pos = 0;
+                }
+                self.pending.extend_from_slice(drain);
+                drain.clear();
+            }
+        }
+        let n = self.pending_remaining().min(dst.len() - out.pos);
+        dst[out.pos..out.pos + n]
+            .copy_from_slice(&self.pending[self.pending_pos..self.pending_pos + n]);
+        self.pending_pos += n;
+        out.pos += n;
+        if self.pending_pos == self.pending.len() {
+            self.pending.clear();
+            self.pending_pos = 0;
+        }
+    }
+}
+
+impl ZSTD_CCtx {
+    /// Lazily start a streaming frame from the sticky parameters. No-op if
+    /// one is already in flight.
+    fn ensure_stream(&mut self) -> Result<(), ZSTD_ErrorCode> {
+        if self.stream.is_some() {
+            return Ok(());
+        }
+        let params = self.params;
+        let Some(resolved) = params.resolve() else {
+            return Err(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
+        };
+        let mut enc = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(params.level));
+        let mut setup = || -> Result<(), codec::io::Error> {
+            enc.set_parameters(&resolved)?;
+            enc.set_content_checksum(params.checksum_flag)?;
+            // The pledge is single-use (consumed by this frame): record it
+            // in the header unless the content-size flag forbids it.
+            if params.pledged_src_size != CONTENTSIZE_UNKNOWN && params.content_size_flag {
+                enc.set_pledged_content_size(params.pledged_src_size)?;
+            }
+            Ok(())
+        };
+        if setup().is_err() {
+            return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+        }
+        self.params.pledged_src_size = CONTENTSIZE_UNKNOWN;
+        self.stream = Some(CStreamState {
+            encoder: Some(enc),
+            pending: Vec::new(),
+            pending_pos: 0,
+        });
+        Ok(())
+    }
+}
+
+/// `ZSTD_CStream* ZSTD_createCStream(void)` — same object as a `ZSTD_CCtx`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_createCStream() -> *mut ZSTD_CCtx {
+    crate::context::ZSTD_createCCtx()
+}
+
+/// `size_t ZSTD_freeCStream(ZSTD_CStream* zcs)` — `NULL` is a no-op.
+///
+/// # Safety
+/// `zcs` must be a live pointer from `ZSTD_createCStream` /
+/// `ZSTD_createCCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_freeCStream(zcs: *mut ZSTD_CCtx) -> usize {
+    unsafe { crate::context::ZSTD_freeCCtx(zcs) }
+}
+
+/// `size_t ZSTD_CStreamInSize(void)` — recommended input granule
+/// (`ZSTD_BLOCKSIZE_MAX`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_CStreamInSize() -> usize {
+    BLOCK_SIZE_MAX
+}
+
+/// `size_t ZSTD_CStreamOutSize(void)` — output size guaranteeing room to
+/// flush one complete compressed block
+/// (`compressBound(BLOCKSIZE_MAX) + blockHeader(3) + checksum(4)`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_CStreamOutSize() -> usize {
+    crate::simple::ZSTD_compressBound(BLOCK_SIZE_MAX) + 3 + 4
+}
+
+/// Borrowed views over the caller's streaming buffer structs.
+type StreamBuffers<'a> = (
+    &'a mut ZSTD_outBuffer,
+    &'a mut ZSTD_inBuffer,
+    &'a mut [u8],
+    &'a [u8],
+);
+
+/// Validate the caller's buffer structs; returns the borrowed `(dst, src)`
+/// slices.
+///
+/// # Safety
+/// Caller guarantees the buffer pointers are valid for their `size` fields.
+unsafe fn stream_buffers<'a>(
+    output: *mut ZSTD_outBuffer,
+    input: *mut ZSTD_inBuffer,
+) -> Result<StreamBuffers<'a>, ZSTD_ErrorCode> {
+    if output.is_null() || input.is_null() {
+        return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let out = unsafe { &mut *output };
+    let inp = unsafe { &mut *input };
+    if out.pos > out.size || inp.pos > inp.size {
+        return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dst = unsafe { crate::ffi::out_slice(out.dst as *mut u8, out.size) };
+    let src = unsafe { crate::ffi::in_slice(inp.src as *const u8, inp.size) };
+    Ok((out, inp, dst, src))
+}
+
+/// `size_t ZSTD_compressStream2(ZSTD_CCtx* cctx, ZSTD_outBuffer* output,
+/// ZSTD_inBuffer* input, ZSTD_EndDirective endOp)`.
+///
+/// Single-threaded blocking semantics: input is consumed in full on every
+/// call (compressed bytes accumulate on the context when `output` is too
+/// small); the return value is the number of bytes still to be flushed
+/// (`0` after `ZSTD_e_end` means the frame is complete).
+///
+/// # Safety
+/// `cctx` must be live; `output` / `input` must point to valid buffer
+/// structs whose `dst` / `src` are valid for their `size` fields.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compressStream2(
+    cctx: *mut ZSTD_CCtx,
+    output: *mut ZSTD_outBuffer,
+    input: *mut ZSTD_inBuffer,
+    end_op: c_int,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    let (out, inp, dst, src) = match unsafe { stream_buffers(output, input) } {
+        Ok(v) => v,
+        Err(code) => return encode(code),
+    };
+    if !matches!(end_op, ZSTD_E_CONTINUE | ZSTD_E_FLUSH | ZSTD_E_END) {
+        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
+    if let Err(code) = cctx.ensure_stream() {
+        return encode(code);
+    }
+    let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<usize, ZSTD_ErrorCode> {
+        let stream = cctx.stream.as_mut().expect("ensure_stream installed state");
+        // Consume ALL remaining input: the in-memory drain has no
+        // backpressure, so `Write` never short-counts.
+        if inp.pos < inp.size {
+            let Some(enc) = stream.encoder.as_mut() else {
+                // Frame already ended but not fully flushed: only flush/end
+                // directives are legal (upstream stage_wrong).
+                return Err(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+            };
+            use std::io::Write;
+            if enc.write_all(&src[inp.pos..]).is_err() {
+                return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+            }
+            inp.pos = inp.size;
+        }
+        match end_op {
+            ZSTD_E_FLUSH => {
+                if let Some(enc) = stream.encoder.as_mut() {
+                    use std::io::Write;
+                    if enc.flush().is_err() {
+                        return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+                    }
+                }
+            }
+            ZSTD_E_END => {
+                if let Some(enc) = stream.encoder.take() {
+                    match enc.finish() {
+                        Ok(drain) => {
+                            if stream.pending_pos == stream.pending.len() {
+                                stream.pending.clear();
+                                stream.pending_pos = 0;
+                            }
+                            stream.pending.extend_from_slice(&drain);
+                        }
+                        Err(_) => return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC),
+                    }
+                }
+            }
+            _ => {}
+        }
+        stream.copy_out(out, dst);
+        let remaining = stream.pending_remaining();
+        if end_op == ZSTD_E_END && remaining == 0 {
+            // Frame complete and fully flushed: drop the stream state so the
+            // next call starts a new frame from the sticky parameters.
+            cctx.stream = None;
+        }
+        Ok(remaining)
+    }));
+    match outcome {
+        Ok(Ok(remaining)) => remaining,
+        Ok(Err(code)) => encode(code),
+        Err(_) => {
+            // A panic mid-stream leaves the encoder state undefined; drop it
+            // so the context is reusable (upstream requires an explicit
+            // reset, which `ensure_stream` makes implicit here).
+            cctx.stream = None;
+            encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
+        }
+    }
+}
+
+/// `size_t ZSTD_initCStream(ZSTD_CStream* zcs, int compressionLevel)` —
+/// legacy: session reset + clear dictionary + set the level.
+///
+/// # Safety
+/// `zcs` must be a live pointer from `ZSTD_createCStream`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_initCStream(zcs: *mut ZSTD_CCtx, compression_level: c_int) -> usize {
+    if zcs.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *zcs };
+    cctx.reset_session();
+    // Legacy init clears any previously loaded dictionary.
+    cctx.dict_compressor = None;
+    cctx.dict_serial = 0;
+    cctx.dict_level = 0;
+    cctx.params.level = if compression_level == 0 {
+        3
+    } else {
+        compression_level
+    };
+    0
+}
+
+/// `size_t ZSTD_compressStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output,
+/// ZSTD_inBuffer* input)` — legacy alias for `ZSTD_compressStream2(...,
+/// ZSTD_e_continue)`; returns a recommended next input size.
+///
+/// # Safety
+/// Same contracts as [`ZSTD_compressStream2`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compressStream(
+    zcs: *mut ZSTD_CCtx,
+    output: *mut ZSTD_outBuffer,
+    input: *mut ZSTD_inBuffer,
+) -> usize {
+    let rc = unsafe { ZSTD_compressStream2(zcs, output, input, ZSTD_E_CONTINUE) };
+    if crate::error::ZSTD_isError(rc) != 0 {
+        return rc;
+    }
+    // Legacy return contract: a hint for the next read size.
+    BLOCK_SIZE_MAX
+}
+
+/// `size_t ZSTD_flushStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output)` —
+/// `ZSTD_compressStream2(zcs, output, &empty, ZSTD_e_flush)`.
+///
+/// # Safety
+/// Same contracts as [`ZSTD_compressStream2`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_flushStream(
+    zcs: *mut ZSTD_CCtx,
+    output: *mut ZSTD_outBuffer,
+) -> usize {
+    let mut empty = ZSTD_inBuffer {
+        src: core::ptr::null(),
+        size: 0,
+        pos: 0,
+    };
+    unsafe { ZSTD_compressStream2(zcs, output, &mut empty, ZSTD_E_FLUSH) }
+}
+
+/// `size_t ZSTD_endStream(ZSTD_CStream* zcs, ZSTD_outBuffer* output)` —
+/// `ZSTD_compressStream2(zcs, output, &empty, ZSTD_e_end)`.
+///
+/// # Safety
+/// Same contracts as [`ZSTD_compressStream2`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_endStream(zcs: *mut ZSTD_CCtx, output: *mut ZSTD_outBuffer) -> usize {
+    let mut empty = ZSTD_inBuffer {
+        src: core::ptr::null(),
+        size: 0,
+        pos: 0,
+    };
+    unsafe { ZSTD_compressStream2(zcs, output, &mut empty, ZSTD_E_END) }
+}
+
+/// `ZSTD_DStream* ZSTD_createDStream(void)` — same object as a `ZSTD_DCtx`.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_createDStream() -> *mut ZSTD_DCtx {
+    crate::context::ZSTD_createDCtx()
+}
+
+/// `size_t ZSTD_freeDStream(ZSTD_DStream* zds)` — `NULL` is a no-op.
+///
+/// # Safety
+/// `zds` must be a live pointer from `ZSTD_createDStream` /
+/// `ZSTD_createDCtx`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_freeDStream(zds: *mut ZSTD_DCtx) -> usize {
+    unsafe { crate::context::ZSTD_freeDCtx(zds) }
+}
+
+/// `size_t ZSTD_DStreamInSize(void)` — recommended input granule
+/// (`ZSTD_BLOCKSIZE_MAX + blockHeader(3)`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_DStreamInSize() -> usize {
+    BLOCK_SIZE_MAX + 3
+}
+
+/// `size_t ZSTD_DStreamOutSize(void)` — recommended output granule
+/// (`ZSTD_BLOCKSIZE_MAX`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_DStreamOutSize() -> usize {
+    BLOCK_SIZE_MAX
+}
+
+/// `size_t ZSTD_initDStream(ZSTD_DStream* zds)` — legacy session reset;
+/// returns the recommended first input size.
+///
+/// # Safety
+/// `zds` must be a live pointer from `ZSTD_createDStream`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_initDStream(zds: *mut ZSTD_DCtx) -> usize {
+    if zds.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *zds };
+    dctx.reset_session();
+    dctx.stream_frame_done = true;
+    ZSTD_DStreamInSize()
+}
+
+/// `size_t ZSTD_decompressStream(ZSTD_DStream* zds, ZSTD_outBuffer* output,
+/// ZSTD_inBuffer* input)`.
+///
+/// Consumes from `input`, flushes decoded bytes into `output`, updating both
+/// `pos` fields. Returns `0` once a frame is fully decoded AND flushed; a
+/// non-zero non-error value means more input and/or output room is needed.
+///
+/// # Safety
+/// `zds` must be live; `output` / `input` must point to valid buffer structs
+/// whose `dst` / `src` are valid for their `size` fields.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_decompressStream(
+    zds: *mut ZSTD_DCtx,
+    output: *mut ZSTD_outBuffer,
+    input: *mut ZSTD_inBuffer,
+) -> usize {
+    if zds.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *zds };
+    let (out, inp, dst, src) = match unsafe { stream_buffers(output, input) } {
+        Ok(v) => v,
+        Err(code) => return encode(code),
+    };
+    // Frame boundary: validate the next header and start the frame
+    // explicitly. `decode_from_to` self-initialises only a brand-new
+    // decoder; a reused one parks on the finished previous frame and would
+    // make no progress on the next frame's bytes (an infinite caller loop).
+    if dctx.stream_frame_done {
+        if inp.pos == inp.size {
+            // No active frame and nothing to read: frame-done signal.
+            return 0;
+        }
+        match codec::decoding::read_frame_header_info(&src[inp.pos..], false) {
+            Ok(info) => {
+                // `ZSTD_d_windowLogMax`: refuse oversized windows before any
+                // decode work runs.
+                let limit = 1u64 << dctx.window_log_max;
+                if info.window_size > limit {
+                    return encode(ZSTD_ErrorCode::ZSTD_error_frameParameter_windowTooLarge);
+                }
+                let mut reader = &src[inp.pos..];
+                let reset = catch_unwind(AssertUnwindSafe(|| dctx.decoder.reset(&mut reader)));
+                match reset {
+                    Ok(Ok(())) => {
+                        inp.pos = inp.size - reader.len();
+                        dctx.stream_frame_done = false;
+                    }
+                    Ok(Err(err)) => return encode(code_for_decoder_error(&err)),
+                    Err(_) => {
+                        dctx.decoder = codec::decoding::FrameDecoder::new();
+                        dctx.ddict_serial = 0;
+                        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+                    }
+                }
+            }
+            // The header is split across input chunks: consume nothing and
+            // ask for more input.
+            Err(_) => return 1,
+        }
+    }
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        dctx.decoder
+            .decode_from_to(&src[inp.pos..], &mut dst[out.pos..])
+    }));
+    match outcome {
+        Ok(Ok((read, written))) => {
+            inp.pos += read;
+            out.pos += written;
+            let finished = dctx.decoder.is_finished() && dctx.decoder.can_collect() == 0;
+            dctx.stream_frame_done = finished;
+            if finished {
+                0
+            } else {
+                // Hint: more input (or output room) is required.
+                1
+            }
+        }
+        Ok(Err(err)) => encode(code_for_decoder_error(&err)),
+        Err(_) => {
+            dctx.decoder = codec::decoding::FrameDecoder::new();
+            dctx.ddict_serial = 0;
+            dctx.stream_frame_done = true;
+            encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
+        }
+    }
+}

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -104,6 +104,9 @@ impl ZSTD_CCtx {
         let mut setup = || -> Result<(), codec::io::Error> {
             enc.set_parameters(&resolved)?;
             enc.set_content_checksum(params.checksum_flag)?;
+            if params.target_cblock_size > 0 {
+                enc.set_target_block_size(Some(params.target_cblock_size as u32))?;
+            }
             // The pledge is single-use (consumed by this frame): record it
             // in the header unless the content-size flag forbids it.
             if params.pledged_src_size != CONTENTSIZE_UNKNOWN && params.content_size_flag {

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1068,3 +1068,95 @@ fn dctx_parameter_changes_rejected_mid_frame() {
         crate::streaming::ZSTD_freeDStream(zds);
     }
 }
+
+// Bug regression: ZSTD_compress2 on a context with a streaming frame in
+// flight must be rejected with stage_wrong — starting a one-shot frame
+// mid-stream would interleave two frame lifecycles on one context (and
+// consume the pledge that belongs to the streaming frame).
+#[test]
+fn compress2_rejected_while_stream_in_flight() {
+    let input = sample(64 * 1024);
+    let zcs = crate::streaming::ZSTD_createCStream();
+    let mut outbuf = vec![0u8; 1024];
+    unsafe {
+        // Open a streaming frame and leave it unfinished.
+        let mut inb = ZSTD_inBuffer {
+            src: input.as_ptr() as *const core::ffi::c_void,
+            size: input.len(),
+            pos: 0,
+        };
+        let mut outb = ZSTD_outBuffer {
+            dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+            size: outbuf.len(),
+            pos: 0,
+        };
+        let rc = ZSTD_compressStream2(zcs, &mut outb, &mut inb, 0);
+        assert_eq!(ZSTD_isError(rc), 0);
+
+        let mut compressed = vec![0u8; ZSTD_compressBound(input.len())];
+        let rc = crate::context::ZSTD_compress2(
+            zcs,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_stage_wrong,
+            "compress2 mid-stream must be rejected"
+        );
+
+        // After ending the stream the context accepts one-shots again.
+        loop {
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = ZSTD_endStream(zcs, &mut outb);
+            assert_eq!(ZSTD_isError(rc), 0);
+            if rc == 0 {
+                break;
+            }
+        }
+        let rc = crate::context::ZSTD_compress2(
+            zcs,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(ZSTD_isError(rc), 0, "compress2 must work between frames");
+        crate::streaming::ZSTD_freeCStream(zcs);
+    }
+}
+
+// Bug regression: a malformed frame header fed to ZSTD_decompressStream
+// must surface a decode error, not the "need more input" hint — the hint
+// with no input consumed sends a spec-conformant caller into a spin.
+#[test]
+fn decompress_stream_errors_on_malformed_header() {
+    let zds = crate::streaming::ZSTD_createDStream();
+    let garbage = [0xA5u8; 64]; // wrong magic, plenty of bytes
+    let mut outbuf = vec![0u8; 4096];
+    unsafe {
+        let mut inb = ZSTD_inBuffer {
+            src: garbage.as_ptr() as *const core::ffi::c_void,
+            size: garbage.len(),
+            pos: 0,
+        };
+        let mut outb = ZSTD_outBuffer {
+            dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+            size: outbuf.len(),
+            pos: 0,
+        };
+        let rc = crate::streaming::ZSTD_decompressStream(zds, &mut outb, &mut inb);
+        assert_ne!(
+            ZSTD_isError(rc),
+            0,
+            "malformed header must error, not ask for more input (rc={rc})"
+        );
+        crate::streaming::ZSTD_freeDStream(zds);
+    }
+}

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -988,12 +988,8 @@ fn target_cblock_size_caps_emitted_blocks() {
         assert_eq!(ZSTD_isError(header_len), 0);
         let mut pos = header_len;
         loop {
-            let hdr = u32::from_le_bytes([
-                compressed[pos],
-                compressed[pos + 1],
-                compressed[pos + 2],
-                0,
-            ]);
+            let hdr =
+                u32::from_le_bytes([compressed[pos], compressed[pos + 1], compressed[pos + 2], 0]);
             let last = hdr & 1 != 0;
             let block_type = (hdr >> 1) & 3;
             let size = (hdr >> 3) as usize;

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -570,8 +570,10 @@ use crate::streaming::{
 };
 use core::ffi::c_int;
 
-// ABI invariants: struct sizes match upstream `sizeof` on 64-bit.
+// ABI invariants: struct sizes match upstream `sizeof` on 64-bit (on
+// 32-bit targets `size_t` / pointers halve the layouts).
 #[test]
+#[cfg(target_pointer_width = "64")]
 fn streaming_buffer_abi_sizes() {
     assert_eq!(core::mem::size_of::<ZSTD_inBuffer>(), 24);
     assert_eq!(core::mem::size_of::<ZSTD_outBuffer>(), 24);

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -955,3 +955,121 @@ fn stream_size_hints_match_upstream() {
         ZSTD_compressBound(128 * 1024) + 3 + 4
     );
 }
+
+#[test]
+fn target_cblock_size_caps_emitted_blocks() {
+    // 512 KiB of incompressible data would normally emit 4 full 128 KiB
+    // blocks; with a 1340-byte target every physical block payload must be
+    // at or under the target.
+    let input = sample(512 * 1024);
+    let cctx = ZSTD_createCCtx();
+    let mut compressed = vec![0u8; ZSTD_compressBound(input.len()) + (input.len() / 1340 + 2) * 3];
+    unsafe {
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 130, 1340), 0); // targetCBlockSize
+        let csize = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(ZSTD_isError(csize), 0, "compress2 with target errored");
+        ZSTD_freeCCtx(cctx);
+
+        // Walk the frame's block headers: 3-byte LE `(size << 3) | (type
+        // << 1) | last`; Raw/RLE regenerate `size` bytes, Compressed
+        // blocks carry `size` payload bytes — all must be <= target.
+        let mut zfh = core::mem::MaybeUninit::<ZSTD_FrameHeader>::zeroed();
+        assert_eq!(
+            ZSTD_getFrameHeader(zfh.as_mut_ptr(), compressed.as_ptr(), csize),
+            0
+        );
+        let header_len = ZSTD_frameHeaderSize(compressed.as_ptr(), csize);
+        assert_eq!(ZSTD_isError(header_len), 0);
+        let mut pos = header_len;
+        loop {
+            let hdr = u32::from_le_bytes([
+                compressed[pos],
+                compressed[pos + 1],
+                compressed[pos + 2],
+                0,
+            ]);
+            let last = hdr & 1 != 0;
+            let block_type = (hdr >> 1) & 3;
+            let size = (hdr >> 3) as usize;
+            let payload = match block_type {
+                1 => 1,    // RLE carries one byte
+                _ => size, // Raw / Compressed carry `size` bytes
+            };
+            assert!(
+                size <= 1340,
+                "block at {pos} declares {size} bytes, above the 1340 target"
+            );
+            pos += 3 + payload;
+            if last {
+                break;
+            }
+        }
+        ZSTD_freeDCtx(crate::context::ZSTD_createDCtx()); // keep symbol use balanced
+    }
+}
+
+#[test]
+fn dctx_parameter_changes_rejected_mid_frame() {
+    // Compress two frames; feed only a prefix of the first so the decoder
+    // parks mid-frame, then verify parameter mutation is rejected with
+    // stage_wrong until the session is reset.
+    let input = sample(256 * 1024);
+    let cctx = ZSTD_createCCtx();
+    let mut compressed = vec![0u8; ZSTD_compressBound(input.len())];
+    let csize = unsafe {
+        let csize = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        ZSTD_freeCCtx(cctx);
+        csize
+    };
+    assert_eq!(ZSTD_isError(csize), 0);
+
+    let zds = crate::streaming::ZSTD_createDStream();
+    unsafe {
+        // Between frames: parameter changes are accepted.
+        assert_eq!(ZSTD_DCtx_setParameter(zds, 100, 25), 0);
+
+        let mut outbuf = vec![0u8; 4096];
+        let mut inb = ZSTD_inBuffer {
+            src: compressed.as_ptr() as *const core::ffi::c_void,
+            size: csize / 2, // truncated input: frame stays in flight
+            pos: 0,
+        };
+        let mut outb = ZSTD_outBuffer {
+            dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+            size: outbuf.len(),
+            pos: 0,
+        };
+        let rc = crate::streaming::ZSTD_decompressStream(zds, &mut outb, &mut inb);
+        assert_eq!(ZSTD_isError(rc), 0);
+        assert_ne!(rc, 0, "frame must still be in flight");
+
+        // Mid-frame: setParameter and a parameters-only reset are rejected.
+        let rc = ZSTD_DCtx_setParameter(zds, 100, 26);
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_stage_wrong
+        );
+        let rc = crate::params::ZSTD_DCtx_reset(zds, 2); // ZSTD_reset_parameters
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_stage_wrong
+        );
+
+        // A session reset abandons the frame; parameters mutate again.
+        assert_eq!(crate::params::ZSTD_DCtx_reset(zds, 1), 0);
+        assert_eq!(ZSTD_DCtx_setParameter(zds, 100, 26), 0);
+        crate::streaming::ZSTD_freeDStream(zds);
+    }
+}

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1006,7 +1006,6 @@ fn target_cblock_size_caps_emitted_blocks() {
                 break;
             }
         }
-        ZSTD_freeDCtx(crate::context::ZSTD_createDCtx()); // keep symbol use balanced
     }
 }
 

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -556,3 +556,400 @@ fn create_cdict_rejects_non_dictionary() {
     let cdict = unsafe { ZSTD_createCDict(garbage.as_ptr(), garbage.len(), 3) };
     assert!(cdict.is_null(), "createCDict accepted a non-dictionary");
 }
+
+// ---- Phase 6.2: advanced parameters + streaming ----
+
+use crate::params::{
+    ZSTD_CCtx_getParameter, ZSTD_CCtx_reset, ZSTD_CCtx_setParameter, ZSTD_CCtx_setPledgedSrcSize,
+    ZSTD_DCtx_setParameter, ZSTD_bounds, ZSTD_cParam_getBounds, ZSTD_dParam_getBounds,
+};
+use crate::streaming::{
+    ZSTD_CStreamInSize, ZSTD_CStreamOutSize, ZSTD_DStreamInSize, ZSTD_DStreamOutSize,
+    ZSTD_compressStream2, ZSTD_decompressStream, ZSTD_endStream, ZSTD_flushStream, ZSTD_inBuffer,
+    ZSTD_outBuffer,
+};
+use core::ffi::c_int;
+
+// ABI invariants: struct sizes match upstream `sizeof` on 64-bit.
+#[test]
+fn streaming_buffer_abi_sizes() {
+    assert_eq!(core::mem::size_of::<ZSTD_inBuffer>(), 24);
+    assert_eq!(core::mem::size_of::<ZSTD_outBuffer>(), 24);
+    assert_eq!(core::mem::size_of::<ZSTD_bounds>(), 16);
+}
+
+#[test]
+fn c_param_bounds_cover_stable_set() {
+    // Every stable v1.5.7 cParameter discriminant must report bounds.
+    for param in [
+        100, 101, 102, 103, 104, 105, 106, 107, 130, 160, 161, 162, 163, 164, 200, 201, 202, 400,
+        401, 402,
+    ] {
+        let b = ZSTD_cParam_getBounds(param);
+        assert_eq!(ZSTD_isError(b.error), 0, "param {param} must have bounds");
+        assert!(b.lowerBound <= b.upperBound, "param {param} bounds order");
+    }
+    // Unknown discriminant errors.
+    let b = ZSTD_cParam_getBounds(99);
+    assert_ne!(ZSTD_isError(b.error), 0);
+    let d = ZSTD_dParam_getBounds(100);
+    assert_eq!(ZSTD_isError(d.error), 0);
+    assert_ne!(ZSTD_isError(ZSTD_dParam_getBounds(99).error), 0);
+}
+
+#[test]
+fn set_parameter_validates_and_reads_back() {
+    let cctx = ZSTD_createCCtx();
+    unsafe {
+        // In-bounds values stick and read back.
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 100, 7), 0); // level
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 101, 20), 0); // windowLog
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 201, 1), 0); // checksum
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 107, 9), 0); // strategy btultra2
+        let mut v: c_int = -1;
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 100, &mut v), 0);
+        assert_eq!(v, 7);
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 101, &mut v), 0);
+        assert_eq!(v, 20);
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 201, &mut v), 0);
+        assert_eq!(v, 1);
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 107, &mut v), 0);
+        assert_eq!(v, 9);
+
+        // Out-of-bounds rejected with parameter_outOfBound.
+        let rc = ZSTD_CCtx_setParameter(cctx, 101, 99);
+        assert_ne!(ZSTD_isError(rc), 0);
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound
+        );
+        // Unknown parameter rejected as unsupported.
+        let rc = ZSTD_CCtx_setParameter(cctx, 9999, 1);
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_parameter_unsupported
+        );
+        // 0 returns a tunable to auto.
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 101, 0), 0);
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 101, &mut v), 0);
+        assert_eq!(v, 0);
+
+        // Parameters reset restores defaults.
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 201, 1), 0);
+        assert_eq!(ZSTD_CCtx_reset(cctx, 3), 0); // session_and_parameters
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 201, &mut v), 0);
+        assert_eq!(v, 0);
+        assert_eq!(ZSTD_CCtx_getParameter(cctx, 100, &mut v), 0);
+        assert_eq!(v, 3);
+
+        ZSTD_freeCCtx(cctx);
+    }
+}
+
+#[test]
+fn compress2_roundtrips_with_sticky_parameters() {
+    let input = sample(256 * 1024);
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
+    let mut compressed = vec![0u8; ZSTD_compressBound(input.len())];
+    unsafe {
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 100, 5), 0);
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 201, 1), 0); // checksum on
+        let csize = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(ZSTD_isError(csize), 0, "compress2 reported an error");
+
+        // The checksum flag must show in the frame header.
+        let mut zfh = core::mem::MaybeUninit::<ZSTD_FrameHeader>::zeroed();
+        assert_eq!(
+            ZSTD_getFrameHeader(zfh.as_mut_ptr(), compressed.as_ptr(), csize),
+            0
+        );
+        assert_eq!(zfh.assume_init_ref().checksumFlag, 1);
+
+        let mut restored = vec![0u8; input.len()];
+        let dsize = ZSTD_decompressDCtx(
+            dctx,
+            restored.as_mut_ptr(),
+            restored.len(),
+            compressed.as_ptr(),
+            csize,
+        );
+        assert_eq!(ZSTD_isError(dsize), 0);
+        assert_eq!(dsize, input.len());
+        assert_eq!(restored, input);
+
+        // A mismatching pledge is rejected.
+        assert_eq!(ZSTD_CCtx_setPledgedSrcSize(cctx, 1), 0);
+        let rc = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_srcSize_wrong
+        );
+
+        ZSTD_freeCCtx(cctx);
+        ZSTD_freeDCtx(dctx);
+    }
+}
+
+#[test]
+fn content_size_and_dict_id_flags_apply() {
+    let input = sample(64 * 1024);
+    let cctx = ZSTD_createCCtx();
+    let mut compressed = vec![0u8; ZSTD_compressBound(input.len())];
+    unsafe {
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 200, 0), 0); // contentSizeFlag off
+        let csize = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        assert_eq!(ZSTD_isError(csize), 0);
+        // ZSTD_CONTENTSIZE_UNKNOWN == -1 as u64.
+        let declared = ZSTD_getFrameContentSize(compressed.as_ptr(), csize);
+        assert_eq!(declared, u64::MAX, "FCS must be omitted");
+        ZSTD_freeCCtx(cctx);
+    }
+}
+
+/// Drive a full streaming round-trip with deliberately tiny output buffers
+/// so the flush/end loops exercise the partial-drain paths.
+#[test]
+fn streaming_roundtrip_chunked() {
+    let input = sample(1 << 20);
+    let zcs = crate::streaming::ZSTD_createCStream();
+    let mut compressed: Vec<u8> = Vec::new();
+    unsafe {
+        assert_eq!(ZSTD_CCtx_setParameter(zcs, 100, 3), 0);
+        assert_eq!(ZSTD_CCtx_setParameter(zcs, 201, 1), 0); // checksum
+
+        // Feed in 64 KiB slices with a 1 KiB output buffer.
+        let mut outbuf = vec![0u8; 1024];
+        for chunk in input.chunks(64 * 1024) {
+            let mut inb = ZSTD_inBuffer {
+                src: chunk.as_ptr() as *const core::ffi::c_void,
+                size: chunk.len(),
+                pos: 0,
+            };
+            loop {
+                let mut outb = ZSTD_outBuffer {
+                    dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                    size: outbuf.len(),
+                    pos: 0,
+                };
+                let rc = ZSTD_compressStream2(zcs, &mut outb, &mut inb, 0);
+                assert_eq!(ZSTD_isError(rc), 0, "continue errored");
+                compressed.extend_from_slice(&outbuf[..outb.pos]);
+                if inb.pos == inb.size && rc == 0 {
+                    break;
+                }
+                if inb.pos == inb.size && outb.pos < outb.size {
+                    // Input consumed; leftovers smaller than the buffer will
+                    // drain on the next call or at end.
+                    break;
+                }
+            }
+        }
+        // Finish the frame, looping until fully flushed.
+        loop {
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = ZSTD_endStream(zcs, &mut outb);
+            assert_eq!(ZSTD_isError(rc), 0, "end errored");
+            compressed.extend_from_slice(&outbuf[..outb.pos]);
+            if rc == 0 {
+                break;
+            }
+        }
+        crate::streaming::ZSTD_freeCStream(zcs);
+    }
+
+    // Decompress through the streaming decoder with small buffers too.
+    let zds = crate::streaming::ZSTD_createDStream();
+    let mut restored: Vec<u8> = Vec::new();
+    unsafe {
+        assert_ne!(crate::streaming::ZSTD_initDStream(zds), 0);
+        let mut outbuf = vec![0u8; 4096];
+        let mut inb = ZSTD_inBuffer {
+            src: compressed.as_ptr() as *const core::ffi::c_void,
+            size: compressed.len(),
+            pos: 0,
+        };
+        loop {
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = ZSTD_decompressStream(zds, &mut outb, &mut inb);
+            assert_eq!(ZSTD_isError(rc), 0, "decompressStream errored");
+            restored.extend_from_slice(&outbuf[..outb.pos]);
+            if rc == 0 && inb.pos == inb.size {
+                break;
+            }
+            assert!(
+                outb.pos > 0 || inb.pos < inb.size,
+                "no forward progress in decode loop"
+            );
+        }
+        crate::streaming::ZSTD_freeDStream(zds);
+    }
+    assert_eq!(restored, input, "streaming round-trip must be byte-exact");
+}
+
+#[test]
+fn flush_stream_emits_decodable_prefix_and_two_frames_back_to_back() {
+    let part1 = sample(100_000);
+    let part2 = sample(50_000);
+    let zcs = crate::streaming::ZSTD_createCStream();
+    let mut compressed: Vec<u8> = Vec::new();
+    let mut outbuf = vec![0u8; ZSTD_CStreamOutSize()];
+    unsafe {
+        // Frame 1: write, flush mid-frame, then end.
+        for (data, finish) in [(&part1, false), (&part2, true)] {
+            let mut inb = ZSTD_inBuffer {
+                src: data.as_ptr() as *const core::ffi::c_void,
+                size: data.len(),
+                pos: 0,
+            };
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = ZSTD_compressStream2(zcs, &mut outb, &mut inb, 0);
+            assert_eq!(ZSTD_isError(rc), 0);
+            compressed.extend_from_slice(&outbuf[..outb.pos]);
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = if finish {
+                ZSTD_endStream(zcs, &mut outb)
+            } else {
+                ZSTD_flushStream(zcs, &mut outb)
+            };
+            assert_eq!(ZSTD_isError(rc), 0);
+            assert_eq!(rc, 0, "big buffer must fully drain");
+            compressed.extend_from_slice(&outbuf[..outb.pos]);
+        }
+        // Second frame on the same context (sticky params, new frame).
+        let mut inb = ZSTD_inBuffer {
+            src: part1.as_ptr() as *const core::ffi::c_void,
+            size: part1.len(),
+            pos: 0,
+        };
+        let mut outb = ZSTD_outBuffer {
+            dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+            size: outbuf.len(),
+            pos: 0,
+        };
+        let rc = ZSTD_compressStream2(zcs, &mut outb, &mut inb, 2); // e_end
+        assert_eq!(ZSTD_isError(rc), 0);
+        assert_eq!(rc, 0);
+        compressed.extend_from_slice(&outbuf[..outb.pos]);
+        crate::streaming::ZSTD_freeCStream(zcs);
+    }
+
+    // Both frames decode back-to-back via the streaming decoder.
+    let zds = crate::streaming::ZSTD_createDStream();
+    let mut restored: Vec<u8> = Vec::new();
+    unsafe {
+        let mut outbuf = vec![0u8; ZSTD_DStreamOutSize()];
+        let mut inb = ZSTD_inBuffer {
+            src: compressed.as_ptr() as *const core::ffi::c_void,
+            size: compressed.len(),
+            pos: 0,
+        };
+        while inb.pos < inb.size {
+            let mut outb = ZSTD_outBuffer {
+                dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+                size: outbuf.len(),
+                pos: 0,
+            };
+            let rc = ZSTD_decompressStream(zds, &mut outb, &mut inb);
+            assert_eq!(ZSTD_isError(rc), 0);
+            restored.extend_from_slice(&outbuf[..outb.pos]);
+        }
+        crate::streaming::ZSTD_freeDStream(zds);
+    }
+    let mut expected = part1.clone();
+    expected.extend_from_slice(&part2);
+    expected.extend_from_slice(&part1);
+    assert_eq!(restored, expected);
+}
+
+#[test]
+fn d_window_log_max_rejects_oversized_window() {
+    // Compress 1 MiB at a window the decoder limit will reject.
+    let input = sample(1 << 20);
+    let cctx = ZSTD_createCCtx();
+    let mut compressed = vec![0u8; ZSTD_compressBound(input.len())];
+    let csize = unsafe {
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 101, 20), 0); // windowLog 20
+        // Suppress the FCS so the header carries a window descriptor (a
+        // known content size lets decoders ignore the window entirely).
+        assert_eq!(ZSTD_CCtx_setParameter(cctx, 200, 0), 0);
+        let csize = crate::context::ZSTD_compress2(
+            cctx,
+            compressed.as_mut_ptr(),
+            compressed.len(),
+            input.as_ptr(),
+            input.len(),
+        );
+        ZSTD_freeCCtx(cctx);
+        csize
+    };
+    assert_eq!(ZSTD_isError(csize), 0);
+
+    let zds = crate::streaming::ZSTD_createDStream();
+    unsafe {
+        // Limit below the frame's window log → rejected.
+        assert_eq!(ZSTD_DCtx_setParameter(zds, 100, 10), 0);
+        let mut outbuf = vec![0u8; 4096];
+        let mut inb = ZSTD_inBuffer {
+            src: compressed.as_ptr() as *const core::ffi::c_void,
+            size: compressed.len(),
+            pos: 0,
+        };
+        let mut outb = ZSTD_outBuffer {
+            dst: outbuf.as_mut_ptr() as *mut core::ffi::c_void,
+            size: outbuf.len(),
+            pos: 0,
+        };
+        let rc = ZSTD_decompressStream(zds, &mut outb, &mut inb);
+        assert_eq!(
+            ZSTD_getErrorCode(rc),
+            ZSTD_ErrorCode::ZSTD_error_frameParameter_windowTooLarge
+        );
+        crate::streaming::ZSTD_freeDStream(zds);
+    }
+}
+
+#[test]
+fn stream_size_hints_match_upstream() {
+    assert_eq!(ZSTD_CStreamInSize(), 128 * 1024);
+    assert_eq!(ZSTD_DStreamInSize(), 128 * 1024 + 3);
+    assert_eq!(ZSTD_DStreamOutSize(), 128 * 1024);
+    assert_eq!(
+        ZSTD_CStreamOutSize(),
+        ZSTD_compressBound(128 * 1024) + 3 + 4
+    );
+}

--- a/c-api/tests/c_consumer.c
+++ b/c-api/tests/c_consumer.c
@@ -83,6 +83,86 @@ int main(void) {
     size_t bad = ZSTD_decompress(out, n, garbage, sizeof garbage);
     if (!ZSTD_isError(bad)) return 15;
 
+    /* Advanced parameter API + ZSTD_compress2. */
+    cctx = ZSTD_createCCtx();
+    if (!cctx) return 16;
+    {
+        ZSTD_bounds wb = ZSTD_cParam_getBounds(ZSTD_c_windowLog);
+        if (ZSTD_isError(wb.error) || wb.lowerBound > wb.upperBound) return 17;
+        if (ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, 7))) return 18;
+        if (ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_checksumFlag, 1))) return 19;
+        if (!ZSTD_isError(ZSTD_CCtx_setParameter(cctx, ZSTD_c_windowLog, 99))) return 20;
+        int got = -1;
+        if (ZSTD_isError(ZSTD_CCtx_getParameter(cctx, ZSTD_c_compressionLevel, &got)) || got != 7)
+            return 21;
+        size_t c3 = ZSTD_compress2(cctx, comp, bound, input, n);
+        if (ZSTD_isError(c3)) {
+            fprintf(stderr, "compress2: %s\n", ZSTD_getErrorName(c3));
+            return 22;
+        }
+        dctx = ZSTD_createDCtx();
+        if (!dctx) return 16;
+        size_t d3 = ZSTD_decompressDCtx(dctx, out, n, comp, c3);
+        if (ZSTD_isError(d3) || d3 != n || memcmp(out, input, n) != 0) return 23;
+        ZSTD_freeDCtx(dctx);
+        if (ZSTD_isError(ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters))) return 24;
+    }
+    ZSTD_freeCCtx(cctx);
+
+    /* Streaming round trip: chunked compress, then chunked decompress. */
+    {
+        ZSTD_CStream *zcs = ZSTD_createCStream();
+        ZSTD_DStream *zds = ZSTD_createDStream();
+        if (!zcs || !zds) return 25;
+        size_t out_cap = ZSTD_CStreamOutSize();
+        unsigned char *sbuf = (unsigned char *)malloc(out_cap);
+        unsigned char *scomp = (unsigned char *)malloc(bound + 64);
+        if (!sbuf || !scomp) return 2;
+        size_t scomp_len = 0;
+        const size_t chunk = 64 * 1024;
+        for (size_t off = 0; off < n; off += chunk) {
+            size_t len = n - off < chunk ? n - off : chunk;
+            ZSTD_inBuffer inb = {input + off, len, 0};
+            while (inb.pos < inb.size) {
+                ZSTD_outBuffer outb = {sbuf, out_cap, 0};
+                size_t rc = ZSTD_compressStream2(zcs, &outb, &inb, ZSTD_e_continue);
+                if (ZSTD_isError(rc)) return 26;
+                memcpy(scomp + scomp_len, sbuf, outb.pos);
+                scomp_len += outb.pos;
+            }
+        }
+        for (;;) {
+            ZSTD_outBuffer outb = {sbuf, out_cap, 0};
+            size_t rc = ZSTD_endStream(zcs, &outb);
+            if (ZSTD_isError(rc)) return 27;
+            memcpy(scomp + scomp_len, sbuf, outb.pos);
+            scomp_len += outb.pos;
+            if (rc == 0) break;
+        }
+        ZSTD_freeCStream(zcs);
+
+        memset(out, 0, n);
+        size_t restored = 0;
+        ZSTD_inBuffer inb = {scomp, scomp_len, 0};
+        size_t dout_cap = ZSTD_DStreamOutSize();
+        unsigned char *dbuf = (unsigned char *)malloc(dout_cap);
+        if (!dbuf) return 2;
+        for (;;) {
+            ZSTD_outBuffer outb = {dbuf, dout_cap, 0};
+            size_t rc = ZSTD_decompressStream(zds, &outb, &inb);
+            if (ZSTD_isError(rc)) return 28;
+            memcpy(out + restored, dbuf, outb.pos);
+            restored += outb.pos;
+            if (rc == 0 && inb.pos == inb.size) break;
+            if (outb.pos == 0 && inb.pos == inb.size) return 29; /* stalled */
+        }
+        ZSTD_freeDStream(zds);
+        if (restored != n || memcmp(out, input, n) != 0) return 30;
+        free(sbuf);
+        free(scomp);
+        free(dbuf);
+    }
+
     free(input);
     free(out);
     free(comp);

--- a/zstd/CHANGELOG.md
+++ b/zstd/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.35](https://github.com/structured-world/structured-zstd/compare/v0.0.34...v0.0.35) - 2026-06-11
+
+### Added
+
+- *(c-api)* advanced parameter API + streaming surface (compressStream2 / decompressStream) ([#396](https://github.com/structured-world/structured-zstd/pull/396))
+
+### Performance
+
+- *(encode)* size the output reservation from the observed ratio ([#398](https://github.com/structured-world/structured-zstd/pull/398))
+- *(encode)* allocation-free copy-mode dictionary restore ([#397](https://github.com/structured-world/structured-zstd/pull/397))
+
 ## [0.0.34](https://github.com/structured-world/structured-zstd/compare/v0.0.33...v0.0.34) - 2026-06-10
 
 ### Added

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structured-zstd"
-version = "0.0.34"
+version = "0.0.35"
 rust-version = "1.92"
 authors = [
     "Moritz Borcherding <moritz.borcherding@web.de>",

--- a/zstd/src/common/mod.rs
+++ b/zstd/src/common/mod.rs
@@ -19,6 +19,9 @@ pub const MAX_WINDOW_SIZE: u64 = (1 << 41) + 7 * (1 << 38);
 ///
 /// <https://github.com/facebook/zstd/blob/eca205fc7849a61ab287492931a04960ac58e031/doc/educational_decoder/zstd_decompress.c#L28-L29>
 pub const MAX_BLOCK_SIZE: u32 = 128 * 1024;
+/// Smallest accepted block-size target (upstream `ZSTD_TARGETCBLOCKSIZE_MIN`):
+/// below this the per-block header overhead dominates any latency benefit.
+pub const MIN_TARGET_BLOCK_SIZE: u32 = 1340;
 
 /// Decoder window-size limit (128 MiB = `1 << 27`), matching upstream zstd's
 /// default `ZSTD_d_windowLogMax` (`ZSTD_WINDOWLOG_LIMIT_DEFAULT = 27`). Frames

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -121,6 +121,14 @@ pub struct FrameCompressor<
     /// frame by being handed the right dictionary explicitly. Set via
     /// [`Self::set_dictionary_id_flag`].
     dict_id_flag: bool,
+    /// Upper bound on emitted block sizes (semantics of upstream
+    /// `ZSTD_c_targetCBlockSize`): capping the RAW block length at the
+    /// target bounds every physical block's compressed payload at the
+    /// target too (a compressed block never exceeds its raw input — the
+    /// raw-block fallback fires otherwise), so blocks land at or under
+    /// `target + 3` header bytes on the wire. `None` = no target (full
+    /// 128 KiB blocks). Set via [`Self::set_target_block_size`].
+    target_block_size: Option<u32>,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
     /// Block-layout introspection populated at the end of every
@@ -840,6 +848,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             content_checksum: false,
             content_size_flag: true,
             dict_id_flag: true,
+            target_block_size: None,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
@@ -1116,7 +1125,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             }
         }
         let _clear_guard = ClearBorrowedOnDrop(core::ptr::addr_of_mut!(self.state.matcher));
-        let block_capacity = MAX_BLOCK_SIZE as usize;
+        let block_capacity = self.block_capacity();
         let mut start = 0usize;
         while start < input.len() {
             reserve_for_next_block(out, blocks_start, start as u64, input.len() - start);
@@ -1187,6 +1196,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             content_checksum: false,
             content_size_flag: true,
             dict_id_flag: true,
+            target_block_size: None,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
@@ -1242,6 +1252,23 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// the dictionary explicitly.
     pub fn set_dictionary_id_flag(&mut self, emit: bool) {
         self.dict_id_flag = emit;
+    }
+
+    /// Set an upper bound on emitted block sizes (semantics of upstream
+    /// `ZSTD_c_targetCBlockSize`): every physical block's payload is capped
+    /// at `target` bytes (+3-byte block header on the wire), trading some
+    /// ratio for bounded per-block latency. The value is clamped to
+    /// `[1340, 131072]` (the upstream bounds). `None` removes the target.
+    pub fn set_target_block_size(&mut self, target: Option<u32>) {
+        self.target_block_size =
+            target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+    }
+
+    /// The active block-size cap: the configured target, or the format's
+    /// 128 KiB block ceiling.
+    fn block_capacity(&self) -> usize {
+        self.target_block_size
+            .map_or(crate::common::MAX_BLOCK_SIZE as usize, |t| t as usize)
     }
 
     /// Before calling [FrameCompressor::compress] you need to set the source.
@@ -1583,7 +1610,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // Read up to one donor block. When the pre-block splitter keeps a
             // suffix, top it back up before compressing the next block, matching
             // ZSTD_compress_frameChunk() over a contiguous input buffer.
-            let block_capacity = MAX_BLOCK_SIZE as usize;
+            let block_capacity = self.block_capacity();
             // Always draw the block buffer from the matcher's recycled pool
             // (its capacity already covers the block size, so the resize below
             // stays in-place). Any carried pre-split suffix is copied in, and

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1260,8 +1260,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// ratio for bounded per-block latency. The value is clamped to
     /// `[1340, 131072]` (the upstream bounds). `None` removes the target.
     pub fn set_target_block_size(&mut self, target: Option<u32>) {
-        self.target_block_size =
-            target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+        self.target_block_size = target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
     }
 
     /// The active block-size cap: the configured target, or the format's

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -958,7 +958,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             self.run_borrowed_block_loop(input, out)
         } else {
             let mut cursor: &[u8] = input;
-            self.run_owned_block_loop(&mut cursor, prep.initial_size_hint, out)
+            self.run_owned_block_loop(&mut cursor, prep.initial_size_hint, true, out)
         }
     }
 
@@ -1258,9 +1258,15 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// `ZSTD_c_targetCBlockSize`): every physical block's payload is capped
     /// at `target` bytes (+3-byte block header on the wire), trading some
     /// ratio for bounded per-block latency. The value is clamped to
-    /// `[1340, 131072]` (the upstream bounds). `None` removes the target.
+    /// `[MIN_TARGET_BLOCK_SIZE, MAX_BLOCK_SIZE]` (the upstream bounds).
+    /// `None` removes the target.
     pub fn set_target_block_size(&mut self, target: Option<u32>) {
-        self.target_block_size = target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+        self.target_block_size = target.map(|t| {
+            t.clamp(
+                crate::common::MIN_TARGET_BLOCK_SIZE,
+                crate::common::MAX_BLOCK_SIZE,
+            )
+        });
     }
 
     /// The active block-size cap: the configured target, or the format's
@@ -1378,7 +1384,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             Vec::with_capacity(initial_all_blocks_cap(prep.initial_size_hint));
         let mut block_source = ReaderBlockSource(&mut source);
         let total_uncompressed =
-            self.run_owned_block_loop(&mut block_source, prep.initial_size_hint, &mut all_blocks);
+            self.run_owned_block_loop(&mut block_source, prep.initial_size_hint, false, &mut all_blocks);
         self.uncompressed_data = Some(source);
         self.finish_frame(all_blocks, total_uncompressed, &prep);
     }
@@ -1590,6 +1596,12 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         &mut self,
         source: &mut S,
         initial_size_hint: Option<u64>,
+        // Whether `initial_size_hint` is the input's exact length (the
+        // one-shot slice paths) or a caller-provided estimate (the streaming
+        // `Read` path, where `set_source_size_hint` is advisory). An exact
+        // hint drives the one-shot ratio reservation; an estimate is only
+        // trusted up to a small lookahead past the bytes actually read.
+        hint_is_exact: bool,
         out: &mut Vec<u8>,
     ) -> u64 {
         // Compressed blocks are appended to `out` from its current end. The
@@ -1684,7 +1696,19 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 total_uncompressed - uncompressed_data.len() as u64 - pending_input.len() as u64;
             match initial_size_hint {
                 Some(hint) if hint >= total_uncompressed => {
-                    reserve_for_next_block(out, blocks_start, emitted, (hint - emitted) as usize);
+                    // An advisory hint (streaming path) is only trusted up to
+                    // a small lookahead past the bytes actually read: a hint
+                    // far above the real input would otherwise reserve the
+                    // whole phantom remainder up front.
+                    let hint_remaining = hint - emitted;
+                    let remaining = if hint_is_exact {
+                        hint_remaining
+                    } else {
+                        let buffered = total_uncompressed - emitted;
+                        const HINT_LOOKAHEAD: u64 = 64 * 1024;
+                        hint_remaining.min(buffered + HINT_LOOKAHEAD)
+                    };
+                    reserve_for_next_block(out, blocks_start, emitted, remaining as usize);
                 }
                 _ => {
                     out.reserve(uncompressed_data.len() + 3 + 16);

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -109,6 +109,18 @@ pub struct FrameCompressor<
     /// time, so without `hash` no checksum is emitted regardless. Set via
     /// [`Self::set_content_checksum`].
     content_checksum: bool,
+    /// Whether to record `Frame_Content_Size` in the frame header when the
+    /// total size is known (semantics of upstream `ZSTD_c_contentSizeFlag`).
+    /// Default `true`, matching upstream. With the flag off the header
+    /// carries a window descriptor instead (single-segment requires an FCS,
+    /// so it is disabled too). Set via [`Self::set_content_size_flag`].
+    content_size_flag: bool,
+    /// Whether to record the dictionary ID in the frame header when a
+    /// dictionary is attached (semantics of upstream `ZSTD_c_dictIDFlag`).
+    /// Default `true`, matching upstream. Decoders can still decode the
+    /// frame by being handed the right dictionary explicitly. Set via
+    /// [`Self::set_dictionary_id_flag`].
+    dict_id_flag: bool,
     #[cfg(feature = "hash")]
     hasher: XxHash64,
     /// Block-layout introspection populated at the end of every
@@ -783,6 +795,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             },
             magicless: false,
             content_checksum: false,
+            content_size_flag: true,
+            dict_id_flag: true,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
@@ -1121,6 +1135,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             compression_level,
             magicless: false,
             content_checksum: false,
+            content_size_flag: true,
+            dict_id_flag: true,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
             #[cfg(feature = "lsm")]
@@ -1158,6 +1174,24 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// this setting.
     pub fn set_content_checksum(&mut self, emit: bool) {
         self.content_checksum = emit;
+    }
+
+    /// Enable or disable recording `Frame_Content_Size` in the frame header
+    /// when the total size is known (semantics of upstream
+    /// `ZSTD_c_contentSizeFlag`). Default `true`, matching upstream. With
+    /// the flag off the header carries a window descriptor instead (and the
+    /// single-segment layout, which requires an FCS, is disabled).
+    pub fn set_content_size_flag(&mut self, emit: bool) {
+        self.content_size_flag = emit;
+    }
+
+    /// Enable or disable recording the dictionary ID in the frame header
+    /// when a dictionary is attached (semantics of upstream
+    /// `ZSTD_c_dictIDFlag`). Default `true`, matching upstream. Frames
+    /// emitted with the flag off still decode when the decoder is handed
+    /// the dictionary explicitly.
+    pub fn set_dictionary_id_flag(&mut self, emit: bool) {
+        self.dict_id_flag = emit;
     }
 
     /// Before calling [FrameCompressor::compress] you need to set the source.
@@ -1647,15 +1681,19 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     fn append_frame_header(&self, total_uncompressed: u64, prep: &FramePrep, out: &mut Vec<u8>) {
         // Match the donor framing policy for pledged one-shot inputs: use a
         // single-segment frame whenever the source fits the active window.
-        let single_segment = !prep.use_dictionary_state
+        // A single-segment frame REQUIRES an FCS field, so suppressing the
+        // content size (`content_size_flag` off) also forces the windowed
+        // layout, mirroring upstream.
+        let single_segment = self.content_size_flag
+            && !prep.use_dictionary_state
             && prep.source_size_hint_known
             && total_uncompressed >= 512
             && total_uncompressed <= prep.window_size;
         let header = FrameHeader {
-            frame_content_size: Some(total_uncompressed),
+            frame_content_size: self.content_size_flag.then_some(total_uncompressed),
             single_segment,
             content_checksum: cfg!(feature = "hash") && self.content_checksum,
-            dictionary_id: if prep.use_dictionary_state {
+            dictionary_id: if prep.use_dictionary_state && self.dict_id_flag {
                 self.dictionary.as_ref().map(|dict| dict.inner.id as u64)
             } else {
                 None
@@ -2825,6 +2863,86 @@ mod tests {
             compressor.state.fse_tables.of_previous.is_some(),
             "dictionary entropy should seed previous of table before first block"
         );
+    }
+
+    // `set_content_size_flag(false)`: the header must omit the FCS field
+    // (and the single-segment layout that requires it) while the frame
+    // still round-trips through our decoder.
+    #[test]
+    fn content_size_flag_off_omits_fcs_and_roundtrips() {
+        let payload = alloc::vec![0x42u8; 4096];
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        let mut with_fcs = Vec::new();
+        compressor.compress_independent_frame_into(&payload, &mut with_fcs);
+
+        compressor.set_content_size_flag(false);
+        let mut without_fcs = Vec::new();
+        compressor.compress_independent_frame_into(&payload, &mut without_fcs);
+
+        let parsed_with = crate::decoding::frame::read_frame_header(with_fcs.as_slice())
+            .expect("flag-on frame header must parse")
+            .0;
+        assert_eq!(parsed_with.frame_content_size(), 4096);
+
+        let parsed_without = crate::decoding::frame::read_frame_header(without_fcs.as_slice())
+            .expect("flag-off frame header must parse")
+            .0;
+        // 0 is the decoder's "unknown content size" sentinel.
+        assert_eq!(
+            parsed_without.frame_content_size(),
+            0,
+            "FCS must be omitted with the content-size flag off"
+        );
+
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        // `decode_all_to_vec` fills existing capacity (no FCS to pre-size
+        // from with the flag off), so reserve the expected payload upfront.
+        let mut decoded = Vec::with_capacity(payload.len() + 64);
+        decoder
+            .decode_all_to_vec(&without_fcs, &mut decoded)
+            .expect("flag-off frame must decode");
+        assert_eq!(decoded, payload);
+    }
+
+    // `set_dictionary_id_flag(false)`: a dict-compressed frame must omit
+    // the dictionary ID and still decode when the dictionary is handed to
+    // the decoder explicitly.
+    #[test]
+    fn dict_id_flag_off_omits_dictionary_id_and_roundtrips() {
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"dictionary-keyed payload dictionary-keyed payload".repeat(8);
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dictionary bytes should parse");
+        compressor.set_dictionary_id_flag(false);
+        let mut frame = Vec::new();
+        compressor.compress_independent_frame_into(&payload, &mut frame);
+
+        let parsed = crate::decoding::frame::read_frame_header(frame.as_slice())
+            .expect("frame header must parse")
+            .0;
+        assert_eq!(
+            parsed.dictionary_id(),
+            None,
+            "dictionary id must be omitted with the dict-id flag off"
+        );
+
+        // With the ID omitted the decoder cannot look the dictionary up by
+        // header; hand it explicitly (the `reset_with_dict_handle` path).
+        let mut sd = crate::decoding::StreamingDecoder::new_with_dictionary_bytes(
+            frame.as_slice(),
+            dict_raw,
+        )
+        .expect("decoder must accept the dictionary");
+        let mut dec = Vec::new();
+        std::io::Read::read_to_end(&mut sd, &mut dec)
+            .expect("frame must decode with the dictionary handed explicitly");
+        assert_eq!(dec, payload);
     }
 
     // Regression test: `heap_size()` must count the retained Huffman tables

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1383,8 +1383,12 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         let mut all_blocks: Vec<u8> =
             Vec::with_capacity(initial_all_blocks_cap(prep.initial_size_hint));
         let mut block_source = ReaderBlockSource(&mut source);
-        let total_uncompressed =
-            self.run_owned_block_loop(&mut block_source, prep.initial_size_hint, false, &mut all_blocks);
+        let total_uncompressed = self.run_owned_block_loop(
+            &mut block_source,
+            prep.initial_size_hint,
+            false,
+            &mut all_blocks,
+        );
         self.uncompressed_data = Some(source);
         self.finish_frame(all_blocks, total_uncompressed, &prep);
     }

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -32,6 +32,10 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     last_error_kind: Option<ErrorKind>,
     last_error_message: Option<String>,
     frame_started: bool,
+    /// Upper bound on emitted block sizes (upstream `ZSTD_c_targetCBlockSize`
+    /// semantics; see `FrameCompressor::set_target_block_size`). `None` =
+    /// the format's 128 KiB ceiling.
+    target_block_size: Option<u32>,
     pledged_content_size: Option<u64>,
     bytes_consumed: u64,
     /// Effective strategy tag when a public-parameter
@@ -129,6 +133,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             last_error_kind: None,
             last_error_message: None,
             frame_started: false,
+            target_block_size: None,
             pledged_content_size: None,
             bytes_consumed: 0,
             strategy_override: None,
@@ -148,6 +153,21 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
     /// emitted the flag is fixed, so a late change returns an error rather
     /// than producing a header/trailer mismatch. Without the `hash` feature
     /// no checksum is emitted regardless.
+    /// Set an upper bound on emitted block sizes (upstream
+    /// `ZSTD_c_targetCBlockSize` semantics; clamped to `[1340, 131072]`).
+    /// Must be set before the first write.
+    pub fn set_target_block_size(&mut self, target: Option<u32>) -> Result<(), Error> {
+        self.ensure_open()?;
+        if self.frame_started {
+            return Err(invalid_input_error(
+                "the block-size target must be set before the first write",
+            ));
+        }
+        self.target_block_size =
+            target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+        Ok(())
+    }
+
     pub fn set_content_checksum(&mut self, emit: bool) -> Result<(), Error> {
         self.ensure_open()?;
         if self.frame_started {
@@ -499,7 +519,10 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
 
     fn block_capacity(&self) -> usize {
         let matcher_window = self.state.matcher.window_size() as usize;
-        core::cmp::max(1, core::cmp::min(matcher_window, MAX_BLOCK_SIZE as usize))
+        let ceiling = self
+            .target_block_size
+            .map_or(MAX_BLOCK_SIZE as usize, |t| t as usize);
+        core::cmp::max(1, core::cmp::min(matcher_window, ceiling))
     }
 
     fn allocate_pending_space(&mut self, block_capacity: usize) -> Vec<u8> {

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -146,16 +146,10 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         }
     }
 
-    /// Enable or disable the trailing XXH64 content checksum
-    /// (upstream `ZSTD_c_checksumFlag`). Default `false`, matching the
-    /// upstream library default (`ZSTD_c_checksumFlag = 0`). Must be called
-    /// before the first [`write`](Write::write); once the frame header is
-    /// emitted the flag is fixed, so a late change returns an error rather
-    /// than producing a header/trailer mismatch. Without the `hash` feature
-    /// no checksum is emitted regardless.
     /// Set an upper bound on emitted block sizes (upstream
-    /// `ZSTD_c_targetCBlockSize` semantics; clamped to `[1340, 131072]`).
-    /// Must be set before the first write.
+    /// `ZSTD_c_targetCBlockSize` semantics; clamped to
+    /// `[MIN_TARGET_BLOCK_SIZE, MAX_BLOCK_SIZE]`). Must be set before the
+    /// first write.
     pub fn set_target_block_size(&mut self, target: Option<u32>) -> Result<(), Error> {
         self.ensure_open()?;
         if self.frame_started {
@@ -163,10 +157,22 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                 "the block-size target must be set before the first write",
             ));
         }
-        self.target_block_size = target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+        self.target_block_size = target.map(|t| {
+            t.clamp(
+                crate::common::MIN_TARGET_BLOCK_SIZE,
+                crate::common::MAX_BLOCK_SIZE,
+            )
+        });
         Ok(())
     }
 
+    /// Enable or disable the trailing XXH64 content checksum
+    /// (upstream `ZSTD_c_checksumFlag`). Default `false`, matching the
+    /// upstream library default (`ZSTD_c_checksumFlag = 0`). Must be called
+    /// before the first [`write`](Write::write); once the frame header is
+    /// emitted the flag is fixed, so a late change returns an error rather
+    /// than producing a header/trailer mismatch. Without the `hash` feature
+    /// no checksum is emitted regardless.
     pub fn set_content_checksum(&mut self, emit: bool) -> Result<(), Error> {
         self.ensure_open()?;
         if self.frame_started {

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -163,8 +163,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                 "the block-size target must be set before the first write",
             ));
         }
-        self.target_block_size =
-            target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
+        self.target_block_size = target.map(|t| t.clamp(1340, crate::common::MAX_BLOCK_SIZE));
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Phase 6.2 slice 1 of #127: the stable advanced-parameter and streaming C API surface. The advanced dictionary attach surface (`ZSTD_CCtx_loadDictionary` / `refCDict` / `refPrefix` families) and the `ZSTD_estimate*` static-API queries follow in a second PR — the combined diff would cross the review-size threshold (~1.7k lines here already).

## Changes

**Codec (`zstd`):**
- `FrameCompressor::set_content_size_flag` / `set_dictionary_id_flag` (upstream `ZSTD_c_contentSizeFlag` / `ZSTD_c_dictIDFlag` semantics, both default on). Flag off omits the FCS field (forcing the windowed layout) or the dictionary ID; round-trip tests for both, ID-less dict frames decode via the explicit-dictionary path.

**C ABI (`c-api`), 25 new symbols:**
- **Parameters**: `ZSTD_cParam_getBounds` / `ZSTD_dParam_getBounds` (`ZSTD_bounds`, 16-byte ABI snapshot), `ZSTD_CCtx_setParameter` / `getParameter` over the full v1.5.7 stable `ZSTD_cParameter` set (sticky `CCtxParams`; 0 = auto; workers accepted but single-threaded per the issue's 6.4 deferral), `ZSTD_DCtx_setParameter` / `getParameter` (`windowLogMax`), `ZSTD_CCtx_setPledgedSrcSize`, `ZSTD_CCtx_reset` / `ZSTD_DCtx_reset` (session / parameters / both).
- **`ZSTD_compress2`**: one-shot over the sticky set, pledge validated against srcSize (`srcSize_wrong`), checksum / content-size / dict-id flags land in the frame header.
- **Streaming**: `ZSTD_inBuffer` / `ZSTD_outBuffer` (24-byte ABI snapshots), `ZSTD_createCStream` / `freeCStream` / `createDStream` / `freeDStream` (context aliases), `ZSTD_compressStream2` (continue / flush / end over a push-side `StreamingEncoder` with a pending-drain buffer), legacy `initCStream` / `compressStream` / `flushStream` / `endStream` / `initDStream`, `ZSTD_decompressStream` over `decode_from_to` with explicit frame restarts at frame boundaries, `windowLogMax` enforcement from the parsed header, and the In/Out size hints.

Notable: a reused decoder parks on its finished frame, so without the explicit per-frame restart a multi-frame stream made no forward progress and a spec-conformant caller loop hung — caught by the two-frames-back-to-back test.

## Review-round additions

- **`ZSTD_c_targetCBlockSize` is applied** (was accepted-but-inert): `FrameCompressor` / `StreamingEncoder` gained `set_target_block_size`, capping every physical block's payload at the target (raw length ≤ target bounds the compressed length, so wire blocks land at or under target + 3 header bytes — a strict form of upstream's best-effort convergence); plumbed into `ZSTD_compress2` and the streaming frame start; `MIN_TARGET_BLOCK_SIZE` names the 1340 floor.
- **Stage guards**: `ZSTD_compress2` returns `stage_wrong` while a streaming frame is in flight; `ZSTD_DCtx_setParameter` and the parameters-only `ZSTD_DCtx_reset` reject mid-frame calls.
- **`ZSTD_decompressStream` header-error classification**: truncated header keeps the need-more-input hint, malformed header surfaces the decode error (the hint with nothing consumed used to spin callers), fully-buffered skippable frames are consumed whole.
- **`D_WINDOW_LOG_MAX`** is pointer-width dependent (30 on 32-bit / 31 on 64-bit, matching the vendored header).
- **Advisory-hint reserve cap**: the owned block loop trusts a streaming size hint only up to a 64 KiB lookahead past bytes actually read (an exact one-shot length keeps the precise reservation).
- **v0.0.35 groundwork**: version bump + changelog, standing in for the release automation's release PR (its baseline diff packages the v0.0.34 tag worktree, which fails on that tree's bare path dependency; tagging v0.0.35 on a tree with the fixed manifest gives it a packageable baseline).
- Weekly npm downloads badge in the README.

## Testing

- 880 workspace tests (9 new c-api Rust tests: ABI size snapshots, bounds coverage, set/get/reset, compress2 round-trip + pledge mismatch, chunked 1 MiB streaming round-trip through 1 KiB output buffers, flush + two frames on one context, window-limit rejection, size hints)
- `c_consumer.c` extended: params section + chunked streaming round-trip through the vendored header and the drop-in link name; compiled, linked, and run green locally
- Clippy clean (workspace, `-D warnings`, both feature combos); `thumbv6m-none-eabi` check clean; doc tests green

Part of #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced sticky parameter controls for compressor/decompressor contexts
  * Streaming compression/decompression API with buffer helpers and legacy wrappers
  * One-shot compression that uses context-stored parameters
  * Options to omit frame content-size and dictionary-ID from headers
  * Configurable target block size for emitted blocks

* **Tests**
  * Expanded C-ABI and streaming round-trip tests covering parameter bounds, resets, pledged-size checks, block sizing, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
