### PR TITLE
perf(decode): route dictionary frames through the direct decode path

### DIFF
--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -798,21 +798,16 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
-        // `total_output_counter` gate: dict-source matches are only
-        // valid while the dictionary content is still inside the
-        // visible window. On the inline-exec path
-        // (`UserSliceBackend`) `total_output_counter` is NOT
-        // maintained — it stays at 0 — so the gate is trivially
-        // satisfied. This does NOT cause incorrect behavior on that
-        // path because `dict_content` is always empty for the direct
-        // decode entry (`run_direct_decode`'s
-        // `DecodeBuffer::from_backend` initializes it to empty), so
-        // `bytes_from_dict > self.dict_content.len()` below catches
-        // every would-be dict-source match and returns
-        // `NotEnoughBytesInDictionary`. The
-        // `RingBuffer` / `FlatBuf` paths still maintain the counter
-        // via `push` / `repeat_inner` and rely on it correctly.
-        if self.total_output_counter <= self.window_size as u64 {
+        // Reachability gate: dict-source matches are only valid while
+        // the dictionary content is still inside the visible window.
+        // `RingBuffer` / `FlatBuf` maintain `total_output_counter`
+        // (push / repeat / inline-exec counter bump). On the direct
+        // path (`UserSliceBackend`) the inline executor skips the
+        // counter, but the backend never drains (`head` stays 0), so
+        // `buffer.len()` IS the cumulative output — take the max of
+        // the two so the gate is accurate for every backend.
+        let total_output = self.total_output_counter.max(self.buffer.len() as u64);
+        if total_output <= self.window_size as u64 {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -2262,19 +2262,20 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_inline` returns
             // `Result<(), ExecuteSequencesError>` instead of
             // panicking on capacity overflow; the error propagates
-            // up as `FrameDecoderError`. Eligibility (FCS > 0, no
-            // active dict, remaining `output` slice has WILDCOPY
-            // slack) puts the frame on the fast path that bypasses
-            // the FlatBuf/Ring -> `read()` drain copy. Ineligible
-            // frames (no FCS, active dict, output too small for
-            // slack) fall through to the legacy `decode_blocks` +
-            // `read` drain loop below.
-            let (content_size, fcs_declared, dict_active, window_size) = {
+            // up as `FrameDecoderError`. Eligibility (FCS > 0,
+            // remaining `output` slice holds the declared content)
+            // puts the frame on the fast path that bypasses the
+            // FlatBuf/Ring -> `read()` drain copy. Ineligible frames
+            // (no FCS, output too small) fall through to the legacy
+            // `decode_blocks` + `read` drain loop below. Dictionary
+            // frames are eligible: `run_direct_decode` hands the
+            // shared dict handle to its buffer, and beyond-prefix
+            // offsets resolve through `repeat_from_dict`.
+            let (content_size, fcs_declared, window_size) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.using_dict.is_some(),
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
@@ -2294,8 +2295,7 @@ impl FrameDecoder {
             // that the spec relies on for `offset <= window_size`
             // validation. Path choice no longer alters checksum
             // semantics.
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
+            let direct_eligible = content_size > 0 && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -2409,19 +2409,18 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_inline` returns
             // `Result<(), ExecuteSequencesError>` instead of
             // panicking on capacity overflow; the error propagates
-            // up as `FrameDecoderError`. Eligibility (FCS > 0, no
-            // active dict, remaining `output` slice has WILDCOPY
-            // slack) puts the frame on the fast path that bypasses
-            // the FlatBuf/Ring -> `read()` drain copy. Ineligible
-            // frames (no FCS, active dict, output too small for
-            // slack) fall through to the legacy `decode_blocks` +
-            // `read` drain loop below.
-            let (content_size, fcs_declared, dict_active, window_size) = {
+            // up as `FrameDecoderError`. Eligibility (FCS > 0,
+            // remaining `output` slice holds the declared content)
+            // puts the frame on the fast path that bypasses the
+            // FlatBuf/Ring -> `read()` drain copy. Ineligible frames
+            // (no FCS, output too small) fall through to the legacy
+            // `decode_blocks` + `read` drain loop below. Dictionary
+            // frames are eligible (see the no-lsm path above).
+            let (content_size, fcs_declared, window_size) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.using_dict.is_some(),
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
@@ -2430,8 +2429,7 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_bounded`, so no
             // `WILDCOPY_OVERLENGTH` trailing slack is required (see the
             // no-lsm path above).
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
+            let direct_eligible = content_size > 0 && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -2559,8 +2557,11 @@ impl FrameDecoder {
     ///   trailing slack is required: the trailing sequence(s) take the
     ///   bounded (non-overshooting) copy in
     ///   [`UserSliceBackend::exec_sequence_bounded`].
-    /// - No active dictionary
-    ///   (`self.state.using_dict.is_none()`).
+    ///
+    /// Dictionary frames are supported: the scratch buffer's shared
+    /// dict handle is forwarded to the stack-local `DecodeBuffer`, so
+    /// offsets reaching past the frame's own output resolve through
+    /// `repeat_from_dict` (the ext-dict slow path).
     ///
     /// On return, `input` points at the byte immediately after the
     /// frame's checksum (or after the last block, when the frame
@@ -2590,7 +2591,7 @@ impl FrameDecoder {
         // fields; only `buffer` differs and we don't use that here.
         // Macro-style binding avoids the closure / generic
         // gymnastics of returning multiple `&mut` from a match arm.
-        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size) =
+        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size, dict) =
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => (
                     &mut s.huf,
@@ -2599,6 +2600,7 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
+                    s.buffer.dict.clone(),
                 ),
                 DecoderScratchKind::Ring(s) => (
                     &mut s.huf,
@@ -2607,10 +2609,21 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
+                    s.buffer.dict.clone(),
                 ),
             };
         let backend = UserSliceBackend::from_slice(output);
-        let buffer = DecodeBuffer::from_backend(backend, window_size);
+        let mut buffer = DecodeBuffer::from_backend(backend, window_size);
+        // Dictionary matches on the direct path: hand the shared handle
+        // (refcount bump, no copy) to the stack-local buffer so offsets
+        // reaching past the frame's own output resolve through
+        // `repeat_from_dict` — the same ext-dict slow path the
+        // FlatBuf/Ring backends use. The per-sequence hot path is
+        // untouched: the inline-exec dispatch already routes
+        // beyond-prefix offsets to the cold `repeat()` fallback.
+        if let Some(handle) = dict {
+            buffer.set_dict(handle);
+        }
         let mut direct = DirectScratch {
             huf,
             fse,
@@ -3650,6 +3663,47 @@ mod tests {
         let state = decoder.state.as_ref().expect("state should be initialized");
         assert!(state.frame_header.dictionary_id().is_none());
         assert_eq!(state.using_dict, Some(handle.id()));
+    }
+
+    #[test]
+    fn dict_frame_decodes_through_direct_path() {
+        // A dictionary frame decoded via `decode_all_with_dict_handle`
+        // into a buffer sized exactly to FCS takes the direct path
+        // (UserSliceBackend); matches reaching into the dictionary
+        // content must resolve through `repeat_from_dict`. The payload
+        // embeds dictionary content verbatim so the encoder emits
+        // dict-region matches from the first bytes of the frame.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
+        let dict_tail: alloc::vec::Vec<u8> = handle
+            .as_dict()
+            .dict_content
+            .iter()
+            .rev()
+            .take(2048)
+            .rev()
+            .copied()
+            .collect();
+        let mut payload = dict_tail.clone();
+        payload.extend_from_slice(b"unique suffix after dictionary material 0123456789");
+        payload.extend_from_slice(&dict_tail);
+
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dict load");
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let mut decoder = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len()];
+        let n = decoder
+            .decode_all_with_dict_handle(compressed.as_slice(), &mut out, &handle)
+            .expect("dict frame must decode on the direct path");
+        assert_eq!(n, payload.len());
+        assert_eq!(out, payload, "direct-path dict decode must be byte-exact");
     }
 
     #[cfg(feature = "lsm")]


### PR DESCRIPTION
## Summary

Dictionary frames were the last class excluded from direct decode (straight into the caller's slice): they staged through a window-sized FlatBuf/Ring plus a full drain copy per frame. That exclusion was the residual decompress-dict memory gap (1.92x after #401's exact-growth work) and an extra output-sized copy on every dict frame.

The exclusion turned out to be unnecessary wiring, not missing machinery: the per-kernel inline sequence executors already punt beyond-prefix offsets to the cold `repeat()` fallback, and `repeat_from_dict` is generic over the buffer backend. What was missing:

- `run_direct_decode` now forwards the scratch buffer's shared dict handle (refcount bump, no copy) to its stack-local `DecodeBuffer`, so dict-region offsets resolve through `repeat_from_dict` — the same ext-dict slow path FlatBuf/Ring use
- the dict-reachability gate uses `max(total_output_counter, buffer.len())`: the direct backend never drains (`head` stays 0), so `len()` is the cumulative output that the inline path does not track in the counter
- `!dict_active` removed from both `direct_eligible` gates

The per-sequence hot path is untouched: prefix-resident offsets take the same inline SIMD exec as before; only offsets reaching into the dictionary content go through the cold fallback (donor's extDict arm has the same shape).

## Results (i9, decompress-dict decodecorpus-z000033)

| Cell | main | branch | vs C (1.16 MB) |
|---|---|---|---|
| L22 btultra2_ldm peak | 2.23 MB | **1.09 MB** | 1.92x → **0.94x** |
| L1 fast_ldm peak (Ring path, untouched by #401) | 2.79 MB | **1.14 MB** | 2.40x → **0.98x** |
| small-4k/10k dict cells peak | 161-177 KB | 30-37 KB | **0.27x** |
| L1 fast_ldm wall | 1.414 ms | **1.371 ms** | −3.2% (c_ffi control +1.0% n.s.) |
| L22 wall | 3.237 ms | 3.284 ms | +1.5% at −1.4% c_ffi control — machine drift, neutral |

## Testing

- 823 tests on x86 (i9; the inline-exec macros are x86-only) + 797 on aarch64
- New regression test decodes a dict frame with dict-region matches into an exactly-FCS-sized buffer; verified it FAILS without the handle wire-up (counterfactual run)
- Clippy both feature combos incl. x86 target, fmt