### PR TITLE
build(c-api): add version requirement to the codec path dependency

### DIFF
--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -39,4 +39,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 # Default features pull in std + hash (checksums/LDM) + the per-CPU kernel
 # tiers — the C ABI is a host library, so std is always available here.
 # `dict_builder` adds the dictionary-training surface backing the ZDICT_* C API.
-codec = { path = "../zstd", package = "structured-zstd", features = ["dict_builder"] }
+# The version requirement accompanies the path so `cargo package` can verify
+# this manifest (release-plz packages the workspace; a bare `path` dependency
+# fails its "all dependencies must have a version requirement" check even for
+# publish = false members).
+codec = { path = "../zstd", version = "0.0", package = "structured-zstd", features = ["dict_builder"] }


### PR DESCRIPTION
## Summary

`release-plz release-pr` fails on main: its `cargo package` verification of the workspace rejects `c-api`'s bare `path` dependency on `structured-zstd` ("all dependencies must have a version requirement specified when packaging").

## Changes

Add a loose `version = "0.0"` alongside the path, matching the `cli` (`"0.0"`) and `wasm` (`"0"`) members' style, with a comment explaining why the requirement must accompany the path even for a `publish = false` member.

## Testing

`cargo package -p structured-zstd` (the failing release-plz step) now passes verification locally; `cargo check --workspace` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency management update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->