### PR TITLE
perf(decode): exact window reservations + single-segment dictionary frames

### DIFF
--- a/zstd/examples/decode_loop_dict.rs
+++ b/zstd/examples/decode_loop_dict.rs
@@ -16,9 +16,19 @@
 
 use std::env;
 
+// With `--features dhat-heap`, route allocations through the dhat heap
+// profiler (same pattern as `encode_loop_dict`) for per-call-site
+// allocation counts + peak attribution. Writes `dhat-heap.json` on drop.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 use structured_zstd::decoding::{DictionaryHandle, FrameDecoder};
 
 fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let args: Vec<String> = env::args().collect();
     let iters: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(500_000);
     let payload_path = args

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -323,6 +323,16 @@ pub(crate) trait BufferBackend: Sized {
     /// May or may not allocate depending on current free space.
     fn reserve(&mut self, n: usize);
 
+    /// Like [`Self::reserve`], but growth is sized to the request instead
+    /// of the amortized-doubling policy. For the one-shot window
+    /// pre-reservation: a request that lands one slack past the retained
+    /// capacity (e.g. a dictionary prefix already in the buffer) would
+    /// otherwise DOUBLE a window-sized allocation. Per-block growth keeps
+    /// using `reserve` so streaming paths stay amortized.
+    fn reserve_exact(&mut self, n: usize) {
+        self.reserve(n);
+    }
+
     /// Fallible variant of [`Self::reserve`] for fixed-capacity
     /// backends. Growable backends (`FlatBuf`, `RingBuffer`) call
     /// `reserve` which always succeeds (or aborts on alloc failure)

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -280,17 +280,11 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         true
     }
 
-    /// Pre-allocate capacity for `amount` additional bytes.
-    ///
-    /// Call this before a batch of `push`/`repeat` operations to avoid
-    /// repeated re-allocations inside the hot decode loop.
-    #[inline]
-    pub fn reserve(&mut self, amount: usize) {
-        self.buffer.reserve(amount);
-    }
-
-    /// Exact-growth variant of [`Self::reserve`] for the one-shot window
-    /// pre-reservation (see `BufferBackend::reserve_exact`).
+    /// Pre-allocate capacity for `amount` additional bytes ahead of a batch
+    /// of `push`/`repeat` operations, growing exactly (see
+    /// `BufferBackend::reserve_exact`): every call site is a one-shot
+    /// window-scale reservation where amortized doubling would hold up to
+    /// 2x the window.
     #[inline]
     pub fn reserve_exact(&mut self, amount: usize) {
         self.buffer.reserve_exact(amount);
@@ -1208,7 +1202,7 @@ mod tests {
         // Mirror the fused sequence executor: reserve upfront so no
         // RingBuffer reallocation happens between checkpoint and restore
         // (restore_checkpoint requires a stable underlying allocation).
-        buf.reserve(64);
+        buf.reserve_exact(64);
         buf.push(&[1, 2, 3]);
         let cp = buf.checkpoint();
         buf.push(&[4, 5, 6, 7]);
@@ -1248,7 +1242,7 @@ mod tests {
         // Force a reallocation. RingBuffer grows by powers of two and
         // 4 MiB is well above the initial 64-byte starting capacity, so
         // reserve() must hit reserve_amortized().
-        buf.reserve(4 * 1024 * 1024);
+        buf.reserve_exact(4 * 1024 * 1024);
         buf.push(&[0; 16]);
         assert!(
             !buf.try_restore_checkpoint(cp),
@@ -1630,7 +1624,7 @@ mod tests {
         // Prefetch hints are unobservable from Rust — the assertion is
         // simply that the call completes without panic / UB.
         let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
-        buf.reserve(512);
+        buf.reserve_exact(512);
         buf.push(&[0xAA; 256]);
         buf.prefetch_lookahead_match_source(0);
         buf.prefetch_lookahead_match_source(128);
@@ -1644,7 +1638,7 @@ mod tests {
         // The helper must early-return (bound check) and never touch a
         // slice past the live region.
         let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
-        buf.reserve(64);
+        buf.reserve_exact(64);
         buf.push(&[0x55; 32]);
         buf.prefetch_lookahead_match_source(buf.len());
         buf.prefetch_lookahead_match_source(buf.len() + 1);

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -289,6 +289,13 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.reserve(amount);
     }
 
+    /// Exact-growth variant of [`Self::reserve`] for the one-shot window
+    /// pre-reservation (see `BufferBackend::reserve_exact`).
+    #[inline]
+    pub fn reserve_exact(&mut self, amount: usize) {
+        self.buffer.reserve_exact(amount);
+    }
+
     /// Mutable backend handle. Lets the inline sequence executor
     /// write straight into the backend's physical storage; the
     /// `tail()` cursor on the backend is the authoritative output

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -378,6 +378,18 @@ impl BufferBackend for FlatBuf {
     }
 
     #[inline]
+    fn reserve_exact(&mut self, n: usize) {
+        // Same contract as `reserve` (n additional + wildcopy slack), but
+        // exact growth: the window pre-reservation must not double a
+        // window-sized buffer when a dictionary prefix already occupies
+        // part of the retained capacity.
+        let additional = n
+            .checked_add(WILDCOPY_OVERLENGTH)
+            .expect("FlatBuf::reserve_exact amount + wildcopy slack overflows usize");
+        self.buf.reserve_exact(additional);
+    }
+
+    #[inline]
     fn set_max_capacity(&mut self, max_capacity: usize) {
         self.max_capacity = max_capacity;
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -516,9 +516,14 @@ impl DecoderScratchKind {
     /// under-reserves on reused buffers (see `FlatBuf::reserve`).
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
+        // Exact growth: this is the one-shot pre-reservation, and a request
+        // landing one slack past the retained capacity (e.g. a dictionary
+        // prefix already loaded into the buffer) must not DOUBLE a
+        // window-sized allocation through the amortized policy. Per-block
+        // growth keeps the amortized `reserve`.
         match self {
-            Self::Ring(s) => s.buffer.reserve(window_size),
-            Self::Flat(s) => s.buffer.reserve(window_size),
+            Self::Ring(s) => s.buffer.reserve_exact(window_size),
+            Self::Flat(s) => s.buffer.reserve_exact(window_size),
         }
     }
 
@@ -2314,7 +2319,17 @@ impl FrameDecoder {
             // > 128 KiB otherwise grows through several intermediate
             // sizes with `alloc_zeroed + memcpy` each time).
             if let Some(state) = self.state.as_mut() {
-                state.decoder_scratch.reserve_buffer(window_size as usize);
+                // A declared content size caps the useful window: matches
+                // can never reference further back than the bytes that will
+                // ever exist, so an encoder-declared window above the FCS
+                // (e.g. a level-preset window on a smaller input) must not
+                // inflate the reservation.
+                let useful_window = if fcs_declared {
+                    window_size.min(content_size)
+                } else {
+                    window_size
+                };
+                state.decoder_scratch.reserve_buffer(useful_window as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {
@@ -2446,7 +2461,17 @@ impl FrameDecoder {
             // `window_size` once so the per-block growth cycle is
             // skipped (see same comment on the no-lsm path above).
             if let Some(state) = self.state.as_mut() {
-                state.decoder_scratch.reserve_buffer(window_size as usize);
+                // A declared content size caps the useful window: matches
+                // can never reference further back than the bytes that will
+                // ever exist, so an encoder-declared window above the FCS
+                // (e.g. a level-preset window on a smaller input) must not
+                // inflate the reservation.
+                let useful_window = if fcs_declared {
+                    window_size.min(content_size)
+                } else {
+                    window_size
+                };
+                state.decoder_scratch.reserve_buffer(useful_window as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -158,7 +158,13 @@ where
         "sequence section update bits exceed 56-bit budget"
     );
 
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Exact growth: this worst-case pre-block reservation is a no-op while
+    // the frame-entry window reservation covers it, and on the frame's LAST
+    // block (where the remaining content is smaller than a full block) the
+    // amortized policy would DOUBLE the window-sized buffer for a tail
+    // worth a fraction of a block. The ring backend keeps its own
+    // amortized growth via the trait default.
+    buffer.reserve_exact(MAX_BLOCK_SIZE as usize);
     // Arm the per-block output ceiling so a malformed / adversarial block
     // whose sequences over-produce cannot grow the buffer past
     // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1712,8 +1712,12 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     fn append_frame_header(&self, total_uncompressed: u64, prep: &FramePrep, out: &mut Vec<u8>) {
         // Match the donor framing policy for pledged one-shot inputs: use a
         // single-segment frame whenever the source fits the active window.
-        let single_segment = !prep.use_dictionary_state
-            && prep.source_size_hint_known
+        // Dictionary frames qualify too (the reference emits
+        // single-segment + dictionary-ID headers): the dictionary is decoder
+        // setup state, not part of the regenerated segment, and dropping the
+        // window descriptor lets decoders size their buffer from the FCS
+        // instead of the level's (often much larger) preset window.
+        let single_segment = prep.source_size_hint_known
             && total_uncompressed >= 512
             && total_uncompressed <= prep.window_size;
         let header = FrameHeader {
@@ -2928,6 +2932,45 @@ mod tests {
             .decode_all_to_vec(&out, &mut decoded)
             .expect("frame must decode");
         assert_eq!(decoded, input);
+    }
+
+    // A dictionary frame with a known content size that fits the window
+    // must take the single-segment layout (reference parity): the window
+    // descriptor would otherwise advertise the level's preset window and
+    // decoders would size their buffers from it instead of the FCS.
+    #[test]
+    fn dict_frame_with_known_size_is_single_segment() {
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"dictionary-keyed payload dictionary-keyed payload".repeat(64);
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dictionary bytes should parse");
+        let mut frame = Vec::new();
+        compressor.compress_independent_frame_into(&payload, &mut frame);
+
+        let parsed = crate::decoding::frame::read_frame_header(frame.as_slice())
+            .expect("frame header must parse")
+            .0;
+        assert!(
+            parsed.descriptor.single_segment_flag(),
+            "dict frame with known size <= window must be single-segment"
+        );
+        assert!(parsed.dictionary_id().is_some());
+        assert_eq!(parsed.frame_content_size(), payload.len() as u64);
+
+        // Round-trip through our own decoder with the dictionary.
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        decoder
+            .add_dict_from_bytes(dict_raw)
+            .expect("decoder must accept the dictionary");
+        let mut decoded = Vec::with_capacity(payload.len() + 64);
+        decoder
+            .decode_all_to_vec(&frame, &mut decoded)
+            .expect("single-segment dict frame must decode");
+        assert_eq!(decoded, payload);
     }
 
     // Regression test: `heap_size()` must count the retained Huffman tables


### PR DESCRIPTION
## Summary

Dashboard memory outsiders: `decodecorpus-z000033` decompress-dict `level_22_btultra2_ldm` rust_stream at **3.66× the reference peak** on i686-gnu / x86_64-gnu / x86_64-musl alike.

Two compounding causes:

1. **Amortized doubling on window-scale reservations.** The sequence decoder's worst-case pre-block `reserve(MAX_BLOCK_SIZE)` lands on the frame's LAST block with the buffer one block short — the amortized policy then DOUBLES the window-sized FlatBuf: a 1 MiB dictionary frame held a 2 MiB buffer for a 112 KiB tail.
2. **Dictionary frames never took the single-segment layout** (`!use_dictionary_state` in the header builder, with no recorded rationale — the reference emits single-segment + dictionary-ID headers for the same input). Our dict frames carried a window descriptor with the level's preset window (2 MiB at L22 for a 1 MiB input), and decoders sized their buffers from it.

## Changes

- `BufferBackend::reserve_exact` (FlatBuf exact growth; the ring keeps its own amortized policy via the trait default): the frame-entry window pre-reservation and the sequence decoder's pre-block reservation grow exactly. Per-block growth elsewhere stays amortized.
- The non-direct path clamps the window reservation to the declared content size (matches can never reference further back than the bytes that will ever exist).
- Dictionary frames with a known content size that fits the window take the single-segment layout (reference parity); round-trip + header-shape tests.
- `DecodeBuffer::reserve` folded into the exact variant (no remaining users).

## Results (i9, compare_ffi_memory)

| Cell (decompress) | main | branch | vs C |
|---|---|---|---|
| z000033 L22 ldm_dict rust_stream | 4.25 MB | **2.23 MB** | 3.66× → **1.92×** |
| z000033 L22 ldm_dict c_stream | 3.17 MB | 2.23 MB | 2.73× → 1.92× |
| small-4k / small-10k ldm_dict rust_stream | 325 KB | 161-177 KB | 2.4-2.5× → **1.26-1.31×** |

decode_loop_dict on the L22 ldm+dict frame: decoder workspace 2.08 → 1.04 MiB.

The residual 1.92× on the 1 MiB cell is the dictionary frames' exclusion from the direct decode path (the reference writes straight into dst; we stage through the window buffer) — the ext-dict direct-decode branch is the follow-up PR of this track.

## Testing

- 832 tests (new: single-segment dict-frame header shape + round-trip), incl. cross-validation (FFI decodes our new dict-frame headers)
- Clippy both combos, fmt, thumbv6m — clean