### PR TITLE
perf: dict decode peak + direct path + repcode gate + entropy table build

### DIFF
--- a/zstd/examples/decode_loop_dict.rs
+++ b/zstd/examples/decode_loop_dict.rs
@@ -16,9 +16,19 @@
 
 use std::env;
 
+// With `--features dhat-heap`, route allocations through the dhat heap
+// profiler (same pattern as `encode_loop_dict`) for per-call-site
+// allocation counts + peak attribution. Writes `dhat-heap.json` on drop.
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
 use structured_zstd::decoding::{DictionaryHandle, FrameDecoder};
 
 fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let args: Vec<String> = env::args().collect();
     let iters: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(500_000);
     let payload_path = args

--- a/zstd/examples/decode_loop_dict.rs
+++ b/zstd/examples/decode_loop_dict.rs
@@ -12,6 +12,9 @@
 //!
 //! Build: `cargo build --profile flamegraph -p structured-zstd
 //!          --example decode_loop_dict`
+//! Build with heap profiling (writes `dhat-heap.json` on exit):
+//!        `cargo build --release -p structured-zstd
+//!          --example decode_loop_dict --features dhat-heap`
 //! Run:   `decode_loop_dict <iters> <payload.zst> <dict> <expected_len>`
 
 use std::env;

--- a/zstd/examples/decode_loop_dict.rs
+++ b/zstd/examples/decode_loop_dict.rs
@@ -29,9 +29,6 @@ static ALLOC: dhat::Alloc = dhat::Alloc;
 use structured_zstd::decoding::{DictionaryHandle, FrameDecoder};
 
 fn main() {
-    #[cfg(feature = "dhat-heap")]
-    let _dhat = dhat::Profiler::new_heap();
-
     let args: Vec<String> = env::args().collect();
     let iters: u32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(500_000);
     let payload_path = args
@@ -50,6 +47,13 @@ fn main() {
 
     let mut decoder = FrameDecoder::new();
     let mut output = vec![0u8; expected_len];
+
+    // Arm the profiler only after the one-time setup (file reads, dict
+    // parse, decoder + output-buffer allocation) so `dhat-heap.json`
+    // attributes allocations to the repeated decode path alone.
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
     let mut sink: usize = 0;
     for _ in 0..iters {
         let n = decoder

--- a/zstd/src/bit_io/bit_reader.rs
+++ b/zstd/src/bit_io/bit_reader.rs
@@ -14,17 +14,6 @@ impl<'s> BitReader<'s> {
         self.source.len() * 8 - self.idx
     }
 
-    pub fn bits_read(&self) -> usize {
-        self.idx
-    }
-
-    pub fn return_bits(&mut self, n: usize) {
-        if n > self.idx {
-            panic!("Cant return this many bits");
-        }
-        self.idx -= n;
-    }
-
     // `#[inline]` so the hot caller (`read_probabilities`, which calls this
     // per FSE NCount symbol with mostly-constant `n`) folds it in and
     // const-propagates `n`, collapsing the multi-byte branch for the common

--- a/zstd/src/decoding/buffer_backend.rs
+++ b/zstd/src/decoding/buffer_backend.rs
@@ -323,6 +323,16 @@ pub(crate) trait BufferBackend: Sized {
     /// May or may not allocate depending on current free space.
     fn reserve(&mut self, n: usize);
 
+    /// Like [`Self::reserve`], but growth is sized to the request instead
+    /// of the amortized-doubling policy. For the one-shot window
+    /// pre-reservation: a request that lands one slack past the retained
+    /// capacity (e.g. a dictionary prefix already in the buffer) would
+    /// otherwise DOUBLE a window-sized allocation. Per-block growth keeps
+    /// using `reserve` so streaming paths stay amortized.
+    fn reserve_exact(&mut self, n: usize) {
+        self.reserve(n);
+    }
+
     /// Fallible variant of [`Self::reserve`] for fixed-capacity
     /// backends. Growable backends (`FlatBuf`, `RingBuffer`) call
     /// `reserve` which always succeeds (or aborts on alloc failure)

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -280,17 +280,11 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         true
     }
 
-    /// Pre-allocate capacity for `amount` additional bytes.
-    ///
-    /// Call this before a batch of `push`/`repeat` operations to avoid
-    /// repeated re-allocations inside the hot decode loop.
-    #[inline]
-    pub fn reserve(&mut self, amount: usize) {
-        self.buffer.reserve(amount);
-    }
-
-    /// Exact-growth variant of [`Self::reserve`] for the one-shot window
-    /// pre-reservation (see `BufferBackend::reserve_exact`).
+    /// Pre-allocate capacity for `amount` additional bytes ahead of a batch
+    /// of `push`/`repeat` operations, growing exactly (see
+    /// `BufferBackend::reserve_exact`): every call site is a one-shot
+    /// window-scale reservation where amortized doubling would hold up to
+    /// 2x the window.
     #[inline]
     pub fn reserve_exact(&mut self, amount: usize) {
         self.buffer.reserve_exact(amount);
@@ -1208,7 +1202,7 @@ mod tests {
         // Mirror the fused sequence executor: reserve upfront so no
         // RingBuffer reallocation happens between checkpoint and restore
         // (restore_checkpoint requires a stable underlying allocation).
-        buf.reserve(64);
+        buf.reserve_exact(64);
         buf.push(&[1, 2, 3]);
         let cp = buf.checkpoint();
         buf.push(&[4, 5, 6, 7]);
@@ -1248,7 +1242,7 @@ mod tests {
         // Force a reallocation. RingBuffer grows by powers of two and
         // 4 MiB is well above the initial 64-byte starting capacity, so
         // reserve() must hit reserve_amortized().
-        buf.reserve(4 * 1024 * 1024);
+        buf.reserve_exact(4 * 1024 * 1024);
         buf.push(&[0; 16]);
         assert!(
             !buf.try_restore_checkpoint(cp),
@@ -1630,7 +1624,7 @@ mod tests {
         // Prefetch hints are unobservable from Rust — the assertion is
         // simply that the call completes without panic / UB.
         let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
-        buf.reserve(512);
+        buf.reserve_exact(512);
         buf.push(&[0xAA; 256]);
         buf.prefetch_lookahead_match_source(0);
         buf.prefetch_lookahead_match_source(128);
@@ -1644,7 +1638,7 @@ mod tests {
         // The helper must early-return (bound check) and never touch a
         // slice past the live region.
         let mut buf = DecodeBuffer::<RingBuffer>::new(1024);
-        buf.reserve(64);
+        buf.reserve_exact(64);
         buf.push(&[0x55; 32]);
         buf.prefetch_lookahead_match_source(buf.len());
         buf.prefetch_lookahead_match_source(buf.len() + 1);

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -1125,6 +1125,40 @@ mod tests {
     use alloc::vec::Vec;
 
     #[test]
+    fn dict_offsets_rejected_after_direct_path_window_drop() {
+        // The direct decode path writes through the inline executors
+        // (which skip `total_output_counter`) and bounds the visible
+        // buffer with `drop_to_window_size()` between blocks. Once
+        // cumulative output exceeds the window, dictionary-backed
+        // offsets are out of reach per the spec; the reachability gate
+        // must not reopen just because the visible length was capped
+        // back to `window_size`.
+        use crate::decoding::dictionary::Dictionary;
+        use crate::decoding::user_slice_buf::UserSliceBackend;
+
+        let mut out = vec![0u8; 300];
+        let backend = UserSliceBackend::from_slice(out.as_mut_slice());
+        let mut buf = DecodeBuffer::from_backend(backend, 100);
+        let dict = Dictionary::from_raw_content(7, vec![0xAB; 64]).expect("raw-content dictionary");
+        buf.set_dict(dict.into_handle());
+
+        // Mimic the inline executor: produce 250 bytes without touching
+        // `total_output_counter`, exceeding the 100-byte window.
+        BufferBackend::extend(&mut buf.buffer, &[1u8; 250]);
+        buf.drop_to_window_size();
+        assert_eq!(buf.len(), 100, "visible buffer capped to the window");
+
+        // offset 110 > len 100 reaches 10 bytes into the dictionary;
+        // cumulative output (250) already exceeds the window (100), so
+        // this must be rejected, not served from the dictionary.
+        let result = buf.repeat_from_dict(110, 5);
+        assert!(
+            result.is_err(),
+            "dict-backed offset must be unreachable once output exceeded the window, got {result:?}"
+        );
+    }
+
+    #[test]
     fn from_backend_clears_prepopulated_backend() {
         // Regression for the round-8 review fix: `from_backend` must
         // normalise a caller-supplied backend so the logical counters

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -804,9 +804,11 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // `RingBuffer` / `FlatBuf` maintain `total_output_counter`
         // (push / repeat / inline-exec counter bump). On the direct
         // path (`UserSliceBackend`) the inline executor skips the
-        // counter, but the backend never drains (`head` stays 0), so
-        // `buffer.len()` IS the cumulative output — take the max of
-        // the two so the gate is accurate for every backend.
+        // counter, so `buffer.len()` carries the cumulative output
+        // until the first between-blocks `drop_to_window_size()`, and
+        // that drop latches the counter above the window before capping
+        // the visible length — the max of the two stays accurate for
+        // every backend.
         let total_output = self.total_output_counter.max(self.buffer.len() as u64);
         if total_output <= self.window_size as u64 {
             // at least part of that repeat is from the dictionary content
@@ -932,16 +934,23 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     ///
     /// Returns the number of bytes whose visibility was discarded.
     ///
-    /// Does NOT mutate `total_output_counter`: that counter tracks
-    /// total bytes produced (incremented by `push` / `repeat` /
-    /// `extend_and_fill`). Advancing `head` just hides
-    /// already-produced bytes from the visible region; counting them
-    /// again would double-count and break `repeat_from_dict`'s offset
-    /// reachability check.
+    /// Catches `total_output_counter` up to the visible length before
+    /// dropping (never adds — adding the dropped amount would
+    /// double-count on backends whose `push` / `repeat` already
+    /// counted those bytes). On the direct path the inline executors
+    /// skip the counter, so without the catch-up the cap below would
+    /// shrink `len()` back under `window_size` and reopen
+    /// `repeat_from_dict`'s reachability gate even though cumulative
+    /// output already exceeded the window. A drop only ever happens
+    /// when `len() > window_size`, so the catch-up permanently latches
+    /// the counter above the window — exactly what the boolean gate
+    /// needs. On `RingBuffer` / `FlatBuf` the counter is already exact
+    /// (`>= len()`) and the `max` is a no-op.
     pub fn drop_to_window_size(&mut self) -> usize {
         match self.can_drain_to_window_size() {
             None => 0,
             Some(can_drop) => {
+                self.total_output_counter = self.total_output_counter.max(self.buffer.len() as u64);
                 self.buffer.drop_first_n(can_drop);
                 can_drop
             }

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -799,21 +799,16 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
-        // `total_output_counter` gate: dict-source matches are only
-        // valid while the dictionary content is still inside the
-        // visible window. On the inline-exec path
-        // (`UserSliceBackend`) `total_output_counter` is NOT
-        // maintained — it stays at 0 — so the gate is trivially
-        // satisfied. This does NOT cause incorrect behavior on that
-        // path because `dict_content` is always empty for the direct
-        // decode entry (`run_direct_decode`'s
-        // `DecodeBuffer::from_backend` initializes it to empty), so
-        // `bytes_from_dict > self.dict_content.len()` below catches
-        // every would-be dict-source match and returns
-        // `NotEnoughBytesInDictionary`. The
-        // `RingBuffer` / `FlatBuf` paths still maintain the counter
-        // via `push` / `repeat_inner` and rely on it correctly.
-        if self.total_output_counter <= self.window_size as u64 {
+        // Reachability gate: dict-source matches are only valid while
+        // the dictionary content is still inside the visible window.
+        // `RingBuffer` / `FlatBuf` maintain `total_output_counter`
+        // (push / repeat / inline-exec counter bump). On the direct
+        // path (`UserSliceBackend`) the inline executor skips the
+        // counter, but the backend never drains (`head` stays 0), so
+        // `buffer.len()` IS the cumulative output — take the max of
+        // the two so the gate is accurate for every backend.
+        let total_output = self.total_output_counter.max(self.buffer.len() as u64);
+        if total_output <= self.window_size as u64 {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();
 

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -289,6 +289,13 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.reserve(amount);
     }
 
+    /// Exact-growth variant of [`Self::reserve`] for the one-shot window
+    /// pre-reservation (see `BufferBackend::reserve_exact`).
+    #[inline]
+    pub fn reserve_exact(&mut self, amount: usize) {
+        self.buffer.reserve_exact(amount);
+    }
+
     /// Mutable backend handle. Lets the inline sequence executor
     /// write straight into the backend's physical storage; the
     /// `tail()` cursor on the backend is the authoritative output

--- a/zstd/src/decoding/flat_buf.rs
+++ b/zstd/src/decoding/flat_buf.rs
@@ -378,6 +378,18 @@ impl BufferBackend for FlatBuf {
     }
 
     #[inline]
+    fn reserve_exact(&mut self, n: usize) {
+        // Same contract as `reserve` (n additional + wildcopy slack), but
+        // exact growth: the window pre-reservation must not double a
+        // window-sized buffer when a dictionary prefix already occupies
+        // part of the retained capacity.
+        let additional = n
+            .checked_add(WILDCOPY_OVERLENGTH)
+            .expect("FlatBuf::reserve_exact amount + wildcopy slack overflows usize");
+        self.buf.reserve_exact(additional);
+    }
+
+    #[inline]
     fn set_max_capacity(&mut self, max_capacity: usize) {
         self.max_capacity = max_capacity;
     }

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -527,9 +527,21 @@ impl DecoderScratchKind {
         // prefix already loaded into the buffer) must not DOUBLE a
         // window-sized allocation through the amortized policy. Per-block
         // growth keeps the amortized `reserve`.
+        //
+        // `reserve_exact` takes ADDITIONAL capacity, so request only the
+        // shortfall past the bytes already buffered: the decode_all
+        // fallback loop re-enters `decode_blocks` once per strategy chunk,
+        // and re-requesting the full window each iteration would grow a
+        // window-sized buffer toward 2x window.
         match self {
-            Self::Ring(s) => s.buffer.reserve_exact(window_size),
-            Self::Flat(s) => s.buffer.reserve_exact(window_size),
+            Self::Ring(s) => {
+                let additional = window_size.saturating_sub(s.buffer.len());
+                s.buffer.reserve_exact(additional);
+            }
+            Self::Flat(s) => {
+                let additional = window_size.saturating_sub(s.buffer.len());
+                s.buffer.reserve_exact(additional);
+            }
         }
     }
 

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -148,6 +148,12 @@ fn block_body_decode_error(
 /// ```
 pub struct FrameDecoder {
     state: Option<FrameDecoderState>,
+    /// Test-only observability: frames decoded via `run_direct_decode`.
+    /// The direct and buffered paths are byte-identical, so dispatch
+    /// regressions (e.g. re-excluding dictionary frames from the direct
+    /// gate) are invisible to output assertions; tests pin the path here.
+    #[cfg(test)]
+    direct_frames: u64,
     // Registered dictionaries are stored by shared handle (Arc/Rc) so a
     // single content copy is referenced by every frame the decoder decodes
     // (donor `ZSTD_refDDict`), rather than re-copied into the decode buffer
@@ -792,6 +798,22 @@ pub struct PartialDecode {
 }
 
 impl FrameDecoderState {
+    /// Window size to actually reserve for this frame's decode buffer.
+    /// A declared content size caps the useful window: matches can never
+    /// reference further back than the bytes that will ever exist, so an
+    /// encoder-declared window above the FCS (e.g. a level-preset window
+    /// on a smaller input) must not inflate the reservation. Every
+    /// `reserve_buffer` site routes through this so the cap is uniform
+    /// across `decode_all_impl`, `decode_blocks`, and the partial path.
+    fn useful_window_size(&self) -> usize {
+        let window_size = self.frame_header.window_size().unwrap_or(0);
+        if self.frame_header.fcs_declared() {
+            window_size.min(self.frame_header.frame_content_size()) as usize
+        } else {
+            window_size as usize
+        }
+    }
+
     /// Construct a new frame decoder state, reading the frame header
     /// from `source`. When `magicless` is `true`, the 4-byte magic
     /// number prefix is NOT consumed (donor `ZSTD_f_zstd1_magicless`).
@@ -884,6 +906,8 @@ impl FrameDecoder {
     pub fn new() -> FrameDecoder {
         FrameDecoder {
             state: None,
+            #[cfg(test)]
+            direct_frames: 0,
             owned_dicts: BTreeMap::new(),
             #[cfg(target_has_atomic = "ptr")]
             shared_dicts: BTreeMap::new(),
@@ -1466,15 +1490,15 @@ impl FrameDecoder {
         }
 
         // Streaming entry point: pre-reserve the backing buffer to
-        // `window_size` so multi-block frames don't pay repeated
+        // the FCS-capped window so multi-block frames don't pay repeated
         // `reserve_amortized` grow steps (128 KiB → 256 KiB → ... →
         // window) as blocks accumulate. `decode_all` does the same up
         // front in `decode_all_impl`; this mirrors it for callers
         // driving `decode_blocks` directly. Idempotent — the
         // backend's `reserve` early-returns when capacity is already
         // sufficient.
-        let window_size = state.frame_header.window_size().unwrap_or(0) as usize;
-        state.decoder_scratch.reserve_buffer(window_size);
+        let useful_window = state.useful_window_size();
+        state.decoder_scratch.reserve_buffer(useful_window);
 
         let mut block_dec = decoding::block_decoder::new();
 
@@ -1683,10 +1707,11 @@ impl FrameDecoder {
             state.decoder_scratch.set_compute_hash(compute_hash);
         }
 
-        // Mirror `decode_blocks`: pre-reserve the backing buffer to
-        // `window_size` so multi-block frames don't pay repeated grow steps.
-        let window_size = state.frame_header.window_size().unwrap_or(0) as usize;
-        state.decoder_scratch.reserve_buffer(window_size);
+        // Mirror `decode_blocks`: pre-reserve the backing buffer to the
+        // FCS-capped window so multi-block frames don't pay repeated grow
+        // steps.
+        let useful_window = state.useful_window_size();
+        state.decoder_scratch.reserve_buffer(useful_window);
 
         // Cold resume: prime the match window + restore entropy/repcode state +
         // advance the block cursor BEFORE the loop, so the first in-range block
@@ -2276,12 +2301,11 @@ impl FrameDecoder {
             // frames are eligible: `run_direct_decode` hands the
             // shared dict handle to its buffer, and beyond-prefix
             // offsets resolve through `repeat_from_dict`.
-            let (content_size, fcs_declared, window_size) = {
+            let (content_size, fcs_declared) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
             // Direct decode requires only that the caller slice holds the
@@ -2319,17 +2343,12 @@ impl FrameDecoder {
             // > 128 KiB otherwise grows through several intermediate
             // sizes with `alloc_zeroed + memcpy` each time).
             if let Some(state) = self.state.as_mut() {
-                // A declared content size caps the useful window: matches
-                // can never reference further back than the bytes that will
-                // ever exist, so an encoder-declared window above the FCS
-                // (e.g. a level-preset window on a smaller input) must not
-                // inflate the reservation.
-                let useful_window = if fcs_declared {
-                    window_size.min(content_size)
-                } else {
-                    window_size
-                };
-                state.decoder_scratch.reserve_buffer(useful_window as usize);
+                // FCS-capped via `useful_window_size` — the same cap
+                // `decode_blocks` applies, so its per-iteration reserve in
+                // the loop below cannot grow the buffer back to the raw
+                // frame window.
+                let useful_window = state.useful_window_size();
+                state.decoder_scratch.reserve_buffer(useful_window);
             }
             let frame_start_total = total_bytes_written;
             loop {
@@ -2431,12 +2450,11 @@ impl FrameDecoder {
             // (no FCS, output too small) fall through to the legacy
             // `decode_blocks` + `read` drain loop below. Dictionary
             // frames are eligible (see the no-lsm path above).
-            let (content_size, fcs_declared, window_size) = {
+            let (content_size, fcs_declared) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
             // Only `cap >= frame_content_size` needed; the trailing
@@ -2459,17 +2477,12 @@ impl FrameDecoder {
             // `window_size` once so the per-block growth cycle is
             // skipped (see same comment on the no-lsm path above).
             if let Some(state) = self.state.as_mut() {
-                // A declared content size caps the useful window: matches
-                // can never reference further back than the bytes that will
-                // ever exist, so an encoder-declared window above the FCS
-                // (e.g. a level-preset window on a smaller input) must not
-                // inflate the reservation.
-                let useful_window = if fcs_declared {
-                    window_size.min(content_size)
-                } else {
-                    window_size
-                };
-                state.decoder_scratch.reserve_buffer(useful_window as usize);
+                // FCS-capped via `useful_window_size` — the same cap
+                // `decode_blocks` applies, so its per-iteration reserve in
+                // the loop below cannot grow the buffer back to the raw
+                // frame window.
+                let useful_window = state.useful_window_size();
+                state.decoder_scratch.reserve_buffer(useful_window);
             }
             let frame_start_total = total_bytes_written;
             loop {
@@ -2598,6 +2611,10 @@ impl FrameDecoder {
         output: &mut [u8],
         content_size: u64,
     ) -> Result<usize, FrameDecoderError> {
+        #[cfg(test)]
+        {
+            self.direct_frames += 1;
+        }
         use super::block_decoder;
         use super::decode_buffer::DecodeBuffer;
         use super::scratch::DirectScratch;
@@ -3729,6 +3746,13 @@ mod tests {
             .expect("dict frame must decode on the direct path");
         assert_eq!(n, payload.len());
         assert_eq!(out, payload, "direct-path dict decode must be byte-exact");
+        // Both paths are byte-identical, so pin the dispatch itself: a
+        // re-introduced dict exclusion in the direct gate would silently
+        // fall back to the buffered path and leave the asserts above green.
+        assert_eq!(
+            decoder.direct_frames, 1,
+            "dict frame must take the direct path, not the buffered fallback"
+        );
     }
 
     #[cfg(feature = "lsm")]

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1709,7 +1709,10 @@ impl FrameDecoder {
 
         // Mirror `decode_blocks`: pre-reserve the backing buffer to the
         // FCS-capped window so multi-block frames don't pay repeated grow
-        // steps.
+        // steps. The RAW frame window stays separately bound — the resume
+        // logic below bounds match reach by the frame's window semantics,
+        // not by the (possibly smaller) reservation cap.
+        let window_size = state.frame_header.window_size().unwrap_or(0) as usize;
         let useful_window = state.useful_window_size();
         state.decoder_scratch.reserve_buffer(useful_window);
 
@@ -4113,6 +4116,10 @@ mod tests {
         // actually emitted into the drain buffer.
         let payload: Vec<u8> = (0..200_000u32).map(|i| (i & 0xFF) as u8).collect();
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        // Content checksum is opt-in (library default mirrors libzstd's
+        // checksum-off); request it so the checksum_range assertion below
+        // exercises the hash-gated trailer accounting.
+        compressor.set_content_checksum(true);
         compressor.set_source(payload.as_slice());
         let mut compressed = Vec::new();
         compressor.set_drain(&mut compressed);

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -3711,6 +3711,32 @@ mod tests {
     }
 
     #[test]
+    fn reserve_buffer_reserves_the_shortfall_not_the_full_window_again() {
+        // `Vec::reserve_exact` takes ADDITIONAL capacity. The decode_all
+        // fallback loop re-enters decode_blocks once per strategy chunk,
+        // and each entry pre-reserves the window: re-requesting the FULL
+        // window on a buffer already holding ~window bytes of history
+        // would grow it toward 2x window, defeating the peak-memory cap
+        // the exact-growth policy exists for.
+        use super::DecoderScratchKind;
+        let window = 1usize << 20;
+        let mut scratch = DecoderScratchKind::new_flat(window);
+        scratch.reserve_buffer(window);
+        let data = alloc::vec![0u8; window];
+        match &mut scratch {
+            super::DecoderScratchKind::Flat(s) => s.buffer.push(&data),
+            super::DecoderScratchKind::Ring(_) => unreachable!("new_flat builds Flat"),
+        }
+        scratch.reserve_buffer(window);
+        let workspace = scratch.workspace_bytes();
+        assert!(
+            workspace < window * 3 / 2,
+            "second reserve_buffer grew a full window past the buffered \
+             history: workspace {workspace} bytes vs window {window}"
+        );
+    }
+
+    #[test]
     fn dict_frame_decodes_through_direct_path() {
         // A dictionary frame decoded via `decode_all_with_dict_handle`
         // into a buffer sized exactly to FCS takes the direct path

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -512,14 +512,15 @@ impl DecoderScratchKind {
     /// `new_flat` are each lazy (no pre-reserve), so a direct-eligible
     /// frame writes only through `UserSliceBackend` and leaves this
     /// buffer empty.
-    /// `window_size` is the ADDITIONAL-bytes argument the backend `reserve`
-    /// contract expects (Vec-style `reserve(additional)` → `capacity >= len +
-    /// additional`, plus the backend's wildcopy slack). This is always called at
-    /// frame entry on a freshly-reset buffer (`len == 0`), so the additional
-    /// request equals the desired total window capacity. Do NOT pass
-    /// `window_size - buffer.len()`: when `len == 0` it's identical, and the
-    /// backend `reserve` impls deliberately reject that form because it
-    /// under-reserves on reused buffers (see `FlatBuf::reserve`).
+    ///
+    /// `window_size` is the TARGET visible-window capacity: callers pass
+    /// the full window, and the method itself computes the shortfall past
+    /// the bytes already buffered before calling the backend's
+    /// ADDITIONAL-semantics `reserve_exact`. That keeps re-entries (the
+    /// decode_all fallback loop runs `decode_blocks` once per strategy
+    /// chunk, and streaming callers invoke it per call) from growing a
+    /// window-full buffer toward 2x window, while per-block growth keeps
+    /// the amortized `reserve`.
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
         // Exact growth: this is the one-shot pre-reservation, and a request

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -3768,9 +3768,14 @@ mod tests {
             .rev()
             .copied()
             .collect();
-        let mut payload = dict_tail.clone();
+        // No in-frame duplicate of the dictionary bytes: with a second
+        // copy in the payload the encoder may emit the later copy as an
+        // in-frame match, and the test would stay green even if the
+        // direct path stopped forwarding the dictionary handle. A
+        // single copy forces every dict-region match through
+        // `repeat_from_dict`.
+        let mut payload = dict_tail;
         payload.extend_from_slice(b"unique suffix after dictionary material 0123456789");
-        payload.extend_from_slice(&dict_tail);
 
         let mut compressor = FrameCompressor::new(CompressionLevel::Default);
         compressor
@@ -3780,6 +3785,21 @@ mod tests {
         let mut compressed = Vec::new();
         compressor.set_drain(&mut compressed);
         compressor.compress();
+
+        // Fixture sanity: the frame must actually depend on the
+        // dictionary, otherwise the decode below never exercises
+        // dict-region match resolution.
+        let mut plain = Vec::new();
+        let mut no_dict = FrameCompressor::new(CompressionLevel::Default);
+        no_dict.set_source(payload.as_slice());
+        no_dict.set_drain(&mut plain);
+        no_dict.compress();
+        assert!(
+            compressed.len() < plain.len(),
+            "fixture must depend on the dictionary: dict {} bytes vs plain {} bytes",
+            compressed.len(),
+            plain.len()
+        );
 
         let mut decoder = FrameDecoder::new();
         let mut out = alloc::vec![0u8; payload.len()];

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -516,9 +516,14 @@ impl DecoderScratchKind {
     /// under-reserves on reused buffers (see `FlatBuf::reserve`).
     #[inline]
     fn reserve_buffer(&mut self, window_size: usize) {
+        // Exact growth: this is the one-shot pre-reservation, and a request
+        // landing one slack past the retained capacity (e.g. a dictionary
+        // prefix already loaded into the buffer) must not DOUBLE a
+        // window-sized allocation through the amortized policy. Per-block
+        // growth keeps the amortized `reserve`.
         match self {
-            Self::Ring(s) => s.buffer.reserve(window_size),
-            Self::Flat(s) => s.buffer.reserve(window_size),
+            Self::Ring(s) => s.buffer.reserve_exact(window_size),
+            Self::Flat(s) => s.buffer.reserve_exact(window_size),
         }
     }
 
@@ -2314,7 +2319,17 @@ impl FrameDecoder {
             // > 128 KiB otherwise grows through several intermediate
             // sizes with `alloc_zeroed + memcpy` each time).
             if let Some(state) = self.state.as_mut() {
-                state.decoder_scratch.reserve_buffer(window_size as usize);
+                // A declared content size caps the useful window: matches
+                // can never reference further back than the bytes that will
+                // ever exist, so an encoder-declared window above the FCS
+                // (e.g. a level-preset window on a smaller input) must not
+                // inflate the reservation.
+                let useful_window = if fcs_declared {
+                    window_size.min(content_size)
+                } else {
+                    window_size
+                };
+                state.decoder_scratch.reserve_buffer(useful_window as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {
@@ -2446,7 +2461,17 @@ impl FrameDecoder {
             // `window_size` once so the per-block growth cycle is
             // skipped (see same comment on the no-lsm path above).
             if let Some(state) = self.state.as_mut() {
-                state.decoder_scratch.reserve_buffer(window_size as usize);
+                // A declared content size caps the useful window: matches
+                // can never reference further back than the bytes that will
+                // ever exist, so an encoder-declared window above the FCS
+                // (e.g. a level-preset window on a smaller input) must not
+                // inflate the reservation.
+                let useful_window = if fcs_declared {
+                    window_size.min(content_size)
+                } else {
+                    window_size
+                };
+                state.decoder_scratch.reserve_buffer(useful_window as usize);
             }
             let frame_start_total = total_bytes_written;
             loop {

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -2267,19 +2267,20 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_inline` returns
             // `Result<(), ExecuteSequencesError>` instead of
             // panicking on capacity overflow; the error propagates
-            // up as `FrameDecoderError`. Eligibility (FCS > 0, no
-            // active dict, remaining `output` slice has WILDCOPY
-            // slack) puts the frame on the fast path that bypasses
-            // the FlatBuf/Ring -> `read()` drain copy. Ineligible
-            // frames (no FCS, active dict, output too small for
-            // slack) fall through to the legacy `decode_blocks` +
-            // `read` drain loop below.
-            let (content_size, fcs_declared, dict_active, window_size) = {
+            // up as `FrameDecoderError`. Eligibility (FCS > 0,
+            // remaining `output` slice holds the declared content)
+            // puts the frame on the fast path that bypasses the
+            // FlatBuf/Ring -> `read()` drain copy. Ineligible frames
+            // (no FCS, output too small) fall through to the legacy
+            // `decode_blocks` + `read` drain loop below. Dictionary
+            // frames are eligible: `run_direct_decode` hands the
+            // shared dict handle to its buffer, and beyond-prefix
+            // offsets resolve through `repeat_from_dict`.
+            let (content_size, fcs_declared, window_size) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.using_dict.is_some(),
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
@@ -2299,8 +2300,7 @@ impl FrameDecoder {
             // that the spec relies on for `offset <= window_size`
             // validation. Path choice no longer alters checksum
             // semantics.
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
+            let direct_eligible = content_size > 0 && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -2424,19 +2424,18 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_inline` returns
             // `Result<(), ExecuteSequencesError>` instead of
             // panicking on capacity overflow; the error propagates
-            // up as `FrameDecoderError`. Eligibility (FCS > 0, no
-            // active dict, remaining `output` slice has WILDCOPY
-            // slack) puts the frame on the fast path that bypasses
-            // the FlatBuf/Ring -> `read()` drain copy. Ineligible
-            // frames (no FCS, active dict, output too small for
-            // slack) fall through to the legacy `decode_blocks` +
-            // `read` drain loop below.
-            let (content_size, fcs_declared, dict_active, window_size) = {
+            // up as `FrameDecoderError`. Eligibility (FCS > 0,
+            // remaining `output` slice holds the declared content)
+            // puts the frame on the fast path that bypasses the
+            // FlatBuf/Ring -> `read()` drain copy. Ineligible frames
+            // (no FCS, output too small) fall through to the legacy
+            // `decode_blocks` + `read` drain loop below. Dictionary
+            // frames are eligible (see the no-lsm path above).
+            let (content_size, fcs_declared, window_size) = {
                 let state_ref = self.state.as_ref().expect("init populated state");
                 (
                     state_ref.frame_header.frame_content_size(),
                     state_ref.frame_header.fcs_declared(),
-                    state_ref.using_dict.is_some(),
                     state_ref.frame_header.window_size().unwrap_or(0),
                 )
             };
@@ -2445,8 +2444,7 @@ impl FrameDecoder {
             // `UserSliceBackend::exec_sequence_bounded`, so no
             // `WILDCOPY_OVERLENGTH` trailing slack is required (see the
             // no-lsm path above).
-            let direct_eligible =
-                content_size > 0 && !dict_active && (output.len() as u64) >= content_size;
+            let direct_eligible = content_size > 0 && (output.len() as u64) >= content_size;
             if direct_eligible {
                 let written = self.run_direct_decode(&mut input, output, content_size)?;
                 output = &mut output[written..];
@@ -2584,8 +2582,11 @@ impl FrameDecoder {
     ///   trailing slack is required: the trailing sequence(s) take the
     ///   bounded (non-overshooting) copy in
     ///   [`UserSliceBackend::exec_sequence_bounded`].
-    /// - No active dictionary
-    ///   (`self.state.using_dict.is_none()`).
+    ///
+    /// Dictionary frames are supported: the scratch buffer's shared
+    /// dict handle is forwarded to the stack-local `DecodeBuffer`, so
+    /// offsets reaching past the frame's own output resolve through
+    /// `repeat_from_dict` (the ext-dict slow path).
     ///
     /// On return, `input` points at the byte immediately after the
     /// frame's checksum (or after the last block, when the frame
@@ -2615,7 +2616,7 @@ impl FrameDecoder {
         // fields; only `buffer` differs and we don't use that here.
         // Macro-style binding avoids the closure / generic
         // gymnastics of returning multiple `&mut` from a match arm.
-        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size) =
+        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size, dict) =
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => (
                     &mut s.huf,
@@ -2624,6 +2625,7 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
+                    s.buffer.dict.clone(),
                 ),
                 DecoderScratchKind::Ring(s) => (
                     &mut s.huf,
@@ -2632,10 +2634,21 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
+                    s.buffer.dict.clone(),
                 ),
             };
         let backend = UserSliceBackend::from_slice(output);
-        let buffer = DecodeBuffer::from_backend(backend, window_size);
+        let mut buffer = DecodeBuffer::from_backend(backend, window_size);
+        // Dictionary matches on the direct path: hand the shared handle
+        // (refcount bump, no copy) to the stack-local buffer so offsets
+        // reaching past the frame's own output resolve through
+        // `repeat_from_dict` — the same ext-dict slow path the
+        // FlatBuf/Ring backends use. The per-sequence hot path is
+        // untouched: the inline-exec dispatch already routes
+        // beyond-prefix offsets to the cold `repeat()` fallback.
+        if let Some(handle) = dict {
+            buffer.set_dict(handle);
+        }
         let mut direct = DirectScratch {
             huf,
             fse,
@@ -3675,6 +3688,47 @@ mod tests {
         let state = decoder.state.as_ref().expect("state should be initialized");
         assert!(state.frame_header.dictionary_id().is_none());
         assert_eq!(state.using_dict, Some(handle.id()));
+    }
+
+    #[test]
+    fn dict_frame_decodes_through_direct_path() {
+        // A dictionary frame decoded via `decode_all_with_dict_handle`
+        // into a buffer sized exactly to FCS takes the direct path
+        // (UserSliceBackend); matches reaching into the dictionary
+        // content must resolve through `repeat_from_dict`. The payload
+        // embeds dictionary content verbatim so the encoder emits
+        // dict-region matches from the first bytes of the frame.
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let handle = DictionaryHandle::decode_dict(dict_raw).expect("dictionary should parse");
+        let dict_tail: alloc::vec::Vec<u8> = handle
+            .as_dict()
+            .dict_content
+            .iter()
+            .rev()
+            .take(2048)
+            .rev()
+            .copied()
+            .collect();
+        let mut payload = dict_tail.clone();
+        payload.extend_from_slice(b"unique suffix after dictionary material 0123456789");
+        payload.extend_from_slice(&dict_tail);
+
+        let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dict load");
+        compressor.set_source(payload.as_slice());
+        let mut compressed = Vec::new();
+        compressor.set_drain(&mut compressed);
+        compressor.compress();
+
+        let mut decoder = FrameDecoder::new();
+        let mut out = alloc::vec![0u8; payload.len()];
+        let n = decoder
+            .decode_all_with_dict_handle(compressed.as_slice(), &mut out, &handle)
+            .expect("dict frame must decode on the direct path");
+        assert_eq!(n, payload.len());
+        assert_eq!(out, payload, "direct-path dict decode must be byte-exact");
     }
 
     #[cfg(feature = "lsm")]

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -1401,11 +1401,12 @@ pub(crate) fn maybe_update_fse_tables(
     let ll_mode = modes.ll_mode();
     match ll_mode {
         ModeType::FSECompressed => {
-            let bytes = scratch.literal_lengths.build_decoder(source, LL_MAX_LOG)?;
+            let bytes = scratch.literal_lengths.build_decoder_fused(
+                source,
+                LL_MAX_LOG,
+                crate::fse::SeqMeta::Packed(&LL_META),
+            )?;
             bytes_read += bytes;
-            scratch
-                .literal_lengths
-                .enrich_with_packed_seq_meta(&LL_META);
 
             vprintln!("Updating ll table");
             vprintln!("Used bytes: {}", bytes);
@@ -1461,8 +1462,11 @@ pub(crate) fn maybe_update_fse_tables(
     let of_mode = modes.of_mode();
     match of_mode {
         ModeType::FSECompressed => {
-            let bytes = scratch.offsets.build_decoder(of_source, OF_MAX_LOG)?;
-            scratch.offsets.enrich_for_offsets();
+            let bytes = scratch.offsets.build_decoder_fused(
+                of_source,
+                OF_MAX_LOG,
+                crate::fse::SeqMeta::Offsets,
+            )?;
             vprintln!("Updating of table");
             vprintln!("Used bytes: {}", bytes);
             bytes_read += bytes;
@@ -1518,8 +1522,11 @@ pub(crate) fn maybe_update_fse_tables(
     let ml_mode = modes.ml_mode();
     match ml_mode {
         ModeType::FSECompressed => {
-            let bytes = scratch.match_lengths.build_decoder(ml_source, ML_MAX_LOG)?;
-            scratch.match_lengths.enrich_with_packed_seq_meta(&ML_META);
+            let bytes = scratch.match_lengths.build_decoder_fused(
+                ml_source,
+                ML_MAX_LOG,
+                crate::fse::SeqMeta::Packed(&ML_META),
+            )?;
             bytes_read += bytes;
             vprintln!("Updating ml table");
             vprintln!("Used bytes: {}", bytes);

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -158,7 +158,13 @@ where
         "sequence section update bits exceed 56-bit budget"
     );
 
-    buffer.reserve(MAX_BLOCK_SIZE as usize);
+    // Exact growth: this worst-case pre-block reservation is a no-op while
+    // the frame-entry window reservation covers it, and on the frame's LAST
+    // block (where the remaining content is smaller than a full block) the
+    // amortized policy would DOUBLE the window-sized buffer for a tail
+    // worth a fraction of a block. The ring backend keeps its own
+    // amortized growth via the trait default.
+    buffer.reserve_exact(MAX_BLOCK_SIZE as usize);
     // Arm the per-block output ceiling so a malformed / adversarial block
     // whose sequences over-produce cannot grow the buffer past
     // `len + MAX_BLOCK_SIZE` (a decompression-bomb OOM on the growable

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1831,9 +1831,13 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // single-segment frame whenever the source fits the active window.
         // A single-segment frame REQUIRES an FCS field, so suppressing the
         // content size (`content_size_flag` off) also forces the windowed
-        // layout, mirroring upstream.
+        // layout, mirroring upstream. Dictionary frames qualify (the
+        // reference emits single-segment + dictionary-ID headers): the
+        // dictionary is decoder setup state, not part of the regenerated
+        // segment, and dropping the window descriptor lets decoders size
+        // their buffer from the FCS instead of the level's (often much
+        // larger) preset window.
         let single_segment = self.content_size_flag
-            && !prep.use_dictionary_state
             && prep.source_size_hint_known
             && total_uncompressed >= 512
             && total_uncompressed <= prep.window_size;
@@ -3139,6 +3143,45 @@ mod tests {
             .decode_all_to_vec(&out, &mut decoded)
             .expect("frame must decode");
         assert_eq!(decoded, input);
+    }
+
+    // A dictionary frame with a known content size that fits the window
+    // must take the single-segment layout (reference parity): the window
+    // descriptor would otherwise advertise the level's preset window and
+    // decoders would size their buffers from it instead of the FCS.
+    #[test]
+    fn dict_frame_with_known_size_is_single_segment() {
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        let payload = b"dictionary-keyed payload dictionary-keyed payload".repeat(64);
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Fastest);
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dictionary bytes should parse");
+        let mut frame = Vec::new();
+        compressor.compress_independent_frame_into(&payload, &mut frame);
+
+        let parsed = crate::decoding::frame::read_frame_header(frame.as_slice())
+            .expect("frame header must parse")
+            .0;
+        assert!(
+            parsed.descriptor.single_segment_flag(),
+            "dict frame with known size <= window must be single-segment"
+        );
+        assert!(parsed.dictionary_id().is_some());
+        assert_eq!(parsed.frame_content_size(), payload.len() as u64);
+
+        // Round-trip through our own decoder with the dictionary.
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        decoder
+            .add_dict_from_bytes(dict_raw)
+            .expect("decoder must accept the dictionary");
+        let mut decoded = Vec::with_capacity(payload.len() + 64);
+        decoder
+            .decode_all_to_vec(&frame, &mut decoded)
+            .expect("single-segment dict frame must decode");
+        assert_eq!(decoded, payload);
     }
 
     // Regression test: `heap_size()` must count the retained Huffman tables

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1834,9 +1834,9 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // layout, mirroring upstream. Dictionary frames qualify (the
         // reference emits single-segment + dictionary-ID headers): the
         // dictionary is decoder setup state, not part of the regenerated
-        // segment, and dropping the window descriptor lets decoders size
-        // their buffer from the FCS instead of the level's (often much
-        // larger) preset window.
+        // segment, so the frame keeps single-segment wire layout and
+        // decoders keep their single-allocation paths (our own decoder
+        // already caps reservation to min(window, FCS) either way).
         let single_segment = self.content_size_flag
             && prep.source_size_hint_known
             && total_uncompressed >= 512
@@ -3146,9 +3146,9 @@ mod tests {
     }
 
     // A dictionary frame with a known content size that fits the window
-    // must take the single-segment layout (reference parity): the window
-    // descriptor would otherwise advertise the level's preset window and
-    // decoders would size their buffers from it instead of the FCS.
+    // must take the single-segment layout (reference parity): the
+    // dictionary is decoder setup state, not part of the regenerated
+    // segment, so it must not force the windowed multi-segment layout.
     #[test]
     fn dict_frame_with_known_size_is_single_segment() {
         let dict_raw = include_bytes!("../../dict_tests/dictionary");

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -3182,6 +3182,16 @@ mod tests {
             .decode_all_to_vec(&frame, &mut decoded)
             .expect("single-segment dict frame must decode");
         assert_eq!(decoded, payload);
+
+        // Reference-decoder cross-check: our serializer and parser could
+        // share a bug and still self-roundtrip, so the on-wire
+        // single-segment + dictionary-ID layout must also decode through
+        // the C implementation.
+        let ffi_decoded = zstd::bulk::Decompressor::with_dictionary(dict_raw)
+            .expect("reference decompressor must accept the dictionary")
+            .decompress(&frame, payload.len() + 64)
+            .expect("reference zstd must accept the single-segment dict frame");
+        assert_eq!(ffi_decoded, payload);
     }
 
     // Regression test: `heap_size()` must count the retained Huffman tables

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4495,6 +4495,31 @@ macro_rules! for_each_repcode_candidate_body {
                 continue;
             }
             let candidate_idx = candidate_pos - $table.history_abs_start;
+            // Donor `ZSTD_readMINMATCH` gate (zstd_opt.c:657-674): a
+            // 4-byte (3-byte when min_match_len == 3) equality probe
+            // before the full prefix scan. Equivalent filtering — a
+            // mismatch here means `match_len < min_match_len`, which
+            // the post-scan check rejects anyway — but it skips the
+            // prefix-kernel call for the common no-match case (rep
+            // offsets rarely hit on low-redundancy input).
+            //
+            // SAFETY: `current_idx + 4 <= concat_len` (early return
+            // above) and `candidate_idx < current_idx` (rep >= 1), so
+            // both 4-byte reads stay inside `concat`.
+            let gate_matches = unsafe {
+                let cand = base.add(candidate_idx).cast::<u32>().read_unaligned();
+                let cur = base.add(current_idx).cast::<u32>().read_unaligned();
+                if $min_match_len == 3 {
+                    // Compare the low-address 3 bytes regardless of
+                    // endianness: byte-shift on LE, mask via to_le.
+                    (cand.to_le() & 0x00FF_FFFF) == (cur.to_le() & 0x00FF_FFFF)
+                } else {
+                    cand == cur
+                }
+            };
+            if !gate_matches {
+                continue;
+            }
             // SAFETY: `candidate_idx ≤ current_idx < concat_len` (since
             // candidate_pos ≤ abs_pos and we early-returned on
             // `current_idx + 4 > concat_len`). `max` clamps to the shorter

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -1,4 +1,4 @@
-use crate::bit_io::{BitReader, BitReaderReversed};
+use crate::bit_io::BitReaderReversed;
 use crate::cpu_kernel::CpuKernel;
 use crate::decoding::errors::{FSEDecoderError, FSETableError};
 use alloc::vec::Vec;
@@ -757,8 +757,40 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
     fn read_probabilities(&mut self, source: &[u8], max_log: u8) -> Result<usize, FSETableError> {
         self.symbol_probabilities.clear(); //just clear, we will fill a probability for each entry anyways. No need to force new allocs here
 
-        let mut br = BitReader::new(source);
-        self.accuracy_log = ACC_LOG_OFFSET + (br.get_bits(4)? as u8);
+        // Donor `FSE_readNCount` cursor shape: a flat little-endian bit
+        // position over `source`, extracting each field with one whole-word
+        // load. The generic `BitReader::get_bits` assembled fields
+        // byte-by-byte with per-call divisions — measured ~6% of decode
+        // wall on table-dense btopt frames.
+        let total_bits = source.len() * 8;
+        let mut bit_pos: usize = 0;
+        #[inline(always)]
+        fn field_at(source: &[u8], bit_pos: usize, n: usize) -> u64 {
+            debug_assert!(n <= 32);
+            let byte = bit_pos >> 3;
+            let mut window = [0u8; 8];
+            let take = source.len().saturating_sub(byte).min(8);
+            window[..take].copy_from_slice(&source[byte..byte + take]);
+            (u64::from_le_bytes(window) >> (bit_pos & 7)) & ((1u64 << n) - 1)
+        }
+        macro_rules! read_bits {
+            ($n:expr) => {{
+                let n: usize = $n;
+                if total_bits - bit_pos < n {
+                    return Err(FSETableError::GetBitsError(
+                        crate::bit_io::GetBitsError::NotEnoughRemainingBits {
+                            requested: n,
+                            remaining: total_bits - bit_pos,
+                        },
+                    ));
+                }
+                let v = field_at(source, bit_pos, n);
+                bit_pos += n;
+                v
+            }};
+        }
+
+        self.accuracy_log = ACC_LOG_OFFSET + (read_bits!(4) as u8);
         if self.accuracy_log > ENTRY_MAX_ACCURACY_LOG {
             return Err(FSETableError::AccLogTooBig {
                 got: self.accuracy_log,
@@ -782,14 +814,14 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
             let max_remaining_value = probability_sum - probability_counter + 1;
             let bits_to_read = highest_bit_set(max_remaining_value);
 
-            let unchecked_value = br.get_bits(bits_to_read as usize)? as u32;
+            let unchecked_value = read_bits!(bits_to_read as usize) as u32;
 
             let low_threshold = ((1 << bits_to_read) - 1) - (max_remaining_value);
             let mask = (1 << (bits_to_read - 1)) - 1;
             let small_value = unchecked_value & mask;
 
             let value = if small_value < low_threshold {
-                br.return_bits(1);
+                bit_pos -= 1;
                 small_value
             } else if unchecked_value > mask {
                 unchecked_value - low_threshold
@@ -812,7 +844,7 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
             } else {
                 //fast skip further zero probabilities
                 loop {
-                    let skip_amount = br.get_bits(2)? as usize;
+                    let skip_amount = read_bits!(2) as usize;
 
                     self.symbol_probabilities
                         .resize(self.symbol_probabilities.len() + skip_amount, 0);
@@ -836,10 +868,10 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
             });
         }
 
-        let bytes_read = if br.bits_read().is_multiple_of(8) {
-            br.bits_read() / 8
+        let bytes_read = if bit_pos.is_multiple_of(8) {
+            bit_pos / 8
         } else {
-            (br.bits_read() / 8) + 1
+            (bit_pos / 8) + 1
         };
 
         Ok(bytes_read)

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -373,11 +373,23 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
 
     /// returns how many BYTEs (not bits) were read while building the decoder
     pub fn build_decoder(&mut self, source: &[u8], max_log: u8) -> Result<usize, FSETableError> {
+        self.build_decoder_fused(source, max_log, SeqMeta::None)
+    }
+
+    /// [`Self::build_decoder`] with the sequence-axis meta fused into the
+    /// build loop — replaces the build-then-enrich double pass on the
+    /// hot per-block table rebuild path.
+    pub(crate) fn build_decoder_fused(
+        &mut self,
+        source: &[u8],
+        max_log: u8,
+        meta: SeqMeta<'_>,
+    ) -> Result<usize, FSETableError> {
         let max_log = max_log.min(ENTRY_MAX_ACCURACY_LOG);
         self.accuracy_log = 0;
 
         let bytes_read = self.read_probabilities(source, max_log)?;
-        self.build_decoding_table()?;
+        self.build_decoding_table_meta(meta)?;
 
         Ok(bytes_read)
     }
@@ -521,8 +533,12 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
     /// well-defined empty state a freshly-constructed `FSETable` has;
     /// any subsequent `init_state` returns `TableIsUninitialized`.
     fn build_decoding_table(&mut self) -> Result<(), FSETableError> {
+        self.build_decoding_table_meta(SeqMeta::None)
+    }
+
+    fn build_decoding_table_meta(&mut self, meta: SeqMeta<'_>) -> Result<(), FSETableError> {
         let mut spread = core::mem::take(&mut self.symbol_spread_buffer);
-        let result = self.build_decoding_table_inner(&mut spread);
+        let result = self.build_decoding_table_inner(&mut spread, meta);
         self.symbol_spread_buffer = spread;
         if result.is_err() {
             self.reset();
@@ -530,7 +546,11 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
         result
     }
 
-    fn build_decoding_table_inner(&mut self, spread: &mut Vec<u8>) -> Result<(), FSETableError> {
+    fn build_decoding_table_inner(
+        &mut self,
+        spread: &mut Vec<u8>,
+        meta: SeqMeta<'_>,
+    ) -> Result<(), FSETableError> {
         let nb_symbols = self.symbol_probabilities.len();
         if nb_symbols > self.max_symbol as usize + 1 {
             return Err(FSETableError::TooManySymbols { got: nb_symbols });
@@ -704,7 +724,25 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
             // formula bug instead of silently producing a
             // malformed entry.
             let new_state_u32 = (next_state << nb) - table_size_u32;
-            self.decode[state_idx] = E::from_raw(new_state_u32 as u16, symbol, nb);
+            let entry = E::from_raw(new_state_u32 as u16, symbol, nb);
+            // Fused enrich: write the sequence meta in the same pass
+            // instead of re-walking the finished table. `from_raw`
+            // zero-inits the meta fields, so the no-meta arms match
+            // the post-pass results exactly.
+            self.decode[state_idx] = match meta {
+                SeqMeta::None => entry,
+                SeqMeta::Packed(packed) => {
+                    let m = packed.get(symbol as usize).copied().unwrap_or(0);
+                    entry.with_seq_meta(m & 0x00FF_FFFF, (m >> 24) as u8)
+                }
+                SeqMeta::Offsets => {
+                    if symbol < 32 {
+                        entry.with_seq_meta(1u32 << symbol, symbol)
+                    } else {
+                        entry
+                    }
+                }
+            };
         }
 
         // Commit the live span. The loop wrote every `state_idx ∈
@@ -982,11 +1020,35 @@ const _: [(); 8] = [(); core::mem::size_of::<SeqSymbol>()];
 /// `num_additional_bits` from caller-provided meta and discards
 /// `symbol`.
 #[doc(hidden)]
+/// Sequence-axis meta source fused into the table-build loop. The donor
+/// fills `baseValue` / `nbAdditionalBits` during table construction
+/// (`ZSTD_buildSeqTable`); building first and enriching in a second
+/// full-table pass doubles the entry traffic on table-dense frames.
+#[derive(Clone, Copy)]
+pub enum SeqMeta<'a> {
+    /// No sequence meta (Huffman-weight / literal tables).
+    None,
+    /// Packed LL / ML meta: `base = m & 0x00FF_FFFF`, `bits = m >> 24`.
+    Packed(&'a [u32]),
+    /// Closed-form OF meta: `base = 1 << code`, `bits = code` for
+    /// `code < 32`; zeros otherwise.
+    Offsets,
+}
+
 pub trait FseEntry: Copy + Default {
     /// Bits to read on state transition. Hot-path access.
     fn num_bits(&self) -> u8;
     /// Base index for next state. Hot-path access.
     fn new_state(&self) -> u16;
+    /// Attach sequence meta (`base_value` / `num_additional_bits`) during
+    /// the build loop. Entries without those fields keep the no-op
+    /// default.
+    #[inline(always)]
+    fn with_seq_meta(self, base_value: u32, num_additional_bits: u8) -> Self {
+        let _ = (base_value, num_additional_bits);
+        self
+    }
+
     /// Build-time constructor from the raw (new_state, symbol, num_bits)
     /// triple produced by `build_decoding_table`. Implementations may
     /// drop `symbol` (e.g. [`SeqSymbol`] mirrors donor `ZSTD_seqSymbol`
@@ -1018,6 +1080,13 @@ impl FseEntry for Entry {
 }
 
 impl FseEntry for SeqSymbol {
+    #[inline(always)]
+    fn with_seq_meta(mut self, base_value: u32, num_additional_bits: u8) -> Self {
+        self.base_value = base_value;
+        self.num_additional_bits = num_additional_bits;
+        self
+    }
+
     #[inline(always)]
     fn num_bits(&self) -> u8 {
         self.num_bits

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -550,6 +550,16 @@ impl HuffmanTable {
                         if w > MAX_MAX_NUM_BITS {
                             return Err(err::WeightBiggerThanMaxNumBits { got: w });
                         }
+                        // The cap lives here, not at the loop bottom: the two
+                        // early-break paths push a final weight after the
+                        // bottom check would have run, and 256 explicit
+                        // weights would wrap symbol index 256 to 0 through
+                        // the u8 entry packing in the table fill.
+                        if weights.len() >= 255 {
+                            return Err(err::TooManyWeights {
+                                got: weights.len() + 1,
+                            });
+                        }
                         weight_rank_count[w as usize] += 1;
                         if w > 0 {
                             weight_sum += 1u32 << (w - 1);
@@ -589,10 +599,6 @@ impl HuffmanTable {
                         //collect final states
                         push_weight!(dec1.decode_symbol());
                         break;
-                    }
-                    //maximum number of weights is 255 because we use u8 symbols and the last weight is inferred from the sum of all others
-                    if weights.len() > 255 {
-                        return Err(err::TooManyWeights { got: weights.len() });
                     }
                 }
                 self.weight_sum = weight_sum;

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -332,6 +332,17 @@ pub struct HuffmanTable {
     bits: Vec<u8>,
     bit_ranks: Vec<u32>,
     rank_indexes: Vec<usize>,
+    /// Running `sum(1 << (w - 1))` accumulated WHILE weights decode
+    /// (donor `HUF_readStats` keeps the same running stats), replacing a
+    /// separate post-decode pass over `weights`.
+    weight_sum: u32,
+    /// Per-weight occurrence counts accumulated during weight decode
+    /// (donor `rankStats`); `bit_ranks` derives from this without
+    /// re-walking the code-length array.
+    weight_rank_count: [u32; (MAX_MAX_NUM_BITS as usize) + 1],
+    /// Inferred last weight, stashed by `compute_huffman_bits` for the
+    /// `bit_ranks` derivation in `build_table_from_weights`.
+    last_weight: u8,
     /// In some cases, the list of weights is compressed using FSE compression.
     fse_table: FSETable,
 }
@@ -359,6 +370,9 @@ impl HuffmanTable {
             bits: Vec::with_capacity(256),
             bit_ranks: Vec::with_capacity(11),
             rank_indexes: Vec::with_capacity(11),
+            weight_sum: 0,
+            weight_rank_count: [0; (MAX_MAX_NUM_BITS as usize) + 1],
+            last_weight: 0,
             fse_table: FSETable::new(255),
         }
     }
@@ -387,6 +401,9 @@ impl HuffmanTable {
         self.bits.clear();
         self.bit_ranks.clear();
         self.rank_indexes.clear();
+        self.weight_sum = 0;
+        self.weight_rank_count = [0; (MAX_MAX_NUM_BITS as usize) + 1];
+        self.last_weight = 0;
         self.fse_table.reset();
     }
 
@@ -522,7 +539,28 @@ impl HuffmanTable {
                 dec1.init_state(&mut br)?;
                 dec2.init_state(&mut br)?;
 
-                self.weights.clear();
+                // Disjoint-field borrow: `dec1`/`dec2` hold `&self.fse_table`,
+                // so the weight sink is taken as a field borrow. The running
+                // stats (donor `HUF_readStats` shape) accumulate in locals
+                // and commit to `self` after the loop, replacing the
+                // separate weight-sum and rank-count passes.
+                let weights = &mut self.weights;
+                weights.clear();
+                let mut weight_sum = 0u32;
+                let mut weight_rank_count = [0u32; (MAX_MAX_NUM_BITS as usize) + 1];
+                macro_rules! push_weight {
+                    ($w:expr) => {{
+                        let w: u8 = $w;
+                        if w > MAX_MAX_NUM_BITS {
+                            return Err(err::WeightBiggerThanMaxNumBits { got: w });
+                        }
+                        weight_rank_count[w as usize] += 1;
+                        if w > 0 {
+                            weight_sum += 1u32 << (w - 1);
+                        }
+                        weights.push(w);
+                    }};
+                }
 
                 // The weights FSE table is built with a max accuracy_log of 6
                 // (the `build_decoder(fse_stream, 6)` call above), so each state
@@ -539,32 +577,30 @@ impl HuffmanTable {
                 loop {
                     br.ensure_bits(WEIGHTS_REFILL_BUDGET);
 
-                    let w = dec1.decode_symbol();
-                    self.weights.push(w);
+                    push_weight!(dec1.decode_symbol());
                     dec1.update_state_fast(&mut br);
 
                     if br.bits_remaining() <= -1 {
                         //collect final states
-                        self.weights.push(dec2.decode_symbol());
+                        push_weight!(dec2.decode_symbol());
                         break;
                     }
 
-                    let w = dec2.decode_symbol();
-                    self.weights.push(w);
+                    push_weight!(dec2.decode_symbol());
                     dec2.update_state_fast(&mut br);
 
                     if br.bits_remaining() <= -1 {
                         //collect final states
-                        self.weights.push(dec1.decode_symbol());
+                        push_weight!(dec1.decode_symbol());
                         break;
                     }
                     //maximum number of weights is 255 because we use u8 symbols and the last weight is inferred from the sum of all others
-                    if self.weights.len() > 255 {
-                        return Err(err::TooManyWeights {
-                            got: self.weights.len(),
-                        });
+                    if weights.len() > 255 {
+                        return Err(err::TooManyWeights { got: weights.len() });
                     }
                 }
+                self.weight_sum = weight_sum;
+                self.weight_rank_count = weight_rank_count;
             }
             // If the header byte is greater than or equal to 128,
             // weights are directly represented, where each weight is
@@ -576,7 +612,9 @@ impl HuffmanTable {
                 // weights are directly encoded
                 let weights_raw = &source[1..];
                 let num_weights = header - 127;
-                self.weights.resize(num_weights as usize, 0);
+                self.weights.clear();
+                let mut weight_sum = 0u32;
+                let mut weight_rank_count = [0u32; (MAX_MAX_NUM_BITS as usize) + 1];
 
                 let bytes_needed = if num_weights.is_multiple_of(2) {
                     num_weights as usize / 2
@@ -593,16 +631,30 @@ impl HuffmanTable {
 
                 // Unpack both nibbles per source byte in one iteration —
                 // the per-index parity branch defeated unrolling and read
-                // every byte twice.
+                // every byte twice. The running stats accumulate alongside
+                // (donor `HUF_readStats` shape).
+                let mut push_weight = |w: u8, weights: &mut Vec<u8>| -> Result<(), err> {
+                    if w > MAX_MAX_NUM_BITS {
+                        return Err(err::WeightBiggerThanMaxNumBits { got: w });
+                    }
+                    weight_rank_count[w as usize] += 1;
+                    if w > 0 {
+                        weight_sum += 1u32 << (w - 1);
+                    }
+                    weights.push(w);
+                    Ok(())
+                };
                 let mut idx = 0usize;
                 for &byte in &weights_raw[..bytes_needed] {
-                    self.weights[idx] = byte >> 4;
+                    push_weight(byte >> 4, &mut self.weights)?;
                     idx += 1;
                     if idx < num_weights as usize {
-                        self.weights[idx] = byte & 0xF;
+                        push_weight(byte & 0xF, &mut self.weights)?;
                         idx += 1;
                     }
                 }
+                self.weight_sum = weight_sum;
+                self.weight_rank_count = weight_rank_count;
                 bits_read += num_weights as usize * 4;
             }
         }
@@ -627,13 +679,10 @@ impl HuffmanTable {
         self.bits.clear();
         self.bits.resize(self.weights.len() + 1, 0);
 
-        let mut weight_sum: u32 = 0;
-        for w in &self.weights {
-            if *w > MAX_MAX_NUM_BITS {
-                return Err(err::WeightBiggerThanMaxNumBits { got: *w });
-            }
-            weight_sum += if *w > 0 { 1_u32 << (*w - 1) } else { 0 };
-        }
+        // `weight_sum` was accumulated while the weights decoded
+        // (`read_weights` validates each weight <= MAX_MAX_NUM_BITS as it
+        // lands), so no re-walk of `weights` is needed here.
+        let weight_sum: u32 = self.weight_sum;
 
         if weight_sum == 0 {
             return Err(err::MissingWeights);
@@ -648,6 +697,7 @@ impl HuffmanTable {
         }
 
         let last_weight = highest_bit_set(left_over) as u8;
+        self.last_weight = last_weight;
 
         for symbol in 0..self.weights.len() {
             let bits = if self.weights[symbol] > 0 {
@@ -672,11 +722,18 @@ impl HuffmanTable {
     fn build_table_from_weights(&mut self) -> Result<(), HuffmanTableError> {
         let max_bits = self.compute_huffman_bits()?;
 
+        // Derive the code-length histogram from the per-weight counts
+        // accumulated during weight decode instead of re-walking `bits`:
+        // a weight `w > 0` maps to `bits = max_bits + 1 - w`, weight 0
+        // stays code-length 0, and the inferred last symbol contributes
+        // one extra entry at its derived length.
         self.bit_ranks.clear();
         self.bit_ranks.resize((max_bits + 1) as usize, 0);
-        for num_bits in &self.bits {
-            self.bit_ranks[(*num_bits) as usize] += 1;
+        self.bit_ranks[0] = self.weight_rank_count[0];
+        for w in 1..=max_bits {
+            self.bit_ranks[(max_bits + 1 - w) as usize] = self.weight_rank_count[w as usize];
         }
+        self.bit_ranks[(max_bits + 1 - self.last_weight) as usize] += 1;
 
         let table_size = 1usize << self.max_num_bits;
 
@@ -794,6 +851,9 @@ mod tests {
             bits: Vec::new(),
             bit_ranks: Vec::new(),
             rank_indexes: Vec::new(),
+            weight_sum: 0,
+            weight_rank_count: [0; (MAX_MAX_NUM_BITS as usize) + 1],
+            last_weight: 0,
             fse_table: FSETable::new(255),
         }
     }

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -591,14 +591,19 @@ impl HuffmanTable {
                     });
                 }
 
-                for idx in 0..num_weights {
-                    if idx % 2 == 0 {
-                        self.weights[idx as usize] = weights_raw[idx as usize / 2] >> 4;
-                    } else {
-                        self.weights[idx as usize] = weights_raw[idx as usize / 2] & 0xF;
+                // Unpack both nibbles per source byte in one iteration —
+                // the per-index parity branch defeated unrolling and read
+                // every byte twice.
+                let mut idx = 0usize;
+                for &byte in &weights_raw[..bytes_needed] {
+                    self.weights[idx] = byte >> 4;
+                    idx += 1;
+                    if idx < num_weights as usize {
+                        self.weights[idx] = byte & 0xF;
+                        idx += 1;
                     }
-                    bits_read += 4;
                 }
+                bits_read += num_weights as usize * 4;
             }
         }
 
@@ -719,11 +724,24 @@ impl HuffmanTable {
                 let len = 1usize << (max_bits - bits_for_symbol);
                 self.rank_indexes[bits_for_symbol as usize] += len;
                 let packed = u16::from(symbol as u8) | (u16::from(bits_for_symbol) << 8);
-                // Constant-`packed` write of a contiguous run: LLVM lowers
-                // this to the same vectorised broadcast store as `<[u16]>::fill`
-                // (the donor's hand-rolled 64-bit `HUF_DEltX1` broadcast), just
-                // into uninitialised memory.
-                for slot in &mut slots[base_idx..base_idx + len] {
+                // Donor `HUF_DEltX1`-style broadcast fill: replicate the
+                // 16-bit entry across a 64-bit lane and store four entries
+                // per write. LLVM does NOT auto-vectorise the per-slot
+                // `MaybeUninit::write` loop (it lowered to scalar `movw`
+                // stores, measured hot on table-dense btopt frames), so the
+                // widening is done by hand; the < 4-entry tail stays scalar.
+                let run = &mut slots[base_idx..base_idx + len];
+                let packed64 = u64::from(packed) * 0x0001_0001_0001_0001;
+                let mut chunks = run.chunks_exact_mut(4);
+                for chunk in &mut chunks {
+                    // SAFETY: `[MaybeUninit<u16>; 4]` is 8 contiguous bytes
+                    // with no padding; an unaligned u64 store initialises
+                    // exactly those four slots.
+                    unsafe {
+                        chunk.as_mut_ptr().cast::<u64>().write_unaligned(packed64);
+                    }
+                }
+                for slot in chunks.into_remainder() {
                     slot.write(packed);
                 }
             }

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -331,7 +331,6 @@ pub struct HuffmanTable {
     state_mask: u64,
     bits: Vec<u8>,
     bit_ranks: Vec<u32>,
-    rank_indexes: Vec<usize>,
     /// Running `sum(1 << (w - 1))` accumulated WHILE weights decode
     /// (donor `HUF_readStats` keeps the same running stats), replacing a
     /// separate post-decode pass over `weights`.
@@ -355,7 +354,6 @@ impl HuffmanTable {
             + self.weights.capacity()
             + self.bits.capacity()
             + self.bit_ranks.capacity() * core::mem::size_of::<u32>()
-            + self.rank_indexes.capacity() * core::mem::size_of::<usize>()
             + self.fse_table.heap_bytes()
     }
 
@@ -369,7 +367,6 @@ impl HuffmanTable {
             state_mask: 0,
             bits: Vec::with_capacity(256),
             bit_ranks: Vec::with_capacity(11),
-            rank_indexes: Vec::with_capacity(11),
             weight_sum: 0,
             weight_rank_count: [0; (MAX_MAX_NUM_BITS as usize) + 1],
             last_weight: 0,
@@ -382,7 +379,7 @@ impl HuffmanTable {
     pub fn reinit_from(&mut self, other: &Self) {
         self.reset();
         // Copy ONLY the decode-time state. `weights` / `bits` /
-        // `rank_indexes` and the weight-decoding `fse_table` are build-time
+        // `rank scratch and the weight-decoding `fse_table` are build-time
         // scratch (repopulated when a block carries a new HUF table); the
         // literal-decode hot path reads only `packed_decode` + `max_num_bits`
         // + `state_mask`. Skipping the rest mirrors the donor copying just the
@@ -400,7 +397,6 @@ impl HuffmanTable {
         self.state_mask = 0;
         self.bits.clear();
         self.bit_ranks.clear();
-        self.rank_indexes.clear();
         self.weight_sum = 0;
         self.weight_rank_count = [0; (MAX_MAX_NUM_BITS as usize) + 1];
         self.last_weight = 0;
@@ -671,7 +667,7 @@ impl HuffmanTable {
     /// parsed `weights`, returning `max_bits`. This is the slice of the
     /// table build the ENCODER side needs: [`Self::to_encoder_table`] reads
     /// only `bits` + `max_num_bits`. The decode lookup-table fill
-    /// (`bit_ranks` / `packed_decode` / `rank_indexes`) is decoder-only and
+    /// (`bit_ranks` / `packed_decode` / rank offsets) is decoder-only and
     /// lives in [`Self::build_table_from_weights`].
     fn compute_huffman_bits(&mut self) -> Result<u8, HuffmanTableError> {
         use HuffmanTableError as err;
@@ -737,13 +733,14 @@ impl HuffmanTable {
 
         let table_size = 1usize << self.max_num_bits;
 
-        //starting codes for each rank
-        self.rank_indexes.clear();
-        self.rank_indexes.resize((max_bits + 1) as usize, 0);
-
-        self.rank_indexes[max_bits as usize] = 0;
-        for bits in (1..self.rank_indexes.len() as u8).rev() {
-            self.rank_indexes[bits as usize - 1] = self.rank_indexes[bits as usize]
+        // Starting offset for each code-length rank, in a fixed local
+        // sized 16 so the fill loop below indexes it with a masked code
+        // length and the optimizer drops the bounds check (code lengths
+        // cap at MAX_MAX_NUM_BITS = 11). Same descending prefix walk as
+        // the previous heap-allocated form.
+        let mut rank_start = [0usize; 16];
+        for bits in (1..=max_bits).rev() {
+            rank_start[bits as usize - 1] = rank_start[bits as usize]
                 + self.bit_ranks[bits as usize] as usize * (1 << (max_bits - bits));
         }
 
@@ -753,61 +750,79 @@ impl HuffmanTable {
         // pre-zero (`ZSTD_memset ... is not necessary`). Assert the total
         // span equals `table_size` before trusting the unchecked `set_len`.
         assert!(
-            self.rank_indexes[0] == table_size,
-            "rank_idx[0]: {} should be: {}",
-            self.rank_indexes[0],
+            rank_start[0] == table_size,
+            "rank_start[0]: {} should be: {}",
+            rank_start[0],
             table_size
         );
 
         // Write into the uninitialised tail (`spare_capacity_mut`) and only
         // `set_len` after the fill completes, avoiding the redundant
-        // zero-then-overwrite of a `resize(_, 0)`. `slots` borrows only the
-        // `packed_decode` field, so the loop's reads of `bits` and writes to
-        // `rank_indexes` (disjoint fields) coexist.
+        // zero-then-overwrite of a `resize(_, 0)`.
         self.packed_decode.clear();
         self.packed_decode.reserve(table_size);
-        let slots = self.packed_decode.spare_capacity_mut();
+        let slots_ptr = self
+            .packed_decode
+            .spare_capacity_mut()
+            .as_mut_ptr()
+            .cast::<u16>();
 
-        for symbol in 0..self.bits.len() {
-            let bits_for_symbol = self.bits[symbol];
-            if bits_for_symbol != 0 {
-                // allocate code for the symbol and set in the table
-                // a code ignores all max_bits - bits[symbol] bits, so it gets
-                // a range that spans all of those in the decoding table.
-                // Donor `HUF_DEltX1` packing: low byte = symbol, high
-                // byte = nbBits. `num_bits ≤ 11` always fits in the
-                // upper byte alongside an 8-bit symbol.
-                let base_idx = self.rank_indexes[bits_for_symbol as usize];
-                let len = 1usize << (max_bits - bits_for_symbol);
-                self.rank_indexes[bits_for_symbol as usize] += len;
-                let packed = u16::from(symbol as u8) | (u16::from(bits_for_symbol) << 8);
-                // Donor `HUF_DEltX1`-style broadcast fill: replicate the
-                // 16-bit entry across a 64-bit lane and store four entries
-                // per write. LLVM does NOT auto-vectorise the per-slot
-                // `MaybeUninit::write` loop (it lowered to scalar `movw`
-                // stores, measured hot on table-dense btopt frames), so the
-                // widening is done by hand; the < 4-entry tail stays scalar.
-                let run = &mut slots[base_idx..base_idx + len];
-                let packed64 = u64::from(packed) * 0x0001_0001_0001_0001;
-                let mut chunks = run.chunks_exact_mut(4);
-                for chunk in &mut chunks {
-                    // SAFETY: `[MaybeUninit<u16>; 4]` is 8 contiguous bytes
-                    // with no padding; an unaligned u64 store initialises
-                    // exactly those four slots.
-                    unsafe {
-                        chunk.as_mut_ptr().cast::<u64>().write_unaligned(packed64);
-                    }
+        // Per-symbol run fill, donor `HUF_DEltX1` shape: every live symbol
+        // claims a contiguous run inside its code-length rank, and the
+        // 16-bit entry broadcasts four-at-a-time through a 64-bit store
+        // (LLVM lowered the per-slot `MaybeUninit::write` loop to scalar
+        // `movw`s, and the heap-Vec rank cursor paid a memory-bound bounds
+        // check per symbol — both measured hot on table-dense frames).
+        // `filled` re-proves full [0, table_size) coverage in release
+        // builds before `set_len` exposes the entries.
+        let mut filled = 0usize;
+        for (symbol, &bits_for_symbol) in self.bits.iter().enumerate() {
+            if bits_for_symbol == 0 {
+                continue;
+            }
+            // Code lengths are `max_bits + 1 - w` with `1 <= w <= max_bits
+            // <= 11`; the mask only helps the optimizer prove the fixed
+            // 16-slot index in range.
+            let rank = (bits_for_symbol & 0xF) as usize;
+            let base_idx = rank_start[rank];
+            let len = 1usize << (max_bits - bits_for_symbol);
+            rank_start[rank] = base_idx + len;
+            // Release-mode run-bounds gate (a register compare, unlike the
+            // slice form's memory-bound check): a desync between
+            // `bit_ranks` and `bits` must fail loudly, not write OOB.
+            assert!(
+                base_idx + len <= table_size,
+                "huffman rank run [{base_idx}, +{len}) escapes table {table_size}",
+            );
+            let packed = u16::from(symbol as u8) | (u16::from(bits_for_symbol) << 8);
+            let packed64 = u64::from(packed) * 0x0001_0001_0001_0001;
+            // SAFETY: `reserve(table_size)` guaranteed the capacity and the
+            // assert above bounds this run inside it; four `u16` slots are
+            // 8 contiguous padding-free bytes, so each unaligned u64 store
+            // initialises exactly four entries.
+            unsafe {
+                let run = slots_ptr.add(base_idx);
+                let mut off = 0usize;
+                while off + 4 <= len {
+                    run.add(off).cast::<u64>().write_unaligned(packed64);
+                    off += 4;
                 }
-                for slot in chunks.into_remainder() {
-                    slot.write(packed);
+                while off < len {
+                    run.add(off).write(packed);
+                    off += 1;
                 }
             }
+            filled += len;
         }
 
-        // SAFETY: the rank walk covers [0, table_size) exactly (asserted via
-        // `rank_indexes[0] == table_size`); `reserve(table_size)` guaranteed
-        // capacity; every slot in that range was written by the loop above,
-        // so no uninitialised entry is exposed.
+        // SAFETY: the rank walk partitions [0, table_size) (anchored by the
+        // `rank_start[0] == table_size` assert) and `filled` proves every
+        // slot in that range was written, so no uninitialised entry is
+        // exposed.
+        assert!(
+            filled == table_size,
+            "huffman table fill covered {filled} of {table_size} slots",
+        );
         unsafe {
             self.packed_decode.set_len(table_size);
         }
@@ -850,7 +865,6 @@ mod tests {
             state_mask: 0b11,
             bits: Vec::new(),
             bit_ranks: Vec::new(),
-            rank_indexes: Vec::new(),
             weight_sum: 0,
             weight_rank_count: [0; (MAX_MAX_NUM_BITS as usize) + 1],
             last_weight: 0,

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -873,6 +873,52 @@ mod tests {
     }
 
     #[test]
+    fn build_decoder_rejects_fse_streams_with_256_explicit_weights() {
+        // The format caps explicit weights at 255: symbols are u8 and one
+        // more weight is inferred, so 256 explicit weights would create a
+        // 257-symbol table whose last index wraps through `symbol as u8`.
+        // FSE-encode exactly 256 weights (alternating 1/2 keeps the table
+        // otherwise valid: weight_sum 384, leftover 128 = 2^7) the same way
+        // the encoder's weight-description path does, and require a loud
+        // `TooManyWeights` instead of acceptance.
+        use crate::bit_io::BitWriter;
+        use crate::fse::fse_encoder::{FSEEncoder, build_table_from_symbol_counts};
+
+        let weights: Vec<u8> = (0..256).map(|i| if i % 2 == 0 { 1 } else { 2 }).collect();
+
+        let mut encoded = Vec::new();
+        {
+            let mut writer = BitWriter::from(&mut encoded);
+            let mut counts = [0usize; 13];
+            for &w in &weights {
+                counts[w as usize] += 1;
+            }
+            let mut encoder = FSEEncoder::new(
+                build_table_from_symbol_counts(&counts, 6, false),
+                &mut writer,
+            );
+            encoder.encode_interleaved(&weights);
+            writer.flush();
+        }
+        assert!(
+            encoded.len() < 128,
+            "fixture must fit the FSE-described header byte, got {}",
+            encoded.len()
+        );
+
+        let mut description = Vec::with_capacity(encoded.len() + 1);
+        description.push(encoded.len() as u8);
+        description.extend_from_slice(&encoded);
+
+        let mut table = HuffmanTable::new();
+        let result = table.build_decoder(description.as_slice());
+        assert!(
+            matches!(result, Err(HuffmanTableError::TooManyWeights { .. })),
+            "256 explicit weights must be rejected, got {result:?}"
+        );
+    }
+
+    #[test]
     fn decode_symbol_and_advance_scalar_matches_manual_transition() {
         let table = test_table();
         let initial_state = 1_u64;


### PR DESCRIPTION
## Summary

Consolidated performance branch (supersedes the closed #401 / #402), now based directly on `main` after #400 merged. Four tracks, one review:

### 1. Decompress-dict memory peak (was 3.66x the reference)

- **Exact growth for window-scale reservations**: the sequence decoder's worst-case pre-block `reserve(MAX_BLOCK_SIZE)` landed on the frame's LAST block with the buffer one block short — amortized doubling then held a 2 MiB buffer for a 1 MiB frame. `BufferBackend::reserve_exact` (FlatBuf exact, Ring keeps its policy) + clamp of the window pre-reserve to declared content size. `reserve_buffer` requests only the shortfall past bytes already buffered, so re-entries never grow a window-full buffer toward 2x window.
- **Single-segment layout for dictionary frames**: the exclusion had no recorded rationale and the reference emits single-segment + dictionary-ID headers; our dict frames carried the level's preset window (2 MiB at L22 for a 1 MiB input) and decoders sized buffers from it. Composed with `content_size_flag`: the flag still forces the windowed layout when off.
- **Dictionary frames on the direct decode path**: the last excluded class — they staged through FlatBuf/Ring plus a full drain copy. The per-kernel inline executors already punt beyond-prefix offsets to the cold `repeat()` fallback and `repeat_from_dict` is backend-generic, so the wire-up is: forward the scratch dict handle to the direct buffer, and base the dict-reachability gate on `max(total_output_counter, len())`, with `drop_to_window_size()` latching the counter above the window before capping the visible length (the inline executors skip per-sequence counter upkeep).

### 2. Opt-parser repcode gate (compress, BT levels)

Donor `ZSTD_readMINMATCH` equality probe (zstd_opt.c:657-674) before the full prefix scan on each of the three per-position rep candidates. Equivalent filtering (a gate miss implies `match_len < min_match_len`), byte-identical output; skips the prefix-kernel call on the common no-hit case.

### 3. Entropy table build (decode, table-dense btopt/splitBlock frames)

On z000033 L17 btopt, entropy-table rebuilds were 38.6% of decode wall. Four byte-identical wins:

- **Sequence-table meta fused into FSE table construction** (`SeqMeta`): baseValue/nbAdditionalBits filled during the build loop (donor `ZSTD_buildSeqTable` shape) instead of a separate enrich pass over the finished table.
- **Huffman weight stats fused into weight decoding**: weight sum, per-rank counts and last-weight tracked while weights stream in, instead of a second pass; `bit_ranks` then derived arithmetically.
- **FSE `read_probabilities` rewritten as a flat little-endian cursor** (donor `FSE_readNCount` shape) over the 8-byte zero-padded window.
- **Register-resident rank cursors for the Huffman table fill**: the heap-Vec rank cursor paid a memory-bound bounds check per live symbol (the hottest single instruction of the build); now a fixed 16-slot local indexed by masked code length, raw-cursor run fill with a register run gate, and a release-mode coverage count anchoring the `set_len`.

### 4. Misc

- Decode example gains optional heap-profiling support (dhat) for memory-band diagnostics.

## Results (i9)

| Cell | before | after | vs C |
|---|---|---|---|
| decompress-dict z000033 L22 ldm peak | 4.25 MB (3.66x) | **1.09 MB** | **0.94x — below C** |
| decompress-dict z000033 L1 fast_ldm peak | 2.79 MB (2.40x) | **1.14 MB** | **0.98x** |
| decompress-dict small-4k/10k peaks | 2.4-2.5x | 0.27x | below C |
| decompress-dict L1 fast_ldm wall | — | −3.2% | (drain copy gone) |
| compress-dict small-10k-random L22 wall | 1.555 ms | **1.417 ms (−8.9%)** | c_ffi control −1.0% |
| compress z000033 L19 no-dict wall | — | ~−1.5-2% net of control | |
| decompress z000033 L17 btopt wall | 2.78 ms | **2.65 ms (−4.7%)** | ratio 1.60x → 1.52x |

## Testing

- 897 workspace tests on aarch64 (incl. test-first regressions for the 256-weight cap and the direct-path dict reachability latch), x86 CI covers the inline-exec macros
- Direct-path dict regression test verified to FAIL without the handle wire-up (counterfactual run)
- Byte-identity: cross-validation + level22-parity suites green (repcode gate and all entropy-build changes provably do not change output)
- Each entropy-build win A/B-benched on i9 with flat c_ffi control arms
- Clippy both feature combos incl. x86 target, fmt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional heap profiling in decode examples for memory analysis.
  * Dictionary-attached frames can be encoded as single-segment when size permits.
  * Direct decode fast-path now supports dictionary-backed frames.

* **Improvements**
  * More precise buffer reservation to reduce over-allocation.
  * Faster match-candidate filtering to speed up compression decisions.
  * More efficient Huffman and FSE table construction and sequence metadata handling.

* **API**
  * Streamlined bit-reading interface (fewer primitive operations exposed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
