### PR TITLE
perf(encode): allocation-free copy-mode dictionary restore

### DIFF
--- a/zstd/src/encoding/dict_attach.rs
+++ b/zstd/src/encoding/dict_attach.rs
@@ -18,7 +18,7 @@
 //! dict/input boundary, the build-once cache flag, and invalidation.
 
 /// Lifecycle holder for an attached, immutable dictionary table of type `T`.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub(crate) struct DictAttach<T> {
     /// The immutable dictionary table, built once over the dictionary region.
     /// `Some` activates the backend's dual-probe kernel; `None` means no dict
@@ -34,6 +34,24 @@ pub(crate) struct DictAttach<T> {
     /// per-frame `reset` and skips the re-hash. Cleared on parameter change,
     /// history eviction, or dictionary attach/clear via [`Self::invalidate`].
     primed: bool,
+}
+
+impl<T: Clone> Clone for DictAttach<T> {
+    fn clone(&self) -> Self {
+        Self {
+            table: self.table.clone(),
+            region_len: self.region_len,
+            primed: self.primed,
+        }
+    }
+
+    // Recurse into the table's `clone_from` (via `Option::clone_from`) so
+    // snapshot restores reuse the retained table buffers.
+    fn clone_from(&mut self, source: &Self) {
+        self.table.clone_from(&source.table);
+        self.region_len = source.region_len;
+        self.primed = source.primed;
+    }
 }
 
 impl<T> DictAttach<T> {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2045,12 +2045,35 @@ impl Matcher for MatchGeneratorDriver {
                     && self
                         .reset_size_log
                         .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
+                // Copy-mode dictionary frame whose primed snapshot matches
+                // this exact resolved shape: `restore_primed_dictionary`
+                // (called right after this reset; the caller gates the
+                // restore on the same size bucket and the restore re-checks
+                // the same key) will `clone_from` the snapshot over this
+                // matcher, replacing the table contents and bias wholesale —
+                // the reset's full-table memset would be thrown away. The
+                // key components mirror `reset_shape` below: Simple leaves
+                // `resolved_table_bits` 0, never carries an LDM override,
+                // and `fast_attach` is false in copy mode by construction.
+                let table_overwritten_by_restore = matches!(dict_hint, Some(size) if size > 0)
+                    && !dict_attach_epoch
+                    && self.primed.as_ref().is_some_and(|(_, _, captured)| {
+                        *captured
+                            == PrimedKey {
+                                level,
+                                params,
+                                table_bits: 0,
+                                fast_attach: false,
+                                ldm: None,
+                            }
+                    });
                 m.reset(
                     params.window_log,
                     fast.hash_log,
                     fast.mls,
                     fast.step_size,
                     dict_attach_epoch,
+                    table_overwritten_by_restore,
                 );
             }
             MatcherStorage::Dfast(dfast) => {
@@ -2411,40 +2434,57 @@ impl Matcher for MatchGeneratorDriver {
             fast_attach,
             ldm,
         };
-        let (mut storage, budget) = match &self.primed {
-            Some((storage, budget, captured_key)) if *captured_key == key => {
-                (storage.clone(), *budget)
-            }
-            _ => return false,
+        let Some((snapshot, budget, captured_key)) = &self.primed else {
+            return false;
         };
-        // A binary-tree snapshot is stored WITHOUT its live hash / chain / hash3
-        // tables (they hold no dictionary entries — the dict lives in `dms` +
-        // history; see `capture_primed_dictionary`). Re-allocate them zeroed to
-        // the snapshot's geometry, exactly reproducing the post-prime state (all
-        // `HC_EMPTY`). This is a full storage replace, so no stale live-table
-        // entry from a prior frame can survive — `ensure_tables` only allocates
-        // when the length mismatches, so a full (HC / non-BT) snapshot whose
-        // tables are already present is left untouched.
-        if let MatcherStorage::HashChain(hc) = &mut storage {
-            hc.table.ensure_tables();
+        if *captured_key != key {
+            return false;
         }
-        // The snapshot does not retain the LDM producer (it holds no dict state;
-        // see `capture_primed_dictionary`). Carry over the frame's freshly-reset
-        // producer — built this frame by `reset` with the same params the
-        // snapshot key pins, and empty (no input processed yet), so it is
-        // equivalent to the producer the snapshot was captured with.
-        #[cfg(feature = "hash")]
-        {
-            let fresh_ldm = if let MatcherStorage::HashChain(hc) = &mut self.storage {
-                hc.take_ldm_producer()
-            } else {
-                None
-            };
-            if let MatcherStorage::HashChain(hc) = &mut storage {
-                hc.set_ldm_producer(fresh_ldm);
+        let budget = *budget;
+        match (&mut self.storage, snapshot) {
+            // Same-variant Fast restore: copy the snapshot into the retained
+            // live storage. `clone_from` reuses the history / hash-table /
+            // dict-table buffers, so this is the donor CDict table-copy
+            // regime's cost (pure copies) instead of a full per-frame
+            // allocation + copy + drop cycle.
+            (MatcherStorage::Simple(live), MatcherStorage::Simple(snap)) => {
+                live.clone_from(snap);
+            }
+            (live, snapshot_storage) => {
+                let mut storage = snapshot_storage.clone();
+                // A binary-tree snapshot is stored WITHOUT its live hash /
+                // chain / hash3 tables (they hold no dictionary entries — the
+                // dict lives in `dms` + history; see
+                // `capture_primed_dictionary`). Re-allocate them zeroed to the
+                // snapshot's geometry, exactly reproducing the post-prime
+                // state (all `HC_EMPTY`). This is a full storage replace, so
+                // no stale live-table entry from a prior frame can survive —
+                // `ensure_tables` only allocates when the length mismatches,
+                // so a full (HC / non-BT) snapshot whose tables are already
+                // present is left untouched.
+                if let MatcherStorage::HashChain(hc) = &mut storage {
+                    hc.table.ensure_tables();
+                }
+                // The snapshot does not retain the LDM producer (it holds no
+                // dict state; see `capture_primed_dictionary`). Carry over the
+                // frame's freshly-reset producer — built this frame by `reset`
+                // with the same params the snapshot key pins, and empty (no
+                // input processed yet), so it is equivalent to the producer
+                // the snapshot was captured with.
+                #[cfg(feature = "hash")]
+                {
+                    let fresh_ldm = if let MatcherStorage::HashChain(hc) = live {
+                        hc.take_ldm_producer()
+                    } else {
+                        None
+                    };
+                    if let MatcherStorage::HashChain(hc) = &mut storage {
+                        hc.set_ldm_producer(fresh_ldm);
+                    }
+                }
+                *live = storage;
             }
         }
-        self.storage = storage;
         self.dictionary_retained_budget = budget;
         true
     }

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -53,7 +53,6 @@ const PRIME_8_BYTES: u64 = 0xCF1BBCDCB7A56463;
 /// initial prefix (where the `+= (ip0 == prefixStart)` adjustment at
 /// loop entry skips it) or is below `prefixStartIndex` and filtered by
 /// the in-range check.
-#[derive(Clone)]
 pub(crate) struct FastHashTable {
     table: Vec<u32>,
     /// Donor `hash_log` — number of bits the hash output is reduced to.
@@ -73,6 +72,28 @@ pub(crate) struct FastHashTable {
     /// ([`Self::hot_state`] — the no-dict kernels) and on cached dict
     /// tables; only the dict-attach main table advances it.
     bias: u32,
+}
+
+impl Clone for FastHashTable {
+    fn clone(&self) -> Self {
+        Self {
+            table: self.table.clone(),
+            hash_log: self.hash_log,
+            mls: self.mls,
+            bias: self.bias,
+        }
+    }
+
+    // Real buffer reuse: the per-frame dictionary snapshot restore
+    // `clone_from`s the whole matcher, and the table is its dominant
+    // allocation — copying into the retained buffer avoids a fresh
+    // table-sized allocation per frame.
+    fn clone_from(&mut self, source: &Self) {
+        self.table.clone_from(&source.table);
+        self.hash_log = source.hash_log;
+        self.mls = source.mls;
+        self.bias = source.bias;
+    }
 }
 
 impl FastHashTable {

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1790,6 +1790,51 @@ mod tests {
         assert_eq!(m.max_window_size, 1usize << 16);
     }
 
+    // The copy-mode restore fast path: a same-shape reset with
+    // `table_overwritten_by_restore` must leave the table contents
+    // untouched (the snapshot restore replaces them right after), while
+    // the plain same-shape reset must memset them. Guards against a
+    // refactor silently reintroducing the wasted per-frame clear — or,
+    // worse, dropping the clear on the plain path.
+    #[test]
+    fn reset_keeps_table_when_overwritten_by_restore() {
+        let mut m = FastKernelMatcher::new();
+        m.reset(16, 10, 4, 2, false, false);
+        let probe_hash = 7u32;
+        // SAFETY: hash 7 < (1 << hash_log = 1024) table entries.
+        unsafe { m.hash_table.put(probe_hash, 0xCAFE) };
+
+        // Same shape + restore-pending: contents survive the reset.
+        m.reset(16, 10, 4, 2, false, true);
+        // SAFETY: same bounds as the put above.
+        assert_eq!(
+            unsafe { m.hash_table.get(probe_hash) },
+            0xCAFE,
+            "restore-pending reset must not clear the table"
+        );
+
+        // Plain same-shape reset: contents are memset back to empty.
+        m.reset(16, 10, 4, 2, false, false);
+        // SAFETY: same bounds as the put above.
+        assert_eq!(
+            unsafe { m.hash_table.get(probe_hash) },
+            0,
+            "plain reset must clear the table"
+        );
+
+        // Shape change overrides the flag: the table is rebuilt at the
+        // new geometry even when a restore is claimed to be pending.
+        unsafe { m.hash_table.put(probe_hash, 0xCAFE) };
+        m.reset(16, 11, 4, 2, false, true);
+        assert_eq!(m.hash_table.hash_log(), 11);
+        // SAFETY: hash 7 < (1 << 11) table entries.
+        assert_eq!(
+            unsafe { m.hash_table.get(probe_hash) },
+            0,
+            "shape change must rebuild the table regardless of the flag"
+        );
+    }
+
     /// Drive the matcher through a single block whose tail contains
     /// a repeated 4-byte run — the kernel must emit at least one
     /// `Sequence::Triple` with `match_len >= 4` and the bookkeeping

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -138,7 +138,6 @@ const INITIAL_PREFIX_START_INDEX: u32 = 1;
 ///   across blocks (cleared only on full `reset`).
 /// - `pending` holds the most recently `commit_space`'d block before
 ///   `start_matching` appends it onto `history` and runs the kernel.
-#[derive(Clone)]
 pub(crate) struct FastKernelMatcher {
     /// Concatenated input history: prior-block bytes followed by the
     /// most-recently-committed (still pending-matching) tail.
@@ -255,6 +254,52 @@ pub(crate) struct FastKernelMatcher {
     table_pos_high_water: usize,
 }
 
+impl Clone for FastKernelMatcher {
+    fn clone(&self) -> Self {
+        Self {
+            history: self.history.clone(),
+            prefix_start_index: self.prefix_start_index,
+            rep: self.rep,
+            offset_hist: self.offset_hist,
+            hash_table: self.hash_table.clone(),
+            max_window_size: self.max_window_size,
+            window_log: self.window_log,
+            use_cmov: self.use_cmov,
+            step_size: self.step_size,
+            pending: self.pending.clone(),
+            last_block_start: self.last_block_start,
+            recycled_space: self.recycled_space.clone(),
+            borrowed: self.borrowed,
+            last_borrowed_block: self.last_borrowed_block,
+            dict: self.dict.clone(),
+            table_pos_high_water: self.table_pos_high_water,
+        }
+    }
+
+    // The per-frame dictionary snapshot restore `clone_from`s this whole
+    // matcher; reusing the retained `history` / hash-table / dict-table
+    // buffers turns that restore into pure copies (no allocations), which
+    // is what the donor's CDict table-copy regime pays.
+    fn clone_from(&mut self, source: &Self) {
+        self.history.clone_from(&source.history);
+        self.prefix_start_index = source.prefix_start_index;
+        self.rep = source.rep;
+        self.offset_hist = source.offset_hist;
+        self.hash_table.clone_from(&source.hash_table);
+        self.max_window_size = source.max_window_size;
+        self.window_log = source.window_log;
+        self.use_cmov = source.use_cmov;
+        self.step_size = source.step_size;
+        self.pending.clone_from(&source.pending);
+        self.last_block_start = source.last_block_start;
+        self.recycled_space.clone_from(&source.recycled_space);
+        self.borrowed = source.borrowed;
+        self.last_borrowed_block = source.last_borrowed_block;
+        self.dict.clone_from(&source.dict);
+        self.table_pos_high_water = source.table_pos_high_water;
+    }
+}
+
 impl FastKernelMatcher {
     /// Test-only zero-arg constructor that bakes in the donor's
     /// level-1 defaults. Production code goes through
@@ -367,6 +412,12 @@ impl FastKernelMatcher {
         mls: u32,
         step_size: usize,
         dict_attach_epoch: bool,
+        // The caller (driver) has a primed-snapshot whose key matches this
+        // exact reset shape and WILL `clone_from` it over this matcher
+        // right after the reset (the copy-mode dictionary restore). The
+        // table contents and epoch bias are about to be replaced
+        // wholesale, so the full-table memset here would be pure waste.
+        table_overwritten_by_restore: bool,
     ) {
         assert!(
             step_size >= 2,
@@ -378,7 +429,13 @@ impl FastKernelMatcher {
             window_log <= 30,
             "FastKernelMatcher requires window_log <= 30 (got {window_log})"
         );
-        if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
+        if table_overwritten_by_restore
+            && self.hash_table.hash_log() == hash_log
+            && self.hash_table.mls() == mls
+        {
+            // Leave the table untouched: the snapshot restore copies the
+            // primed contents (and bias) over it immediately after.
+        } else if self.hash_table.hash_log() != hash_log || self.hash_table.mls() != mls {
             // Parameters changed — rebuild the table at the new size.
             // Cannot reuse the old allocation because the hash table
             // dimensions are baked in at construction. A reshape also
@@ -1559,6 +1616,7 @@ mod tests {
             FAST_LEVEL_1_MLS,
             2,
             false,
+            false,
         );
         // After reset the borrowed window is dropped — back to the
         // (now empty) owned buffer, never the dangling external range.
@@ -1702,6 +1760,7 @@ mod tests {
             FAST_LEVEL_1_MLS,
             2,
             false,
+            false,
         );
 
         // Post-reset: history empty (HISTORY_DRAIN_BASE=0; no
@@ -1724,7 +1783,7 @@ mod tests {
         let mut m = FastKernelMatcher::new();
         // Force a parameter change — every Vec we hand the new
         // FastHashTable will be a fresh allocation.
-        m.reset(16, 10, 4, 2, false);
+        m.reset(16, 10, 4, 2, false, false);
         assert_eq!(m.hash_table.hash_log(), 10);
         assert_eq!(m.hash_table.mls(), 4);
         assert_eq!(m.window_log, 16);


### PR DESCRIPTION
## Summary

Dashboard outsider: x86_64-musl `small-10k-random` compress-dict level_-7_fast at 0.1686 (−83.14%).

Sources in the 8..16 KiB bucket take the donor's dictionary COPY regime (`attachDictSizeCutoffs`: fast 8 KiB). Our per-frame snapshot restore implemented that copy as `storage.clone()` — a fresh history + hash-table + dict-table allocation set per frame, copied, with the old set dropped — and the reset that ran just before it memset the live table the restore immediately overwrote. glibc absorbs the malloc/free churn; musl mallocng pays full price (the musl-only signature: gnu wall was already near-neutral).

## Changes

- **Manual `Clone` with real `clone_from`** for `FastKernelMatcher` / `FastHashTable` / `DictAttach`: the restore copies the snapshot into the retained live buffers — the donor CDict table-copy regime's actual cost (pure copies, zero allocations).
- **`restore_primed_dictionary`** dispatches same-variant `Simple` restores through `clone_from`; other backends keep the existing full-clone path (their copy economics are separate tracks).
- **Reset memset elision**: the driver's Fast reset skips the full-table clear when a primed snapshot matching the exact resolved shape is about to be restored — the same key the restore re-checks, and the gate (`dict_hint` set only under `use_dictionary_state`, the same ceil-log bucket and cutoff on both sides) makes the skip fire exactly when the copy follows. The copy supplies both the contents and the epoch bias.

## Results (i9, tight consecutive A/B pairs, nice −10, 300k frames of 10 KiB + 1280 B dict at L−7)

| Target | main | branch | Δ |
|---|---|---|---|
| **musl** | 9.28 s | 3.63 s | **−61% (2.6×)** |
| gnu | 3.55 s | 3.57 s | neutral |

musl now sits at gnu's wall time — the allocator-amplified gap is gone. Output bytes unchanged (sum-compare on the target fixture + a dfast dict case; 829 tests incl. cross-validation). dhat: zero steady-state allocations per frame on the copy-restore path.

## Testing

- `cargo nextest run -p structured-zstd --features dict_builder`: 829 passed
- Clippy clean on default and `--no-default-features --features std`; `thumbv6m-none-eabi` check clean
- i9 wall-clock pairs above; byte-identity verified on two fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved snapshot restore and cloning to preserve existing buffers and reuse allocations, reducing needless reinitialization.
  * Optimized table reset behavior to skip redundant clearing when a subsequent restore will overwrite contents, improving performance and consistency.

* **Tests**
  * Added/updated tests to verify conditional table preservation and correct restore semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->