### PR TITLE
feat(c-api): dictionary attach surface + estimates + fastCover; wasm prepared dictionary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,7 @@ jobs:
             ZSTD_compress_usingCDict_advanced \
             ZSTD_getDictID_fromDict ZSTD_getDictID_fromFrame \
             ZSTD_estimateCCtxSize ZSTD_estimateCCtxSize_usingCParams \
+            ZSTD_estimateCStreamSize_usingCParams \
             ZSTD_estimateDCtxSize ZSTD_estimateCStreamSize ZSTD_estimateDStreamSize \
             ZDICT_trainFromBuffer_fastCover ZDICT_optimizeTrainFromBuffer_fastCover; do
             if ! grep -qx "$sym" <<<"$exported"; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,12 @@ jobs:
             ZSTD_CCtx_refPrefix ZSTD_CCtx_refPrefix_advanced \
             ZSTD_DCtx_loadDictionary ZSTD_DCtx_loadDictionary_byReference \
             ZSTD_DCtx_loadDictionary_advanced ZSTD_DCtx_refDDict ZSTD_DCtx_refPrefix \
+            ZSTD_DCtx_refPrefix_advanced \
+            ZSTD_compress_usingCDict ZSTD_decompress_usingDDict \
+            ZSTD_createCDict ZSTD_createCDict_byReference ZSTD_freeCDict \
+            ZSTD_createDDict ZSTD_createDDict_byReference ZSTD_freeDDict \
+            ZSTD_sizeof_CDict ZSTD_sizeof_DDict \
+            ZSTD_getDictID_fromCDict ZSTD_getDictID_fromDDict \
             ZSTD_compress_usingDict ZSTD_decompress_usingDict \
             ZSTD_createCDict_advanced ZSTD_createDDict_advanced \
             ZSTD_compress_usingCDict_advanced \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,19 @@ jobs:
             ZSTD_frameHeaderSize ZSTD_getFrameHeader ZSTD_getFrameHeader_advanced \
             ZSTD_findDecompressedSize ZSTD_decompressBound \
             ZDICT_trainFromBuffer ZDICT_finalizeDictionary ZDICT_getDictID \
-            ZDICT_getDictHeaderSize ZDICT_isError ZDICT_getErrorName; do
+            ZDICT_getDictHeaderSize ZDICT_isError ZDICT_getErrorName \
+            ZSTD_CCtx_loadDictionary ZSTD_CCtx_loadDictionary_byReference \
+            ZSTD_CCtx_loadDictionary_advanced ZSTD_CCtx_refCDict \
+            ZSTD_CCtx_refPrefix ZSTD_CCtx_refPrefix_advanced \
+            ZSTD_DCtx_loadDictionary ZSTD_DCtx_loadDictionary_byReference \
+            ZSTD_DCtx_loadDictionary_advanced ZSTD_DCtx_refDDict ZSTD_DCtx_refPrefix \
+            ZSTD_compress_usingDict ZSTD_decompress_usingDict \
+            ZSTD_createCDict_advanced ZSTD_createDDict_advanced \
+            ZSTD_compress_usingCDict_advanced \
+            ZSTD_getDictID_fromDict ZSTD_getDictID_fromFrame \
+            ZSTD_estimateCCtxSize ZSTD_estimateCCtxSize_usingCParams \
+            ZSTD_estimateDCtxSize ZSTD_estimateCStreamSize ZSTD_estimateDStreamSize \
+            ZDICT_trainFromBuffer_fastCover ZDICT_optimizeTrainFromBuffer_fastCover; do
             if ! grep -qx "$sym" <<<"$exported"; then
               echo "::error::symbol $sym not exported from $so"
               missing=1

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -217,6 +217,13 @@ impl ZSTD_CCtx {
 
     /// [`Self::apply_attached_dict`] for the streaming encoder: same
     /// semantics, applied to the per-frame [`StreamingEncoder`].
+    ///
+    /// Deliberately does NOT call `set_dictionary_id_flag(false)` for the
+    /// raw-content arms: the synthetic-ID suppression for the streaming
+    /// path lives at the (only) caller, `ensure_stream`, which combines
+    /// [`Self::attach_suppresses_dict_id`] with the sticky
+    /// `ZSTD_c_dictIDFlag` knob right after this returns — setting it here
+    /// too would split one decision across two layers.
     pub(crate) fn apply_attached_dict_streaming(
         &self,
         enc: &mut codec::encoding::StreamingEncoder<Vec<u8>>,

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -1,0 +1,780 @@
+//! Context-attached dictionaries: the `ZSTD_CCtx_loadDictionary` /
+//! `ZSTD_CCtx_refCDict` / `ZSTD_CCtx_refPrefix` family and its `ZSTD_DCtx`
+//! mirror, plus the `*_usingDict` one-shots.
+//!
+//! Attach state lives on the context and is applied at every frame start
+//! (`ZSTD_compress2`, `ZSTD_compressStream2`, `ZSTD_decompressDCtx`,
+//! `ZSTD_decompressStream`). `loadDictionary` / `refCDict` / `refDDict` are
+//! sticky (they survive `ZSTD_reset_session_only`); `refPrefix` is single-use
+//! and consumed by the next frame, both per upstream `zstd.h`.
+//!
+//! Raw-content dictionaries (no `ZSTD_MAGIC_DICTIONARY` prefix, and every
+//! `refPrefix`) are modelled as a parsed dictionary with a synthetic non-zero
+//! ID whose emission is suppressed (`set_dictionary_id_flag(false)`), so the
+//! wire never carries the placeholder; decode-side the synthetic ID only has
+//! to agree between the two attach paths, which it does by construction.
+
+use core::ffi::{c_int, c_uint};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+use codec::decoding::{ContentChecksum, Dictionary, DictionaryHandle};
+use codec::encoding::{CompressionLevel, FrameCompressor};
+
+use crate::cdict::{ZSTD_CDict, ZSTD_DDict, next_dict_serial};
+use crate::context::{ZSTD_CCtx, ZSTD_DCtx};
+use crate::error::{ZSTD_ErrorCode, code_for_decoder_error, encode};
+use crate::ffi::{in_slice, out_slice};
+
+/// `ZSTD_dictContentType_e` discriminants (`zstd.h`).
+pub(crate) const ZSTD_DCT_AUTO: c_int = 0;
+pub(crate) const ZSTD_DCT_RAW_CONTENT: c_int = 1;
+pub(crate) const ZSTD_DCT_FULL_DICT: c_int = 2;
+
+/// `ZSTD_dictMagicNumber` little-endian prefix of a serialized dictionary.
+const DICT_MAGIC: u32 = 0xEC30_A437;
+
+/// Synthetic non-zero ID for raw-content dictionaries. The encoder attach
+/// path requires a non-zero ID, but raw-content frames never put it on the
+/// wire (the ID flag is suppressed); the decoder side uses the same constant
+/// so an ID-less frame resolves against the same dictionary object.
+const RAW_CONTENT_DICT_ID: u32 = u32::MAX;
+
+/// Dictionary state attached to a compression context.
+pub(crate) enum CCtxDictAttach {
+    /// No dictionary: frames compress dictionary-less.
+    None,
+    /// `ZSTD_CCtx_loadDictionary*`: sticky copied dictionary bytes.
+    /// `raw_content` selects the raw-content modelling (synthetic ID,
+    /// suppressed on the wire); `serial` keys the context's cached
+    /// dict-compressor so a re-load invalidates it.
+    Load {
+        raw: Vec<u8>,
+        raw_content: bool,
+        serial: u64,
+    },
+    /// `ZSTD_CCtx_refCDict`: sticky reference to a caller-owned `ZSTD_CDict`.
+    /// Per the C contract the CDict must outlive its use by this context.
+    /// The serial snapshot keys the cached compressor (ABA-safe, see
+    /// [`crate::cdict::next_dict_serial`]).
+    RefCDict {
+        cdict: *const ZSTD_CDict,
+        serial: u64,
+    },
+    /// `ZSTD_CCtx_refPrefix*`: single-use raw-content dictionary for the
+    /// next frame only.
+    Prefix { content: Vec<u8>, serial: u64 },
+}
+
+/// Dictionary state attached to a decompression context. All variants hold
+/// the dictionary pre-parsed as a [`DictionaryHandle`] (`Arc`-shared), so the
+/// per-frame application is a refcount bump.
+pub(crate) enum DCtxDictAttach {
+    None,
+    /// `ZSTD_DCtx_loadDictionary*`: sticky.
+    Load {
+        handle: DictionaryHandle,
+    },
+    /// `ZSTD_DCtx_refDDict`: sticky reference; the parse of the DDict's bytes
+    /// is cached here keyed by its serial.
+    RefDDict {
+        serial: u64,
+        handle: DictionaryHandle,
+    },
+    /// `ZSTD_DCtx_refPrefix`: single-use raw-content dictionary.
+    Prefix {
+        handle: DictionaryHandle,
+    },
+}
+
+/// Parse caller bytes into a decode-side [`DictionaryHandle`] honouring the
+/// `ZSTD_dictContentType_e` selection.
+pub(crate) fn parse_decode_dict(
+    dict: &[u8],
+    content_type: c_int,
+) -> Result<DictionaryHandle, ZSTD_ErrorCode> {
+    let has_magic =
+        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+    let full = match content_type {
+        ZSTD_DCT_AUTO => has_magic,
+        ZSTD_DCT_RAW_CONTENT => false,
+        ZSTD_DCT_FULL_DICT => {
+            if !has_magic {
+                return Err(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted);
+            }
+            true
+        }
+        _ => return Err(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound),
+    };
+    let parsed = if full {
+        Dictionary::decode_dict(dict)
+            .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?
+    } else {
+        Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, dict.to_vec())
+            .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?
+    };
+    Ok(DictionaryHandle::from_dictionary(parsed))
+}
+
+/// Whether `dict` selects raw-content modelling on the encode side.
+fn encode_raw_content(dict: &[u8], content_type: c_int) -> Result<bool, ZSTD_ErrorCode> {
+    let has_magic =
+        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+    match content_type {
+        ZSTD_DCT_AUTO => Ok(!has_magic),
+        ZSTD_DCT_RAW_CONTENT => Ok(true),
+        ZSTD_DCT_FULL_DICT => {
+            if !has_magic {
+                return Err(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted);
+            }
+            Ok(false)
+        }
+        _ => Err(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound),
+    }
+}
+
+impl ZSTD_CCtx {
+    /// Attach the context's dictionary state (if any) to a freshly-built
+    /// frame compressor. Returns `Err` when the attached dictionary cannot
+    /// be applied (corrupt bytes, freed CDict contract violation surfaces as
+    /// UB per the C API and cannot be detected here).
+    ///
+    /// `Prefix` is single-use: the caller must invoke
+    /// [`Self::consume_prefix`] once the frame has actually started.
+    pub(crate) fn apply_attached_dict(
+        &self,
+        enc: &mut FrameCompressor,
+    ) -> Result<(), ZSTD_ErrorCode> {
+        match &self.attached_dict {
+            CCtxDictAttach::None => Ok(()),
+            CCtxDictAttach::Load {
+                raw, raw_content, ..
+            } => {
+                if *raw_content {
+                    let dict = Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, raw.clone())
+                        .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                    enc.set_dictionary(dict)
+                        .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                    enc.set_dictionary_id_flag(false);
+                } else {
+                    enc.set_dictionary_from_bytes(raw)
+                        .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                }
+                Ok(())
+            }
+            CCtxDictAttach::RefCDict { cdict, .. } => {
+                // SAFETY: C contract — the CDict outlives every context that
+                // references it (`ZSTD_CCtx_refCDict` lifetime rule).
+                let cdict = unsafe { &**cdict };
+                cdict
+                    .attach_to(enc)
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)
+            }
+            CCtxDictAttach::Prefix { content, .. } => {
+                let dict = Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, content.clone())
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                enc.set_dictionary(dict)
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                enc.set_dictionary_id_flag(false);
+                Ok(())
+            }
+        }
+    }
+
+    /// [`Self::apply_attached_dict`] for the streaming encoder: same
+    /// semantics, applied to the per-frame [`StreamingEncoder`].
+    pub(crate) fn apply_attached_dict_streaming(
+        &self,
+        enc: &mut codec::encoding::StreamingEncoder<Vec<u8>>,
+    ) -> Result<(), ZSTD_ErrorCode> {
+        use codec::encoding::EncoderDictionary;
+        let corrupted = |_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted;
+        match &self.attached_dict {
+            CCtxDictAttach::None => Ok(()),
+            CCtxDictAttach::Load {
+                raw, raw_content, ..
+            } => {
+                if *raw_content {
+                    let dict = Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, raw.clone())
+                        .map_err(corrupted)?;
+                    enc.set_encoder_dictionary(EncoderDictionary::from_dictionary(dict))
+                        .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)
+                } else {
+                    enc.set_dictionary_from_bytes(raw)
+                        .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)
+                }
+            }
+            CCtxDictAttach::RefCDict { cdict, .. } => {
+                // SAFETY: C contract — live CDict (see `apply_attached_dict`).
+                let cdict = unsafe { &**cdict };
+                cdict
+                    .attach_to_streaming(enc)
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)
+            }
+            CCtxDictAttach::Prefix { content, .. } => {
+                let dict = Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, content.clone())
+                    .map_err(corrupted)?;
+                enc.set_encoder_dictionary(EncoderDictionary::from_dictionary(dict))
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)
+            }
+        }
+    }
+
+    /// Cache key for the dictionary-attached compressor: the attach
+    /// identity (`0` = no dictionary).
+    pub(crate) fn attach_serial(&self) -> u64 {
+        match &self.attached_dict {
+            CCtxDictAttach::None => 0,
+            CCtxDictAttach::Load { serial, .. } => *serial,
+            CCtxDictAttach::RefCDict { serial, .. } => *serial,
+            CCtxDictAttach::Prefix { serial, .. } => *serial,
+        }
+    }
+
+    /// The compression level frames must use under the current attach:
+    /// a referenced CDict's parameters win over the context's sticky level
+    /// (upstream rule); every other attach keeps the context level.
+    pub(crate) fn attach_level(&self) -> c_int {
+        match &self.attached_dict {
+            // SAFETY: C contract — live CDict (see `apply_attached_dict`).
+            CCtxDictAttach::RefCDict { cdict, .. } => unsafe { &**cdict }.level,
+            _ => self.params.level,
+        }
+    }
+
+    /// Drop a single-use prefix after the frame that consumed it started.
+    pub(crate) fn consume_prefix(&mut self) {
+        if matches!(self.attached_dict, CCtxDictAttach::Prefix { .. }) {
+            self.attached_dict = CCtxDictAttach::None;
+        }
+    }
+
+    /// Whether any dictionary is attached.
+    pub(crate) fn has_attached_dict(&self) -> bool {
+        !matches!(self.attached_dict, CCtxDictAttach::None)
+    }
+
+    /// Whether the attach models raw content (synthetic dictionary ID that
+    /// must never reach the wire, regardless of `ZSTD_c_dictIDFlag`).
+    pub(crate) fn attach_suppresses_dict_id(&self) -> bool {
+        match &self.attached_dict {
+            CCtxDictAttach::Load { raw_content, .. } => *raw_content,
+            CCtxDictAttach::Prefix { .. } => true,
+            // SAFETY: C contract — live CDict (see `apply_attached_dict`).
+            CCtxDictAttach::RefCDict { cdict, .. } => unsafe { &**cdict }.raw_content,
+            CCtxDictAttach::None => false,
+        }
+    }
+
+    /// Whether compression parameters come from the referenced CDict rather
+    /// than the context's sticky parameters (upstream: a referenced CDict's
+    /// parameters win).
+    pub(crate) fn attach_params_from_cdict(&self) -> bool {
+        matches!(self.attached_dict, CCtxDictAttach::RefCDict { .. })
+    }
+}
+
+impl ZSTD_DCtx {
+    /// The dictionary handle the next frame must decode with, if any.
+    pub(crate) fn attached_handle(&self) -> Option<DictionaryHandle> {
+        match &self.attached_ddict {
+            DCtxDictAttach::None => None,
+            DCtxDictAttach::Load { handle } => Some(handle.clone()),
+            DCtxDictAttach::RefDDict { handle, .. } => Some(handle.clone()),
+            DCtxDictAttach::Prefix { handle } => Some(handle.clone()),
+        }
+    }
+
+    /// Drop a single-use prefix after the frame that consumed it started.
+    pub(crate) fn consume_prefix(&mut self) {
+        if matches!(self.attached_ddict, DCtxDictAttach::Prefix { .. }) {
+            self.attached_ddict = DCtxDictAttach::None;
+        }
+    }
+}
+
+/// Shared body of the `ZSTD_CCtx_loadDictionary*` family.
+///
+/// # Safety
+/// `dict` valid for `dict_size` bytes (or `NULL` + 0); `cctx` live.
+unsafe fn cctx_load_dictionary(
+    cctx: *mut ZSTD_CCtx,
+    dict: *const u8,
+    dict_size: usize,
+    content_type: c_int,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    let dict = unsafe { in_slice(dict, dict_size) };
+    if dict.is_empty() {
+        // Upstream: loading a NULL / empty dictionary clears the attach.
+        cctx.attached_dict = CCtxDictAttach::None;
+        return 0;
+    }
+    let raw_content = match encode_raw_content(dict, content_type) {
+        Ok(v) => v,
+        Err(code) => return encode(code),
+    };
+    if !raw_content {
+        // Fail-fast parse so a corrupt dictionary errors here, not at the
+        // next compression (upstream parity).
+        let parsed = catch_unwind(AssertUnwindSafe(|| {
+            codec::encoding::EncoderDictionary::from_bytes(dict)
+        }));
+        match parsed {
+            Ok(Ok(_)) => {}
+            _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
+        }
+    }
+    cctx.attached_dict = CCtxDictAttach::Load {
+        raw: dict.to_vec(),
+        raw_content,
+        serial: next_dict_serial(),
+    };
+    0
+}
+
+/// `size_t ZSTD_CCtx_loadDictionary(ZSTD_CCtx* cctx, const void* dict, size_t
+/// dictSize)` — sticky dictionary for all frames started after this call.
+/// Content type is auto-detected from the magic. `NULL` / empty clears.
+///
+/// # Safety
+/// `cctx` must be live; `dict` valid for `dictSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary(
+    cctx: *mut ZSTD_CCtx,
+    dict: *const u8,
+    dict_size: usize,
+) -> usize {
+    unsafe { cctx_load_dictionary(cctx, dict, dict_size, ZSTD_DCT_AUTO) }
+}
+
+/// `ZSTD_CCtx_loadDictionary_byReference` — we always copy the bytes, so this
+/// is behaviourally identical to [`ZSTD_CCtx_loadDictionary`] (the caller's
+/// buffer need not outlive the context).
+///
+/// # Safety
+/// Same as [`ZSTD_CCtx_loadDictionary`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_byReference(
+    cctx: *mut ZSTD_CCtx,
+    dict: *const u8,
+    dict_size: usize,
+) -> usize {
+    unsafe { cctx_load_dictionary(cctx, dict, dict_size, ZSTD_DCT_AUTO) }
+}
+
+/// `ZSTD_CCtx_loadDictionary_advanced` — explicit load method + content type.
+/// The load method is accepted and ignored (bytes are always copied).
+///
+/// # Safety
+/// Same as [`ZSTD_CCtx_loadDictionary`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_loadDictionary_advanced(
+    cctx: *mut ZSTD_CCtx,
+    dict: *const u8,
+    dict_size: usize,
+    _load_method: c_int,
+    content_type: c_int,
+) -> usize {
+    unsafe { cctx_load_dictionary(cctx, dict, dict_size, content_type) }
+}
+
+/// `size_t ZSTD_CCtx_refCDict(ZSTD_CCtx* cctx, const ZSTD_CDict* cdict)` —
+/// sticky reference; the CDict's parameters win for referenced frames. `NULL`
+/// clears the attach.
+///
+/// # Safety
+/// `cctx` must be live; `cdict` must stay live for as long as this context
+/// compresses with it (C contract), or be `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_refCDict(
+    cctx: *mut ZSTD_CCtx,
+    cdict: *const ZSTD_CDict,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    if cdict.is_null() {
+        cctx.attached_dict = CCtxDictAttach::None;
+        return 0;
+    }
+    let serial = unsafe { &*cdict }.serial;
+    cctx.attached_dict = CCtxDictAttach::RefCDict { cdict, serial };
+    0
+}
+
+/// Shared body of `ZSTD_CCtx_refPrefix*`.
+///
+/// # Safety
+/// `prefix` valid for `prefix_size` bytes (or `NULL` + 0); `cctx` live.
+unsafe fn cctx_ref_prefix(
+    cctx: *mut ZSTD_CCtx,
+    prefix: *const u8,
+    prefix_size: usize,
+    content_type: c_int,
+) -> usize {
+    if cctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    if cctx.stream_in_progress() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    // A prefix is raw content by definition; `ZSTD_DCT_FULL_DICT` is the only
+    // rejected selector (upstream refPrefix_advanced accepts auto/rawContent).
+    if content_type == ZSTD_DCT_FULL_DICT {
+        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
+    let prefix = unsafe { in_slice(prefix, prefix_size) };
+    if prefix.is_empty() {
+        cctx.attached_dict = CCtxDictAttach::None;
+        return 0;
+    }
+    cctx.attached_dict = CCtxDictAttach::Prefix {
+        content: prefix.to_vec(),
+        serial: next_dict_serial(),
+    };
+    0
+}
+
+/// `size_t ZSTD_CCtx_refPrefix(ZSTD_CCtx* cctx, const void* prefix, size_t
+/// prefixSize)` — single-use raw-content dictionary for the next frame only.
+///
+/// # Safety
+/// `cctx` must be live; `prefix` valid for `prefixSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_refPrefix(
+    cctx: *mut ZSTD_CCtx,
+    prefix: *const u8,
+    prefix_size: usize,
+) -> usize {
+    unsafe { cctx_ref_prefix(cctx, prefix, prefix_size, ZSTD_DCT_RAW_CONTENT) }
+}
+
+/// `ZSTD_CCtx_refPrefix_advanced` — explicit content type (`fullDict` is
+/// rejected; a prefix is raw content).
+///
+/// # Safety
+/// Same as [`ZSTD_CCtx_refPrefix`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_CCtx_refPrefix_advanced(
+    cctx: *mut ZSTD_CCtx,
+    prefix: *const u8,
+    prefix_size: usize,
+    content_type: c_int,
+) -> usize {
+    unsafe { cctx_ref_prefix(cctx, prefix, prefix_size, content_type) }
+}
+
+/// Shared body of the `ZSTD_DCtx_loadDictionary*` family.
+///
+/// # Safety
+/// `dict` valid for `dict_size` bytes (or `NULL` + 0); `dctx` live.
+unsafe fn dctx_load_dictionary(
+    dctx: *mut ZSTD_DCtx,
+    dict: *const u8,
+    dict_size: usize,
+    content_type: c_int,
+) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    if !dctx.stream_frame_done {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    let dict = unsafe { in_slice(dict, dict_size) };
+    if dict.is_empty() {
+        dctx.attached_ddict = DCtxDictAttach::None;
+        return 0;
+    }
+    let parsed = catch_unwind(AssertUnwindSafe(|| parse_decode_dict(dict, content_type)));
+    match parsed {
+        Ok(Ok(handle)) => {
+            dctx.attached_ddict = DCtxDictAttach::Load { handle };
+            0
+        }
+        Ok(Err(code)) => encode(code),
+        Err(_) => encode(ZSTD_ErrorCode::ZSTD_error_GENERIC),
+    }
+}
+
+/// `size_t ZSTD_DCtx_loadDictionary(ZSTD_DCtx* dctx, const void* dict, size_t
+/// dictSize)` — sticky dictionary used to decode the following frames. `NULL`
+/// / empty clears.
+///
+/// # Safety
+/// `dctx` must be live; `dict` valid for `dictSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary(
+    dctx: *mut ZSTD_DCtx,
+    dict: *const u8,
+    dict_size: usize,
+) -> usize {
+    unsafe { dctx_load_dictionary(dctx, dict, dict_size, ZSTD_DCT_AUTO) }
+}
+
+/// `ZSTD_DCtx_loadDictionary_byReference` — identical to
+/// [`ZSTD_DCtx_loadDictionary`]; the bytes are always copied.
+///
+/// # Safety
+/// Same as [`ZSTD_DCtx_loadDictionary`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_byReference(
+    dctx: *mut ZSTD_DCtx,
+    dict: *const u8,
+    dict_size: usize,
+) -> usize {
+    unsafe { dctx_load_dictionary(dctx, dict, dict_size, ZSTD_DCT_AUTO) }
+}
+
+/// `ZSTD_DCtx_loadDictionary_advanced` — explicit load method (ignored; bytes
+/// are copied) + content type.
+///
+/// # Safety
+/// Same as [`ZSTD_DCtx_loadDictionary`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_loadDictionary_advanced(
+    dctx: *mut ZSTD_DCtx,
+    dict: *const u8,
+    dict_size: usize,
+    _load_method: c_int,
+    content_type: c_int,
+) -> usize {
+    unsafe { dctx_load_dictionary(dctx, dict, dict_size, content_type) }
+}
+
+/// `size_t ZSTD_DCtx_refDDict(ZSTD_DCtx* dctx, const ZSTD_DDict* ddict)` —
+/// sticky reference. The DDict's bytes are parsed once here and cached on the
+/// context keyed by the DDict's serial. `NULL` clears.
+///
+/// # Safety
+/// `dctx` must be live; `ddict` must be a live `ZSTD_DDict`, or `NULL`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
+    dctx: *mut ZSTD_DCtx,
+    ddict: *const ZSTD_DDict,
+) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    if !dctx.stream_frame_done {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    if ddict.is_null() {
+        dctx.attached_ddict = DCtxDictAttach::None;
+        return 0;
+    }
+    let ddict = unsafe { &*ddict };
+    if let DCtxDictAttach::RefDDict { serial, .. } = &dctx.attached_ddict
+        && *serial == ddict.serial
+    {
+        return 0;
+    }
+    let parsed = catch_unwind(AssertUnwindSafe(|| {
+        parse_decode_dict(&ddict.raw, ZSTD_DCT_AUTO)
+    }));
+    match parsed {
+        Ok(Ok(handle)) => {
+            dctx.attached_ddict = DCtxDictAttach::RefDDict {
+                serial: ddict.serial,
+                handle,
+            };
+            0
+        }
+        Ok(Err(code)) => encode(code),
+        Err(_) => encode(ZSTD_ErrorCode::ZSTD_error_GENERIC),
+    }
+}
+
+/// `size_t ZSTD_DCtx_refPrefix(ZSTD_DCtx* dctx, const void* prefix, size_t
+/// prefixSize)` — single-use raw-content dictionary for the next frame only.
+///
+/// # Safety
+/// `dctx` must be live; `prefix` valid for `prefixSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
+    dctx: *mut ZSTD_DCtx,
+    prefix: *const u8,
+    prefix_size: usize,
+) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    if !dctx.stream_frame_done {
+        return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
+    }
+    let prefix = unsafe { in_slice(prefix, prefix_size) };
+    if prefix.is_empty() {
+        dctx.attached_ddict = DCtxDictAttach::None;
+        return 0;
+    }
+    let parsed = catch_unwind(AssertUnwindSafe(|| {
+        parse_decode_dict(prefix, ZSTD_DCT_RAW_CONTENT)
+    }));
+    match parsed {
+        Ok(Ok(handle)) => {
+            dctx.attached_ddict = DCtxDictAttach::Prefix { handle };
+            0
+        }
+        Ok(Err(code)) => encode(code),
+        Err(_) => encode(ZSTD_ErrorCode::ZSTD_error_GENERIC),
+    }
+}
+
+/// `size_t ZSTD_compress_usingDict(ZSTD_CCtx* ctx, void* dst, size_t
+/// dstCapacity, const void* src, size_t srcSize, const void* dict, size_t
+/// dictSize, int compressionLevel)` — one-shot compression with one-off
+/// dictionary bytes at an explicit level. Per upstream this path rebuilds the
+/// dictionary tables on every call; prefer a `ZSTD_CDict` for reuse.
+///
+/// # Safety
+/// `ctx` must be live; `dst` / `src` / `dict` valid for their lengths (or
+/// `NULL` + 0 each).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compress_usingDict(
+    ctx: *mut ZSTD_CCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+    dict: *const u8,
+    dict_size: usize,
+    compression_level: c_int,
+) -> usize {
+    if ctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *ctx };
+    let src = unsafe { in_slice(src, src_size) };
+    let dict = unsafe { in_slice(dict, dict_size) };
+    let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<(), ZSTD_ErrorCode> {
+        cctx.scratch.clear();
+        let mut enc: FrameCompressor =
+            FrameCompressor::new(CompressionLevel::from_level(compression_level));
+        enc.set_content_checksum(false);
+        if !dict.is_empty() {
+            let raw_content = encode_raw_content(dict, ZSTD_DCT_AUTO)?;
+            if raw_content {
+                let parsed = Dictionary::from_raw_content(RAW_CONTENT_DICT_ID, dict.to_vec())
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                enc.set_dictionary(parsed)
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+                enc.set_dictionary_id_flag(false);
+            } else {
+                enc.set_dictionary_from_bytes(dict)
+                    .map_err(|_| ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted)?;
+            }
+        }
+        enc.compress_independent_frame_into(src, &mut cctx.scratch);
+        Ok(())
+    }));
+    match outcome {
+        Ok(Ok(())) => {}
+        Ok(Err(code)) => return encode(code),
+        Err(_) => return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC),
+    }
+    let len = cctx.scratch.len();
+    if len > dst_capacity {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
+    }
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    dst[..len].copy_from_slice(&cctx.scratch);
+    len
+}
+
+/// `size_t ZSTD_decompress_usingDict(ZSTD_DCtx* dctx, void* dst, size_t
+/// dstCapacity, const void* src, size_t srcSize, const void* dict, size_t
+/// dictSize)` — one-shot decompression with one-off dictionary bytes.
+///
+/// # Safety
+/// `dctx` must be live; `dst` / `src` / `dict` valid for their lengths (or
+/// `NULL` + 0 each).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_decompress_usingDict(
+    dctx: *mut ZSTD_DCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+    dict: *const u8,
+    dict_size: usize,
+) -> usize {
+    if dctx.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let dctx = unsafe { &mut *dctx };
+    let src = unsafe { in_slice(src, src_size) };
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    let dict = unsafe { in_slice(dict, dict_size) };
+    let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<usize, ZSTD_ErrorCode> {
+        dctx.decoder.set_content_checksum(ContentChecksum::Verify);
+        if dict.is_empty() {
+            dctx.decoder
+                .decode_all(src, dst)
+                .map_err(|err| code_for_decoder_error(&err))
+        } else {
+            let handle = parse_decode_dict(dict, ZSTD_DCT_AUTO)?;
+            dctx.decoder
+                .decode_all_with_dict_handle(src, dst, &handle)
+                .map_err(|err| code_for_decoder_error(&err))
+        }
+    }));
+    match outcome {
+        Ok(Ok(written)) => {
+            dctx.stream_frame_done = true;
+            written
+        }
+        Ok(Err(code)) => {
+            dctx.stream_frame_done = true;
+            encode(code)
+        }
+        Err(_) => {
+            dctx.decoder = codec::decoding::FrameDecoder::new();
+            dctx.stream_frame_done = true;
+            dctx.ddict_serial = 0;
+            encode(ZSTD_ErrorCode::ZSTD_error_GENERIC)
+        }
+    }
+}
+
+/// `unsigned ZSTD_getDictID_fromDict(const void* dict, size_t dictSize)` —
+/// the dictionary ID from serialized dictionary bytes, or 0 for raw content /
+/// too-short input.
+///
+/// # Safety
+/// `dict` must be valid for `dictSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_getDictID_fromDict(dict: *const u8, dict_size: usize) -> c_uint {
+    let dict = unsafe { in_slice(dict, dict_size) };
+    crate::cdict::dict_id_from_bytes(dict)
+}
+
+/// `unsigned ZSTD_getDictID_fromFrame(const void* src, size_t srcSize)` —
+/// the dictionary ID declared in a frame header, or 0 when the header omits
+/// it / cannot be parsed from the provided bytes.
+///
+/// # Safety
+/// `src` must be valid for `srcSize` bytes (or `NULL` + 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_getDictID_fromFrame(src: *const u8, src_size: usize) -> c_uint {
+    let src = unsafe { in_slice(src, src_size) };
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        codec::decoding::read_frame_header_info(src, false)
+    }));
+    match outcome {
+        Ok(Ok(info)) => info.dictionary_id.unwrap_or(0),
+        _ => 0,
+    }
+}

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -110,8 +110,9 @@ impl DCtxDictAttach {
             DCtxDictAttach::Load { handle }
             | DCtxDictAttach::RefDDict { handle, .. }
             | DCtxDictAttach::Prefix { handle } => {
-                handle.as_dict().dict_content.len()
-                    + core::mem::size_of::<codec::decoding::Dictionary>()
+                // Content plus the parsed entropy tables' heap; the inline
+                // FSE decode arrays are covered by the struct size term.
+                handle.as_dict().heap_bytes() + core::mem::size_of::<codec::decoding::Dictionary>()
             }
         }
     }
@@ -771,6 +772,14 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDict(
     let src = unsafe { in_slice(src, src_size) };
     let dst = unsafe { out_slice(dst, dst_capacity) };
     let dict = unsafe { in_slice(dict, dict_size) };
+    // Deliberately NO `stream_frame_done` guard here: the stage_wrong check
+    // is the contract of the ZSTD_DCtx_* dictionary MUTATORS (they must not
+    // swap the dictionary under an open streaming frame). A one-shot decode
+    // owns its frames whole — `decode_all*` re-initializes per frame (header
+    // re-parse, entropy/offset/scratch reset), so a context abandoned
+    // mid-stream cannot leak state in. Same semantics as ZSTD_decompressDCtx,
+    // covered by the decompress_stream_recovers_after_oneshot_on_midframe_context
+    // regression test; every exit path below restores the frame boundary.
     let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<usize, ZSTD_ErrorCode> {
         dctx.decoder.set_content_checksum(ContentChecksum::Verify);
         if dict.is_empty() {

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -617,8 +617,11 @@ pub unsafe extern "C" fn ZSTD_DCtx_refDDict(
     {
         return 0;
     }
+    // Honour the DDict's creation-time content-type selection (same as
+    // ZSTD_decompress_usingDDict): an explicit rawContent DDict must not be
+    // re-classified on the magic at use time.
     let parsed = catch_unwind(AssertUnwindSafe(|| {
-        parse_decode_dict(&ddict.raw, ZSTD_DCT_AUTO)
+        parse_decode_dict(&ddict.raw, ddict.content_type)
     }));
     match parsed {
         Ok(Ok(handle)) => {

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -65,6 +65,19 @@ pub(crate) enum CCtxDictAttach {
     Prefix { content: Vec<u8>, serial: u64 },
 }
 
+impl CCtxDictAttach {
+    /// Heap bytes owned by the attach state. Referenced (`RefCDict`)
+    /// dictionaries are caller-owned and excluded, matching upstream's
+    /// `ZSTD_sizeof_CCtx` treatment of referenced dictionaries.
+    pub(crate) fn heap_size(&self) -> usize {
+        match self {
+            CCtxDictAttach::None | CCtxDictAttach::RefCDict { .. } => 0,
+            CCtxDictAttach::Load { raw, .. } => raw.capacity(),
+            CCtxDictAttach::Prefix { content, .. } => content.capacity(),
+        }
+    }
+}
+
 /// Dictionary state attached to a decompression context. All variants hold
 /// the dictionary pre-parsed as a [`DictionaryHandle`] (`Arc`-shared), so the
 /// per-frame application is a refcount bump.
@@ -86,14 +99,35 @@ pub(crate) enum DCtxDictAttach {
     },
 }
 
+impl DCtxDictAttach {
+    /// Heap bytes owned by the attach state: the parsed dictionary behind
+    /// `loadDictionary` / `refPrefix` is context-owned (counted); a
+    /// referenced `DDict`'s parse is cached here but its bytes belong to
+    /// the caller's handle, so only the parsed copy is reported.
+    pub(crate) fn heap_size(&self) -> usize {
+        match self {
+            DCtxDictAttach::None => 0,
+            DCtxDictAttach::Load { handle }
+            | DCtxDictAttach::RefDDict { handle, .. }
+            | DCtxDictAttach::Prefix { handle } => {
+                handle.as_dict().dict_content.len()
+                    + core::mem::size_of::<codec::decoding::Dictionary>()
+            }
+        }
+    }
+}
+
 /// Parse caller bytes into a decode-side [`DictionaryHandle`] honouring the
 /// `ZSTD_dictContentType_e` selection.
 pub(crate) fn parse_decode_dict(
     dict: &[u8],
     content_type: c_int,
 ) -> Result<DictionaryHandle, ZSTD_ErrorCode> {
+    // The magic is 4 bytes; classify on those alone (a magic-prefixed blob
+    // shorter than a full header then fails the parse as corrupted instead
+    // of silently degrading to raw content).
     let has_magic =
-        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+        dict.len() >= 4 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
     let full = match content_type {
         ZSTD_DCT_AUTO => has_magic,
         ZSTD_DCT_RAW_CONTENT => false,
@@ -118,7 +152,7 @@ pub(crate) fn parse_decode_dict(
 /// Whether `dict` selects raw-content modelling on the encode side.
 fn encode_raw_content(dict: &[u8], content_type: c_int) -> Result<bool, ZSTD_ErrorCode> {
     let has_magic =
-        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+        dict.len() >= 4 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
     match content_type {
         ZSTD_DCT_AUTO => Ok(!has_magic),
         ZSTD_DCT_RAW_CONTENT => Ok(true),
@@ -429,9 +463,10 @@ unsafe fn cctx_ref_prefix(
     if cctx.stream_in_progress() {
         return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
     }
-    // A prefix is raw content by definition; `ZSTD_DCT_FULL_DICT` is the only
-    // rejected selector (upstream refPrefix_advanced accepts auto/rawContent).
-    if content_type == ZSTD_DCT_FULL_DICT {
+    // A prefix is raw content by definition: only the auto / rawContent
+    // selectors are meaningful; everything else (fullDict, out-of-range
+    // discriminants) is rejected.
+    if !matches!(content_type, ZSTD_DCT_AUTO | ZSTD_DCT_RAW_CONTENT) {
         return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
     }
     let prefix = unsafe { in_slice(prefix, prefix_size) };
@@ -631,6 +666,24 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix(
         Ok(Err(code)) => encode(code),
         Err(_) => encode(ZSTD_ErrorCode::ZSTD_error_GENERIC),
     }
+}
+
+/// `ZSTD_DCtx_refPrefix_advanced` — explicit content type (`fullDict` is
+/// rejected; a prefix is raw content).
+///
+/// # Safety
+/// Same as [`ZSTD_DCtx_refPrefix`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
+    dctx: *mut ZSTD_DCtx,
+    prefix: *const u8,
+    prefix_size: usize,
+    content_type: c_int,
+) -> usize {
+    if !matches!(content_type, ZSTD_DCT_AUTO | ZSTD_DCT_RAW_CONTENT) {
+        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
+    unsafe { ZSTD_DCtx_refPrefix(dctx, prefix, prefix_size) }
 }
 
 /// `size_t ZSTD_compress_usingDict(ZSTD_CCtx* ctx, void* dst, size_t

--- a/c-api/src/attach.rs
+++ b/c-api/src/attach.rs
@@ -471,16 +471,19 @@ unsafe fn cctx_ref_prefix(
     if cctx.stream_in_progress() {
         return encode(ZSTD_ErrorCode::ZSTD_error_stage_wrong);
     }
+    // NULL/empty is the API's clear signal and wins over selector
+    // validation (upstream clears and returns 0 before looking at the
+    // content type).
+    let prefix = unsafe { in_slice(prefix, prefix_size) };
+    if prefix.is_empty() {
+        cctx.attached_dict = CCtxDictAttach::None;
+        return 0;
+    }
     // A prefix is raw content by definition: only the auto / rawContent
     // selectors are meaningful; everything else (fullDict, out-of-range
     // discriminants) is rejected.
     if !matches!(content_type, ZSTD_DCT_AUTO | ZSTD_DCT_RAW_CONTENT) {
         return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
-    }
-    let prefix = unsafe { in_slice(prefix, prefix_size) };
-    if prefix.is_empty() {
-        cctx.attached_dict = CCtxDictAttach::None;
-        return 0;
     }
     cctx.attached_dict = CCtxDictAttach::Prefix {
         content: prefix.to_vec(),
@@ -691,7 +694,9 @@ pub unsafe extern "C" fn ZSTD_DCtx_refPrefix_advanced(
     prefix_size: usize,
     content_type: c_int,
 ) -> usize {
-    if !matches!(content_type, ZSTD_DCT_AUTO | ZSTD_DCT_RAW_CONTENT) {
+    // NULL/empty is the clear signal and wins over selector validation
+    // (the delegate runs its own null/stage checks and then clears).
+    if prefix_size > 0 && !matches!(content_type, ZSTD_DCT_AUTO | ZSTD_DCT_RAW_CONTENT) {
         return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
     }
     unsafe { ZSTD_DCtx_refPrefix(dctx, prefix, prefix_size) }

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -307,6 +307,12 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
         }
     }
     let params = cctx_params_from_cparams(&cparams);
+    // Validate the explicit parameters up front: an unsupported combination
+    // must fail creation (NULL) rather than silently skip `set_parameters`
+    // at attach time.
+    if params.resolve().is_none() {
+        return core::ptr::null_mut();
+    }
     try_box(ZSTD_CDict {
         raw: dict.to_vec(),
         id: if raw_content {

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -116,7 +116,7 @@ impl ZSTD_CDict {
                 .map_err(|_| ())?;
             enc.set_encoder_dictionary(EncoderDictionary::from_dictionary(dict))
                 .map_err(|_| ())?;
-            enc.set_dictionary_id_flag(false);
+            enc.set_dictionary_id_flag(false).map_err(|_| ())?;
         } else {
             enc.set_dictionary_from_bytes(&self.raw).map_err(|_| ())?;
         }
@@ -148,8 +148,11 @@ pub unsafe extern "C" fn ZSTD_createCDict(
     // parse for encoding (fail-fast entropy-table build; the per-context
     // attach re-parses from the retained bytes), anything else is a
     // raw-content dictionary.
+    // Classify on the 4-byte magic alone; a truncated magic-prefixed blob
+    // then fails the encoder parse below as corrupted (upstream parity)
+    // instead of silently degrading to raw content.
     let raw_content =
-        dict.len() < 8 || u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) != DICT_MAGIC;
+        dict.len() < 4 || u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) != DICT_MAGIC;
     if !raw_content {
         let outcome = catch_unwind(AssertUnwindSafe(|| EncoderDictionary::from_bytes(dict)));
         match outcome {
@@ -278,7 +281,10 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
     cparams: ZSTD_compressionParameters,
     custom_mem: ZSTD_customMem,
 ) -> *mut ZSTD_CDict {
-    if !custom_mem.customAlloc.is_null() || !custom_mem.customFree.is_null() {
+    if !custom_mem.customAlloc.is_null()
+        || !custom_mem.customFree.is_null()
+        || !custom_mem.opaque.is_null()
+    {
         return core::ptr::null_mut();
     }
     let dict = unsafe { in_slice(dict_buffer, dict_size) };
@@ -286,7 +292,7 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
         return core::ptr::null_mut();
     }
     let has_magic =
-        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+        dict.len() >= 4 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
     let raw_content = match dict_content_type {
         crate::attach::ZSTD_DCT_AUTO => !has_magic,
         crate::attach::ZSTD_DCT_RAW_CONTENT => true,
@@ -331,7 +337,10 @@ pub unsafe extern "C" fn ZSTD_createDDict_advanced(
     dict_content_type: c_int,
     custom_mem: ZSTD_customMem,
 ) -> *mut ZSTD_DDict {
-    if !custom_mem.customAlloc.is_null() || !custom_mem.customFree.is_null() {
+    if !custom_mem.customAlloc.is_null()
+        || !custom_mem.customFree.is_null()
+        || !custom_mem.opaque.is_null()
+    {
         return core::ptr::null_mut();
     }
     let dict = unsafe { in_slice(dict_buffer, dict_size) };

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -456,6 +456,9 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
         enc.set_content_checksum(false);
         enc.set_content_size_flag(true);
         enc.set_dictionary_id_flag(!cdict_ref.raw_content);
+        // The cache is shared with ZSTD_compress2's dict path, which may
+        // have set a block-size cap; this entry point is cap-less.
+        enc.set_target_block_size(None);
         scratch.clear();
         enc.compress_independent_frame_into(src, scratch);
         Ok::<(), ()>(())
@@ -527,6 +530,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict_advanced(
         // Raw-content dictionaries never emit their synthetic ID regardless
         // of the flag.
         enc.set_dictionary_id_flag(fparams.noDictIDFlag == 0 && !cdict_ref.raw_content);
+        enc.set_target_block_size(None);
         scratch.clear();
         enc.compress_independent_frame_into(src, scratch);
         Ok::<(), ()>(())

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -230,9 +230,10 @@ pub struct ZSTD_customMem {
 }
 
 /// Representative compression level for an explicit strategy ordinal: feeds
-/// the level-derived defaults for the knobs `cParams` leaves at 0.
-fn level_for_strategy(strategy: c_uint) -> c_int {
-    match strategy {
+/// the level-derived defaults for the knobs `cParams` leaves at 0. `None`
+/// for ordinals outside `ZSTD_strategy`'s 1..=9 (invalid input, not a tier).
+fn level_for_strategy(strategy: c_uint) -> Option<c_int> {
+    Some(match strategy {
         1 => 1,  // fast
         2 => 3,  // dfast
         3 => 5,  // greedy
@@ -241,17 +242,21 @@ fn level_for_strategy(strategy: c_uint) -> c_int {
         6 => 13, // btlazy2
         7 => 16, // btopt
         8 => 18, // btultra
-        _ => 19, // btultra2 (and out-of-range falls into the strongest tier)
-    }
+        9 => 19, // btultra2
+        _ => return None,
+    })
 }
 
 /// Map explicit `ZSTD_compressionParameters` to the sticky-parameter
 /// snapshot the codec resolves (0 = auto for every knob, upstream rule).
-fn cctx_params_from_cparams(cparams: &ZSTD_compressionParameters) -> crate::params::CCtxParams {
+/// `None` when the strategy ordinal is outside `ZSTD_strategy`'s range.
+fn cctx_params_from_cparams(
+    cparams: &ZSTD_compressionParameters,
+) -> Option<crate::params::CCtxParams> {
     use codec::encoding::Strategy;
     let opt = |v: c_uint| if v == 0 { None } else { Some(v) };
-    crate::params::CCtxParams {
-        level: level_for_strategy(cparams.strategy),
+    Some(crate::params::CCtxParams {
+        level: level_for_strategy(cparams.strategy)?,
         window_log: opt(cparams.windowLog),
         hash_log: opt(cparams.hashLog),
         chain_log: opt(cparams.chainLog),
@@ -260,7 +265,7 @@ fn cctx_params_from_cparams(cparams: &ZSTD_compressionParameters) -> crate::para
         target_length: opt(cparams.targetLength),
         strategy: Strategy::from_ordinal(cparams.strategy),
         ..crate::params::CCtxParams::default()
-    }
+    })
 }
 
 /// `ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t
@@ -306,10 +311,12 @@ pub unsafe extern "C" fn ZSTD_createCDict_advanced(
             _ => return core::ptr::null_mut(),
         }
     }
-    let params = cctx_params_from_cparams(&cparams);
-    // Validate the explicit parameters up front: an unsupported combination
-    // must fail creation (NULL) rather than silently skip `set_parameters`
-    // at attach time.
+    // Validate the explicit parameters up front: an invalid strategy ordinal
+    // or an unsupported combination must fail creation (NULL) rather than
+    // silently skip `set_parameters` at attach time.
+    let Some(params) = cctx_params_from_cparams(&cparams) else {
+        return core::ptr::null_mut();
+    };
     if params.resolve().is_none() {
         return core::ptr::null_mut();
     }

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -45,7 +45,7 @@ const DICT_MAGIC: u32 = 0xEC30_A437;
 /// Parse the dictionary ID from a serialized dictionary header, or `0` for a
 /// raw-content dictionary (no magic) / too-short buffer. Matches
 /// `ZSTD_getDictID_fromDict` semantics.
-fn dict_id_from_bytes(dict: &[u8]) -> u32 {
+pub(crate) fn dict_id_from_bytes(dict: &[u8]) -> u32 {
     if dict.len() < 8 || u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) != DICT_MAGIC {
         return 0;
     }
@@ -65,6 +65,12 @@ pub struct ZSTD_CDict {
     pub(crate) level: c_int,
     /// Never-reused identity for context cache validation (see [`DICT_SERIAL`]).
     pub(crate) serial: u64,
+    /// Raw-content dictionary (no `ZSTD_MAGIC_DICTIONARY`): modelled with a
+    /// synthetic ID that is suppressed on the wire.
+    pub(crate) raw_content: bool,
+    /// Explicit compression parameters (`ZSTD_createCDict_advanced`); the
+    /// CDict's parameters win over a referencing context's sticky knobs.
+    pub(crate) cparams: Option<crate::params::CCtxParams>,
 }
 
 /// Opaque prepared decompression dictionary: the dictionary bytes plus its ID.
@@ -74,6 +80,53 @@ pub struct ZSTD_DDict {
     pub(crate) id: u32,
     /// Never-reused identity for context cache validation (see [`DICT_SERIAL`]).
     pub(crate) serial: u64,
+    /// `ZSTD_dictContentType_e` selected at creation (auto for the plain
+    /// constructors); honoured when the bytes are parsed at use.
+    pub(crate) content_type: c_int,
+}
+
+impl ZSTD_CDict {
+    /// Attach this dictionary (and its explicit parameters, if any) to a
+    /// one-shot frame compressor. Raw-content dictionaries are modelled with
+    /// a synthetic suppressed ID.
+    pub(crate) fn attach_to(&self, enc: &mut FrameCompressor) -> Result<(), ()> {
+        if self.raw_content {
+            let dict = codec::decoding::Dictionary::from_raw_content(u32::MAX, self.raw.clone())
+                .map_err(|_| ())?;
+            enc.set_dictionary(dict).map_err(|_| ())?;
+            enc.set_dictionary_id_flag(false);
+        } else {
+            enc.set_dictionary_from_bytes(&self.raw).map_err(|_| ())?;
+        }
+        if let Some(cparams) = &self.cparams
+            && let Some(resolved) = cparams.resolve()
+        {
+            enc.set_parameters(&resolved);
+        }
+        Ok(())
+    }
+
+    /// [`Self::attach_to`] for the streaming encoder.
+    pub(crate) fn attach_to_streaming(
+        &self,
+        enc: &mut codec::encoding::StreamingEncoder<Vec<u8>>,
+    ) -> Result<(), ()> {
+        if self.raw_content {
+            let dict = codec::decoding::Dictionary::from_raw_content(u32::MAX, self.raw.clone())
+                .map_err(|_| ())?;
+            enc.set_encoder_dictionary(EncoderDictionary::from_dictionary(dict))
+                .map_err(|_| ())?;
+            enc.set_dictionary_id_flag(false);
+        } else {
+            enc.set_dictionary_from_bytes(&self.raw).map_err(|_| ())?;
+        }
+        if let Some(cparams) = &self.cparams
+            && let Some(resolved) = cparams.resolve()
+        {
+            enc.set_parameters(&resolved).map_err(|_| ())?;
+        }
+        Ok(())
+    }
 }
 
 /// `ZSTD_CDict* ZSTD_createCDict(const void* dictBuffer, size_t dictSize, int
@@ -91,13 +144,21 @@ pub unsafe extern "C" fn ZSTD_createCDict(
     compression_level: c_int,
 ) -> *mut ZSTD_CDict {
     let dict = unsafe { in_slice(dict_buffer, dict_size) };
-    // Validate the dictionary parses for encoding (build the encoder entropy
-    // tables once here as a fail-fast; the per-context attach re-parses from the
-    // retained bytes). A dictionary that cannot be parsed yields NULL.
-    let outcome = catch_unwind(AssertUnwindSafe(|| EncoderDictionary::from_bytes(dict)));
-    match outcome {
-        Ok(Ok(_)) => {}
-        _ => return core::ptr::null_mut(),
+    // Auto content type (upstream createCDict): a magic-prefixed blob must
+    // parse for encoding (fail-fast entropy-table build; the per-context
+    // attach re-parses from the retained bytes), anything else is a
+    // raw-content dictionary.
+    let raw_content =
+        dict.len() < 8 || u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) != DICT_MAGIC;
+    if !raw_content {
+        let outcome = catch_unwind(AssertUnwindSafe(|| EncoderDictionary::from_bytes(dict)));
+        match outcome {
+            Ok(Ok(_)) => {}
+            _ => return core::ptr::null_mut(),
+        }
+    }
+    if dict.is_empty() {
+        return core::ptr::null_mut();
     }
     let id = dict_id_from_bytes(dict);
     try_box(ZSTD_CDict {
@@ -105,6 +166,8 @@ pub unsafe extern "C" fn ZSTD_createCDict(
         id,
         level: compression_level,
         serial: next_dict_serial(),
+        raw_content,
+        cparams: None,
     })
 }
 
@@ -123,6 +186,177 @@ pub unsafe extern "C" fn ZSTD_createCDict_byReference(
     compression_level: c_int,
 ) -> *mut ZSTD_CDict {
     unsafe { ZSTD_createCDict(dict_buffer, dict_size, compression_level) }
+}
+
+/// `ZSTD_compressionParameters` — ABI mirror of the upstream struct
+/// (7 × `unsigned`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types, non_snake_case)]
+pub struct ZSTD_compressionParameters {
+    pub windowLog: c_uint,
+    pub chainLog: c_uint,
+    pub hashLog: c_uint,
+    pub searchLog: c_uint,
+    pub minMatch: c_uint,
+    pub targetLength: c_uint,
+    /// `ZSTD_strategy` ordinal (`fast = 1` … `btultra2 = 9`).
+    pub strategy: c_uint,
+}
+
+/// `ZSTD_frameParameters` — ABI mirror of the upstream struct (3 × `int`).
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types, non_snake_case)]
+pub struct ZSTD_frameParameters {
+    pub contentSizeFlag: c_int,
+    pub checksumFlag: c_int,
+    pub noDictIDFlag: c_int,
+}
+
+/// `ZSTD_customMem` — ABI mirror (alloc fn, free fn, opaque). Custom
+/// allocators are not supported: only the all-`NULL` value (`ZSTD_defaultCMem`)
+/// is accepted; anything else fails creation.
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types, non_snake_case)]
+pub struct ZSTD_customMem {
+    pub customAlloc: *const core::ffi::c_void,
+    pub customFree: *const core::ffi::c_void,
+    pub opaque: *const core::ffi::c_void,
+}
+
+/// Representative compression level for an explicit strategy ordinal: feeds
+/// the level-derived defaults for the knobs `cParams` leaves at 0.
+fn level_for_strategy(strategy: c_uint) -> c_int {
+    match strategy {
+        1 => 1,  // fast
+        2 => 3,  // dfast
+        3 => 5,  // greedy
+        4 => 6,  // lazy
+        5 => 9,  // lazy2
+        6 => 13, // btlazy2
+        7 => 16, // btopt
+        8 => 18, // btultra
+        _ => 19, // btultra2 (and out-of-range falls into the strongest tier)
+    }
+}
+
+/// Map explicit `ZSTD_compressionParameters` to the sticky-parameter
+/// snapshot the codec resolves (0 = auto for every knob, upstream rule).
+fn cctx_params_from_cparams(cparams: &ZSTD_compressionParameters) -> crate::params::CCtxParams {
+    use codec::encoding::Strategy;
+    let opt = |v: c_uint| if v == 0 { None } else { Some(v) };
+    crate::params::CCtxParams {
+        level: level_for_strategy(cparams.strategy),
+        window_log: opt(cparams.windowLog),
+        hash_log: opt(cparams.hashLog),
+        chain_log: opt(cparams.chainLog),
+        search_log: opt(cparams.searchLog),
+        min_match: opt(cparams.minMatch),
+        target_length: opt(cparams.targetLength),
+        strategy: Strategy::from_ordinal(cparams.strategy),
+        ..crate::params::CCtxParams::default()
+    }
+}
+
+/// `ZSTD_CDict* ZSTD_createCDict_advanced(const void* dictBuffer, size_t
+/// dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e
+/// dictContentType, ZSTD_compressionParameters cParams, ZSTD_customMem
+/// customMem)` — explicit content type + compression parameters. The load
+/// method is ignored (bytes are always copied); custom allocators are not
+/// supported (`customMem` must be all-`NULL`).
+///
+/// # Safety
+/// `dict_buffer` must be valid for `dict_size` bytes (or `NULL` with 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createCDict_advanced(
+    dict_buffer: *const u8,
+    dict_size: usize,
+    _dict_load_method: c_int,
+    dict_content_type: c_int,
+    cparams: ZSTD_compressionParameters,
+    custom_mem: ZSTD_customMem,
+) -> *mut ZSTD_CDict {
+    if !custom_mem.customAlloc.is_null() || !custom_mem.customFree.is_null() {
+        return core::ptr::null_mut();
+    }
+    let dict = unsafe { in_slice(dict_buffer, dict_size) };
+    if dict.is_empty() {
+        return core::ptr::null_mut();
+    }
+    let has_magic =
+        dict.len() >= 8 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+    let raw_content = match dict_content_type {
+        crate::attach::ZSTD_DCT_AUTO => !has_magic,
+        crate::attach::ZSTD_DCT_RAW_CONTENT => true,
+        crate::attach::ZSTD_DCT_FULL_DICT if has_magic => false,
+        _ => return core::ptr::null_mut(),
+    };
+    if !raw_content {
+        let outcome = catch_unwind(AssertUnwindSafe(|| EncoderDictionary::from_bytes(dict)));
+        match outcome {
+            Ok(Ok(_)) => {}
+            _ => return core::ptr::null_mut(),
+        }
+    }
+    let params = cctx_params_from_cparams(&cparams);
+    try_box(ZSTD_CDict {
+        raw: dict.to_vec(),
+        id: if raw_content {
+            0
+        } else {
+            dict_id_from_bytes(dict)
+        },
+        level: params.level,
+        serial: next_dict_serial(),
+        raw_content,
+        cparams: Some(params),
+    })
+}
+
+/// `ZSTD_DDict* ZSTD_createDDict_advanced(const void* dictBuffer, size_t
+/// dictSize, ZSTD_dictLoadMethod_e dictLoadMethod, ZSTD_dictContentType_e
+/// dictContentType, ZSTD_customMem customMem)` — explicit content type. The
+/// load method is ignored (bytes are always copied); custom allocators are
+/// not supported.
+///
+/// # Safety
+/// `dict_buffer` must be valid for `dict_size` bytes (or `NULL` with 0).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_createDDict_advanced(
+    dict_buffer: *const u8,
+    dict_size: usize,
+    _dict_load_method: c_int,
+    dict_content_type: c_int,
+    custom_mem: ZSTD_customMem,
+) -> *mut ZSTD_DDict {
+    if !custom_mem.customAlloc.is_null() || !custom_mem.customFree.is_null() {
+        return core::ptr::null_mut();
+    }
+    let dict = unsafe { in_slice(dict_buffer, dict_size) };
+    if dict.is_empty() {
+        return core::ptr::null_mut();
+    }
+    if !matches!(
+        dict_content_type,
+        crate::attach::ZSTD_DCT_AUTO
+            | crate::attach::ZSTD_DCT_RAW_CONTENT
+            | crate::attach::ZSTD_DCT_FULL_DICT
+    ) {
+        return core::ptr::null_mut();
+    }
+    let id = if dict_content_type == crate::attach::ZSTD_DCT_RAW_CONTENT {
+        0
+    } else {
+        dict_id_from_bytes(dict)
+    };
+    try_box(ZSTD_DDict {
+        raw: dict.to_vec(),
+        id,
+        serial: next_dict_serial(),
+        content_type: dict_content_type,
+    })
 }
 
 /// `size_t ZSTD_freeCDict(ZSTD_CDict* CDict)` — free the dictionary; `NULL` is a
@@ -203,8 +437,7 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
             // Upstream ZSTD_compress_usingCDict leaves checksum off unless the
             // CDict's params enabled it; we match the plain default.
             enc.set_content_checksum(false);
-            enc.set_dictionary_from_bytes(&cdict_ref.raw)
-                .map_err(|_| ())?;
+            cdict_ref.attach_to(&mut enc)?;
             cctx.dict_compressor = Some(enc);
             cctx.dict_serial = key;
             cctx.dict_level = cdict_ref.level;
@@ -217,6 +450,12 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
             ..
         } = cctx;
         let enc = dict_compressor.as_mut().expect("just ensured Some");
+        // Per-call frame-flag reset: the cached compressor is shared with
+        // ZSTD_compress_usingCDict_advanced, whose explicit fParams must not
+        // leak into subsequent plain calls.
+        enc.set_content_checksum(false);
+        enc.set_content_size_flag(true);
+        enc.set_dictionary_id_flag(!cdict_ref.raw_content);
         scratch.clear();
         enc.compress_independent_frame_into(src, scratch);
         Ok::<(), ()>(())
@@ -226,6 +465,75 @@ pub unsafe extern "C" fn ZSTD_compress_usingCDict(
         _ => {
             // A panic / parse failure can leave the cached compressor in an
             // unknown state; drop it so the next call rebuilds cleanly.
+            cctx.dict_compressor = None;
+            cctx.dict_serial = 0;
+            return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+        }
+    }
+    let len = cctx.scratch.len();
+    if len > dst_capacity {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
+    }
+    let dst = unsafe { out_slice(dst, dst_capacity) };
+    dst[..len].copy_from_slice(&cctx.scratch);
+    len
+}
+
+/// `size_t ZSTD_compress_usingCDict_advanced(ZSTD_CCtx* cctx, void* dst,
+/// size_t dstCapacity, const void* src, size_t srcSize, const ZSTD_CDict*
+/// cdict, ZSTD_frameParameters fParams)` — [`ZSTD_compress_usingCDict`] with
+/// explicit frame parameters (content-size / checksum / dictionary-ID flags).
+///
+/// # Safety
+/// Same as [`ZSTD_compress_usingCDict`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZSTD_compress_usingCDict_advanced(
+    cctx: *mut ZSTD_CCtx,
+    dst: *mut u8,
+    dst_capacity: usize,
+    src: *const u8,
+    src_size: usize,
+    cdict: *const ZSTD_CDict,
+    fparams: ZSTD_frameParameters,
+) -> usize {
+    if cctx.is_null() || cdict.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let cctx = unsafe { &mut *cctx };
+    let cdict_ref = unsafe { &*cdict };
+    let src = unsafe { in_slice(src, src_size) };
+    let key = cdict_ref.serial;
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        if cctx.dict_compressor.is_none()
+            || cctx.dict_serial != key
+            || cctx.dict_level != cdict_ref.level
+        {
+            let mut enc: FrameCompressor =
+                FrameCompressor::new(CompressionLevel::from_level(cdict_ref.level));
+            cdict_ref.attach_to(&mut enc)?;
+            cctx.dict_compressor = Some(enc);
+            cctx.dict_serial = key;
+            cctx.dict_level = cdict_ref.level;
+        }
+        let ZSTD_CCtx {
+            scratch,
+            dict_compressor,
+            ..
+        } = cctx;
+        let enc = dict_compressor.as_mut().expect("just ensured Some");
+        enc.set_content_checksum(fparams.checksumFlag != 0);
+        enc.set_content_size_flag(fparams.contentSizeFlag != 0);
+        // Raw-content dictionaries never emit their synthetic ID regardless
+        // of the flag.
+        enc.set_dictionary_id_flag(fparams.noDictIDFlag == 0 && !cdict_ref.raw_content);
+        scratch.clear();
+        enc.compress_independent_frame_into(src, scratch);
+        Ok::<(), ()>(())
+    }));
+    match outcome {
+        Ok(Ok(())) => {}
+        _ => {
             cctx.dict_compressor = None;
             cctx.dict_serial = 0;
             return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
@@ -252,11 +560,15 @@ pub unsafe extern "C" fn ZSTD_createDDict(
     dict_size: usize,
 ) -> *mut ZSTD_DDict {
     let dict = unsafe { in_slice(dict_buffer, dict_size) };
+    if dict.is_empty() {
+        return core::ptr::null_mut();
+    }
     let id = dict_id_from_bytes(dict);
     try_box(ZSTD_DDict {
         raw: dict.to_vec(),
         id,
         serial: next_dict_serial(),
+        content_type: crate::attach::ZSTD_DCT_AUTO,
     })
 }
 
@@ -339,28 +651,31 @@ pub unsafe extern "C" fn ZSTD_decompress_usingDDict(
     let dst = unsafe { out_slice(dst, dst_capacity) };
     let key = ddict_ref.serial;
 
-    if dctx.ddict_serial != key {
-        let added = catch_unwind(AssertUnwindSafe(|| {
-            dctx.decoder.add_dict_from_bytes(&ddict_ref.raw)
+    // Parse the dictionary once per DDict (keyed by its serial); decoding
+    // then forces the parsed handle per frame, which also covers raw-content
+    // dictionaries and ID-less frames.
+    if dctx.ddict_serial != key || dctx.ddict_handle.is_none() {
+        let parsed = catch_unwind(AssertUnwindSafe(|| {
+            crate::attach::parse_decode_dict(&ddict_ref.raw, ddict_ref.content_type)
         }));
-        match added {
-            Ok(Ok(())) => dctx.ddict_serial = key,
-            // A clean parse failure leaves the decoder untouched, so it stays
-            // reusable as-is.
-            Ok(Err(_)) => return encode(ZSTD_ErrorCode::ZSTD_error_dictionary_corrupted),
-            // A panic may have mutated the decoder mid-load, leaving it poisoned;
-            // replace it with a fresh one and drop the stale cache key so the
-            // next call re-loads cleanly rather than trusting a broken decoder.
+        match parsed {
+            Ok(Ok(handle)) => {
+                dctx.ddict_handle = Some(handle);
+                dctx.ddict_serial = key;
+            }
+            Ok(Err(code)) => return encode(code),
             Err(_) => {
-                dctx.decoder = codec::decoding::FrameDecoder::new();
-                dctx.stream_frame_done = true;
+                dctx.ddict_handle = None;
                 dctx.ddict_serial = 0;
                 return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
             }
         }
     }
+    let handle = dctx.ddict_handle.clone().expect("just ensured Some");
     dctx.decoder.set_content_checksum(ContentChecksum::Verify);
-    let outcome = catch_unwind(AssertUnwindSafe(|| dctx.decoder.decode_all(src, dst)));
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        dctx.decoder.decode_all_with_dict_handle(src, dst, &handle)
+    }));
     match outcome {
         Ok(Ok(written)) => {
             // One-shot consumed whole frames: the context is back at a

--- a/c-api/src/cdict.rs
+++ b/c-api/src/cdict.rs
@@ -353,13 +353,15 @@ pub unsafe extern "C" fn ZSTD_createDDict_advanced(
     if dict.is_empty() {
         return core::ptr::null_mut();
     }
-    if !matches!(
-        dict_content_type,
-        crate::attach::ZSTD_DCT_AUTO
-            | crate::attach::ZSTD_DCT_RAW_CONTENT
-            | crate::attach::ZSTD_DCT_FULL_DICT
-    ) {
-        return core::ptr::null_mut();
+    // FULL_DICT requires the dictionary magic up front: failing here mirrors
+    // the CDict creator and the loadDictionary paths, instead of handing out
+    // a handle that only fails later at decompression time.
+    let has_magic =
+        dict.len() >= 4 && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == DICT_MAGIC;
+    match dict_content_type {
+        crate::attach::ZSTD_DCT_AUTO | crate::attach::ZSTD_DCT_RAW_CONTENT => {}
+        crate::attach::ZSTD_DCT_FULL_DICT if has_magic => {}
+        _ => return core::ptr::null_mut(),
     }
     let id = if dict_content_type == crate::attach::ZSTD_DCT_RAW_CONTENT {
         0

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -267,8 +267,19 @@ pub unsafe extern "C" fn ZSTD_compress2(
     if pledged != crate::params::CONTENTSIZE_UNKNOWN && pledged != src_size as u64 {
         return encode(ZSTD_ErrorCode::ZSTD_error_srcSize_wrong);
     }
-    let Some(resolved) = cctx.params.resolve() else {
-        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
+    // A referenced CDict's compression parameters are authoritative
+    // (upstream rule), so the sticky knobs are resolved — and can reject —
+    // only when they will actually drive the frame; an unsupported sticky
+    // combination must not break a valid RefCDict path.
+    let resolved = if cctx.attach_params_from_cdict() {
+        None
+    } else {
+        match cctx.params.resolve() {
+            Some(resolved) => Some(resolved),
+            None => {
+                return encode(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
+            }
+        }
     };
     let params = cctx.params;
     let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<(), ZSTD_ErrorCode> {
@@ -298,9 +309,10 @@ pub unsafe extern "C" fn ZSTD_compress2(
             } = cctx;
             let enc = dict_compressor.as_mut().expect("just ensured Some");
             // A referenced CDict's compression parameters win (upstream
-            // rule); every other attach honours the sticky knobs.
-            if !params_from_cdict {
-                enc.set_parameters(&resolved);
+            // rule); every other attach honours the sticky knobs
+            // (`resolved` is `Some` exactly when they apply).
+            if !params_from_cdict && let Some(resolved) = &resolved {
+                enc.set_parameters(resolved);
             }
             enc.set_content_checksum(params.checksum_flag);
             enc.set_content_size_flag(params.content_size_flag);
@@ -317,7 +329,10 @@ pub unsafe extern "C" fn ZSTD_compress2(
         } else {
             let mut enc: FrameCompressor =
                 FrameCompressor::new(CompressionLevel::from_level(params.level));
-            enc.set_parameters(&resolved);
+            // No attach on this path, so the sticky knobs always resolved.
+            if let Some(resolved) = &resolved {
+                enc.set_parameters(resolved);
+            }
             enc.set_content_checksum(params.checksum_flag);
             enc.set_content_size_flag(params.content_size_flag);
             enc.set_dictionary_id_flag(params.dict_id_flag);
@@ -422,6 +437,12 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> usize {
     core::mem::size_of::<ZSTD_DCtx>()
         + dctx.decoder.workspace_size()
         + dctx.attached_ddict.heap_size()
+        // The parsed-dictionary cache behind ZSTD_decompress_usingDDict is
+        // context-owned (the parse copy, not the caller's DDict bytes).
+        + dctx.ddict_handle.as_ref().map_or(0, |h| {
+            h.as_dict().dict_content.len()
+                + core::mem::size_of::<codec::decoding::Dictionary>()
+        })
 }
 
 /// `size_t ZSTD_decompressDCtx(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity,

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -186,6 +186,7 @@ pub unsafe extern "C" fn ZSTD_sizeof_CCtx(cctx: *const ZSTD_CCtx) -> usize {
             .as_ref()
             .map_or(0, |enc| enc.heap_size())
         + cctx.stream.as_ref().map_or(0, |s| s.heap_size())
+        + cctx.attached_dict.heap_size()
 }
 
 /// `size_t ZSTD_compressCCtx(ZSTD_CCtx* cctx, void* dst, size_t dstCapacity,
@@ -418,7 +419,9 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> usize {
         return 0;
     }
     let dctx = unsafe { &*dctx };
-    core::mem::size_of::<ZSTD_DCtx>() + dctx.decoder.workspace_size()
+    core::mem::size_of::<ZSTD_DCtx>()
+        + dctx.decoder.workspace_size()
+        + dctx.attached_ddict.heap_size()
 }
 
 /// `size_t ZSTD_decompressDCtx(ZSTD_DCtx* dctx, void* dst, size_t dstCapacity,

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -344,7 +344,7 @@ pub unsafe extern "C" fn ZSTD_compress2(
         Ok(())
     }));
     match outcome {
-        Ok(Ok(())) => cctx.consume_prefix(),
+        Ok(Ok(())) => {}
         Ok(Err(code)) => {
             cctx.dict_compressor = None;
             cctx.dict_serial = 0;
@@ -362,6 +362,10 @@ pub unsafe extern "C" fn ZSTD_compress2(
     }
     let dst = unsafe { out_slice(dst, dst_capacity) };
     dst[..len].copy_from_slice(&cctx.scratch);
+    // The single-use prefix is spent only now that the frame actually
+    // reached the caller: a dstSize_tooSmall failure above must leave it
+    // armed for the retry with a bigger buffer.
+    cctx.consume_prefix();
     len
 }
 

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -464,16 +464,19 @@ pub unsafe extern "C" fn ZSTD_decompressDCtx(
     // buffer, so there is no allocation for the parameter to limit.
     dctx.decoder.set_content_checksum(ContentChecksum::Verify);
     // Context-attached dictionary (`ZSTD_DCtx_loadDictionary` / `refDDict` /
-    // `refPrefix`) applies to the frames of this one-shot; a prefix is
-    // single-use and consumed regardless of outcome.
+    // `refPrefix`) applies to the frames of this one-shot. A prefix is
+    // single-use, but "use" means a frame actually started with it — the
+    // streaming path consumes it only after a successful reset, so the
+    // one-shot consumes it only on success (a garbage input must not eat
+    // the prefix out from under the retry).
     let attached = dctx.attached_handle();
-    dctx.consume_prefix();
     let outcome = catch_unwind(AssertUnwindSafe(|| match &attached {
         Some(handle) => dctx.decoder.decode_all_with_dict_handle(src, dst, handle),
         None => dctx.decoder.decode_all(src, dst),
     }));
     match outcome {
         Ok(Ok(written)) => {
+            dctx.consume_prefix();
             // The one-shot consumed whole frames; the context sits at a
             // frame boundary again. Without this, a context abandoned
             // mid-stream earlier would make the next

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -442,10 +442,11 @@ pub unsafe extern "C" fn ZSTD_sizeof_DCtx(dctx: *const ZSTD_DCtx) -> usize {
         + dctx.decoder.workspace_size()
         + dctx.attached_ddict.heap_size()
         // The parsed-dictionary cache behind ZSTD_decompress_usingDDict is
-        // context-owned (the parse copy, not the caller's DDict bytes).
+        // context-owned (the parse copy, not the caller's DDict bytes);
+        // same accounting as the attach path: content + entropy-table heap
+        // plus the inline struct.
         + dctx.ddict_handle.as_ref().map_or(0, |h| {
-            h.as_dict().dict_content.len()
-                + core::mem::size_of::<codec::decoding::Dictionary>()
+            h.as_dict().heap_bytes() + core::mem::size_of::<codec::decoding::Dictionary>()
         })
 }
 

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -304,9 +304,14 @@ pub unsafe extern "C" fn ZSTD_compress2(
             enc.set_content_checksum(params.checksum_flag);
             enc.set_content_size_flag(params.content_size_flag);
             enc.set_dictionary_id_flag(params.dict_id_flag && !suppress_id);
-            if params.target_cblock_size > 0 {
-                enc.set_target_block_size(Some(params.target_cblock_size as u32));
-            }
+            // The cached compressor outlives parameter changes: clear the cap
+            // explicitly when the sticky knob is back at 0 (auto), or a cap
+            // set by an earlier call would silently survive.
+            enc.set_target_block_size(if params.target_cblock_size > 0 {
+                Some(params.target_cblock_size as u32)
+            } else {
+                None
+            });
             enc.compress_independent_frame_into(src, scratch);
         } else {
             let mut enc: FrameCompressor =

--- a/c-api/src/context.rs
+++ b/c-api/src/context.rs
@@ -77,6 +77,10 @@ pub struct ZSTD_CCtx {
     /// rather than raw address so a freed-then-realloc'd handle can't alias.
     pub(crate) dict_serial: u64,
     pub(crate) dict_level: c_int,
+    /// Context-attached dictionary (`ZSTD_CCtx_loadDictionary` /
+    /// `ZSTD_CCtx_refCDict` / `ZSTD_CCtx_refPrefix`), applied at every frame
+    /// start by `ZSTD_compress2` / `ZSTD_compressStream2`.
+    pub(crate) attached_dict: crate::attach::CCtxDictAttach,
 }
 
 /// Opaque decompression context. Wraps a reusable [`FrameDecoder`] so its
@@ -90,12 +94,19 @@ pub struct ZSTD_DCtx {
     /// Whether the streaming decoder sits at a frame boundary (the next
     /// `ZSTD_decompressStream` input starts a new frame). `true` initially.
     pub(crate) stream_frame_done: bool,
+    /// Context-attached dictionary (`ZSTD_DCtx_loadDictionary` /
+    /// `ZSTD_DCtx_refDDict` / `ZSTD_DCtx_refPrefix`), applied at every frame
+    /// start by `ZSTD_decompressDCtx` / `ZSTD_decompressStream`.
+    pub(crate) attached_ddict: crate::attach::DCtxDictAttach,
     /// Identity of the `DDict` whose content was last loaded into `decoder`
     /// (its never-reused serial; `0` = none), so repeated
     /// `ZSTD_decompress_usingDDict` calls with the same DDict skip re-adding it.
     /// Reset to `0` whenever `decoder` is replaced, so a fresh decoder is never
     /// trusted to still hold the previously-loaded dictionary.
     pub(crate) ddict_serial: u64,
+    /// Parsed-dictionary cache for `ZSTD_decompress_usingDDict`, keyed by
+    /// `ddict_serial`: repeated calls with the same DDict skip the re-parse.
+    pub(crate) ddict_handle: Option<codec::decoding::DictionaryHandle>,
 }
 
 /// `ZSTD_CCtx* ZSTD_createCCtx(void)`. Returns `NULL` on allocation failure
@@ -109,6 +120,7 @@ pub extern "C" fn ZSTD_createCCtx() -> *mut ZSTD_CCtx {
         dict_compressor: None,
         dict_serial: 0,
         dict_level: 0,
+        attached_dict: crate::attach::CCtxDictAttach::None,
     })
 }
 
@@ -134,6 +146,7 @@ impl ZSTD_CCtx {
         self.dict_compressor = None;
         self.dict_serial = 0;
         self.dict_level = 0;
+        self.attached_dict = crate::attach::CCtxDictAttach::None;
     }
 }
 
@@ -257,21 +270,70 @@ pub unsafe extern "C" fn ZSTD_compress2(
         return encode(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
     };
     let params = cctx.params;
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
+    let outcome = catch_unwind(AssertUnwindSafe(|| -> Result<(), ZSTD_ErrorCode> {
         cctx.scratch.clear();
-        let mut enc: FrameCompressor =
-            FrameCompressor::new(CompressionLevel::from_level(params.level));
-        enc.set_parameters(&resolved);
-        enc.set_content_checksum(params.checksum_flag);
-        enc.set_content_size_flag(params.content_size_flag);
-        enc.set_dictionary_id_flag(params.dict_id_flag);
-        if params.target_cblock_size > 0 {
-            enc.set_target_block_size(Some(params.target_cblock_size as u32));
+        if cctx.has_attached_dict() {
+            // Dictionary frames route through the context's cached
+            // dict-compressor (same cache as ZSTD_compress_usingCDict, keyed
+            // by attach serial + level) so repeated frames with the same
+            // attach skip the dictionary re-parse / re-prime.
+            let key = cctx.attach_serial();
+            let level = cctx.attach_level();
+            if cctx.dict_compressor.is_none() || cctx.dict_serial != key || cctx.dict_level != level
+            {
+                let mut enc: FrameCompressor =
+                    FrameCompressor::new(CompressionLevel::from_level(level));
+                cctx.apply_attached_dict(&mut enc)?;
+                cctx.dict_compressor = Some(enc);
+                cctx.dict_serial = key;
+                cctx.dict_level = level;
+            }
+            let suppress_id = cctx.attach_suppresses_dict_id();
+            let params_from_cdict = cctx.attach_params_from_cdict();
+            let ZSTD_CCtx {
+                scratch,
+                dict_compressor,
+                ..
+            } = cctx;
+            let enc = dict_compressor.as_mut().expect("just ensured Some");
+            // A referenced CDict's compression parameters win (upstream
+            // rule); every other attach honours the sticky knobs.
+            if !params_from_cdict {
+                enc.set_parameters(&resolved);
+            }
+            enc.set_content_checksum(params.checksum_flag);
+            enc.set_content_size_flag(params.content_size_flag);
+            enc.set_dictionary_id_flag(params.dict_id_flag && !suppress_id);
+            if params.target_cblock_size > 0 {
+                enc.set_target_block_size(Some(params.target_cblock_size as u32));
+            }
+            enc.compress_independent_frame_into(src, scratch);
+        } else {
+            let mut enc: FrameCompressor =
+                FrameCompressor::new(CompressionLevel::from_level(params.level));
+            enc.set_parameters(&resolved);
+            enc.set_content_checksum(params.checksum_flag);
+            enc.set_content_size_flag(params.content_size_flag);
+            enc.set_dictionary_id_flag(params.dict_id_flag);
+            if params.target_cblock_size > 0 {
+                enc.set_target_block_size(Some(params.target_cblock_size as u32));
+            }
+            enc.compress_independent_frame_into(src, &mut cctx.scratch);
         }
-        enc.compress_independent_frame_into(src, &mut cctx.scratch);
+        Ok(())
     }));
-    if outcome.is_err() {
-        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    match outcome {
+        Ok(Ok(())) => cctx.consume_prefix(),
+        Ok(Err(code)) => {
+            cctx.dict_compressor = None;
+            cctx.dict_serial = 0;
+            return encode(code);
+        }
+        Err(_) => {
+            cctx.dict_compressor = None;
+            cctx.dict_serial = 0;
+            return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+        }
     }
     let len = cctx.scratch.len();
     if len > dst_capacity {
@@ -290,7 +352,9 @@ pub extern "C" fn ZSTD_createDCtx() -> *mut ZSTD_DCtx {
         decoder: FrameDecoder::new(),
         window_log_max: crate::params::WINDOW_LOG_LIMIT_DEFAULT,
         stream_frame_done: true,
+        attached_ddict: crate::attach::DCtxDictAttach::None,
         ddict_serial: 0,
+        ddict_handle: None,
     })
 }
 
@@ -315,6 +379,8 @@ impl ZSTD_DCtx {
         self.decoder = FrameDecoder::new();
         self.stream_frame_done = true;
         self.ddict_serial = 0;
+        self.ddict_handle = None;
+        self.attached_ddict = crate::attach::DCtxDictAttach::None;
     }
 }
 
@@ -389,7 +455,15 @@ pub unsafe extern "C" fn ZSTD_decompressDCtx(
     // The single-pass decode writes into the caller's dst with no window
     // buffer, so there is no allocation for the parameter to limit.
     dctx.decoder.set_content_checksum(ContentChecksum::Verify);
-    let outcome = catch_unwind(AssertUnwindSafe(|| dctx.decoder.decode_all(src, dst)));
+    // Context-attached dictionary (`ZSTD_DCtx_loadDictionary` / `refDDict` /
+    // `refPrefix`) applies to the frames of this one-shot; a prefix is
+    // single-use and consumed regardless of outcome.
+    let attached = dctx.attached_handle();
+    dctx.consume_prefix();
+    let outcome = catch_unwind(AssertUnwindSafe(|| match &attached {
+        Some(handle) => dctx.decoder.decode_all_with_dict_handle(src, dst, handle),
+        None => dctx.decoder.decode_all(src, dst),
+    }));
     match outcome {
         Ok(Ok(written)) => {
             // The one-shot consumed whole frames; the context sits at a

--- a/c-api/src/dict.rs
+++ b/c-api/src/dict.rs
@@ -95,6 +95,183 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer(
     dict.len()
 }
 
+/// `ZDICT_fastCover_params_t` — FastCOVER tuning, ABI-identical to `zdict.h`.
+#[repr(C)]
+#[derive(Copy, Clone)]
+#[allow(non_camel_case_types, non_snake_case)]
+pub struct ZDICT_fastCover_params_t {
+    /// Segment size (0 = optimize over the default candidate grid).
+    pub k: c_uint,
+    /// Dmer size (0 = optimize; only 6 / 8 are meaningful upstream).
+    pub d: c_uint,
+    /// Frequency-array log size (0 = default 20).
+    pub f: c_uint,
+    /// Optimization step count (0 = default grid).
+    pub steps: c_uint,
+    /// Training thread count; this build trains on the calling thread.
+    pub nbThreads: c_uint,
+    /// Fraction of samples used for training vs testing (0.0 = default).
+    pub splitPoint: f64,
+    /// Acceleration factor (0 = default 1).
+    pub accel: c_uint,
+    /// Shrink-dict toggle (accepted; the trainer always sizes to capacity).
+    pub shrinkDict: c_uint,
+    /// Shrink-dict regression bound (accepted with `shrinkDict`).
+    pub shrinkDictMaxRegression: c_uint,
+    pub zParams: ZDICT_params_t,
+}
+
+/// Map caller FastCOVER parameters onto the trainer's options. `optimize`
+/// distinguishes the plain train entry (explicit k/d required upstream) from
+/// the optimizing entry (0 = sweep the candidate grid).
+fn fastcover_options(params: &ZDICT_fastCover_params_t, optimize: bool) -> FastCoverOptions {
+    let mut opts = FastCoverOptions {
+        optimize,
+        ..FastCoverOptions::default()
+    };
+    if params.k != 0 {
+        opts.k = params.k as usize;
+        if optimize {
+            opts.k_candidates = vec![params.k as usize];
+        }
+    }
+    if params.d != 0 {
+        opts.d = params.d as usize;
+        if optimize {
+            opts.d_candidates = vec![params.d as usize];
+        }
+    }
+    if params.f != 0 {
+        opts.f = params.f;
+        if optimize {
+            opts.f_candidates = vec![params.f];
+        }
+    }
+    if params.accel != 0 {
+        opts.accel = params.accel as usize;
+    }
+    if params.splitPoint > 0.0 {
+        opts.split_point = params.splitPoint;
+    }
+    opts
+}
+
+/// Shared body of the FastCOVER train entry points.
+///
+/// # Safety
+/// Buffer contracts of [`ZDICT_trainFromBuffer`].
+unsafe fn train_fastcover(
+    dict_buffer: *mut u8,
+    dict_capacity: usize,
+    samples_buffer: *const u8,
+    samples_sizes: *const usize,
+    nb_samples: c_uint,
+    params: &ZDICT_fastCover_params_t,
+    optimize: bool,
+) -> usize {
+    let Some(total) = (unsafe { total_sample_len(samples_sizes, nb_samples) }) else {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
+    };
+    let samples = unsafe { in_slice(samples_buffer, total) };
+    let finalize = FinalizeOptions {
+        dict_id: (params.zParams.dictID != 0).then_some(params.zParams.dictID),
+    };
+    let opts = fastcover_options(params, optimize);
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        let mut out = Vec::new();
+        create_fastcover_dict_from_source(samples, &mut out, dict_capacity, &opts, finalize)
+            .map(|_| out)
+    }));
+    let dict = match outcome {
+        Ok(Ok(dict)) => dict,
+        _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed),
+    };
+    if dict.len() > dict_capacity {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
+    }
+    let out = unsafe { crate::ffi::out_slice(dict_buffer, dict_capacity) };
+    out[..dict.len()].copy_from_slice(&dict);
+    dict.len()
+}
+
+/// `size_t ZDICT_trainFromBuffer_fastCover(void* dictBuffer, size_t
+/// dictBufferCapacity, const void* samplesBuffer, const size_t* samplesSizes,
+/// unsigned nbSamples, ZDICT_fastCover_params_t parameters)` — FastCOVER
+/// training with explicit parameters (no optimization sweep).
+///
+/// # Safety
+/// Buffer contracts of [`ZDICT_trainFromBuffer`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
+    dict_buffer: *mut u8,
+    dict_capacity: usize,
+    samples_buffer: *const u8,
+    samples_sizes: *const usize,
+    nb_samples: c_uint,
+    parameters: ZDICT_fastCover_params_t,
+) -> usize {
+    unsafe {
+        train_fastcover(
+            dict_buffer,
+            dict_capacity,
+            samples_buffer,
+            samples_sizes,
+            nb_samples,
+            &parameters,
+            false,
+        )
+    }
+}
+
+/// `size_t ZDICT_optimizeTrainFromBuffer_fastCover(void* dictBuffer, size_t
+/// dictBufferCapacity, const void* samplesBuffer, const size_t* samplesSizes,
+/// unsigned nbSamples, ZDICT_fastCover_params_t* parameters)` — FastCOVER
+/// training with a parameter sweep over the candidate grid; explicit non-zero
+/// `k` / `d` / `f` pin that axis. The chosen values are written back into
+/// `parameters` on success, per upstream.
+///
+/// # Safety
+/// Buffer contracts of [`ZDICT_trainFromBuffer`]; `parameters` must be a
+/// valid, writable pointer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_fastCover(
+    dict_buffer: *mut u8,
+    dict_capacity: usize,
+    samples_buffer: *const u8,
+    samples_sizes: *const usize,
+    nb_samples: c_uint,
+    parameters: *mut ZDICT_fastCover_params_t,
+) -> usize {
+    if parameters.is_null() {
+        return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
+    }
+    let params = unsafe { *parameters };
+    let written = unsafe {
+        train_fastcover(
+            dict_buffer,
+            dict_capacity,
+            samples_buffer,
+            samples_sizes,
+            nb_samples,
+            &params,
+            true,
+        )
+    };
+    if !crate::error::result_is_error(written) {
+        // The trainer does not report the swept winner back, so pin the
+        // write-back to the effective values (defaults where the caller
+        // passed 0). Upstream writes the chosen k/d/f here.
+        let opts = fastcover_options(&params, true);
+        let p = unsafe { &mut *parameters };
+        p.k = opts.k as c_uint;
+        p.d = opts.d as c_uint;
+        p.f = opts.f;
+        p.accel = opts.accel as c_uint;
+    }
+    written
+}
+
 /// `size_t ZDICT_finalizeDictionary(void* dstDictBuffer, size_t maxDictSize,
 /// const void* dictContent, size_t dictContentSize, const void* samplesBuffer,
 /// const size_t* samplesSizes, unsigned nbSamples, ZDICT_params_t parameters)`.

--- a/c-api/src/dict.rs
+++ b/c-api/src/dict.rs
@@ -108,7 +108,11 @@ pub struct ZDICT_fastCover_params_t {
     pub d: c_uint,
     /// Frequency-array log size (0 = default 20).
     pub f: c_uint,
-    /// Optimization step count (0 = default grid).
+    /// Optimization step count. Accepted for ABI compatibility but not a
+    /// sweep bound here: upstream uses `steps` to budget how many (k, d)
+    /// pairs its optimizer tries, while this trainer always sweeps the full
+    /// candidate grid (a superset of any step budget), so honouring a
+    /// smaller `steps` could only degrade the chosen dictionary.
     pub steps: c_uint,
     /// Training thread count; this build trains on the calling thread.
     pub nbThreads: c_uint,

--- a/c-api/src/dict.rs
+++ b/c-api/src/dict.rs
@@ -228,6 +228,13 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
     nb_samples: c_uint,
     parameters: ZDICT_fastCover_params_t,
 ) -> usize {
+    // The non-optimizing entry requires explicit segment/dmer sizes:
+    // upstream rejects 0 here (the optimizing entry is the one that sweeps
+    // defaults), so silently substituting the candidate-grid defaults would
+    // accept invalid input.
+    if parameters.k == 0 || parameters.d == 0 {
+        return encode(ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
     unsafe {
         train_fastcover(
             dict_buffer,

--- a/c-api/src/dict.rs
+++ b/c-api/src/dict.rs
@@ -8,7 +8,9 @@ use core::ffi::{c_char, c_int, c_uint};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use codec::decoding::Dictionary;
-use codec::dictionary::{FastCoverOptions, FinalizeOptions, create_fastcover_dict_from_source};
+use codec::dictionary::{
+    FastCoverOptions, FastCoverTuned, FinalizeOptions, create_fastcover_dict_from_source,
+};
 
 use crate::error::{ZSTD_ErrorCode, encode};
 use crate::ffi::in_slice;
@@ -160,6 +162,13 @@ fn fastcover_options(params: &ZDICT_fastCover_params_t, optimize: bool) -> FastC
 ///
 /// # Safety
 /// Buffer contracts of [`ZDICT_trainFromBuffer`].
+/// Sweep mode for [`train_fastcover`]: plain training pins the caller's
+/// explicit parameters; optimizing reports the sweep's winner back.
+enum FastCoverMode<'a> {
+    Plain,
+    Optimize(&'a mut FastCoverTuned),
+}
+
 unsafe fn train_fastcover(
     dict_buffer: *mut u8,
     dict_capacity: usize,
@@ -167,7 +176,7 @@ unsafe fn train_fastcover(
     samples_sizes: *const usize,
     nb_samples: c_uint,
     params: &ZDICT_fastCover_params_t,
-    optimize: bool,
+    mode: FastCoverMode<'_>,
 ) -> usize {
     let Some(total) = (unsafe { total_sample_len(samples_sizes, nb_samples) }) else {
         return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
@@ -176,17 +185,21 @@ unsafe fn train_fastcover(
     let finalize = FinalizeOptions {
         dict_id: (params.zParams.dictID != 0).then_some(params.zParams.dictID),
     };
+    let optimize = matches!(mode, FastCoverMode::Optimize(_));
     let opts = fastcover_options(params, optimize);
 
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         let mut out = Vec::new();
         create_fastcover_dict_from_source(samples, &mut out, dict_capacity, &opts, finalize)
-            .map(|_| out)
+            .map(|tuned| (out, tuned))
     }));
-    let dict = match outcome {
-        Ok(Ok(dict)) => dict,
+    let (dict, tuned) = match outcome {
+        Ok(Ok(pair)) => pair,
         _ => return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed),
     };
+    if let FastCoverMode::Optimize(slot) = mode {
+        *slot = tuned;
+    }
     if dict.len() > dict_capacity {
         return encode(ZSTD_ErrorCode::ZSTD_error_dstSize_tooSmall);
     }
@@ -219,7 +232,7 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer_fastCover(
             samples_sizes,
             nb_samples,
             &parameters,
-            false,
+            FastCoverMode::Plain,
         )
     }
 }
@@ -247,6 +260,13 @@ pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_fastCover(
         return encode(ZSTD_ErrorCode::ZSTD_error_GENERIC);
     }
     let params = unsafe { *parameters };
+    let mut tuned = FastCoverTuned {
+        k: 0,
+        d: 0,
+        f: 0,
+        accel: 0,
+        score: 0,
+    };
     let written = unsafe {
         train_fastcover(
             dict_buffer,
@@ -255,19 +275,16 @@ pub unsafe extern "C" fn ZDICT_optimizeTrainFromBuffer_fastCover(
             samples_sizes,
             nb_samples,
             &params,
-            true,
+            FastCoverMode::Optimize(&mut tuned),
         )
     };
     if !crate::error::result_is_error(written) {
-        // The trainer does not report the swept winner back, so pin the
-        // write-back to the effective values (defaults where the caller
-        // passed 0). Upstream writes the chosen k/d/f here.
-        let opts = fastcover_options(&params, true);
+        // Write back the sweep's actual winner (upstream semantics).
         let p = unsafe { &mut *parameters };
-        p.k = opts.k as c_uint;
-        p.d = opts.d as c_uint;
-        p.f = opts.f;
-        p.accel = opts.accel as c_uint;
+        p.k = tuned.k as c_uint;
+        p.d = tuned.d as c_uint;
+        p.f = tuned.f;
+        p.accel = tuned.accel as c_uint;
     }
     written
 }

--- a/c-api/src/dict.rs
+++ b/c-api/src/dict.rs
@@ -72,6 +72,11 @@ pub unsafe extern "C" fn ZDICT_trainFromBuffer(
     let Some(total) = (unsafe { total_sample_len(samples_sizes, nb_samples) }) else {
         return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
     };
+    // A NULL buffer with a non-zero length is caller error, reported as an
+    // encoded error code — it must never reach slice construction.
+    if (samples_buffer.is_null() && total > 0) || (dict_buffer.is_null() && dict_capacity > 0) {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
+    }
     let samples = unsafe { in_slice(samples_buffer, total) };
 
     let outcome = catch_unwind(AssertUnwindSafe(|| {
@@ -185,6 +190,10 @@ unsafe fn train_fastcover(
     let Some(total) = (unsafe { total_sample_len(samples_sizes, nb_samples) }) else {
         return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
     };
+    // NULL + non-zero length is caller error, not a slice to build.
+    if (samples_buffer.is_null() && total > 0) || (dict_buffer.is_null() && dict_capacity > 0) {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
+    }
     let samples = unsafe { in_slice(samples_buffer, total) };
     let finalize = FinalizeOptions {
         dict_id: (params.zParams.dictID != 0).then_some(params.zParams.dictID),
@@ -331,6 +340,13 @@ pub unsafe extern "C" fn ZDICT_finalizeDictionary(
     let Some(total) = (unsafe { total_sample_len(samples_sizes, nb_samples) }) else {
         return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
     };
+    // NULL + non-zero length is caller error, not a slice to build.
+    if (samples_buffer.is_null() && total > 0)
+        || (dict_content.is_null() && dict_content_size > 0)
+        || (dst_dict_buffer.is_null() && max_dict_size > 0)
+    {
+        return encode(ZSTD_ErrorCode::ZSTD_error_dictionaryCreation_failed);
+    }
     let content = unsafe { in_slice(dict_content, dict_content_size) };
     let samples = unsafe { in_slice(samples_buffer, total) };
     // dictID 0 means "derive a compliant id"; any non-zero value is forced.

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -45,6 +45,7 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     if cparams.windowLog > WINDOW_LOG_MAX
         || cparams.hashLog > TABLE_LOG_MAX
         || cparams.chainLog > TABLE_LOG_MAX
+        || !(1..=9).contains(&cparams.strategy)
     {
         return crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
     }
@@ -59,7 +60,11 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     } else {
         4usize << cparams.chainLog
     };
-    core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + 3 * BLOCK_SIZE_MAX
+    // Binary-tree strategies retain the optimal-parser workspace (and, for
+    // btultra/btultra2, the HC3 side table) on top of the hash/chain tables.
+    let bt =
+        codec::encoding::estimated_bt_strategy_extra_bytes(cparams.strategy, cparams.windowLog);
+    core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + bt + 3 * BLOCK_SIZE_MAX
 }
 
 /// `size_t ZSTD_estimateCStreamSize_usingCParams(ZSTD_compressionParameters

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -15,6 +15,10 @@ use crate::context::{ZSTD_CCtx, ZSTD_DCtx};
 /// 128 KiB — the format's maximum block size; bounds per-block staging.
 const BLOCK_SIZE_MAX: usize = 128 * 1024;
 
+/// `ZSTD_WINDOWLOG_MAX` for the target's pointer width (upstream: 30 on
+/// 32-bit, 31 on 64-bit). Inputs past it are rejected with an encoded error.
+const WINDOW_LOG_MAX: core::ffi::c_uint = if usize::BITS >= 64 { 31 } else { 30 };
+
 /// `size_t ZSTD_estimateCCtxSize(int maxCompressionLevel)` — budget for a
 /// one-shot compression context at the given level.
 #[unsafe(no_mangle)]
@@ -28,16 +32,23 @@ pub extern "C" fn ZSTD_estimateCCtxSize(max_compression_level: c_int) -> usize {
 /// plus the hash + chain tables the parameters request, plus block staging.
 #[unsafe(no_mangle)]
 pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionParameters) -> usize {
-    let window = 1usize << cparams.windowLog.clamp(10, 31);
+    // Out-of-range parameters are an error, not a number to clamp: upstream
+    // validates cParams here and returns an encoded error code (the size_t
+    // ABI carries them — test with ZSTD_isError). The bounds below also
+    // prove the plain arithmetic cannot overflow on any target.
+    if cparams.windowLog > WINDOW_LOG_MAX || cparams.hashLog > 30 || cparams.chainLog > 30 {
+        return crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
+    let window = 1usize << cparams.windowLog.max(10);
     let hash = if cparams.hashLog == 0 {
         0
     } else {
-        4usize << cparams.hashLog.min(30)
+        4usize << cparams.hashLog
     };
     let chain = if cparams.chainLog == 0 {
         0
     } else {
-        4usize << cparams.chainLog.min(30)
+        4usize << cparams.chainLog
     };
     core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + 3 * BLOCK_SIZE_MAX
 }
@@ -57,6 +68,9 @@ pub extern "C" fn ZSTD_estimateDCtxSize() -> usize {
 /// input/output staging buffers.
 #[unsafe(no_mangle)]
 pub extern "C" fn ZSTD_estimateCStreamSize(max_compression_level: c_int) -> usize {
+    // `from_level` clamps the level and the per-level estimate is bounded by
+    // the largest real table set (a few hundred MiB), so plain addition
+    // provably cannot overflow.
     ZSTD_estimateCCtxSize(max_compression_level) + 2 * BLOCK_SIZE_MAX
 }
 
@@ -65,5 +79,12 @@ pub extern "C" fn ZSTD_estimateCStreamSize(max_compression_level: c_int) -> usiz
 /// the window history buffer plus one output block plus the fixed tables.
 #[unsafe(no_mangle)]
 pub extern "C" fn ZSTD_estimateDStreamSize(max_window_size: usize) -> usize {
+    // A window beyond the format's maximum is invalid input, not a number
+    // to absorb: return an encoded error (size_t ABI, test with
+    // ZSTD_isError) so a garbage SIZE_MAX cannot wrap into an
+    // underestimate. The bound also proves the plain addition in range.
+    if max_window_size > (1usize << WINDOW_LOG_MAX) {
+        return crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    }
     ZSTD_estimateDCtxSize() + max_window_size + BLOCK_SIZE_MAX
 }

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -98,7 +98,11 @@ pub extern "C" fn ZSTD_estimateCStreamSize_usingCParams(
     if crate::error::result_is_error(base) {
         return base;
     }
-    base + 2 * BLOCK_SIZE_MAX
+    // Same checked-sum discipline as the one-shot estimate: a validated
+    // `base` can still sit within 256 KiB of usize::MAX on a 32-bit target.
+    base.checked_add(2 * BLOCK_SIZE_MAX).unwrap_or_else(|| {
+        crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound)
+    })
 }
 
 /// `size_t ZSTD_estimateDCtxSize(void)` — budget for a decompression

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -69,7 +69,20 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     // loud signal beats a silent widening.
     let bt =
         codec::encoding::estimated_bt_strategy_extra_bytes(cparams.strategy, cparams.windowLog);
-    core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + bt + 3 * BLOCK_SIZE_MAX
+    // The per-field bounds keep each TERM inside usize, but on a 32-bit
+    // target the SUM can still wrap (e.g. windowLog 30 + hashLog 29 +
+    // chainLog 29) — an under-reported budget is worse than an error for a
+    // sizing contract, so overflow comes back encoded.
+    let Some(total) = core::mem::size_of::<ZSTD_CCtx>()
+        .checked_add(window)
+        .and_then(|v| v.checked_add(hash))
+        .and_then(|v| v.checked_add(chain))
+        .and_then(|v| v.checked_add(bt))
+        .and_then(|v| v.checked_add(3 * BLOCK_SIZE_MAX))
+    else {
+        return crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
+    };
+    total
 }
 
 /// `size_t ZSTD_estimateCStreamSize_usingCParams(ZSTD_compressionParameters

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -62,6 +62,22 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + 3 * BLOCK_SIZE_MAX
 }
 
+/// `size_t ZSTD_estimateCStreamSize_usingCParams(ZSTD_compressionParameters
+/// cParams)` — streaming budget from explicit compression parameters: the
+/// one-shot estimate plus the streaming input/output staging buffers.
+/// Invalid parameters propagate as an encoded error (test with
+/// `ZSTD_isError`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateCStreamSize_usingCParams(
+    cparams: ZSTD_compressionParameters,
+) -> usize {
+    let base = ZSTD_estimateCCtxSize_usingCParams(cparams);
+    if crate::error::result_is_error(base) {
+        return base;
+    }
+    base + 2 * BLOCK_SIZE_MAX
+}
+
 /// `size_t ZSTD_estimateDCtxSize(void)` — budget for a decompression
 /// context before any frame allocates its window (the window itself is
 /// sized per frame; see `ZSTD_estimateDStreamSize`).

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -1,0 +1,69 @@
+//! `ZSTD_estimate*` — memory-budget estimates for contexts and streams.
+//!
+//! The figures are derived from the codec's own per-level tuning table
+//! (`estimated_compression_workspace_bytes`), so they track this library's
+//! real allocations rather than replicating upstream's numbers; like
+//! upstream they are budget upper bounds, not exact accounting.
+
+use core::ffi::c_int;
+
+use codec::encoding::{CompressionLevel, estimated_compression_workspace_bytes};
+
+use crate::cdict::ZSTD_compressionParameters;
+use crate::context::{ZSTD_CCtx, ZSTD_DCtx};
+
+/// 128 KiB — the format's maximum block size; bounds per-block staging.
+const BLOCK_SIZE_MAX: usize = 128 * 1024;
+
+/// `size_t ZSTD_estimateCCtxSize(int maxCompressionLevel)` — budget for a
+/// one-shot compression context at the given level.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateCCtxSize(max_compression_level: c_int) -> usize {
+    core::mem::size_of::<ZSTD_CCtx>()
+        + estimated_compression_workspace_bytes(CompressionLevel::from_level(max_compression_level))
+}
+
+/// `size_t ZSTD_estimateCCtxSize_usingCParams(ZSTD_compressionParameters
+/// cParams)` — budget from explicit compression parameters: window history
+/// plus the hash + chain tables the parameters request, plus block staging.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionParameters) -> usize {
+    let window = 1usize << cparams.windowLog.clamp(10, 31);
+    let hash = if cparams.hashLog == 0 {
+        0
+    } else {
+        4usize << cparams.hashLog.min(30)
+    };
+    let chain = if cparams.chainLog == 0 {
+        0
+    } else {
+        4usize << cparams.chainLog.min(30)
+    };
+    core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + 3 * BLOCK_SIZE_MAX
+}
+
+/// `size_t ZSTD_estimateDCtxSize(void)` — budget for a decompression
+/// context before any frame allocates its window (the window itself is
+/// sized per frame; see `ZSTD_estimateDStreamSize`).
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateDCtxSize() -> usize {
+    // Entropy tables (Huffman + 3×FSE) plus the per-block literal staging
+    // dominate the pre-window footprint.
+    core::mem::size_of::<ZSTD_DCtx>() + 192 * 1024
+}
+
+/// `size_t ZSTD_estimateCStreamSize(int maxCompressionLevel)` — budget for a
+/// streaming compression context: the one-shot estimate plus the streaming
+/// input/output staging buffers.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateCStreamSize(max_compression_level: c_int) -> usize {
+    ZSTD_estimateCCtxSize(max_compression_level) + 2 * BLOCK_SIZE_MAX
+}
+
+/// `size_t ZSTD_estimateDStreamSize(size_t maxWindowSize)` — budget for a
+/// streaming decompression context decoding frames up to `maxWindowSize`:
+/// the window history buffer plus one output block plus the fixed tables.
+#[unsafe(no_mangle)]
+pub extern "C" fn ZSTD_estimateDStreamSize(max_window_size: usize) -> usize {
+    ZSTD_estimateDCtxSize() + max_window_size + BLOCK_SIZE_MAX
+}

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -19,6 +19,10 @@ const BLOCK_SIZE_MAX: usize = 128 * 1024;
 /// 32-bit, 31 on 64-bit). Inputs past it are rejected with an encoded error.
 const WINDOW_LOG_MAX: core::ffi::c_uint = if usize::BITS >= 64 { 31 } else { 30 };
 
+/// Hash/chain table-log ceiling: upstream's 30, additionally bounded so the
+/// `4 << log` table-size term fits `usize` on 32-bit targets.
+const TABLE_LOG_MAX: core::ffi::c_uint = if usize::BITS >= 64 { 30 } else { 29 };
+
 /// `size_t ZSTD_estimateCCtxSize(int maxCompressionLevel)` — budget for a
 /// one-shot compression context at the given level.
 #[unsafe(no_mangle)]
@@ -35,8 +39,13 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     // Out-of-range parameters are an error, not a number to clamp: upstream
     // validates cParams here and returns an encoded error code (the size_t
     // ABI carries them — test with ZSTD_isError). The bounds below also
-    // prove the plain arithmetic cannot overflow on any target.
-    if cparams.windowLog > WINDOW_LOG_MAX || cparams.hashLog > 30 || cparams.chainLog > 30 {
+    // prove the plain arithmetic cannot overflow: `TABLE_LOG_MAX` keeps
+    // `4 << log` inside `usize` on 32-bit targets too, where the upstream
+    // 30-bit table-log ceiling alone would let `4 << 30` wrap.
+    if cparams.windowLog > WINDOW_LOG_MAX
+        || cparams.hashLog > TABLE_LOG_MAX
+        || cparams.chainLog > TABLE_LOG_MAX
+    {
         return crate::error::encode(crate::error::ZSTD_ErrorCode::ZSTD_error_parameter_outOfBound);
     }
     let window = 1usize << cparams.windowLog.max(10);

--- a/c-api/src/estimate.rs
+++ b/c-api/src/estimate.rs
@@ -62,6 +62,11 @@ pub extern "C" fn ZSTD_estimateCCtxSize_usingCParams(cparams: ZSTD_compressionPa
     };
     // Binary-tree strategies retain the optimal-parser workspace (and, for
     // btultra/btultra2, the HC3 side table) on top of the hash/chain tables.
+    // No cast on purpose: this crate only targets platforms where C's
+    // `unsigned int` is 32-bit (it emits the host `libzstd.so.1`), so
+    // `c_uint == u32` here and clippy rejects a redundant conversion. On a
+    // hypothetical 16-bit `c_uint` target this line fails to compile — a
+    // loud signal beats a silent widening.
     let bt =
         codec::encoding::estimated_bt_strategy_extra_bytes(cparams.strategy, cparams.windowLog);
     core::mem::size_of::<ZSTD_CCtx>() + window + hash + chain + bt + 3 * BLOCK_SIZE_MAX

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -10,10 +10,12 @@
 //! dictionary-builder API (`ZDICT_*` from `zdict.h`), dictionary contexts
 //! (`ZSTD_CDict` / `ZSTD_DDict`), the streaming API
 //! (`ZSTD_compressStream2` / `ZSTD_decompressStream` and the legacy
-//! `ZSTD_*Stream` entry points), and the advanced-parameter surface
-//! (`ZSTD_CCtx_setParameter` and friends). The experimental
-//! `ZDICT_STATIC_LINKING_ONLY` trainers and dictionary attach/ref
-//! parameters land in later phases.
+//! `ZSTD_*Stream` entry points), the advanced-parameter surface
+//! (`ZSTD_CCtx_setParameter` and friends), the dictionary attach/ref
+//! family (`ZSTD_CCtx_loadDictionary` / `refCDict` / `refPrefix` and the
+//! `ZSTD_DCtx` mirror, plus the `*_usingDict` one-shots), and the
+//! `ZSTD_estimate*` budget queries. The experimental
+//! `ZDICT_STATIC_LINKING_ONLY` trainers land in later phases.
 //!
 //! Every wrapper here is `unsafe extern "C"`; the safety contracts mirror the
 //! upstream documentation (valid `(ptr, len)` buffers, live context handles).

--- a/c-api/src/lib.rs
+++ b/c-api/src/lib.rs
@@ -27,10 +27,12 @@
 //! `no_std + alloc` surface lives in the pure-Rust [`codec`] crate this depends
 //! on; consumers wanting an embedded build link `codec` directly.
 
+mod attach;
 mod cdict;
 mod context;
 mod dict;
 mod error;
+mod estimate;
 mod ffi;
 mod frame;
 mod params;

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -120,8 +120,8 @@ impl ZSTD_CCtx {
         let mut enc = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(level));
         if self.has_attached_dict() {
             self.apply_attached_dict_streaming(&mut enc)?;
-            if suppress_id || !params.dict_id_flag {
-                enc.set_dictionary_id_flag(false);
+            if (suppress_id || !params.dict_id_flag) && enc.set_dictionary_id_flag(false).is_err() {
+                return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
             }
         }
         let mut setup = || -> Result<(), codec::io::Error> {

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -109,13 +109,22 @@ impl ZSTD_CCtx {
             return Ok(());
         }
         let params = self.params;
-        let Some(resolved) = params.resolve() else {
-            return Err(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
-        };
         // A referenced CDict's compression parameters win over the sticky
-        // knobs (upstream rule); other attaches keep the context level.
+        // knobs (upstream rule); other attaches keep the context level. The
+        // sticky knobs are resolved — and can reject — only when they will
+        // actually drive the frame.
         let level = self.attach_level();
         let params_from_cdict = self.attach_params_from_cdict();
+        let resolved = if params_from_cdict {
+            None
+        } else {
+            match params.resolve() {
+                Some(resolved) => Some(resolved),
+                None => {
+                    return Err(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
+                }
+            }
+        };
         let suppress_id = self.attach_suppresses_dict_id();
         let mut enc = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(level));
         if self.has_attached_dict() {
@@ -125,8 +134,8 @@ impl ZSTD_CCtx {
             }
         }
         let mut setup = || -> Result<(), codec::io::Error> {
-            if !params_from_cdict {
-                enc.set_parameters(&resolved)?;
+            if let Some(resolved) = &resolved {
+                enc.set_parameters(resolved)?;
             }
             enc.set_content_checksum(params.checksum_flag)?;
             if params.target_cblock_size > 0 {

--- a/c-api/src/streaming.rs
+++ b/c-api/src/streaming.rs
@@ -112,9 +112,22 @@ impl ZSTD_CCtx {
         let Some(resolved) = params.resolve() else {
             return Err(ZSTD_ErrorCode::ZSTD_error_parameter_combination_unsupported);
         };
-        let mut enc = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(params.level));
+        // A referenced CDict's compression parameters win over the sticky
+        // knobs (upstream rule); other attaches keep the context level.
+        let level = self.attach_level();
+        let params_from_cdict = self.attach_params_from_cdict();
+        let suppress_id = self.attach_suppresses_dict_id();
+        let mut enc = StreamingEncoder::new(Vec::new(), CompressionLevel::from_level(level));
+        if self.has_attached_dict() {
+            self.apply_attached_dict_streaming(&mut enc)?;
+            if suppress_id || !params.dict_id_flag {
+                enc.set_dictionary_id_flag(false);
+            }
+        }
         let mut setup = || -> Result<(), codec::io::Error> {
-            enc.set_parameters(&resolved)?;
+            if !params_from_cdict {
+                enc.set_parameters(&resolved)?;
+            }
             enc.set_content_checksum(params.checksum_flag)?;
             if params.target_cblock_size > 0 {
                 enc.set_target_block_size(Some(params.target_cblock_size as u32))?;
@@ -134,6 +147,7 @@ impl ZSTD_CCtx {
             return Err(ZSTD_ErrorCode::ZSTD_error_GENERIC);
         }
         self.params.pledged_src_size = CONTENTSIZE_UNKNOWN;
+        self.consume_prefix();
         self.stream = Some(CStreamState {
             encoder: Some(enc),
             pending: Vec::new(),
@@ -349,6 +363,7 @@ pub unsafe extern "C" fn ZSTD_initCStream(zcs: *mut ZSTD_CCtx, compression_level
     cctx.dict_compressor = None;
     cctx.dict_serial = 0;
     cctx.dict_level = 0;
+    cctx.attached_dict = crate::attach::CCtxDictAttach::None;
     cctx.params.level = if compression_level == 0 {
         3
     } else {
@@ -504,11 +519,19 @@ pub unsafe extern "C" fn ZSTD_decompressStream(
                 // Idempotent, safe to reapply on every frame start.
                 dctx.decoder
                     .set_content_checksum(codec::decoding::ContentChecksum::Verify);
-                let reset = catch_unwind(AssertUnwindSafe(|| dctx.decoder.reset(&mut reader)));
+                // Context-attached dictionary (`ZSTD_DCtx_loadDictionary` /
+                // `refDDict` / `refPrefix`): start the frame against it; an
+                // attached prefix is single-use and consumed by this frame.
+                let attached = dctx.attached_handle();
+                let reset = catch_unwind(AssertUnwindSafe(|| match &attached {
+                    Some(handle) => dctx.decoder.reset_with_dict_handle(&mut reader, handle),
+                    None => dctx.decoder.reset(&mut reader),
+                }));
                 match reset {
                     Ok(Ok(())) => {
                         inp.pos = inp.size - reader.len();
                         dctx.stream_frame_done = false;
+                        dctx.consume_prefix();
                     }
                     Ok(Err(err)) => return encode(code_for_decoder_error(&err)),
                     Err(_) => {

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2174,7 +2174,7 @@ fn dict_compressor_cache_drops_stale_target_block_size() {
     // Cap the block size for one frame, then reset the knob to 0 (auto).
     assert_eq!(
         ZSTD_isError(unsafe {
-            ZSTD_CCtx_setParameter(cctx, crate::params::ZSTD_C_TARGET_CBLOCK_SIZE, 256)
+            ZSTD_CCtx_setParameter(cctx, crate::params::ZSTD_C_TARGET_CBLOCK_SIZE, 1536)
         }),
         0
     );

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1577,8 +1577,11 @@ fn decompress_stream_recovers_after_failed_oneshot_on_midframe_context() {
 // ---- Phase 6.2 slice 2: dictionary attach + estimates + fastCover ----
 
 use crate::attach::{
-    ZSTD_CCtx_loadDictionary, ZSTD_CCtx_refCDict, ZSTD_CCtx_refPrefix, ZSTD_DCtx_loadDictionary,
-    ZSTD_DCtx_refDDict, ZSTD_DCtx_refPrefix, ZSTD_compress_usingDict, ZSTD_decompress_usingDict,
+    ZSTD_CCtx_loadDictionary, ZSTD_CCtx_loadDictionary_advanced,
+    ZSTD_CCtx_loadDictionary_byReference, ZSTD_CCtx_refCDict, ZSTD_CCtx_refPrefix,
+    ZSTD_DCtx_loadDictionary, ZSTD_DCtx_loadDictionary_advanced,
+    ZSTD_DCtx_loadDictionary_byReference, ZSTD_DCtx_refDDict, ZSTD_DCtx_refPrefix,
+    ZSTD_DCtx_refPrefix_advanced, ZSTD_compress_usingDict, ZSTD_decompress_usingDict,
     ZSTD_getDictID_fromDict, ZSTD_getDictID_fromFrame,
 };
 use crate::cdict::{
@@ -2214,3 +2217,125 @@ fn dict_compressor_cache_drops_stale_target_block_size() {
     unsafe { ZSTD_freeCCtx(cctx) };
 }
 
+#[test]
+fn by_reference_and_advanced_attach_variants_roundtrip() {
+    // The byReference / _advanced wrappers share the load body; exercise
+    // each entry point end-to-end so a signature or routing regression in
+    // any of them fails loudly.
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+    let dict_id = unsafe { ZSTD_getDictID_fromDict(dict.as_ptr(), dict.len()) };
+
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
+    let mut frame = vec![0u8; payload.len() + 512];
+    let mut out = vec![0u8; payload.len() + 64];
+
+    // byReference pair.
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_loadDictionary_byReference(cctx, dict.as_ptr(), dict.len())
+        }),
+        0
+    );
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), written) },
+        dict_id
+    );
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_DCtx_loadDictionary_byReference(dctx, dict.as_ptr(), dict.len())
+        }),
+        0
+    );
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    // _advanced pair with an explicit fullDict content type.
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_loadDictionary_advanced(cctx, dict.as_ptr(), dict.len(), 0, 2)
+        }),
+        0
+    );
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_DCtx_loadDictionary_advanced(dctx, dict.as_ptr(), dict.len(), 0, 2)
+        }),
+        0
+    );
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    // fullDict selector on raw bytes must be rejected on both sides.
+    let raw = [0xCDu8; 64];
+    assert_ne!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_loadDictionary_advanced(cctx, raw.as_ptr(), raw.len(), 0, 2)
+        }),
+        0
+    );
+    assert_ne!(
+        ZSTD_isError(unsafe {
+            ZSTD_DCtx_loadDictionary_advanced(dctx, raw.as_ptr(), raw.len(), 0, 2)
+        }),
+        0
+    );
+
+    // refPrefix_advanced: rawContent accepted + single-use roundtrip,
+    // fullDict rejected.
+    let prefix = dict_payload();
+    let mut p2 = prefix[..1024].to_vec();
+    p2.extend_from_slice(b"advanced prefix tail 0123456789");
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let written =
+        unsafe { ZSTD_compress2(cctx, frame.as_mut_ptr(), frame.len(), p2.as_ptr(), p2.len()) };
+    assert_eq!(ZSTD_isError(written), 0);
+    assert_ne!(
+        ZSTD_isError(unsafe {
+            ZSTD_DCtx_refPrefix_advanced(dctx, prefix.as_ptr(), prefix.len(), 2)
+        }),
+        0,
+        "fullDict selector must be rejected for a prefix"
+    );
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_DCtx_refPrefix_advanced(dctx, prefix.as_ptr(), prefix.len(), 1)
+        }),
+        0
+    );
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], p2.as_slice());
+
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1595,7 +1595,7 @@ use crate::dict::{
 };
 use crate::estimate::{
     ZSTD_estimateCCtxSize, ZSTD_estimateCCtxSize_usingCParams, ZSTD_estimateCStreamSize,
-    ZSTD_estimateDCtxSize, ZSTD_estimateDStreamSize,
+    ZSTD_estimateCStreamSize_usingCParams, ZSTD_estimateDCtxSize, ZSTD_estimateDStreamSize,
 };
 
 /// Dict-friendly payload: repeats material the trained dictionary covers.
@@ -2151,7 +2151,22 @@ fn estimates_are_sane_budgets() {
         targetLength: 0,
         strategy: 2,
     };
-    assert!(ZSTD_estimateCCtxSize_usingCParams(cparams) > (1 << 20) + 2 * (4 << 17));
+    let one_shot = ZSTD_estimateCCtxSize_usingCParams(cparams);
+    assert!(one_shot > (1 << 20) + 2 * (4 << 17));
+    assert!(
+        ZSTD_estimateCStreamSize_usingCParams(cparams) > one_shot,
+        "streaming must budget more than the one-shot"
+    );
+    // Invalid parameters propagate the encoded error through the stream
+    // variant too.
+    let bad = ZSTD_compressionParameters {
+        windowLog: 60,
+        ..cparams
+    };
+    assert_ne!(
+        crate::error::ZSTD_isError(ZSTD_estimateCStreamSize_usingCParams(bad)),
+        0
+    );
 }
 
 #[test]

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2263,7 +2263,13 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
     assert_eq!(ZSTD_isError(read), 0);
     assert_eq!(&out[..read], payload.as_slice());
 
-    // _advanced pair with an explicit fullDict content type.
+    // _advanced pair with an explicit fullDict content type. Fresh contexts:
+    // reusing the by-reference-attached ones above would mask an _advanced
+    // wrapper regressing into a no-op (the earlier attach is still live).
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
     assert_eq!(
         ZSTD_isError(unsafe {
             ZSTD_CCtx_loadDictionary_advanced(cctx, dict.as_ptr(), dict.len(), 0, 2)
@@ -2290,6 +2296,17 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
         unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
     assert_eq!(ZSTD_isError(read), 0);
     assert_eq!(&out[..read], payload.as_slice());
+    // The dict frame must NOT decode on a bare context — proves the
+    // _advanced attach (not a leftover) carried the round-trip above.
+    let bare = ZSTD_createDCtx();
+    let bare_read =
+        unsafe { ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_ne!(
+        ZSTD_isError(bare_read),
+        0,
+        "dict frame decoding bare means the _advanced attach was not exercised"
+    );
+    unsafe { ZSTD_freeDCtx(bare) };
 
     // fullDict selector on raw bytes must be rejected on both sides.
     let raw = [0xCDu8; 64];

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2564,6 +2564,63 @@ fn creation_time_validation_rejects_bad_fastcover_and_full_dict_inputs() {
 }
 
 #[test]
+fn ref_ddict_honours_raw_content_selection_for_magic_prefixed_bytes() {
+    // A DDict created with the explicit rawContent selector must stay raw
+    // content at use time even when its bytes happen to start with the
+    // dictionary magic — re-classifying on the magic would reject the
+    // (perfectly valid) raw bytes as a corrupt serialized dictionary.
+    let mut raw = vec![0x37u8, 0xA4, 0x30, 0xEC];
+    raw.extend_from_slice(b"raw content that merely starts with the dictionary magic 0123456789");
+    let no_mem = ZSTD_customMem {
+        customAlloc: core::ptr::null(),
+        customFree: core::ptr::null(),
+        opaque: core::ptr::null(),
+    };
+    let ddict = unsafe { ZSTD_createDDict_advanced(raw.as_ptr(), raw.len(), 0, 1, no_mem) };
+    assert!(!ddict.is_null(), "rawContent DDict creation must succeed");
+
+    let dctx = ZSTD_createDCtx();
+    let attached = unsafe { ZSTD_DCtx_refDDict(dctx, ddict) };
+    assert_eq!(
+        ZSTD_isError(attached),
+        0,
+        "refDDict must honour the DDict's rawContent selection"
+    );
+
+    // Functional cross-check: a frame compressed against the same raw bytes
+    // decodes through the referenced DDict.
+    let mut payload = raw.clone();
+    payload.extend_from_slice(b"payload tail referencing the raw dict 9876543210");
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_loadDictionary_advanced(cctx, raw.as_ptr(), raw.len(), 0, 1)
+        }),
+        0
+    );
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    let mut out = vec![0u8; payload.len() + 64];
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    unsafe { ZSTD_freeCCtx(cctx) };
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeDDict(ddict) };
+}
+
+#[test]
 fn cdict_advanced_rejects_invalid_strategy_ordinal() {
     // ZSTD_strategy spans 1 (fast) … 9 (btultra2); 0 and out-of-range
     // ordinals are invalid input and must fail creation, not silently map

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2339,3 +2339,60 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
     unsafe { ZSTD_freeDCtx(dctx) };
     unsafe { ZSTD_freeCCtx(cctx) };
 }
+
+#[test]
+fn dctx_ref_prefix_survives_a_failed_one_shot() {
+    // A referenced prefix is single-use, but "use" means a frame actually
+    // started with it — the streaming path consumes it only after a
+    // successful reset. A one-shot that fails before any frame starts
+    // (garbage input here) must leave the prefix attached so the retry
+    // with the real frame still decodes.
+    let prefix = dict_payload();
+    let mut payload = prefix[..1024].to_vec();
+    payload.extend_from_slice(b"prefix retry tail 0123456789");
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_DCtx_refPrefix(dctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let mut out = vec![0u8; payload.len() + 64];
+    let garbage = [0u8; 24];
+    let failed = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            garbage.as_ptr(),
+            garbage.len(),
+        )
+    };
+    assert_ne!(ZSTD_isError(failed), 0, "garbage must fail to decode");
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(
+        ZSTD_isError(read),
+        0,
+        "the prefix must survive the failed one-shot"
+    );
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1590,8 +1590,8 @@ use crate::cdict::{
 };
 use crate::context::ZSTD_compress2;
 use crate::dict::{
-    ZDICT_fastCover_params_t, ZDICT_optimizeTrainFromBuffer_fastCover, ZDICT_params_t,
-    ZDICT_trainFromBuffer_fastCover,
+    ZDICT_fastCover_params_t, ZDICT_finalizeDictionary, ZDICT_optimizeTrainFromBuffer_fastCover,
+    ZDICT_params_t, ZDICT_trainFromBuffer_fastCover,
 };
 use crate::estimate::{
     ZSTD_estimateCCtxSize, ZSTD_estimateCCtxSize_usingCParams, ZSTD_estimateCStreamSize,
@@ -2472,4 +2472,95 @@ fn creation_time_validation_rejects_bad_fastcover_and_full_dict_inputs() {
         ddict.is_null(),
         "FULL_DICT without the dictionary magic must fail at creation"
     );
+}
+
+#[test]
+fn zdict_train_rejects_null_buffers_with_nonzero_lengths() {
+    // A NULL buffer paired with a non-zero length must come back as an
+    // encoded error, never reach slice construction: these are documented
+    // error-returning entry points, not UB traps.
+    let mut samples: Vec<u8> = Vec::new();
+    let mut sizes: Vec<usize> = Vec::new();
+    for i in 0..64u32 {
+        let s = format!("sample line {i} with shared structure\n");
+        sizes.push(s.len());
+        samples.extend_from_slice(s.as_bytes());
+    }
+    let mut dict = vec![0u8; 16 * 1024];
+    let params = ZDICT_fastCover_params_t {
+        k: 200,
+        d: 8,
+        f: 20,
+        steps: 0,
+        nbThreads: 0,
+        splitPoint: 0.0,
+        accel: 1,
+        shrinkDict: 0,
+        shrinkDictMaxRegression: 0,
+        zParams: ZDICT_params_t {
+            compressionLevel: 0,
+            notificationLevel: 0,
+            dictID: 0,
+        },
+    };
+
+    // NULL samples buffer while the sizes sum to a non-zero total.
+    let n = unsafe {
+        ZDICT_trainFromBuffer(
+            dict.as_mut_ptr(),
+            dict.len(),
+            core::ptr::null(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+        )
+    };
+    assert_ne!(ZDICT_isError(n), 0, "NULL samplesBuffer must error");
+
+    let n = unsafe {
+        ZDICT_trainFromBuffer_fastCover(
+            dict.as_mut_ptr(),
+            dict.len(),
+            core::ptr::null(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+            params,
+        )
+    };
+    assert_ne!(
+        ZDICT_isError(n),
+        0,
+        "NULL samplesBuffer must error (fastCover)"
+    );
+
+    // NULL destination buffer with a non-zero capacity.
+    let n = unsafe {
+        ZDICT_trainFromBuffer(
+            core::ptr::null_mut(),
+            dict.len(),
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+        )
+    };
+    assert_ne!(ZDICT_isError(n), 0, "NULL dictBuffer must error");
+
+    // NULL raw content with a non-zero length in the finalizer.
+    let zparams = ZDICT_params_t {
+        compressionLevel: 0,
+        notificationLevel: 0,
+        dictID: 0,
+    };
+    let n = unsafe {
+        ZDICT_finalizeDictionary(
+            dict.as_mut_ptr(),
+            dict.len(),
+            core::ptr::null(),
+            1024,
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+            zparams,
+        )
+    };
+    assert_ne!(ZDICT_isError(n), 0, "NULL dictContent must error");
 }

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2396,3 +2396,63 @@ fn dctx_ref_prefix_survives_a_failed_one_shot() {
     unsafe { ZSTD_freeDCtx(dctx) };
     unsafe { ZSTD_freeCCtx(cctx) };
 }
+
+#[test]
+fn creation_time_validation_rejects_bad_fastcover_and_full_dict_inputs() {
+    // Plain (non-optimizing) fastCover training requires explicit k and d:
+    // upstream rejects 0 with parameter_outOfBound instead of silently
+    // substituting defaults.
+    let mut samples: Vec<u8> = Vec::new();
+    let mut sizes: Vec<usize> = Vec::new();
+    for i in 0..64u32 {
+        let s = format!("sample line {i} with shared structure\n");
+        sizes.push(s.len());
+        samples.extend_from_slice(s.as_bytes());
+    }
+    let mut dict = vec![0u8; 16 * 1024];
+    let params = ZDICT_fastCover_params_t {
+        k: 0,
+        d: 0,
+        f: 20,
+        steps: 0,
+        nbThreads: 0,
+        splitPoint: 0.0,
+        accel: 1,
+        shrinkDict: 0,
+        shrinkDictMaxRegression: 0,
+        zParams: ZDICT_params_t {
+            compressionLevel: 0,
+            notificationLevel: 0,
+            dictID: 0,
+        },
+    };
+    let n = unsafe {
+        ZDICT_trainFromBuffer_fastCover(
+            dict.as_mut_ptr(),
+            dict.len(),
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+            params,
+        )
+    };
+    assert_ne!(
+        ZDICT_isError(n),
+        0,
+        "plain fastCover must reject k == 0 / d == 0"
+    );
+
+    // FULL_DICT bytes without the dictionary magic must fail DDict creation
+    // (the CDict creator and the loadDictionary paths already do).
+    let raw = [0xEEu8; 64];
+    let no_mem = ZSTD_customMem {
+        customAlloc: core::ptr::null(),
+        customFree: core::ptr::null(),
+        opaque: core::ptr::null(),
+    };
+    let ddict = unsafe { ZSTD_createDDict_advanced(raw.as_ptr(), raw.len(), 0, 2, no_mem) };
+    assert!(
+        ddict.is_null(),
+        "FULL_DICT without the dictionary magic must fail at creation"
+    );
+}

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2146,3 +2146,71 @@ fn zdict_fastcover_trains_usable_dictionary() {
     assert_ne!(params.k, 0, "optimize must write back the chosen k");
     assert_ne!(params.d, 0, "optimize must write back the chosen d");
 }
+
+#[test]
+fn dict_compressor_cache_drops_stale_target_block_size() {
+    // The cached dict-compressor is keyed by attach serial + level; frame
+    // FLAGS are re-applied per call, and a target-block-size cap set on one
+    // call must not leak into a later call that reset the parameter to 0.
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_loadDictionary(cctx, dict.as_ptr(), dict.len()) }),
+        0
+    );
+    let mut reference = vec![0u8; payload.len() + 512];
+    let ref_len = unsafe {
+        ZSTD_compress2(
+            cctx,
+            reference.as_mut_ptr(),
+            reference.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(ref_len), 0);
+
+    // Cap the block size for one frame, then reset the knob to 0 (auto).
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_setParameter(cctx, crate::params::ZSTD_C_TARGET_CBLOCK_SIZE, 256)
+        }),
+        0
+    );
+    let mut capped = vec![0u8; payload.len() + 1024];
+    let capped_len = unsafe {
+        ZSTD_compress2(
+            cctx,
+            capped.as_mut_ptr(),
+            capped.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(capped_len), 0);
+    assert_eq!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_setParameter(cctx, crate::params::ZSTD_C_TARGET_CBLOCK_SIZE, 0)
+        }),
+        0
+    );
+    let mut after = vec![0u8; payload.len() + 512];
+    let after_len = unsafe {
+        ZSTD_compress2(
+            cctx,
+            after.as_mut_ptr(),
+            after.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(after_len), 0);
+    assert_eq!(
+        &after[..after_len],
+        &reference[..ref_len],
+        "resetting targetCBlockSize to 0 must restore the uncapped frame"
+    );
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2153,6 +2153,25 @@ fn estimates_are_sane_budgets() {
     };
     let one_shot = ZSTD_estimateCCtxSize_usingCParams(cparams);
     assert!(one_shot > (1 << 20) + 2 * (4 << 17));
+    // Binary-tree strategies must budget the retained optimal-parser
+    // workspace on top of the same table logs.
+    let bt_cparams = ZSTD_compressionParameters {
+        strategy: 8,
+        ..cparams
+    };
+    assert!(
+        ZSTD_estimateCCtxSize_usingCParams(bt_cparams) > one_shot,
+        "btultra cParams must budget more than dfast at equal logs"
+    );
+    // Strategy ordinal is validated like the other cParams bounds.
+    let bad_strategy = ZSTD_compressionParameters {
+        strategy: 42,
+        ..cparams
+    };
+    assert_ne!(
+        crate::error::ZSTD_isError(ZSTD_estimateCCtxSize_usingCParams(bad_strategy)),
+        0
+    );
     assert!(
         ZSTD_estimateCStreamSize_usingCParams(cparams) > one_shot,
         "streaming must budget more than the one-shot"

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1579,7 +1579,7 @@ fn decompress_stream_recovers_after_failed_oneshot_on_midframe_context() {
 use crate::attach::{
     ZSTD_CCtx_loadDictionary, ZSTD_CCtx_loadDictionary_advanced,
     ZSTD_CCtx_loadDictionary_byReference, ZSTD_CCtx_refCDict, ZSTD_CCtx_refPrefix,
-    ZSTD_DCtx_loadDictionary, ZSTD_DCtx_loadDictionary_advanced,
+    ZSTD_CCtx_refPrefix_advanced, ZSTD_DCtx_loadDictionary, ZSTD_DCtx_loadDictionary_advanced,
     ZSTD_DCtx_loadDictionary_byReference, ZSTD_DCtx_refDDict, ZSTD_DCtx_refPrefix,
     ZSTD_DCtx_refPrefix_advanced, ZSTD_compress_usingDict, ZSTD_decompress_usingDict,
     ZSTD_getDictID_fromDict, ZSTD_getDictID_fromFrame,
@@ -2389,12 +2389,21 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
     );
 
     // refPrefix_advanced: rawContent accepted + single-use roundtrip,
-    // fullDict rejected.
+    // fullDict rejected — on both the encoder and decoder sides.
     let prefix = dict_payload();
     let mut p2 = prefix[..1024].to_vec();
     p2.extend_from_slice(b"advanced prefix tail 0123456789");
+    assert_ne!(
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_refPrefix_advanced(cctx, prefix.as_ptr(), prefix.len(), 2)
+        }),
+        0,
+        "fullDict selector must be rejected for an encoder prefix"
+    );
     assert_eq!(
-        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        ZSTD_isError(unsafe {
+            ZSTD_CCtx_refPrefix_advanced(cctx, prefix.as_ptr(), prefix.len(), 1)
+        }),
         0
     );
     let written =

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2423,7 +2423,13 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
     );
 
     // refPrefix_advanced: rawContent accepted + single-use roundtrip,
-    // fullDict rejected — on both the encoder and decoder sides.
+    // fullDict rejected — on both the encoder and decoder sides. Fresh
+    // contexts: the earlier loadDictionary attaches are sticky and could
+    // mask a refPrefix wrapper regressing to a no-op.
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
     let prefix = dict_payload();
     let mut p2 = prefix[..1024].to_vec();
     p2.extend_from_slice(b"advanced prefix tail 0123456789");
@@ -2443,6 +2449,22 @@ fn by_reference_and_advanced_attach_variants_roundtrip() {
     let written =
         unsafe { ZSTD_compress2(cctx, frame.as_mut_ptr(), frame.len(), p2.as_ptr(), p2.len()) };
     assert_eq!(ZSTD_isError(written), 0);
+    // The frame must really depend on the prefix: no advertised ID and no
+    // bare decode.
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), written) },
+        0,
+        "prefix frame must not advertise a dictionary ID"
+    );
+    let bare = ZSTD_createDCtx();
+    let bare_read =
+        unsafe { ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_ne!(
+        ZSTD_isError(bare_read),
+        0,
+        "prefix frame must not decode bare"
+    );
+    unsafe { ZSTD_freeDCtx(bare) };
     assert_ne!(
         ZSTD_isError(unsafe {
             ZSTD_DCtx_refPrefix_advanced(dctx, prefix.as_ptr(), prefix.len(), 2)

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -1855,6 +1855,71 @@ fn ref_prefix_is_single_use_and_roundtrips() {
 }
 
 #[test]
+fn cctx_ref_prefix_survives_a_too_small_destination() {
+    // A prefix is single-use, but "use" means a frame was actually
+    // DELIVERED: a dstSize_tooSmall failure must leave the prefix armed so
+    // the caller's retry with a bigger buffer still compresses against it.
+    let prefix = dict_payload();
+    let mut payload = prefix[..2048].to_vec();
+    payload.extend_from_slice(b"unique suffix after prefix material 0123456789");
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let mut tiny = [0u8; 4];
+    let failed = unsafe {
+        ZSTD_compress2(
+            cctx,
+            tiny.as_mut_ptr(),
+            tiny.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_ne!(ZSTD_isError(failed), 0, "4-byte destination must fail");
+
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+
+    // The retried frame must still depend on the prefix: bare decode fails,
+    // prefixed decode roundtrips.
+    let bare = ZSTD_createDCtx();
+    let mut out = vec![0u8; payload.len() + 64];
+    let read =
+        unsafe { ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_ne!(
+        ZSTD_isError(read),
+        0,
+        "the retry must still compress against the prefix"
+    );
+    unsafe { ZSTD_freeDCtx(bare) };
+
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_DCtx_refPrefix(dctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let read =
+        unsafe { ZSTD_decompressDCtx(dctx, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
 fn streaming_roundtrips_with_loaded_dictionary() {
     let dict = trained_dictionary();
     let payload = dict_payload();

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2674,6 +2674,29 @@ fn cdict_advanced_rejects_invalid_strategy_ordinal() {
 }
 
 #[test]
+fn cparams_estimate_never_underreports_on_32bit() {
+    // windowLog=30 + hashLog=29 + chainLog=29 each pass the per-field
+    // bounds, but their byte sizes sum past u32::MAX: on a 32-bit target
+    // the plain addition wraps and the estimate UNDER-reports — worse than
+    // an error for a sizing contract. The sum must come back as either an
+    // encoded error or a figure that covers at least the window alone.
+    let cparams = ZSTD_compressionParameters {
+        windowLog: 30,
+        chainLog: 29,
+        hashLog: 29,
+        searchLog: 1,
+        minMatch: 5,
+        targetLength: 0,
+        strategy: 1,
+    };
+    let n = ZSTD_estimateCCtxSize_usingCParams(cparams);
+    assert!(
+        crate::error::ZSTD_isError(n) != 0 || n >= (1usize << 30),
+        "estimate must error or cover the window, got {n}"
+    );
+}
+
+#[test]
 fn zdict_train_rejects_null_buffers_with_nonzero_lengths() {
     // A NULL buffer paired with a non-zero length must come back as an
     // encoded error, never reach slice construction: these are documented

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2696,6 +2696,62 @@ fn cdict_advanced_rejects_invalid_strategy_ordinal() {
 }
 
 #[test]
+fn ref_prefix_advanced_clears_on_null_regardless_of_content_type() {
+    // NULL/empty is the API's clear signal and must win over content-type
+    // validation: a clear with any selector (even fullDict) succeeds and
+    // disarms the previous prefix on both context kinds.
+    let prefix = dict_payload();
+    let mut payload = prefix[..1024].to_vec();
+    payload.extend_from_slice(b"clear ordering tail 0123456789");
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let cleared = unsafe { ZSTD_CCtx_refPrefix_advanced(cctx, core::ptr::null(), 0, 2) };
+    assert_eq!(
+        ZSTD_isError(cleared),
+        0,
+        "NULL clear must succeed regardless of the selector"
+    );
+    // The cleared context must compress WITHOUT the prefix: bare decode works.
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    let bare = ZSTD_createDCtx();
+    let mut out = vec![0u8; payload.len() + 64];
+    let read =
+        unsafe { ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0, "cleared prefix must not be used");
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(bare) };
+
+    // Decoder mirror: clear with the fullDict selector succeeds too.
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_DCtx_refPrefix(dctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let dcleared = unsafe { ZSTD_DCtx_refPrefix_advanced(dctx, core::ptr::null(), 0, 2) };
+    assert_eq!(
+        ZSTD_isError(dcleared),
+        0,
+        "decoder NULL clear must succeed regardless of the selector"
+    );
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
 fn cparams_estimate_never_underreports_on_32bit() {
     // windowLog=30 + hashLog=29 + chainLog=29 each pass the per-field
     // bounds, but their byte sizes sum past u32::MAX: on a 32-bit target

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -2540,6 +2540,40 @@ fn creation_time_validation_rejects_bad_fastcover_and_full_dict_inputs() {
 }
 
 #[test]
+fn cdict_advanced_rejects_invalid_strategy_ordinal() {
+    // ZSTD_strategy spans 1 (fast) … 9 (btultra2); 0 and out-of-range
+    // ordinals are invalid input and must fail creation, not silently map
+    // onto the strongest tier.
+    let raw = [0xABu8; 256];
+    let no_mem = ZSTD_customMem {
+        customAlloc: core::ptr::null(),
+        customFree: core::ptr::null(),
+        opaque: core::ptr::null(),
+    };
+    let base = ZSTD_compressionParameters {
+        windowLog: 0,
+        chainLog: 0,
+        hashLog: 0,
+        searchLog: 0,
+        minMatch: 0,
+        targetLength: 0,
+        strategy: 0,
+    };
+    for bad in [0u32, 10, 42] {
+        let cparams = ZSTD_compressionParameters {
+            strategy: bad,
+            ..base
+        };
+        let cdict =
+            unsafe { ZSTD_createCDict_advanced(raw.as_ptr(), raw.len(), 0, 1, cparams, no_mem) };
+        assert!(
+            cdict.is_null(),
+            "strategy ordinal {bad} must fail CDict creation"
+        );
+    }
+}
+
+#[test]
 fn zdict_train_rejects_null_buffers_with_nonzero_lengths() {
     // A NULL buffer paired with a non-zero length must come back as an
     // encoded error, never reach slice construction: these are documented

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -549,12 +549,24 @@ fn sizeof_cctx_counts_cached_dictionary_compressor() {
 }
 
 #[test]
-fn create_cdict_rejects_non_dictionary() {
-    // A buffer with no dictionary magic and no valid entropy is not a parseable
-    // encoder dictionary; createCDict must return NULL (never crash).
-    let garbage = [0xABu8; 64];
-    let cdict = unsafe { ZSTD_createCDict(garbage.as_ptr(), garbage.len(), 3) };
-    assert!(cdict.is_null(), "createCDict accepted a non-dictionary");
+fn create_cdict_treats_unmagicked_bytes_as_raw_content() {
+    // Upstream auto content type: a buffer without the dictionary magic is a
+    // raw-content dictionary (ID 0), not a creation failure.
+    let raw = [0xABu8; 64];
+    let cdict = unsafe { ZSTD_createCDict(raw.as_ptr(), raw.len(), 3) };
+    assert!(!cdict.is_null(), "raw-content createCDict must succeed");
+    assert_eq!(unsafe { ZSTD_getDictID_fromCDict(cdict) }, 0);
+    unsafe { ZSTD_freeCDict(cdict) };
+
+    // An empty dictionary is a creation failure.
+    let cdict = unsafe { ZSTD_createCDict(core::ptr::null(), 0, 3) };
+    assert!(cdict.is_null(), "empty createCDict must fail");
+
+    // A magic-prefixed blob whose tables don't parse is corrupt.
+    let mut corrupt = vec![0x37u8, 0xA4, 0x30, 0xEC];
+    corrupt.extend_from_slice(&[0xFF; 60]);
+    let cdict = unsafe { ZSTD_createCDict(corrupt.as_ptr(), corrupt.len(), 3) };
+    assert!(cdict.is_null(), "corrupt full dict must fail");
 }
 
 // ---- Phase 6.2: advanced parameters + streaming ----
@@ -1560,4 +1572,577 @@ fn decompress_stream_recovers_after_failed_oneshot_on_midframe_context() {
         assert_eq!(restored, input, "post-failure streaming must be byte-exact");
         crate::streaming::ZSTD_freeDStream(zds);
     }
+}
+
+// ---- Phase 6.2 slice 2: dictionary attach + estimates + fastCover ----
+
+use crate::attach::{
+    ZSTD_CCtx_loadDictionary, ZSTD_CCtx_refCDict, ZSTD_CCtx_refPrefix, ZSTD_DCtx_loadDictionary,
+    ZSTD_DCtx_refDDict, ZSTD_DCtx_refPrefix, ZSTD_compress_usingDict, ZSTD_decompress_usingDict,
+    ZSTD_getDictID_fromDict, ZSTD_getDictID_fromFrame,
+};
+use crate::cdict::{
+    ZSTD_compress_usingCDict_advanced, ZSTD_compressionParameters, ZSTD_createCDict_advanced,
+    ZSTD_createDDict_advanced, ZSTD_customMem, ZSTD_frameParameters,
+};
+use crate::context::ZSTD_compress2;
+use crate::dict::{
+    ZDICT_fastCover_params_t, ZDICT_optimizeTrainFromBuffer_fastCover, ZDICT_params_t,
+    ZDICT_trainFromBuffer_fastCover,
+};
+use crate::estimate::{
+    ZSTD_estimateCCtxSize, ZSTD_estimateCCtxSize_usingCParams, ZSTD_estimateCStreamSize,
+    ZSTD_estimateDCtxSize, ZSTD_estimateDStreamSize,
+};
+
+/// Dict-friendly payload: repeats material the trained dictionary covers.
+fn dict_payload() -> Vec<u8> {
+    let mut payload = Vec::new();
+    for i in 0..40u32 {
+        payload.extend_from_slice(
+            format!("tenant=demo table=orders key={i} region=eu payload=aaaaabbbbbccccc\n")
+                .as_bytes(),
+        );
+    }
+    payload
+}
+
+#[test]
+fn cctx_load_dictionary_roundtrips_via_compress2() {
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+    let cctx = ZSTD_createCCtx();
+    let n = unsafe { ZSTD_CCtx_loadDictionary(cctx, dict.as_ptr(), dict.len()) };
+    assert_eq!(ZSTD_isError(n), 0);
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+
+    // The frame carries the dictionary ID and cannot decode without the dict.
+    let dict_id = unsafe { ZSTD_getDictID_fromDict(dict.as_ptr(), dict.len()) };
+    assert_ne!(dict_id, 0);
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), frame.len()) },
+        dict_id
+    );
+    let dctx = ZSTD_createDCtx();
+    let mut out = vec![0u8; payload.len() + 64];
+    let plain = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+        )
+    };
+    assert_ne!(ZSTD_isError(plain), 0, "dict frame must not decode bare");
+
+    // With the dictionary loaded on the DCtx it decodes byte-exact.
+    let n = unsafe { ZSTD_DCtx_loadDictionary(dctx, dict.as_ptr(), dict.len()) };
+    assert_eq!(ZSTD_isError(n), 0);
+    let read = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
+fn raw_content_dictionary_roundtrips_without_wire_id() {
+    // Raw bytes (no magic) attach as raw content; the frame must NOT carry
+    // the synthetic dictionary ID and must decode with the same raw bytes
+    // loaded on the decode side.
+    let raw: Vec<u8> = dict_payload();
+    let mut payload = raw[..1024].to_vec();
+    payload.extend_from_slice(b"and a unique tail 0123456789");
+
+    let cctx = ZSTD_createCCtx();
+    let n = unsafe { ZSTD_CCtx_loadDictionary(cctx, raw.as_ptr(), raw.len()) };
+    assert_eq!(ZSTD_isError(n), 0);
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), frame.len()) },
+        0,
+        "raw-content frame must not advertise a dictionary ID"
+    );
+
+    let dctx = ZSTD_createDCtx();
+    let n = unsafe { ZSTD_DCtx_loadDictionary(dctx, raw.as_ptr(), raw.len()) };
+    assert_eq!(ZSTD_isError(n), 0);
+    let mut out = vec![0u8; payload.len() + 64];
+    let read = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
+fn ref_cdict_and_ref_ddict_roundtrip_via_contexts() {
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+    let cdict = unsafe { ZSTD_createCDict(dict.as_ptr(), dict.len(), 7) };
+    assert!(!cdict.is_null());
+    let ddict = unsafe { ZSTD_createDDict(dict.as_ptr(), dict.len()) };
+    assert!(!ddict.is_null());
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(ZSTD_isError(unsafe { ZSTD_CCtx_refCDict(cctx, cdict) }), 0);
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(ZSTD_isError(unsafe { ZSTD_DCtx_refDDict(dctx, ddict) }), 0);
+    let mut out = vec![0u8; payload.len() + 64];
+    let read = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    // Detach with NULL: the next frame must be dictionary-independent.
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refCDict(cctx, core::ptr::null()) }),
+        0
+    );
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.capacity(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    let bare = ZSTD_createDCtx();
+    let read =
+        unsafe { ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame.as_ptr(), written) };
+    assert_eq!(ZSTD_isError(read), 0, "detached frame must decode bare");
+    unsafe { ZSTD_freeDCtx(bare) };
+
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+    unsafe { ZSTD_freeCDict(cdict) };
+    unsafe { ZSTD_freeDDict(ddict) };
+}
+
+#[test]
+fn ref_prefix_is_single_use_and_roundtrips() {
+    let prefix = dict_payload();
+    let mut payload = prefix[..2048].to_vec();
+    payload.extend_from_slice(b"unique suffix after prefix material 0123456789");
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_refPrefix(cctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), frame.len()) },
+        0
+    );
+
+    // Single-use: the next frame must not depend on the prefix.
+    let mut frame2 = vec![0u8; payload.len() + 512];
+    let written2 = unsafe {
+        ZSTD_compress2(
+            cctx,
+            frame2.as_mut_ptr(),
+            frame2.len(),
+            payload.as_ptr(),
+            payload.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(written2), 0);
+    let bare = ZSTD_createDCtx();
+    let mut out = vec![0u8; payload.len() + 64];
+    let read = unsafe {
+        ZSTD_decompressDCtx(bare, out.as_mut_ptr(), out.len(), frame2.as_ptr(), written2)
+    };
+    assert_eq!(ZSTD_isError(read), 0, "post-prefix frame must decode bare");
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(bare) };
+
+    // The prefixed frame decodes only with the same prefix referenced.
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_DCtx_refPrefix(dctx, prefix.as_ptr(), prefix.len()) }),
+        0
+    );
+    let read = unsafe {
+        ZSTD_decompressDCtx(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
+fn streaming_roundtrips_with_loaded_dictionary() {
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+
+    let cctx = ZSTD_createCCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_CCtx_loadDictionary(cctx, dict.as_ptr(), dict.len()) }),
+        0
+    );
+    let mut frame = vec![0u8; payload.len() + 1024];
+    let mut inb = ZSTD_inBuffer {
+        src: payload.as_ptr().cast(),
+        size: payload.len(),
+        pos: 0,
+    };
+    let mut outb = ZSTD_outBuffer {
+        dst: frame.as_mut_ptr().cast(),
+        size: frame.len(),
+        pos: 0,
+    };
+    let rc = unsafe {
+        ZSTD_compressStream2(cctx, &mut outb, &mut inb, 2 /* ZSTD_e_end */)
+    };
+    assert_eq!(ZSTD_isError(rc), 0);
+    assert_eq!(rc, 0, "single-shot end must finish in one call");
+    frame.truncate(outb.pos);
+
+    let dict_id = unsafe { ZSTD_getDictID_fromDict(dict.as_ptr(), dict.len()) };
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), frame.len()) },
+        dict_id
+    );
+
+    let dctx = ZSTD_createDCtx();
+    assert_eq!(
+        ZSTD_isError(unsafe { ZSTD_DCtx_loadDictionary(dctx, dict.as_ptr(), dict.len()) }),
+        0
+    );
+    let mut out = vec![0u8; payload.len() + 64];
+    let mut inb = ZSTD_inBuffer {
+        src: frame.as_ptr().cast(),
+        size: frame.len(),
+        pos: 0,
+    };
+    let mut outb = ZSTD_outBuffer {
+        dst: out.as_mut_ptr().cast(),
+        size: out.len(),
+        pos: 0,
+    };
+    let rc = unsafe { ZSTD_decompressStream(dctx, &mut outb, &mut inb) };
+    assert_eq!(ZSTD_isError(rc), 0);
+    assert_eq!(rc, 0, "whole frame supplied; decode must finish");
+    assert_eq!(&out[..outb.pos], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
+fn using_dict_one_shots_roundtrip() {
+    let dict = trained_dictionary();
+    let payload = dict_payload();
+    let cctx = ZSTD_createCCtx();
+    let dctx = ZSTD_createDCtx();
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress_usingDict(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+            dict.as_ptr(),
+            dict.len(),
+            5,
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    let mut out = vec![0u8; payload.len() + 64];
+    let read = unsafe {
+        ZSTD_decompress_usingDict(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            written,
+            dict.as_ptr(),
+            dict.len(),
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    // Empty dictionary degrades to the plain one-shots.
+    let written = unsafe {
+        ZSTD_compress_usingDict(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+            core::ptr::null(),
+            0,
+            5,
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    let read = unsafe {
+        ZSTD_decompress_usingDict(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            written,
+            core::ptr::null(),
+            0,
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+}
+
+#[test]
+fn cdict_advanced_honours_cparams_and_fparams() {
+    let raw = dict_payload();
+    let mut payload = raw[..1024].to_vec();
+    payload.extend_from_slice(b"advanced unique tail 0123456789");
+    let no_mem = ZSTD_customMem {
+        customAlloc: core::ptr::null(),
+        customFree: core::ptr::null(),
+        opaque: core::ptr::null(),
+    };
+    let cparams = ZSTD_compressionParameters {
+        windowLog: 0,
+        chainLog: 0,
+        hashLog: 0,
+        searchLog: 0,
+        minMatch: 0,
+        targetLength: 0,
+        strategy: 2, // dfast
+    };
+    let cdict = unsafe {
+        ZSTD_createCDict_advanced(
+            raw.as_ptr(),
+            raw.len(),
+            0,
+            1, // rawContent
+            cparams,
+            no_mem,
+        )
+    };
+    assert!(!cdict.is_null());
+    let ddict = unsafe { ZSTD_createDDict_advanced(raw.as_ptr(), raw.len(), 0, 1, no_mem) };
+    assert!(!ddict.is_null());
+
+    let cctx = ZSTD_createCCtx();
+    let fparams = ZSTD_frameParameters {
+        contentSizeFlag: 1,
+        checksumFlag: 1,
+        noDictIDFlag: 1,
+    };
+    let mut frame = vec![0u8; payload.len() + 512];
+    let written = unsafe {
+        ZSTD_compress_usingCDict_advanced(
+            cctx,
+            frame.as_mut_ptr(),
+            frame.len(),
+            payload.as_ptr(),
+            payload.len(),
+            cdict,
+            fparams,
+        )
+    };
+    assert_eq!(ZSTD_isError(written), 0);
+    frame.truncate(written);
+    assert_eq!(
+        unsafe { ZSTD_getDictID_fromFrame(frame.as_ptr(), frame.len()) },
+        0
+    );
+
+    let dctx = ZSTD_createDCtx();
+    let mut out = vec![0u8; payload.len() + 64];
+    let read = unsafe {
+        ZSTD_decompress_usingDDict(
+            dctx,
+            out.as_mut_ptr(),
+            out.len(),
+            frame.as_ptr(),
+            frame.len(),
+            ddict,
+        )
+    };
+    assert_eq!(ZSTD_isError(read), 0);
+    assert_eq!(&out[..read], payload.as_slice());
+
+    // A non-NULL custom allocator is unsupported and must fail creation.
+    let bad_mem = ZSTD_customMem {
+        customAlloc: ZSTD_createCCtx as *const core::ffi::c_void,
+        customFree: core::ptr::null(),
+        opaque: core::ptr::null(),
+    };
+    let rejected =
+        unsafe { ZSTD_createCDict_advanced(raw.as_ptr(), raw.len(), 0, 1, cparams, bad_mem) };
+    assert!(rejected.is_null());
+
+    unsafe { ZSTD_freeDCtx(dctx) };
+    unsafe { ZSTD_freeCCtx(cctx) };
+    unsafe { ZSTD_freeCDict(cdict) };
+    unsafe { ZSTD_freeDDict(ddict) };
+}
+
+#[test]
+fn estimates_are_sane_budgets() {
+    let l3 = ZSTD_estimateCCtxSize(3);
+    let l19 = ZSTD_estimateCCtxSize(19);
+    assert!(l3 > 1 << 19, "estimate must cover at least the window");
+    assert!(l19 > l3, "higher level must budget more");
+    assert!(ZSTD_estimateCStreamSize(3) > l3);
+    let dctx = ZSTD_estimateDCtxSize();
+    assert!(dctx > core::mem::size_of::<crate::context::ZSTD_DCtx>());
+    assert!(ZSTD_estimateDStreamSize(1 << 20) > dctx + (1 << 20));
+    let cparams = ZSTD_compressionParameters {
+        windowLog: 20,
+        chainLog: 17,
+        hashLog: 17,
+        searchLog: 1,
+        minMatch: 5,
+        targetLength: 0,
+        strategy: 2,
+    };
+    assert!(ZSTD_estimateCCtxSize_usingCParams(cparams) > (1 << 20) + 2 * (4 << 17));
+}
+
+#[test]
+fn zdict_fastcover_trains_usable_dictionary() {
+    let mut samples: Vec<u8> = Vec::new();
+    let mut sizes: Vec<usize> = Vec::new();
+    for i in 0..512u32 {
+        let s = format!("tenant=demo table=orders key={i} region=eu payload=aaaaabbbbbccccc\n");
+        sizes.push(s.len());
+        samples.extend_from_slice(s.as_bytes());
+    }
+    let mut dict = vec![0u8; 64 * 1024];
+    let mut params = ZDICT_fastCover_params_t {
+        k: 256,
+        d: 8,
+        f: 20,
+        steps: 0,
+        nbThreads: 0,
+        splitPoint: 0.0,
+        accel: 1,
+        shrinkDict: 0,
+        shrinkDictMaxRegression: 0,
+        zParams: ZDICT_params_t {
+            compressionLevel: 0,
+            notificationLevel: 0,
+            dictID: 0,
+        },
+    };
+    let n = unsafe {
+        ZDICT_trainFromBuffer_fastCover(
+            dict.as_mut_ptr(),
+            dict.len(),
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+            params,
+        )
+    };
+    assert_eq!(ZDICT_isError(n), 0, "fastCover training failed");
+    assert_ne!(
+        unsafe { ZSTD_getDictID_fromDict(dict.as_ptr(), n) },
+        0,
+        "trained dictionary must carry an ID"
+    );
+
+    // The optimizing entry sweeps when k/d are 0 and writes back the choice.
+    params.k = 0;
+    params.d = 0;
+    let n = unsafe {
+        ZDICT_optimizeTrainFromBuffer_fastCover(
+            dict.as_mut_ptr(),
+            dict.len(),
+            samples.as_ptr(),
+            sizes.as_ptr(),
+            sizes.len() as u32,
+            &mut params,
+        )
+    };
+    assert_eq!(ZDICT_isError(n), 0, "optimize fastCover failed");
+    assert_ne!(params.k, 0, "optimize must write back the chosen k");
+    assert_ne!(params.d, 0, "optimize must write back the chosen d");
 }

--- a/c-api/tests/c_consumer.c
+++ b/c-api/tests/c_consumer.c
@@ -272,6 +272,26 @@ int main(void) {
         if (ZSTD_estimateCStreamSize(3) <= ZSTD_estimateCCtxSize(3)) return 56;
         if (ZSTD_estimateDStreamSize(1 << 20) <= ZSTD_estimateDCtxSize()) return 57;
 
+        /* By-value ABI smoke: structs passed by value across the FFI must
+         * match the Rust-side layout (a drift would misread every field). */
+        {
+            ZSTD_compressionParameters cp = {20, 17, 17, 1, 5, 0, ZSTD_dfast};
+            size_t est = ZSTD_estimateCCtxSize_usingCParams(cp);
+            if (ZSTD_isError(est) || est < ((size_t)1 << 20)) return 58;
+
+            ZDICT_fastCover_params_t fcp;
+            memset(&fcp, 0, sizeof fcp);
+            fcp.k = 256;
+            fcp.d = 8;
+            fcp.f = 20;
+            fcp.accel = 1;
+            unsigned char fdict[16 * 1024];
+            size_t fdict_len = ZDICT_trainFromBuffer_fastCover(
+                fdict, sizeof fdict, samples, sizes, NB_SAMPLES, fcp);
+            if (ZDICT_isError(fdict_len)) return 59;
+            if (ZSTD_getDictID_fromDict(fdict, fdict_len) == 0) return 60;
+        }
+
         ZSTD_freeCDict(cdict);
         ZSTD_freeDDict(ddict);
         ZSTD_freeCCtx(c);

--- a/c-api/tests/c_consumer.c
+++ b/c-api/tests/c_consumer.c
@@ -13,6 +13,8 @@
  */
 #define ZSTD_STATIC_LINKING_ONLY /* expose the experimental frame-inspection API */
 #include <zstd.h>
+#define ZDICT_STATIC_LINKING_ONLY
+#include <zdict.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -168,6 +170,113 @@ int main(void) {
         free(sbuf);
         free(scomp);
         free(dbuf);
+    }
+
+    /* Dictionary attach surface: train, attach on both contexts, round-trip. */
+    {
+        /* Build dict-friendly samples (the random megabyte above doesn't
+         * train a useful dictionary). */
+        enum { NB_SAMPLES = 256, SAMPLE_MAX = 96 };
+        unsigned char *samples = (unsigned char *)malloc((size_t)NB_SAMPLES * SAMPLE_MAX);
+        size_t sizes[NB_SAMPLES];
+        if (!samples) return 2;
+        size_t total = 0;
+        for (int i = 0; i < NB_SAMPLES; i++) {
+            int len = snprintf((char *)samples + total, SAMPLE_MAX,
+                               "tenant=demo table=orders key=%d region=eu "
+                               "payload=aaaaabbbbbccccc\n",
+                               i);
+            if (len <= 0) return 33;
+            sizes[i] = (size_t)len;
+            total += (size_t)len;
+        }
+        unsigned char dict[16 * 1024];
+        size_t dict_len =
+            ZDICT_trainFromBuffer(dict, sizeof dict, samples, sizes, NB_SAMPLES);
+        if (ZDICT_isError(dict_len)) return 34;
+        if (ZSTD_getDictID_fromDict(dict, dict_len) == 0) return 35;
+
+        /* Payload from the same distribution. */
+        unsigned char payload[4096];
+        size_t payload_len = 0;
+        for (int i = 0; i < 40; i++) {
+            int len = snprintf((char *)payload + payload_len,
+                               sizeof payload - payload_len,
+                               "tenant=demo table=orders key=%d region=eu "
+                               "payload=aaaaabbbbbccccc\n",
+                               i);
+            if (len <= 0) return 33;
+            payload_len += (size_t)len;
+        }
+
+        ZSTD_CCtx *c = ZSTD_createCCtx();
+        ZSTD_DCtx *d = ZSTD_createDCtx();
+        if (!c || !d) return 36;
+        if (ZSTD_isError(ZSTD_CCtx_loadDictionary(c, dict, dict_len))) return 37;
+        unsigned char dframe[8192];
+        size_t dframe_len =
+            ZSTD_compress2(c, dframe, sizeof dframe, payload, payload_len);
+        if (ZSTD_isError(dframe_len)) return 38;
+        if (ZSTD_getDictID_fromFrame(dframe, dframe_len) !=
+            ZSTD_getDictID_fromDict(dict, dict_len))
+            return 39;
+        unsigned char dout[8192];
+        if (ZSTD_isError(ZSTD_DCtx_loadDictionary(d, dict, dict_len))) return 40;
+        size_t dread =
+            ZSTD_decompressDCtx(d, dout, sizeof dout, dframe, dframe_len);
+        if (ZSTD_isError(dread) || dread != payload_len ||
+            memcmp(dout, payload, payload_len) != 0)
+            return 41;
+
+        /* CDict / DDict reference attach. */
+        ZSTD_CDict *cdict = ZSTD_createCDict(dict, dict_len, 7);
+        ZSTD_DDict *ddict = ZSTD_createDDict(dict, dict_len);
+        if (!cdict || !ddict) return 42;
+        if (ZSTD_isError(ZSTD_CCtx_reset(c, ZSTD_reset_session_and_parameters)))
+            return 43;
+        if (ZSTD_isError(ZSTD_CCtx_refCDict(c, cdict))) return 44;
+        dframe_len = ZSTD_compress2(c, dframe, sizeof dframe, payload, payload_len);
+        if (ZSTD_isError(dframe_len)) return 45;
+        if (ZSTD_isError(ZSTD_DCtx_refDDict(d, ddict))) return 46;
+        dread = ZSTD_decompressDCtx(d, dout, sizeof dout, dframe, dframe_len);
+        if (ZSTD_isError(dread) || dread != payload_len ||
+            memcmp(dout, payload, payload_len) != 0)
+            return 47;
+
+        /* refPrefix is single-use raw content on both sides. */
+        if (ZSTD_isError(ZSTD_CCtx_reset(c, ZSTD_reset_session_and_parameters)))
+            return 43;
+        if (ZSTD_isError(ZSTD_CCtx_refPrefix(c, samples, total))) return 48;
+        dframe_len = ZSTD_compress2(c, dframe, sizeof dframe, payload, payload_len);
+        if (ZSTD_isError(dframe_len)) return 49;
+        if (ZSTD_getDictID_fromFrame(dframe, dframe_len) != 0) return 50;
+        if (ZSTD_isError(ZSTD_DCtx_refDDict(d, NULL))) return 46;
+        if (ZSTD_isError(ZSTD_DCtx_refPrefix(d, samples, total))) return 51;
+        dread = ZSTD_decompressDCtx(d, dout, sizeof dout, dframe, dframe_len);
+        if (ZSTD_isError(dread) || dread != payload_len ||
+            memcmp(dout, payload, payload_len) != 0)
+            return 52;
+
+        /* One-shot *_usingDict pair. */
+        dframe_len = ZSTD_compress_usingDict(c, dframe, sizeof dframe, payload,
+                                             payload_len, dict, dict_len, 5);
+        if (ZSTD_isError(dframe_len)) return 53;
+        dread = ZSTD_decompress_usingDict(d, dout, sizeof dout, dframe,
+                                          dframe_len, dict, dict_len);
+        if (ZSTD_isError(dread) || dread != payload_len ||
+            memcmp(dout, payload, payload_len) != 0)
+            return 54;
+
+        /* Estimates are non-zero, ordered budgets. */
+        if (ZSTD_estimateCCtxSize(3) == 0) return 55;
+        if (ZSTD_estimateCStreamSize(3) <= ZSTD_estimateCCtxSize(3)) return 56;
+        if (ZSTD_estimateDStreamSize(1 << 20) <= ZSTD_estimateDCtxSize()) return 57;
+
+        ZSTD_freeCDict(cdict);
+        ZSTD_freeDDict(ddict);
+        ZSTD_freeCCtx(c);
+        ZSTD_freeDCtx(d);
+        free(samples);
     }
 
     free(input);

--- a/zstd-wasm/bench/test.mjs
+++ b/zstd-wasm/bench/test.mjs
@@ -191,6 +191,15 @@ for (const payload of [simd, scalar]) {
     boku.freeDCtx(dctx2);
   }
   rawPrepared.free();
+  // A truncated magic-prefixed blob is a corrupt serialized dictionary, not
+  // raw content: the constructor must throw instead of silently accepting it.
+  let truncatedThrew = false;
+  try {
+    new payload.Dictionary(new Uint8Array([0x37, 0xa4, 0x30, 0xec, 0x01]));
+  } catch {
+    truncatedThrew = true;
+  }
+  if (!truncatedThrew) fail("prepared dict: truncated magic blob must throw");
   prepared.free();
 }
 

--- a/zstd-wasm/bench/test.mjs
+++ b/zstd-wasm/bench/test.mjs
@@ -28,6 +28,7 @@ async function loadOurPayload(dir) {
     decompressUsingDict: glue.decompressUsingDict,
     StreamCtor: glue.ZstdDecompressStream,
     CompressStreamCtor: glue.ZstdCompressStream,
+    Dictionary: glue.ZstdDictionary,
   };
 }
 async function loadBokuweb() {
@@ -117,6 +118,58 @@ for (const sample of ["sample-1.service", "sample-2.service"]) {
     if (!eq(simd.decompressUsingDict(cb, dict), data)) fail(`dict ${sample} L${level}: we cannot decode C ref's dict frame`);
     if (!eq(cs, cc)) { divergences++; console.log(`note: dict simd128 != scalar bytes for ${sample} L${level} — allowed`); }
   }
+}
+
+// --- Prepared dictionary: hot-path reuse must match the one-shot dict API ---
+// One ZstdDictionary serves repeated one-shot calls (cached primed encoder),
+// streams on both sides (no per-stream re-parse), and the C reference decodes
+// every frame it produces.
+for (const payload of [simd, scalar]) {
+  const prepared = new payload.Dictionary(dict);
+  if (prepared.id === 0) fail("prepared dict: trained dictionary must carry an ID");
+  for (const sample of ["sample-1.service", "sample-2.service"]) {
+    const data = new Uint8Array(await readFile(here(`fixtures/${sample}`)));
+    for (const level of [3, 19]) {
+      // Repeated calls exercise the cached-compressor path (2nd call reuses
+      // the primed snapshot) and must agree with the parse-per-call API.
+      const first = prepared.compress(data, level);
+      const second = prepared.compress(data, level);
+      if (!eq(prepared.decompress(first), data)) fail(`prepared dict L${level}: round-trip (1st)`);
+      if (!eq(prepared.decompress(second), data)) fail(`prepared dict L${level}: round-trip (2nd)`);
+      const dctx = boku.createDCtx();
+      if (!eq(boku.decompressUsingDict(dctx, second, dict), data))
+        fail(`prepared dict L${level}: C ref cannot decode the cached-path frame`);
+      boku.freeDCtx(dctx);
+      if (!eq(prepared.decompress(payload.compressUsingDict(data, dict, level)), data))
+        fail(`prepared dict L${level}: cannot decode the byte-API dict frame`);
+    }
+    // Streams seeded from the prepared dictionary round-trip through the
+    // prepared decode stream.
+    const cs = payload.CompressStreamCtor.withPreparedDictionary(3, prepared);
+    const out = [cs.push(data), cs.finish()];
+    cs.free();
+    const frame = Buffer.concat(out.map((p) => Buffer.from(p)));
+    const ds = payload.StreamCtor.withPreparedDictionary(prepared);
+    const back = Buffer.concat([Buffer.from(ds.push(new Uint8Array(frame))), Buffer.from(ds.finish())]);
+    ds.free();
+    if (!eq(new Uint8Array(back), data)) fail(`prepared dict stream: ${sample} round-trip`);
+  }
+  // Raw-content dictionaries: id 0, frames carry no dictionary ID, and the
+  // C reference decodes them with the same raw bytes.
+  const rawDict = new Uint8Array(await readFile(here("fixtures/sample-1.service")));
+  const rawPrepared = new payload.Dictionary(rawDict);
+  if (rawPrepared.id !== 0) fail("prepared raw dict: id must be 0");
+  const tail = new TextEncoder().encode("unique raw-dict tail 0123456789");
+  const rawData = new Uint8Array(rawDict.length + tail.length);
+  rawData.set(rawDict); rawData.set(tail, rawDict.length);
+  const rawFrame = rawPrepared.compress(rawData, 3);
+  if (!eq(rawPrepared.decompress(rawFrame), rawData)) fail("prepared raw dict: round-trip");
+  const dctx = boku.createDCtx();
+  if (!eq(boku.decompressUsingDict(dctx, rawFrame, rawDict), rawData))
+    fail("prepared raw dict: C ref cannot decode the raw-content frame");
+  boku.freeDCtx(dctx);
+  rawPrepared.free();
+  prepared.free();
 }
 
 // --- Streaming decompressor: chunked input must equal one-shot output -------

--- a/zstd-wasm/bench/test.mjs
+++ b/zstd-wasm/bench/test.mjs
@@ -217,6 +217,28 @@ for (const payload of [simd, scalar]) {
   ds.free();
   if (!eq(new Uint8Array(back), data)) fail("npm wrapper: stream round-trip");
   zd.free();
+
+  // Raw-content dictionary through the same public API: id 0 and ID-less
+  // frames, so the wrapper's prepared decode stream must force the
+  // dictionary per frame.
+  const rawZd = await npm.ZstdDict.create(data);
+  if (rawZd.id !== 0) fail("npm wrapper: raw-content dict id must be 0");
+  const rawTail = new TextEncoder().encode("npm raw tail 0123456789");
+  const rawData = new Uint8Array(data.length + rawTail.length);
+  rawData.set(data); rawData.set(rawTail, data.length);
+  const rawFrame = rawZd.compress(rawData, 3);
+  if (!eq(rawZd.decompress(rawFrame), rawData)) fail("npm wrapper: raw one-shot round-trip");
+  const rcs = rawZd.compressStream(3);
+  const rawStreamed = Buffer.concat([Buffer.from(rcs.push(rawData)), Buffer.from(rcs.finish())]);
+  rcs.free();
+  const rds = rawZd.decompressStream();
+  const rawBack = Buffer.concat([
+    Buffer.from(rds.push(new Uint8Array(rawStreamed))),
+    Buffer.from(rds.finish()),
+  ]);
+  rds.free();
+  if (!eq(new Uint8Array(rawBack), rawData)) fail("npm wrapper: raw stream round-trip");
+  rawZd.free();
 }
 
 // --- Streaming decompressor: chunked input must equal one-shot output -------

--- a/zstd-wasm/bench/test.mjs
+++ b/zstd-wasm/bench/test.mjs
@@ -168,8 +168,55 @@ for (const payload of [simd, scalar]) {
   if (!eq(boku.decompressUsingDict(dctx, rawFrame, rawDict), rawData))
     fail("prepared raw dict: C ref cannot decode the raw-content frame");
   boku.freeDCtx(dctx);
+  // Raw-content STREAMS: the frames carry no dictionary ID, so this is the
+  // path where the prepared decode stream must force the dictionary per
+  // frame; the C reference cross-checks the produced stream bytes.
+  {
+    const cs = payload.CompressStreamCtor.withPreparedDictionary(3, rawPrepared);
+    const streamFrame = Buffer.concat([
+      Buffer.from(cs.push(rawData)),
+      Buffer.from(cs.finish()),
+    ]);
+    cs.free();
+    const ds = payload.StreamCtor.withPreparedDictionary(rawPrepared);
+    const back = Buffer.concat([
+      Buffer.from(ds.push(new Uint8Array(streamFrame))),
+      Buffer.from(ds.finish()),
+    ]);
+    ds.free();
+    if (!eq(new Uint8Array(back), rawData)) fail("prepared raw dict stream: round-trip");
+    const dctx2 = boku.createDCtx();
+    if (!eq(boku.decompressUsingDict(dctx2, new Uint8Array(streamFrame), rawDict), rawData))
+      fail("prepared raw dict stream: C ref cannot decode the ID-less stream frame");
+    boku.freeDCtx(dctx2);
+  }
   rawPrepared.free();
   prepared.free();
+}
+
+// --- npm wrapper surface (built index.js): the public API users import ------
+// The blocks above exercise the bindgen glue directly; regressions in the
+// TS wrapper (ZstdDict class, stream factories) would slip through, so run
+// one round-trip through the built wrapper as well.
+{
+  const npm = await import("../npm/index.js");
+  const dict = new Uint8Array(await readFile(here("fixtures/service.dict")));
+  const data = new Uint8Array(await readFile(here("fixtures/sample-1.service")));
+  const zd = await npm.ZstdDict.create(dict);
+  if (zd.id === 0) fail("npm wrapper: trained dictionary must carry an ID");
+  const frame = zd.compress(data, 3);
+  if (!eq(zd.decompress(frame), data)) fail("npm wrapper: one-shot round-trip");
+  const cs = zd.compressStream(3);
+  const streamed = Buffer.concat([Buffer.from(cs.push(data)), Buffer.from(cs.finish())]);
+  cs.free();
+  const ds = zd.decompressStream();
+  const back = Buffer.concat([
+    Buffer.from(ds.push(new Uint8Array(streamed))),
+    Buffer.from(ds.finish()),
+  ]);
+  ds.free();
+  if (!eq(new Uint8Array(back), data)) fail("npm wrapper: stream round-trip");
+  zd.free();
 }
 
 // --- Streaming decompressor: chunked input must equal one-shot output -------

--- a/zstd-wasm/npm/index.ts
+++ b/zstd-wasm/npm/index.ts
@@ -52,6 +52,10 @@ interface Payload {
   ) => Uint8Array;
   ZstdDecompressStream: (new (checksum?: ContentChecksum) => DecompressStream) & {
     withDictionary: (dict: Uint8Array, checksum?: ContentChecksum) => DecompressStream;
+    withPreparedDictionary: (
+      dict: WasmDictionary,
+      checksum?: ContentChecksum,
+    ) => DecompressStream;
   };
   ZstdCompressStream: (new (level: number, checksum?: boolean) => CompressStream) & {
     withDictionary: (
@@ -59,7 +63,21 @@ interface Payload {
       dict: Uint8Array,
       checksum?: boolean,
     ) => CompressStream;
+    withPreparedDictionary: (
+      level: number,
+      dict: WasmDictionary,
+      checksum?: boolean,
+    ) => CompressStream;
   };
+  ZstdDictionary: new (dict: Uint8Array) => WasmDictionary;
+}
+
+/** Raw wasm-side prepared-dictionary handle (see {@link ZstdDict}). */
+interface WasmDictionary {
+  readonly id: number;
+  compress(data: Uint8Array, level: number, checksum?: boolean): Uint8Array;
+  decompress(data: Uint8Array, checksum?: ContentChecksum): Uint8Array;
+  free(): void;
 }
 
 /**
@@ -306,4 +324,82 @@ export async function createDecompressStreamWithDictionary(
 ): Promise<DecompressStream> {
   loading ??= load();
   return (await loading).ZstdDecompressStream.withDictionary(dict, checksum);
+}
+
+/**
+ * A dictionary prepared once and reused across many compressions,
+ * decompressions, and streams — the recommended way to use dictionaries when
+ * more than one payload is involved.
+ *
+ * Construction parses the dictionary a single time; afterwards
+ * {@link ZstdDict.compress} reuses a primed encoder (the per-frame dictionary
+ * setup cost disappears), {@link ZstdDict.decompress} reuses one decoder
+ * workspace, and the stream factories seed from the prepared tables instead of
+ * re-parsing the blob. Raw content (no dictionary magic) is accepted; such
+ * dictionaries have `id === 0` and produced frames carry no dictionary ID.
+ *
+ * Call {@link ZstdDict.free} when done to release the wasm-side memory
+ * eagerly (it is otherwise reclaimed with the object).
+ *
+ * ```ts
+ * const dict = await ZstdDict.create(dictBytes);
+ * const frame = dict.compress(payload, 19);
+ * const back = dict.decompress(frame);
+ * const stream = await dict.compressStream(19);
+ * ```
+ */
+export class ZstdDict {
+  /** @internal */
+  private constructor(
+    private readonly inner: WasmDictionary,
+    private readonly module: Payload,
+  ) {}
+
+  /** Parse `dict` once for repeated use. Rejects if a magic-prefixed blob is corrupt. */
+  static async create(dict: Uint8Array): Promise<ZstdDict> {
+    loading ??= load();
+    const module = await loading;
+    return new ZstdDict(new module.ZstdDictionary(dict), module);
+  }
+
+  /** The dictionary ID (0 for raw content). */
+  get id(): number {
+    return this.inner.id;
+  }
+
+  /**
+   * Compress `data` at `level` (defaults to {@link DEFAULT_LEVEL}). The first
+   * call at a given level primes the encoder; following calls reuse the primed
+   * state — the hot path for many small frames against one dictionary.
+   */
+  compress(data: Uint8Array, level: number = DEFAULT_LEVEL, checksum?: boolean): Uint8Array {
+    return this.inner.compress(data, level, checksum);
+  }
+
+  /** Decompress a frame produced with this dictionary. */
+  decompress(data: Uint8Array, checksum?: ContentChecksum): Uint8Array {
+    return this.inner.decompress(data, checksum);
+  }
+
+  /**
+   * Open a streaming compressor seeded from this prepared dictionary (no
+   * per-stream re-parse). Same contract as {@link createCompressStream}.
+   */
+  compressStream(level: number = DEFAULT_LEVEL, checksum?: boolean): CompressStream {
+    return this.module.ZstdCompressStream.withPreparedDictionary(level, this.inner, checksum);
+  }
+
+  /**
+   * Open a streaming decompressor against this prepared dictionary (per-stream
+   * setup is a reference-count bump). Also decodes frames whose headers omit
+   * the dictionary ID. Same contract as {@link createDecompressStream}.
+   */
+  decompressStream(checksum?: ContentChecksum): DecompressStream {
+    return this.module.ZstdDecompressStream.withPreparedDictionary(this.inner, checksum);
+  }
+
+  /** Release the wasm-side dictionary memory eagerly. */
+  free(): void {
+    this.inner.free();
+  }
 }

--- a/zstd-wasm/npm/index.ts
+++ b/zstd-wasm/npm/index.ts
@@ -345,7 +345,7 @@ export async function createDecompressStreamWithDictionary(
  * const dict = await ZstdDict.create(dictBytes);
  * const frame = dict.compress(payload, 19);
  * const back = dict.decompress(frame);
- * const stream = await dict.compressStream(19);
+ * const stream = dict.compressStream(19);
  * ```
  */
 export class ZstdDict {

--- a/zstd-wasm/src/lib.rs
+++ b/zstd-wasm/src/lib.rs
@@ -187,7 +187,10 @@ impl ZstdDictionary {
         if dict.is_empty() {
             return Err(JsError::new("structured-zstd: empty dictionary"));
         }
-        let has_magic = dict.len() >= 8
+        // Any blob long enough to carry the 4-byte magic and starting with
+        // it is a (possibly truncated) serialized dictionary: parse it and
+        // surface corruption instead of silently treating it as raw content.
+        let has_magic = dict.len() >= 4
             && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == 0xEC30_A437;
         let parsed = if has_magic {
             Dictionary::decode_dict(dict).map_err(|err| {

--- a/zstd-wasm/src/lib.rs
+++ b/zstd-wasm/src/lib.rs
@@ -588,7 +588,9 @@ impl ZstdCompressStream {
                 JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
             })?;
         if dict.suppress_id {
-            encoder.set_dictionary_id_flag(false);
+            encoder
+                .set_dictionary_id_flag(false)
+                .expect("flag set before the first write on a fresh encoder");
         }
         Ok(ZstdCompressStream {
             encoder: Some(encoder),

--- a/zstd-wasm/src/lib.rs
+++ b/zstd-wasm/src/lib.rs
@@ -14,8 +14,12 @@
 //! [structured-zstd]: https://crates.io/crates/structured-zstd
 #![cfg(target_arch = "wasm32")]
 
-use structured_zstd::decoding::{BlockDecodingStrategy, FrameDecoder, StreamingDecoder};
-use structured_zstd::encoding::{CompressionLevel, FrameCompressor, StreamingEncoder};
+use structured_zstd::decoding::{
+    BlockDecodingStrategy, Dictionary, DictionaryHandle, FrameDecoder, StreamingDecoder,
+};
+use structured_zstd::encoding::{
+    CompressionLevel, EncoderDictionary, FrameCompressor, StreamingEncoder,
+};
 use structured_zstd::io::{Read, Write};
 use wasm_bindgen::prelude::*;
 
@@ -136,6 +140,147 @@ pub fn decompress_using_dict(
     Ok(out)
 }
 
+/// A dictionary prepared once for repeated use across compressions,
+/// decompressions, and streams — the wasm analogue of C's `ZSTD_CDict` +
+/// `ZSTD_DDict` pair behind one object.
+///
+/// Construction parses the dictionary a single time (entropy decode tables +
+/// encoder conversion). The hot paths then avoid every per-call setup cost:
+///
+/// * [`compress`](Self::compress) keeps a cached frame compressor whose
+///   dictionary-primed match-finder snapshot is reused across calls — the
+///   dominant per-frame cost for small payloads;
+/// * [`decompress`](Self::decompress) reuses one decoder workspace;
+/// * the stream constructors seed from the prepared tables (a table copy on
+///   the encode side, a reference-count bump on the decode side) instead of
+///   re-parsing the blob per stream.
+///
+/// Raw content (bytes without the `0xEC30A437` dictionary magic) is accepted
+/// like upstream's auto mode: such dictionaries have ID 0 and produced frames
+/// carry no dictionary ID.
+#[wasm_bindgen]
+pub struct ZstdDictionary {
+    /// Decode-side shared handle (`Arc`): per-use cost is a refcount bump.
+    handle: DictionaryHandle,
+    /// Encode-side template: streams clone its tables instead of re-parsing.
+    enc_template: EncoderDictionary,
+    /// Raw-content dictionaries carry a synthetic non-zero internal ID that
+    /// must never reach the wire.
+    suppress_id: bool,
+    /// Cached one-shot compressor (dictionary attached + primed snapshot),
+    /// rebuilt only when the requested level changes.
+    cached_enc: Option<FrameCompressor>,
+    cached_level: i32,
+    cached_checksum: bool,
+    /// Reusable one-shot decoder workspace.
+    decoder: FrameDecoder,
+    id: u32,
+}
+
+#[wasm_bindgen]
+impl ZstdDictionary {
+    /// Parse `dict` once for repeated use. Magic-prefixed blobs (e.g. from
+    /// `zstd --train`) parse as full dictionaries; anything else is raw
+    /// content. Throws if a magic-prefixed blob is corrupt.
+    #[wasm_bindgen(constructor)]
+    pub fn new(dict: &[u8]) -> Result<ZstdDictionary, JsError> {
+        if dict.is_empty() {
+            return Err(JsError::new("structured-zstd: empty dictionary"));
+        }
+        let has_magic = dict.len() >= 8
+            && u32::from_le_bytes([dict[0], dict[1], dict[2], dict[3]]) == 0xEC30_A437;
+        let parsed = if has_magic {
+            Dictionary::decode_dict(dict).map_err(|err| {
+                JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
+            })?
+        } else {
+            // Synthetic non-zero ID (the encoder attach path requires one);
+            // never emitted — see `suppress_id`.
+            Dictionary::from_raw_content(u32::MAX, dict.to_vec()).map_err(|err| {
+                JsError::new(&format!("structured-zstd: invalid raw dictionary: {err:?}"))
+            })?
+        };
+        let id = if has_magic { parsed.id } else { 0 };
+        let enc_template = EncoderDictionary::from_dictionary(parsed.clone());
+        let handle = DictionaryHandle::from_dictionary(parsed);
+        Ok(ZstdDictionary {
+            handle,
+            enc_template,
+            suppress_id: !has_magic,
+            cached_enc: None,
+            cached_level: i32::MIN,
+            cached_checksum: false,
+            decoder: FrameDecoder::new(),
+            id,
+        })
+    }
+
+    /// The dictionary ID (0 for raw content).
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Compress `data` with this dictionary at `level` — the hot path for
+    /// many small frames against one dictionary: the first call at a given
+    /// level attaches the prepared tables and primes the match finder, and
+    /// every following call reuses that primed snapshot.
+    ///
+    /// `checksum` is optional (default `false`).
+    pub fn compress(
+        &mut self,
+        data: &[u8],
+        level: i32,
+        checksum: Option<bool>,
+    ) -> Result<Vec<u8>, JsError> {
+        let checksum = checksum.unwrap_or(false);
+        if self.cached_enc.is_none()
+            || self.cached_level != level
+            || self.cached_checksum != checksum
+        {
+            let mut enc: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(level));
+            enc.set_content_checksum(checksum);
+            enc.set_encoder_dictionary(self.enc_template.clone())
+                .map_err(|err| {
+                    JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
+                })?;
+            if self.suppress_id {
+                enc.set_dictionary_id_flag(false);
+            }
+            self.cached_enc = Some(enc);
+            self.cached_level = level;
+            self.cached_checksum = checksum;
+        }
+        let enc = self.cached_enc.as_mut().expect("just ensured Some");
+        Ok(enc.compress_independent_frame(data))
+    }
+
+    /// Decompress a frame produced with this dictionary, reusing the
+    /// prepared tables and one decoder workspace across calls. `checksum`
+    /// behaves as in the module-level `decompress`.
+    pub fn decompress(
+        &mut self,
+        data: &[u8],
+        checksum: Option<ContentChecksum>,
+    ) -> Result<Vec<u8>, JsError> {
+        self.decoder.set_content_checksum(core_checksum(checksum));
+        let mut cursor: &[u8] = data;
+        self.decoder
+            .reset_with_dict_handle(&mut cursor, &self.handle)
+            .map_err(|err| JsError::new(&format!("structured-zstd: bad frame header: {err:?}")))?;
+        self.decoder
+            .decode_blocks(&mut cursor, BlockDecodingStrategy::All)
+            .map_err(|err| {
+                JsError::new(&format!("structured-zstd: dict decompress failed: {err:?}"))
+            })?;
+        let out = self.decoder.collect().unwrap_or_default();
+        self.decoder
+            .verify_content_checksum()
+            .map_err(|err| JsError::new(&format!("structured-zstd: {err}")))?;
+        Ok(out)
+    }
+}
+
 /// Length of a standard zstd frame header in `buf`, plus whether the content
 /// checksum flag is set — or `None` if `buf` does not yet hold the full
 /// header. Standard RFC 8878 §3.1.1 layout; skippable frames are not handled
@@ -193,6 +338,10 @@ fn complete_block_len(buf: &[u8], checksum: bool) -> Option<usize> {
 #[wasm_bindgen]
 pub struct ZstdDecompressStream {
     decoder: FrameDecoder,
+    /// Prepared dictionary forced onto every frame of this stream
+    /// (`withPreparedDictionary`); `None` decodes via the registry /
+    /// dictionary-less path.
+    dict: Option<DictionaryHandle>,
     pending: Vec<u8>,
     header_done: bool,
     checksum: bool,
@@ -211,6 +360,7 @@ impl ZstdDecompressStream {
         decoder.set_content_checksum(core_checksum(checksum));
         ZstdDecompressStream {
             decoder,
+            dict: None,
             pending: Vec::new(),
             header_done: false,
             checksum: false,
@@ -235,11 +385,33 @@ impl ZstdDecompressStream {
         })?;
         Ok(ZstdDecompressStream {
             decoder,
+            dict: None,
             pending: Vec::new(),
             header_done: false,
             checksum: false,
             finished: false,
         })
+    }
+
+    /// Open a streaming decompressor against a [`ZstdDictionary`] prepared
+    /// once: per-stream setup is a reference-count bump, no dictionary
+    /// re-parse. Unlike [`Self::with_dictionary`] this also decodes frames
+    /// whose headers omit the dictionary ID (raw-content dictionaries).
+    #[wasm_bindgen(js_name = withPreparedDictionary)]
+    pub fn with_prepared_dictionary(
+        dict: &ZstdDictionary,
+        checksum: Option<ContentChecksum>,
+    ) -> ZstdDecompressStream {
+        let mut decoder = FrameDecoder::new();
+        decoder.set_content_checksum(core_checksum(checksum));
+        ZstdDecompressStream {
+            decoder,
+            dict: Some(dict.handle.clone()),
+            pending: Vec::new(),
+            header_done: false,
+            checksum: false,
+            finished: false,
+        }
     }
 
     /// Feed more compressed bytes; returns whatever decompressed output is now
@@ -309,9 +481,11 @@ impl ZstdDecompressStream {
                 return Ok(out);
             };
             let mut cursor: &[u8] = &self.pending;
-            self.decoder.init(&mut cursor).map_err(|err| {
-                JsError::new(&format!("structured-zstd: bad frame header: {err:?}"))
-            })?;
+            match &self.dict {
+                Some(handle) => self.decoder.init_with_dict_handle(&mut cursor, handle),
+                None => self.decoder.init(&mut cursor),
+            }
+            .map_err(|err| JsError::new(&format!("structured-zstd: bad frame header: {err:?}")))?;
             let advanced = self.pending.len() - cursor.len();
             self.pending.drain(..advanced);
             self.checksum = checksum;
@@ -390,6 +564,32 @@ impl ZstdCompressStream {
         encoder.set_dictionary_from_bytes(dict).map_err(|err| {
             JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
         })?;
+        Ok(ZstdCompressStream {
+            encoder: Some(encoder),
+        })
+    }
+
+    /// Open a streaming compressor at `level` seeded from a [`ZstdDictionary`]
+    /// prepared once: per-stream setup copies the prepared tables instead of
+    /// re-parsing the dictionary blob (no FSE/HUF table rebuild).
+    #[wasm_bindgen(js_name = withPreparedDictionary)]
+    pub fn with_prepared_dictionary(
+        level: i32,
+        dict: &ZstdDictionary,
+        checksum: Option<bool>,
+    ) -> Result<ZstdCompressStream, JsError> {
+        let mut encoder = StreamingEncoder::new(Vec::new(), CompressionLevel::Level(level));
+        encoder
+            .set_content_checksum(checksum.unwrap_or(false))
+            .expect("fresh streaming encoder accepts the content-checksum toggle");
+        encoder
+            .set_encoder_dictionary(dict.enc_template.clone())
+            .map_err(|err| {
+                JsError::new(&format!("structured-zstd: invalid dictionary: {err:?}"))
+            })?;
+        if dict.suppress_id {
+            encoder.set_dictionary_id_flag(false);
+        }
         Ok(ZstdCompressStream {
             encoder: Some(encoder),
         })

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -13,6 +13,7 @@ use crate::decoding::scratch::HuffmanScratch;
 /// during sequence execution.
 ///
 /// <https://github.com/facebook/zstd/blob/dev/doc/zstd_compression_format.md#dictionary-format>
+#[derive(Clone)]
 pub struct Dictionary {
     /// A 4 byte value used by decoders to check if they can use
     /// the correct dictionary. This value must not be zero.

--- a/zstd/src/decoding/dictionary.rs
+++ b/zstd/src/decoding/dictionary.rs
@@ -58,6 +58,13 @@ pub struct DictionaryHandle {
 pub const MAGIC_NUM: [u8; 4] = [0x37, 0xA4, 0x30, 0xEC];
 
 impl Dictionary {
+    /// Heap bytes owned by this dictionary: the content plus the parsed
+    /// entropy tables' heap (the fixed-size FSE decode arrays are inline,
+    /// counted by `size_of::<Dictionary>()`).
+    pub fn heap_bytes(&self) -> usize {
+        self.dict_content.capacity() + self.fse.heap_bytes() + self.huf.heap_bytes()
+    }
+
     /// Build a dictionary from raw content bytes (without entropy table sections).
     ///
     /// This is primarily intended for dictionaries produced by the `dict_builder`

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -271,6 +271,7 @@ impl<B: BufferBackend> DecoderScratch<B> {
     }
 }
 
+#[derive(Clone)]
 pub struct HuffmanScratch {
     pub table: HuffmanTable,
     /// Copy-on-write source for the literals Huffman table, mirroring the
@@ -364,6 +365,7 @@ enum TableSource {
     Dict,
 }
 
+#[derive(Clone)]
 pub struct FSEScratch {
     pub offsets: AlignedFSETable,
     pub literal_lengths: AlignedFSETable,
@@ -541,6 +543,7 @@ impl Default for FSEScratch {
 // Note: this aligns the table containers, not the `Vec<SeqSymbol>` backing allocations.
 #[cfg_attr(target_arch = "aarch64", repr(align(128)))]
 #[cfg_attr(not(target_arch = "aarch64"), repr(align(64)))]
+#[derive(Clone)]
 pub struct AlignedFSETable(SeqFSETable);
 
 impl AlignedFSETable {

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -98,6 +98,26 @@ impl BtMatcher {
     /// side table only.
     pub(crate) const HASH_MLS: usize = 4;
 
+    /// Steady-state workspace budget for one boxed matcher: the inline
+    /// payload (`HcOptState` cost tables, lit-price arrays) plus the
+    /// retained scratch arenas at their growth bounds — node frontier and
+    /// emitted store (`HC_OPT_NUM + 1` nodes each), the four
+    /// frontier-sized length-price arrays, the per-segment plan buffers,
+    /// and the candidate ladder (`MAX_HC_SEARCH_DEPTH`). LDM is opt-in
+    /// and excluded (`ldm_sequences` stays empty on every level preset).
+    /// Kept next to the struct so the estimator and the real retained
+    /// layout evolve together.
+    pub(crate) fn estimated_workspace_bytes() -> usize {
+        use super::cost_model::HC_OPT_NUM;
+        use super::hc::MAX_HC_SEARCH_DEPTH;
+        let frontier = HC_OPT_NUM + 1;
+        core::mem::size_of::<Self>()
+            + 2 * frontier * core::mem::size_of::<HcOptimalNode>()
+            + 4 * frontier * core::mem::size_of::<u32>()
+            + 2 * frontier * core::mem::size_of::<HcOptimalSequence>()
+            + MAX_HC_SEARCH_DEPTH * core::mem::size_of::<MatchCandidate>()
+    }
+
     /// Append `candidate` to `out` if it's strictly longer than the
     /// best length seen so far (and at least `min_match_len`). Maintains
     /// `best_len_for_skip` so subsequent calls only keep strictly

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -29,6 +29,7 @@ use crate::io::{Read, Write};
 /// [`set_dictionary_from_bytes`](FrameCompressor::set_dictionary_from_bytes))
 /// from ever reaching the decode side — the encoder/decoder dictionary split
 /// mirrors C zstd's `CDict` / `DDict`.
+#[derive(Clone)]
 pub struct EncoderDictionary {
     pub(crate) inner: crate::decoding::Dictionary,
 }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -4779,11 +4779,12 @@ mod tests {
             level_pre_split(CompressionLevel::Better),
             level_pre_split(CompressionLevel::Level(7)),
         );
-        // Best is a pure alias for level 11 (lazy): pin it to the numeric
-        // route so the named path can't drift from the pre-split table.
+        // Best resolves to the level-13 table row (btlazy2): pin it to that
+        // numeric route so the named path can't drift from the pre-split
+        // table.
         assert_eq!(
             level_pre_split(CompressionLevel::Best),
-            level_pre_split(CompressionLevel::Level(11)),
+            level_pre_split(CompressionLevel::Level(13)),
         );
         assert_eq!(level_pre_split(CompressionLevel::Level(2)), Some(0)); // fast
         assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(1)); // dfast

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8212,9 +8212,10 @@ fn pooled_space_keeps_capacity_when_slice_size_shrinks() {
 fn driver_best_to_fastest_releases_oversized_hc_tables() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
 
-    // Initialize at Best routed onto HashChain (the production `Best`
-    // resolves to Row now) — allocates large HC tables (4M hash, 2M chain)
-    // so the swap below exercises the HC drain path this test pins.
+    // Initialize at Best routed onto HashChain via the test-only override
+    // (production `Best` sits on level 13, whose native backend differs) —
+    // allocates large HC tables (4M hash, 2M chain) so the swap below
+    // exercises the HC drain path this test pins.
     driver.reset_on_hc_lazy(CompressionLevel::Best);
     assert_eq!(driver.window_size(), (1u64 << 22));
 
@@ -8660,8 +8661,10 @@ fn primed_snapshot_fast_attach_does_not_over_key_non_simple_backends() {
     // differently and force a needless re-prime. `Best` is a Row-backend lazy
     // level; this also pins the Row arm recording its RESOLVED hash width on
     // the unhinted path (a 0 default there keyed unhinted-vs-hinted apart).
+    // An explicit Row-backend level: `Best` now sits on level 13 (Btlazy2),
+    // so the named alias no longer reaches the Row arm this test pins.
     let mut driver = MatchGeneratorDriver::new(8, 1);
-    let level = CompressionLevel::Best;
+    let level = CompressionLevel::Level(12);
 
     // Capture with no hint.
     driver.reset(level);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -956,7 +956,17 @@ pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
             .unwrap_or(0)
         + params
             .hc
-            .map(|h| (4usize << h.hash_log) + (4usize << h.chain_log))
+            .map(|h| {
+                // The btopt/btultra cascade also allocates the HC3
+                // short-match side table (`HC3_HASH_LOG`); HC-mode lazy
+                // levels leave it sized to zero.
+                let hash3 = if matches!(params.search, super::strategy::SearchMethod::BinaryTree) {
+                    4usize << super::match_table::storage::HC3_HASH_LOG
+                } else {
+                    0
+                };
+                (4usize << h.hash_log) + (4usize << h.chain_log) + hash3
+            })
             .unwrap_or(0)
         + params
             .row

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -983,14 +983,10 @@ pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
             .row
             .map(|r| (4usize << r.hash_bits) + (2usize << r.hash_bits))
             .unwrap_or(0);
-    // BT modes box a `BtMatcher` (inline cost-model tables) plus the
-    // optimal-parse scratch arenas, bounded by the `HC_OPT_NUM` node
-    // frontier (node + emitted-store + candidate entries per slot).
+    // BT modes box a `BtMatcher`; its retained scratch layout is budgeted
+    // next to the struct so estimator and allocator evolve together.
     let bt = if uses_bt {
-        core::mem::size_of::<super::bt::BtMatcher>()
-            + HC_OPT_NUM
-                * (2 * core::mem::size_of::<HcOptimalNode>()
-                    + core::mem::size_of::<MatchCandidate>())
+        super::bt::BtMatcher::estimated_workspace_bytes()
     } else {
         0
     };

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -996,6 +996,22 @@ pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
     window + tables + bt + staging
 }
 
+/// Extra steady-state workspace the binary-tree strategies (ordinals 6..=9,
+/// btlazy2..btultra2) retain beyond the hash/chain tables: the boxed matcher
+/// plus its scratch arenas, and the HC3 short-match side table for
+/// btultra/btultra2 (capped by the window log). 0 for non-BT ordinals.
+pub fn estimated_bt_strategy_extra_bytes(strategy_ordinal: u32, window_log: u32) -> usize {
+    if !(6..=9).contains(&strategy_ordinal) {
+        return 0;
+    }
+    let hash3 = if matches!(strategy_ordinal, 8 | 9) {
+        4usize << super::match_table::storage::HC3_HASH_LOG.min(window_log as usize)
+    } else {
+        0
+    };
+    super::bt::BtMatcher::estimated_workspace_bytes() + hash3
+}
+
 /// Resolve a [`CompressionLevel`] to internal tuning parameters,
 /// optionally adjusted for a known source size.
 fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> LevelParams {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1120,11 +1120,15 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
 /// 128 KiB block. The frame loop reads this instead of hardcoding the
 /// level→split mapping at the call site.
 pub(crate) fn level_pre_split(level: CompressionLevel) -> Option<usize> {
-    // Named presets are pure aliases: resolve to their numeric level and
-    // read the split knob from the same `LevelParams` table as everything
-    // else. `Uncompressed` (raw blocks) has no numeric equivalent.
-    let numeric = level.numeric_level()?;
-    resolve_level_params(CompressionLevel::Level(numeric), None)
+    // Resolve through `resolve_level_params` directly — NOT via the legacy
+    // `numeric_level()` alias — so named presets read the SAME table row as
+    // every other tuning knob (`Best` maps to its own row there, which is
+    // not the row its numeric alias points at). `Uncompressed` (raw
+    // blocks) never splits.
+    if matches!(level, CompressionLevel::Uncompressed) {
+        return None;
+    }
+    resolve_level_params(level, None)
         .pre_split()
         .map(usize::from)
 }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -947,8 +947,21 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
 /// resolves at frame start, so the estimate tracks the real allocations;
 /// it is an upper-bound style budget figure, not an exact accounting.
 pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
+    use super::strategy::StrategyTag;
     let params = resolve_level_params(level, None);
     let window = 1usize << params.window_log;
+    // Mirror `configure()`: the HC3 short-match side table exists only on
+    // the btultra/btultra2 tags (minMatch 3), capped by the window log; the
+    // BT pointer-pair layout fits inside the `4 << chain_log` chain term
+    // (pairs over `chain_log - 1` nodes).
+    let wants_hash3 = matches!(
+        params.strategy_tag,
+        StrategyTag::BtUltra | StrategyTag::BtUltra2
+    );
+    let uses_bt = matches!(
+        params.strategy_tag,
+        StrategyTag::Btlazy2 | StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2
+    );
     let tables = params.fast.map(|f| 4usize << f.hash_log).unwrap_or(0)
         + params
             .dfast
@@ -957,11 +970,9 @@ pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
         + params
             .hc
             .map(|h| {
-                // The btopt/btultra cascade also allocates the HC3
-                // short-match side table (`HC3_HASH_LOG`); HC-mode lazy
-                // levels leave it sized to zero.
-                let hash3 = if matches!(params.search, super::strategy::SearchMethod::BinaryTree) {
-                    4usize << super::match_table::storage::HC3_HASH_LOG
+                let hash3 = if wants_hash3 {
+                    4usize
+                        << super::match_table::storage::HC3_HASH_LOG.min(params.window_log as usize)
                 } else {
                     0
                 };
@@ -972,10 +983,21 @@ pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
             .row
             .map(|r| (4usize << r.hash_bits) + (2usize << r.hash_bits))
             .unwrap_or(0);
+    // BT modes box a `BtMatcher` (inline cost-model tables) plus the
+    // optimal-parse scratch arenas, bounded by the `HC_OPT_NUM` node
+    // frontier (node + emitted-store + candidate entries per slot).
+    let bt = if uses_bt {
+        core::mem::size_of::<super::bt::BtMatcher>()
+            + HC_OPT_NUM
+                * (2 * core::mem::size_of::<HcOptimalNode>()
+                    + core::mem::size_of::<MatchCandidate>())
+    } else {
+        0
+    };
     // Block staging: literal + sequence buffers plus the compressed-block
     // scratch, each bounded by the 128 KiB block size.
     let staging = 3 * (128 * 1024);
-    window + tables + staging
+    window + tables + bt + staging
 }
 
 /// Resolve a [`CompressionLevel`] to internal tuning parameters,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1022,7 +1022,12 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
         }
         CompressionLevel::Default => LEVEL_TABLE[2],
         CompressionLevel::Better => LEVEL_TABLE[6],
-        CompressionLevel::Best => LEVEL_TABLE[10],
+        // Level 13: the first dominant point of the deep-lazy band. The
+        // mls-wide row key lifted the shallow band's ratio enough that
+        // level 11 no longer strictly beats level 7 on the ladder corpus;
+        // the `Best` alias belongs on a config that dominates everything
+        // below it rather than on a hair-thin margin.
+        CompressionLevel::Best => LEVEL_TABLE[12],
         CompressionLevel::Level(n) => {
             if n > 0 {
                 let idx = (n as usize).min(CompressionLevel::MAX_LEVEL as usize) - 1;
@@ -6812,7 +6817,8 @@ fn driver_reset_keeps_strategy_tag_in_sync_with_active_backend() {
     check(CompressionLevel::Fastest, StrategyTag::Fast);
     check(CompressionLevel::Default, StrategyTag::Dfast);
     check(CompressionLevel::Better, StrategyTag::Lazy);
-    check(CompressionLevel::Best, StrategyTag::Lazy);
+    // `Best` sits on level 13 (the first dominant point of the deep band).
+    check(CompressionLevel::Best, StrategyTag::Btlazy2);
 }
 
 #[test]
@@ -9067,7 +9073,12 @@ fn row_hash_and_row_extracts_high_bits() {
 
     let idx = pos - matcher.history_abs_start;
     let concat = matcher.live_history();
-    let value = u32::from_le_bytes(concat[idx..idx + ROW_HASH_KEY_LEN].try_into().unwrap()) as u64;
+    // Mirror `row_key_value`: an mls-wide masked key when 8 lookahead bytes
+    // exist, the 4-byte key in the tail. `idx = 8` on a 16-byte history has
+    // exactly 8 bytes left, so the wide arm applies here.
+    let key_len = matcher.mls.min(6);
+    let value = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap())
+        & ((1u64 << (key_len * 8)) - 1);
     let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(matcher.hash_kernel, value);
     let total_bits = matcher.row_hash_log + ROW_TAG_BITS;
     let combined = hash >> (u64::BITS as usize - total_bits);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -941,6 +941,33 @@ fn level22_btultra2_params_for_source_size(source_size: Option<u64>) -> LevelPar
     }
 }
 
+/// Estimated steady-state heap footprint of a one-shot compression context
+/// at `level` (window history + match-finder tables + block staging), in
+/// bytes. Computed from the same per-level tuning table the encoder
+/// resolves at frame start, so the estimate tracks the real allocations;
+/// it is an upper-bound style budget figure, not an exact accounting.
+pub fn estimated_compression_workspace_bytes(level: CompressionLevel) -> usize {
+    let params = resolve_level_params(level, None);
+    let window = 1usize << params.window_log;
+    let tables = params.fast.map(|f| 4usize << f.hash_log).unwrap_or(0)
+        + params
+            .dfast
+            .map(|d| (4usize << d.long_hash_log) + (4usize << d.short_hash_log))
+            .unwrap_or(0)
+        + params
+            .hc
+            .map(|h| (4usize << h.hash_log) + (4usize << h.chain_log))
+            .unwrap_or(0)
+        + params
+            .row
+            .map(|r| (4usize << r.hash_bits) + (2usize << r.hash_bits))
+            .unwrap_or(0);
+    // Block staging: literal + sequence buffers plus the compressed-block
+    // scratch, each bounded by the 128 KiB block size.
+    let staging = 3 * (128 * 1024);
+    window + tables + staging
+}
+
 /// Resolve a [`CompressionLevel`] to internal tuning parameters,
 /// optionally adjusted for a known source size.
 fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> LevelParams {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -8686,7 +8686,7 @@ fn primed_snapshot_fast_attach_does_not_over_key_non_simple_backends() {
     let restored = driver.restore_primed_dictionary(level);
     assert!(
         restored,
-        "a HashChain snapshot must restore across an unhinted vs large-hinted \
+        "a Row snapshot must restore across an unhinted vs large-hinted \
          reset that resolves to the identical matcher — `fast_attach` is a Fast \
          backend concept and must not over-key non-Simple shapes"
     );

--- a/zstd/src/encoding/match_table/helpers.rs
+++ b/zstd/src/encoding/match_table/helpers.rs
@@ -131,6 +131,7 @@ pub(crate) fn extend_backwards_shared(
 /// invoked once per encoded byte on lazy / Dfast / Row matchers
 /// (~10% exclusive on the default-level profile).
 #[inline]
+#[inline(always)]
 pub(crate) fn repcode_candidate_shared(
     kernel: FastpathKernel,
     concat: &[u8],

--- a/zstd/src/encoding/match_table/helpers.rs
+++ b/zstd/src/encoding/match_table/helpers.rs
@@ -130,7 +130,6 @@ pub(crate) fn extend_backwards_shared(
 /// fallback) and return the best match found, if any. Hot path:
 /// invoked once per encoded byte on lazy / Dfast / Row matchers
 /// (~10% exclusive on the default-level profile).
-#[inline]
 #[inline(always)]
 pub(crate) fn repcode_candidate_shared(
     kernel: FastpathKernel,

--- a/zstd/src/encoding/match_table/helpers.rs
+++ b/zstd/src/encoding/match_table/helpers.rs
@@ -185,9 +185,19 @@ pub(crate) fn repcode_candidate_shared(
                 // `candidate_idx < current_idx`.
                 if candidate_pos >= history_abs_start {
                     let candidate_idx = candidate_pos - history_abs_start;
-                    if concat[candidate_idx..candidate_idx + 4]
-                        == concat[current_idx..current_idx + 4]
-                    {
+                    // Donor `MEM_read32` gate: one unaligned u32 compare. The
+                    // slice-range form paid two bounds checks per rep probe
+                    // (per input byte on the greedy/lazy levels).
+                    // SAFETY: the entry guard established `current_idx +
+                    // min_match_len <= concat.len()` with `min_match_len >= 4`
+                    // (debug-asserted above), and `candidate_idx <
+                    // current_idx`, so both 4-byte reads are in bounds.
+                    let gate = unsafe {
+                        let base = concat.as_ptr();
+                        core::ptr::read_unaligned(base.add(candidate_idx).cast::<u32>())
+                            == core::ptr::read_unaligned(base.add(current_idx).cast::<u32>())
+                    };
+                    if gate {
                         let match_len = common_prefix_len_with_kernel(
                             kernel,
                             &concat[candidate_idx..],

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -96,7 +96,9 @@ mod streaming_encoder;
 pub use frame_compressor::{EncoderDictionary, FrameCompressor};
 #[cfg(feature = "lsm")]
 pub use frame_emit_info::{BlockType, FrameBlock, FrameEmitInfo};
-pub use match_generator::{MatchGeneratorDriver, estimated_compression_workspace_bytes};
+pub use match_generator::{
+    MatchGeneratorDriver, estimated_bt_strategy_extra_bytes, estimated_compression_workspace_bytes,
+};
 pub use parameters::{
     Bounds, CParameter, CompressionParameters, CompressionParametersBuilder, ParameterError,
     Strategy,

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -37,6 +37,10 @@
 //!
 //! All produced frames are valid RFC 8878 Zstandard streams and decode
 //! through both this crate's [`crate::decoding`] module and upstream C zstd.
+//!
+//! For memory budgeting, [`estimated_compression_workspace_bytes`] reports
+//! the approximate steady-state heap footprint of a one-shot compression at
+//! a given level (window + match-finder tables + block staging).
 
 pub(crate) mod block_header;
 pub(crate) mod blocks;

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -347,22 +347,6 @@ impl CompressionLevel {
             _ => Self::Level(level),
         }
     }
-
-    /// Numeric level a named preset is a shortcut for, so per-level config
-    /// (the `LevelParams` table) is resolved uniformly: named presets are
-    /// pure aliases, never a separate config path. `Uncompressed` is the
-    /// one genuine mode (raw blocks) with no numeric equivalent and returns
-    /// `None`.
-    pub(crate) const fn numeric_level(self) -> Option<i32> {
-        match self {
-            Self::Uncompressed => None,
-            Self::Fastest => Some(1),
-            Self::Default => Some(Self::DEFAULT_LEVEL),
-            Self::Better => Some(7),
-            Self::Best => Some(11),
-            Self::Level(n) => Some(n),
-        }
-    }
 }
 
 /// Trait used by the encoder that users can use to extend the matching facilities with their own algorithm

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -92,7 +92,7 @@ mod streaming_encoder;
 pub use frame_compressor::{EncoderDictionary, FrameCompressor};
 #[cfg(feature = "lsm")]
 pub use frame_emit_info::{BlockType, FrameBlock, FrameEmitInfo};
-pub use match_generator::MatchGeneratorDriver;
+pub use match_generator::{MatchGeneratorDriver, estimated_compression_workspace_bytes};
 pub use parameters::{
     Bounds, CParameter, CompressionParameters, CompressionParametersBuilder, ParameterError,
     Strategy,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1525,15 +1525,35 @@ impl RowMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
+    /// Row hash key at `idx`: `key_len` bytes (donor `mls`, 5-6 on the row
+    /// levels) via one masked 8-byte read, degrading to the 4-byte key in
+    /// the last <8 bytes of the window. Shared by the live hash and the
+    /// dictionary row-index build — the two MUST bucket identically or
+    /// dict-region probes go blind.
     #[inline(always)]
+    fn row_key_value(concat: &[u8], idx: usize, key_len: usize) -> u64 {
+        if idx + 8 <= concat.len() {
+            let v = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap());
+            v & ((1u64 << (key_len * 8)) - 1)
+        } else {
+            u32::from_le_bytes(concat[idx..idx + ROW_HASH_KEY_LEN].try_into().unwrap()) as u64
+        }
+    }
+
     pub(crate) fn hash_and_row(&self, abs_pos: usize) -> Option<(usize, u8)> {
         let idx = abs_pos - self.history_abs_start;
         let concat = self.live_history();
         if idx + ROW_HASH_KEY_LEN > concat.len() {
             return None;
         }
-        let value =
-            u32::from_le_bytes(concat[idx..idx + ROW_HASH_KEY_LEN].try_into().unwrap()) as u64;
+        // Donor `ZSTD_hashPtrSalted` hashes `mls` bytes (5-6 on the row
+        // levels), not 4: a wider key cuts the false tag hits whose
+        // candidates then cost a data load + reject in the probe. Read 8
+        // bytes and mask to the key width when the tail allows; the last
+        // <8 bytes of the window keep the 4-byte key (a position hashes
+        // identically in the probe and the insert either way, so the
+        // mixed tail stays self-consistent).
+        let value = Self::row_key_value(concat, idx, self.mls.min(6));
         let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(self.hash_kernel, value);
         let total_bits = self.row_hash_log + ROW_TAG_BITS;
         let combined = hash >> (u64::BITS as usize - total_bits);
@@ -2086,6 +2106,7 @@ impl RowMatchGenerator {
         let row_log = self.row_log;
         let row_hash_log = self.row_hash_log;
         let hash_kernel = self.hash_kernel;
+        let key_len = self.mls.min(6);
         let history_start = self.history_start;
         let concat_len = self.history.len() - history_start;
         // Row hash needs `ROW_HASH_KEY_LEN` readable bytes of lookahead.
@@ -2118,13 +2139,14 @@ impl RowMatchGenerator {
         // is u32-bounded upstream).
         for concat in start_concat..safe_end {
             unsafe {
-                // Little-endian load to match the live probe's
-                // `u32::from_le_bytes` hash (`hash_and_row`); a native-endian
-                // load would bucket dict rows differently on big-endian targets
-                // and lose every attached-dict match there.
-                let value =
-                    u32::from_le((base.add(history_start + concat) as *const u32).read_unaligned())
-                        as u64;
+                // Same key reader as the live `hash_and_row` (width and
+                // endianness): any divergence buckets dict rows differently
+                // and loses every attached-dict match.
+                let value = Self::row_key_value(
+                    core::slice::from_raw_parts(base.add(history_start), concat_len),
+                    concat,
+                    key_len,
+                );
                 let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(hash_kernel, value);
                 let combined = hash >> (u64::BITS as usize - total_bits);
                 let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1530,6 +1530,15 @@ impl RowMatchGenerator {
     /// the last <8 bytes of the window. Shared by the live hash and the
     /// dictionary row-index build — the two MUST bucket identically or
     /// dict-region probes go blind.
+    ///
+    /// The degradation is per window STATE: within one window a position
+    /// hashes identically in the probe and the insert. The last <8
+    /// positions of a pre-primed dictionary are a separate, unfixable
+    /// case — the bytes following them exist only at probe time, so no
+    /// fixed build-time key (4-byte, zero-padded, or otherwise) can match
+    /// the probe's real-byte key there. Those few dict-tail entries stay
+    /// unreachable, mirroring the donor, whose dictionary load also stops
+    /// hashing short of the dictionary end.
     #[inline(always)]
     fn row_key_value(concat: &[u8], idx: usize, key_len: usize) -> u64 {
         if idx + 8 <= concat.len() {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -598,7 +598,20 @@ macro_rules! lazy_parse_body {
                         Some((row, tag)) => $m.insert_at::<$rl>(abs_pos, row, tag),
                         None => $m.insert_position::<$rl>(abs_pos),
                     }
-                    pos += 1;
+                    if carried.is_some() {
+                        // Defer: the lookahead found a better match — step
+                        // exactly one to take it next iteration.
+                        pos += 1;
+                    } else {
+                        // Complete miss: accelerate through weakly-matching
+                        // stretches (upstream zstd `ip += (ip - anchor) >>
+                        // kSearchStrength + 1`, zstd_lazy.c lazy_generic).
+                        // Same softened `SKIP_STRENGTH = 10` as the greedy
+                        // kernel above: the step stays 1 until the literal
+                        // run hits ~1 KiB, protecting ratio on short runs.
+                        const SKIP_STRENGTH: u32 = 10;
+                        pos += ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
+                    }
                 }
             }
 

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -75,6 +75,7 @@ pub(crate) trait RowTags: Copy {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate>;
 }
 
@@ -97,9 +98,10 @@ impl RowTags for ScalarTags {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate> {
         // Scalar has no target feature; the probe body runs as-is.
-        unsafe { matcher.row_probe_scalar::<ROW_LOG>(abs_pos, lit_len) }
+        unsafe { matcher.row_probe_scalar::<ROW_LOG>(abs_pos, lit_len, hash) }
     }
 }
 
@@ -113,9 +115,10 @@ impl RowTags for Sse42Tags {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate> {
         // SAFETY: dispatched only when `tag_kernel == Sse42` (SSE4.2 confirmed).
-        unsafe { matcher.row_probe_sse42::<ROW_LOG>(abs_pos, lit_len) }
+        unsafe { matcher.row_probe_sse42::<ROW_LOG>(abs_pos, lit_len, hash) }
     }
 }
 
@@ -129,9 +132,10 @@ impl RowTags for Avx2Bmi2Tags {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate> {
         // SAFETY: dispatched only when `tag_kernel == Avx2Bmi2` (AVX2+BMI2 confirmed).
-        unsafe { matcher.row_probe_avx2bmi2::<ROW_LOG>(abs_pos, lit_len) }
+        unsafe { matcher.row_probe_avx2bmi2::<ROW_LOG>(abs_pos, lit_len, hash) }
     }
 }
 
@@ -145,9 +149,10 @@ impl RowTags for NeonTags {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate> {
         // SAFETY: dispatched only when `tag_kernel == Neon` (NEON confirmed).
-        unsafe { matcher.row_probe_neon::<ROW_LOG>(abs_pos, lit_len) }
+        unsafe { matcher.row_probe_neon::<ROW_LOG>(abs_pos, lit_len, hash) }
     }
 }
 
@@ -173,10 +178,11 @@ impl RowTags for Simd128Tags {
         matcher: &RowMatchGenerator,
         abs_pos: usize,
         lit_len: usize,
+        hash: Option<(usize, u8)>,
     ) -> Option<MatchCandidate> {
         // wasm simd128 is compile-time; `row_probe_simd128` needs no
         // `#[target_feature]` and the intrinsics inline directly.
-        unsafe { matcher.row_probe_simd128::<ROW_LOG>(abs_pos, lit_len) }
+        unsafe { matcher.row_probe_simd128::<ROW_LOG>(abs_pos, lit_len, hash) }
     }
 }
 
@@ -407,6 +413,7 @@ macro_rules! gen_row_probe {
             &self,
             abs_pos: usize,
             lit_len: usize,
+            hash: Option<(usize, u8)>,
         ) -> Option<MatchCandidate> {
             debug_assert_eq!(ROW_LOG, self.row_log);
             let mls = self.mls;
@@ -416,7 +423,13 @@ macro_rules! gen_row_probe {
                 return None;
             }
 
-            let (row, tag) = self.hash_and_row(abs_pos)?;
+            // `hash` carries the (row, tag) the greedy loop already
+            // computed for this position (and prefetched the row for);
+            // recompute only on the uncarried paths.
+            let (row, tag) = match hash {
+                Some(rt) => rt,
+                None => self.hash_and_row(abs_pos)?,
+            };
             let row_entries = 1usize << ROW_LOG;
             let row_mask = row_entries - 1;
             let row_base = row << ROW_LOG;
@@ -1171,6 +1184,14 @@ impl RowMatchGenerator {
 
         let mut pos = 0usize;
         let mut literals_start = 0usize;
+        // Software pipeline over the dependent row load: on a miss the next
+        // position's (row, tag) is computed ahead and its tag/position rows
+        // prefetched, so the probe's row loads (the hottest instructions of
+        // this loop — a hash-dependent cache miss per position) overlap the
+        // current iteration's tail instead of stalling the next probe.
+        // Donor `ZSTD_RowFindBestMatch` gets the same overlap from its
+        // hash-cache + `ZSTD_row_prefetch` pipeline.
+        let mut carried: Option<(usize, (usize, u8))> = None;
 
         while pos + GREEDY_MIN_LOOKAHEAD <= current_len {
             let abs_pos = current_abs_start + pos;
@@ -1224,11 +1245,15 @@ impl RowMatchGenerator {
             // pure search, no table mutation), so skipping it drops no hash
             // insert — the post-emit `insert_positions(abs_pos, ..)` still
             // indexes the committed span.
+            let hash = match carried.take() {
+                Some((carried_pos, rt)) if carried_pos == abs_pos => Some(rt),
+                _ => None,
+            };
             let chosen = match rep_match {
                 Some(rep) => Some(rep),
                 // SAFETY: `K` selected by `dispatch_tag_kernel!` after `detect`
                 // confirmed its ISA; `K::probe` upholds the feature contract.
-                None => unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len) },
+                None => unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len, hash) },
             };
 
             let Some(candidate) = chosen else {
@@ -1245,7 +1270,21 @@ impl RowMatchGenerator {
                 // drain.
                 const SKIP_STRENGTH: u32 = 10;
                 let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
-                self.insert_position::<ROW_LOG>(abs_pos);
+                // Reuse the probe's (row, tag) for the insert (the rep-hit
+                // path never computed one, so fall back to the hashing
+                // insert there — `hash` is `Some` exactly when the probe
+                // ran on this position).
+                match hash {
+                    Some((row, tag)) => self.insert_at::<ROW_LOG>(abs_pos, row, tag),
+                    None => self.insert_position::<ROW_LOG>(abs_pos),
+                }
+                if step == 1 {
+                    let next_abs = abs_pos + 1;
+                    if let Some((row, tag)) = self.hash_and_row(next_abs) {
+                        self.prefetch_row::<ROW_LOG>(row);
+                        carried = Some((next_abs, (row, tag)));
+                    }
+                }
                 pos += step;
                 continue;
             };
@@ -1384,7 +1423,7 @@ impl RowMatchGenerator {
         let rep = self.repcode_candidate(abs_pos, lit_len);
         // SAFETY: `K` selected by `dispatch_tag_kernel!` after `detect` confirmed
         // its ISA; `K::probe` upholds the per-tier feature contract.
-        let row = unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len) };
+        let row = unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len, None) };
         best_len_offset_candidate(rep, row)
     }
 
@@ -1503,9 +1542,9 @@ impl RowMatchGenerator {
         // SAFETY: `dispatch_tag_kernel!` only selects a `K` whose ISA `detect`
         // confirmed present, upholding `K::probe`'s per-tier feature contract.
         match self.row_log {
-            4 => unsafe { K::probe::<4>(self, abs_pos, lit_len) },
-            5 => unsafe { K::probe::<5>(self, abs_pos, lit_len) },
-            6 => unsafe { K::probe::<6>(self, abs_pos, lit_len) },
+            4 => unsafe { K::probe::<4>(self, abs_pos, lit_len, None) },
+            5 => unsafe { K::probe::<5>(self, abs_pos, lit_len, None) },
+            6 => unsafe { K::probe::<6>(self, abs_pos, lit_len, None) },
             _ => unreachable!("row_log is clamped to 4..=6 in configure()"),
         }
     }
@@ -1632,6 +1671,41 @@ impl RowMatchGenerator {
         let Some((row, tag)) = self.hash_and_row(abs_pos) else {
             return;
         };
+        self.insert_at::<ROW_LOG>(abs_pos, row, tag);
+    }
+
+    /// Prefetch a row's tag bytes and position words into L1 ahead of the
+    /// next iteration's probe (no-op on targets without a prefetch hint).
+    #[inline]
+    fn prefetch_row<const ROW_LOG: usize>(&self, row: usize) {
+        let row_base = row << ROW_LOG;
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            #[cfg(target_arch = "x86")]
+            use core::arch::x86::{_MM_HINT_T0, _mm_prefetch};
+            #[cfg(target_arch = "x86_64")]
+            use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+            // SAFETY: prefetch is a hint and never faults; the indexes are in
+            // bounds by the same `ensure_tables` sizing as `insert_at`.
+            unsafe {
+                _mm_prefetch(self.row_tags.as_ptr().add(row_base).cast(), _MM_HINT_T0);
+                _mm_prefetch(
+                    self.row_positions.as_ptr().add(row_base).cast(),
+                    _MM_HINT_T0,
+                );
+            }
+        }
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+        {
+            let _ = row_base;
+        }
+    }
+
+    /// [`Self::insert_position`] with the (row, tag) pair already computed —
+    /// the greedy miss path reuses the probe's hash instead of re-hashing
+    /// the same position.
+    #[inline]
+    fn insert_at<const ROW_LOG: usize>(&mut self, abs_pos: usize, row: usize, tag: u8) {
         // `ROW_LOG` is the compile-time row width for this monomorphisation;
         // the dispatcher guarantees `ROW_LOG == self.row_log` so the table
         // bounds (`ensure_tables` sized by `self.row_log`) hold.

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1571,6 +1571,7 @@ impl RowMatchGenerator {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn hash_and_row(&self, abs_pos: usize) -> Option<(usize, u8)> {
         let idx = abs_pos - self.history_abs_start;
         let concat = self.live_history();
@@ -1638,6 +1639,7 @@ impl RowMatchGenerator {
     }
 
     #[allow(dead_code)]
+    #[inline(always)]
     pub(crate) fn repcode_candidate(
         &self,
         abs_pos: usize,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -449,15 +449,106 @@ macro_rules! greedy_parse_body {
     }};
 }
 
-macro_rules! gen_row_parse_kernel {
-    ($name:ident, $rl:ident $(, $tf:literal)?) => {
+/// Rep + row best-of-two probe (the lazy search step) with the probe body
+/// expanded inline under the enclosing tier umbrella.
+macro_rules! row_best_match {
+    ($m:expr, $abs_pos:expr, $lit_len:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        let rep = $m.repcode_candidate($abs_pos, $lit_len);
+        let row = row_probe_body!($m, $abs_pos, $lit_len, None, $rl, $use_mask, $maskmac, $cpl);
+        best_len_offset_candidate(rep, row)
+    }};
+}
+
+/// The lazy row parse BODY as a macro — same per-tier monolith shape as
+/// `greedy_parse_body!` for the lazy levels (lookahead via
+/// `pick_lazy_match_shared`, with both its probe sites expanded inline).
+macro_rules! lazy_parse_body {
+    ($m:expr, $handle:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        #[allow(unused_labels)]
+        'parse: {
+            debug_assert_eq!($rl, $m.row_log);
+            $m.ensure_tables();
+
+            let current_len = *$m.chunk_lens.back().unwrap();
+            if current_len == 0 {
+                break 'parse;
+            }
+            let current_abs_start = $m.history_abs_start + $m.window_size - current_len;
+            let backfill_start = $m.backfill_start(current_abs_start);
+            if backfill_start < current_abs_start {
+                $m.insert_positions::<$rl>(backfill_start, current_abs_start);
+            }
+
+            let mls = $m.mls;
+            let mut pos = 0usize;
+            let mut literals_start = 0usize;
+            while pos + mls <= current_len {
+                let abs_pos = current_abs_start + pos;
+                let lit_len = pos - literals_start;
+
+                let best = row_best_match!($m, abs_pos, lit_len, $rl, $use_mask, $maskmac, $cpl);
+                let picked = pick_lazy_match_shared(
+                    abs_pos,
+                    lit_len,
+                    best,
+                    LazyMatchConfig {
+                        target_len: $m.target_len,
+                        min_match_len: $m.mls,
+                        lazy_depth: $m.lazy_depth,
+                        history_abs_end: $m.history_abs_end(),
+                    },
+                    |next_pos, next_lit_len| {
+                        row_best_match!($m, next_pos, next_lit_len, $rl, $use_mask, $maskmac, $cpl)
+                    },
+                );
+                if let Some(candidate) = picked {
+                    $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
+                    let current = &$m.history[$m.history.len() - current_len..];
+                    let start = candidate.start - current_abs_start;
+                    let literals = &current[literals_start..start];
+                    $handle(Sequence::Triple {
+                        literals,
+                        offset: candidate.offset,
+                        match_len: candidate.match_len,
+                    });
+                    let _ = encode_offset_with_history(
+                        candidate.offset as u32,
+                        literals.len() as u32,
+                        &mut $m.offset_hist,
+                    );
+                    pos = start + candidate.match_len;
+                    literals_start = pos;
+                } else {
+                    $m.insert_position::<$rl>(abs_pos);
+                    pos += 1;
+                }
+            }
+
+            while pos + ROW_HASH_KEY_LEN <= current_len {
+                $m.insert_position::<$rl>(current_abs_start + pos);
+                pos += 1;
+            }
+
+            if literals_start < current_len {
+                let current = &$m.history[$m.history.len() - current_len..];
+                $handle(Sequence::Literals {
+                    literals: &current[literals_start..],
+                });
+            }
+        }
+    }};
+}
+
+/// Per-tier lazy kernels (see `gen_greedy_monolith` — same SIMD pairing).
+macro_rules! gen_lazy_monolith {
+    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
         #[allow(unused_unsafe)]
         unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
             &mut self,
-            handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+            mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
         ) {
-            self.$rl::<K, ROW_LOG>(handle_sequence)
+            lazy_parse_body!(self, handle_sequence, ROW_LOG, $use_mask, $maskmac, $cpl)
         }
     };
 }
@@ -1311,82 +1402,6 @@ impl RowMatchGenerator {
             }
         }
     }
-
-    /// Lazy-style parse (depth >= 1) for the Row backend.
-    ///
-    /// Currently unused: the only strategy mapped to `BackendTag::Row`
-    /// is `StrategyTag::Greedy` (level 4), which dispatches to
-    /// [`Self::start_matching_greedy`] via the `debug_assert_eq!` in
-    /// the `BackendTag::Row` arm of
-    /// `MatchGeneratorDriver::compress_block`. This method is kept as
-    /// scaffolding for the case where a future level routes a lazy
-    /// strategy through the Row backend — extracting `pick_lazy_match`
-    /// behavior to a fresh module then would mean re-deriving the
-    /// row-hash machinery, which is wasteful. The `dead_code` allow is
-    /// scoped to this method and its private helpers so any new
-    /// caller will pick them up unmodified.
-    #[inline(always)]
-    pub(crate) fn start_matching_rl<K: RowTags, const ROW_LOG: usize>(
-        &mut self,
-        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        debug_assert_eq!(ROW_LOG, self.row_log);
-        self.ensure_tables();
-
-        let current_len = *self.chunk_lens.back().unwrap();
-        if current_len == 0 {
-            return;
-        }
-        let current_abs_start = self.history_abs_start + self.window_size - current_len;
-        let backfill_start = self.backfill_start(current_abs_start);
-        if backfill_start < current_abs_start {
-            self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
-        }
-
-        let mls = self.mls;
-        let mut pos = 0usize;
-        let mut literals_start = 0usize;
-        while pos + mls <= current_len {
-            let abs_pos = current_abs_start + pos;
-            let lit_len = pos - literals_start;
-
-            let best = self.best_match_rl::<K, ROW_LOG>(abs_pos, lit_len);
-            if let Some(candidate) = self.pick_lazy_match_rl::<K, ROW_LOG>(abs_pos, lit_len, best) {
-                self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
-                let current = &self.history[self.history.len() - current_len..];
-                let start = candidate.start - current_abs_start;
-                let literals = &current[literals_start..start];
-                handle_sequence(Sequence::Triple {
-                    literals,
-                    offset: candidate.offset,
-                    match_len: candidate.match_len,
-                });
-                let _ = encode_offset_with_history(
-                    candidate.offset as u32,
-                    literals.len() as u32,
-                    &mut self.offset_hist,
-                );
-                pos = start + candidate.match_len;
-                literals_start = pos;
-            } else {
-                self.insert_position::<ROW_LOG>(abs_pos);
-                pos += 1;
-            }
-        }
-
-        while pos + ROW_HASH_KEY_LEN <= current_len {
-            self.insert_position::<ROW_LOG>(current_abs_start + pos);
-            pos += 1;
-        }
-
-        if literals_start < current_len {
-            let current = &self.history[self.history.len() - current_len..];
-            handle_sequence(Sequence::Literals {
-                literals: &current[literals_start..],
-            });
-        }
-    }
-
     /// Donor-parity greedy parse for `lazy_depth == 0` (level 5).
     ///
     /// Mirrors `ZSTD_compressBlock_lazy_generic` (`zstd_lazy.c:1560`) with
@@ -1612,19 +1627,47 @@ impl RowMatchGenerator {
         }
     }
 
-    gen_row_parse_kernel!(lazy_scalar, start_matching_rl);
+    gen_lazy_monolith!(
+        lazy_scalar,
+        false,
+        row_tag_mask_scalar,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_row_parse_kernel!(lazy_sse42, start_matching_rl, "sse4.2");
+    gen_lazy_monolith!(
+        lazy_sse42,
+        true,
+        row_tag_mask_sse2,
+        crate::encoding::fastpath::sse42::common_prefix_len_ptr,
+        "sse4.2"
+    );
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_row_parse_kernel!(lazy_avx2bmi2, start_matching_rl, "avx2,bmi2");
+    gen_lazy_monolith!(
+        lazy_avx2bmi2,
+        true,
+        row_tag_mask_avx2,
+        crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
+        "avx2,bmi2"
+    );
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    gen_row_parse_kernel!(lazy_neon, start_matching_rl, "neon");
+    gen_lazy_monolith!(
+        lazy_neon,
+        true,
+        row_tag_mask_neon,
+        crate::encoding::fastpath::neon::common_prefix_len_ptr,
+        "neon"
+    );
     #[cfg(all(
         target_arch = "wasm32",
         target_feature = "simd128",
         feature = "kernel_simd128"
     ))]
-    gen_row_parse_kernel!(lazy_simd128, start_matching_rl);
+    gen_lazy_monolith!(
+        lazy_simd128,
+        true,
+        row_tag_mask_simd128,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
 
     pub(crate) fn start_matching_greedy(
         &mut self,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -545,7 +545,17 @@ macro_rules! lazy_parse_body {
                     {
                         // Defer: the lookahead wins; carry its result so the
                         // next iteration starts from it instead of searching
-                        // the same position again.
+                        // the same position again. Reusing the pre-insert
+                        // result is INTENTIONAL: the deferred-position insert
+                        // only ADDS a row entry, so the carried candidate's
+                        // positions and lengths stay valid — at most the
+                        // carried view misses the just-inserted neighbour as
+                        // a candidate. Upstream zstd's lazy chain has the
+                        // same property (a searched position is never
+                        // searched again, zstd_lazy.c lazy_generic), and the
+                        // size impact is measured at +25 bytes on a 484 KB
+                        // corpus while removing a full duplicate search per
+                        // deferral.
                         carried = Some(next);
                         break 'pick None;
                     }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -504,6 +504,13 @@ macro_rules! lazy_parse_body {
             let mls = $m.mls;
             let mut pos = 0usize;
             let mut literals_start = 0usize;
+            // Lookahead search result carried into the next iteration
+            // (upstream zstd's lazy chain, `zstd_lazy.c` lazy_generic: a
+            // deferred position's successor is never searched twice — the
+            // depth loop carries the better match forward). `Some(r)` means
+            // this iteration's position was already searched as the previous
+            // iteration's lookahead, with result `r`.
+            let mut carried: Option<Option<MatchCandidate>> = None;
             while pos + mls <= current_len {
                 let abs_pos = current_abs_start + pos;
                 let lit_len = pos - literals_start;
@@ -511,26 +518,51 @@ macro_rules! lazy_parse_body {
                 // Hash the position ONCE per iteration: the probe consumes it
                 // and the defer branch reuses it for the insert (upstream zstd
                 // hashes once per position — `ZSTD_RowFindBestMatch` updates
-                // the row as part of the search, `zstd_lazy.c`).
-                let hash = $m.hash_and_row(abs_pos);
-                let best = unsafe { $m.$find::<K, $rl>(abs_pos, lit_len, hash) };
-                let picked = pick_lazy_match_shared(
-                    abs_pos,
-                    lit_len,
-                    best,
-                    LazyMatchConfig {
-                        target_len: $m.target_len,
-                        min_match_len: $m.mls,
-                        lazy_depth: $m.lazy_depth,
-                        history_abs_end: $m.history_abs_end(),
-                    },
+                // the row as part of the search, `zstd_lazy.c`). A carried
+                // iteration skips both: the search already ran.
+                let (hash, best) = match carried.take() {
+                    Some(best) => (None, best),
+                    None => {
+                        let hash = $m.hash_and_row(abs_pos);
+                        let best = unsafe { $m.$find::<K, $rl>(abs_pos, lit_len, hash) };
+                        (hash, best)
+                    }
+                };
+                let picked = 'pick: {
+                    let Some(best) = best else { break 'pick None };
+                    if best.match_len >= $m.target_len
+                        || abs_pos + 1 + $m.mls > $m.history_abs_end()
+                    {
+                        break 'pick Some(best);
+                    }
                     // SAFETY: the enclosing kernel is only entered when its
                     // tier was runtime-detected, so the same-feature search
                     // fn's target_feature contract is upheld.
-                    |next_pos, next_lit_len| unsafe {
-                        $m.$find::<K, $rl>(next_pos, next_lit_len, None)
-                    },
-                );
+                    let next = unsafe { $m.$find::<K, $rl>(abs_pos + 1, lit_len + 1, None) };
+                    if let Some(n) = next
+                        && (n.match_len > best.match_len
+                            || (n.match_len == best.match_len && n.offset < best.offset))
+                    {
+                        // Defer: the lookahead wins; carry its result so the
+                        // next iteration starts from it instead of searching
+                        // the same position again.
+                        carried = Some(next);
+                        break 'pick None;
+                    }
+                    if $m.lazy_depth >= 2 && abs_pos + 2 + $m.mls <= $m.history_abs_end() {
+                        let next2 = unsafe { $m.$find::<K, $rl>(abs_pos + 2, lit_len + 2, None) };
+                        if let Some(n2) = next2
+                            && n2.match_len > best.match_len + 1
+                        {
+                            // Two-ahead defer: carry the one-ahead result
+                            // (the next iteration's own lookahead re-probes
+                            // two-ahead with the deferred position inserted).
+                            carried = Some(next);
+                            break 'pick None;
+                        }
+                    }
+                    Some(best)
+                };
                 if let Some(candidate) = picked {
                     $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
                     let current = &$m.history[$m.history.len() - current_len..];
@@ -550,9 +582,11 @@ macro_rules! lazy_parse_body {
                     literals_start = pos;
                 } else {
                     // Reuse the iteration's hash for the defer-path insert
-                    // instead of rehashing the same position.
-                    if let Some((row, tag)) = hash {
-                        $m.insert_at::<$rl>(abs_pos, row, tag);
+                    // when available (a carried iteration never hashed and
+                    // falls back to the rehashing insert).
+                    match hash {
+                        Some((row, tag)) => $m.insert_at::<$rl>(abs_pos, row, tag),
+                        None => $m.insert_position::<$rl>(abs_pos),
                     }
                     pos += 1;
                 }
@@ -908,6 +942,13 @@ macro_rules! row_probe_body {
                     continue;
                 }
                 let candidate_idx = candidate_pos - $m.history_abs_start;
+                // NOTE: upstream zstd's 4-byte head gate (`MEM_read32(match)
+                // == MEM_read32(ip)`, zstd_lazy.c:1265) was measured NEGATIVE
+                // here both unconditionally (+7% on match-dense z000033 L6,
+                // flat control) and best-gated (+3%); the row walk visits few
+                // false tag hits and the SIMD prefix compare's first vector
+                // already serves as the cheap reject. The tail gate below is
+                // the selective filter that pays.
                 // Speculative tail gate (HC `hash_chain_candidate` parity):
                 // a 4-byte compare at the length the candidate must reach to
                 // outgrow `best` proves whether the full `common_prefix_len`

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -867,6 +867,25 @@ macro_rules! row_probe_body {
             let head = $m.row_heads[row] as usize;
             let max_walk = $m.search_depth.min(row_entries);
 
+            // Prefetch the dict row before the live scan (upstream zstd
+            // prefetches the dictMatchState rows up front,
+            // zstd_lazy.c:1200 `ZSTD_row_prefetch`), hiding the dict-table
+            // load latency behind the live row's work.
+            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+            if let Some(dict) = $m.dict.table() {
+                #[cfg(target_arch = "x86")]
+                use core::arch::x86::{_MM_HINT_T0, _mm_prefetch};
+                #[cfg(target_arch = "x86_64")]
+                use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+                let drow_base = row << $rl;
+                // SAFETY: prefetch is a hint and never faults; indexes are in
+                // bounds by the dict-table sizing.
+                unsafe {
+                    _mm_prefetch(dict.tags.as_ptr().add(drow_base).cast(), _MM_HINT_T0);
+                    _mm_prefetch(dict.positions.as_ptr().add(drow_base).cast(), _MM_HINT_T0);
+                }
+            }
+
             // SIMD tiers precompute the full bitmask once (the tag-match
             // intrinsic inlines under this method's `#[target_feature]`); the
             // scalar tier (`USE_MASK == false`) const-folds this away and does
@@ -993,7 +1012,14 @@ macro_rules! row_probe_body {
 
             // Dict dual-probe (donor `ZSTD_RowFindBestMatch` `dictMatchState`):
             // one bounded immutable dict row (concat-indexed positions).
-            if let Some(dict) = $m.dict.table() {
+            // The candidate budget is SHARED with the live row (upstream
+            // zstd decrements one `nbAttempts` across both rows,
+            // zstd_lazy.c:1308): the dict probe only spends what the live
+            // walk left over.
+            if attempts < max_walk
+                && let Some(dict) = $m.dict.table()
+            {
+                let dict_walk = max_walk - attempts;
                 let dict_end = $m.dict.region_len();
                 let drow_base = row << $rl;
                 let dhead = dict.heads[row] as usize;
@@ -1017,7 +1043,7 @@ macro_rules! row_probe_body {
                 #[allow(unused_mut)]
                 let mut dscan = 0usize;
                 let mut dattempts = 0usize;
-                while dattempts < max_walk {
+                while dattempts < dict_walk {
                     let slot_opt = if $use_mask {
                         if dpending == 0 {
                             None

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1402,6 +1402,7 @@ impl RowMatchGenerator {
         self.history_abs_start + self.live_history().len()
     }
 
+    #[inline(always)]
     pub(crate) fn hash_and_row(&self, abs_pos: usize) -> Option<(usize, u8)> {
         let idx = abs_pos - self.history_abs_start;
         let concat = self.live_history();
@@ -1679,7 +1680,7 @@ impl RowMatchGenerator {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     fn insert_position<const ROW_LOG: usize>(&mut self, abs_pos: usize) {
         let Some((row, tag)) = self.hash_and_row(abs_pos) else {
             return;
@@ -1717,7 +1718,7 @@ impl RowMatchGenerator {
     /// [`Self::insert_position`] with the (row, tag) pair already computed —
     /// the greedy miss path reuses the probe's hash instead of re-hashing
     /// the same position.
-    #[inline]
+    #[inline(always)]
     fn insert_at<const ROW_LOG: usize>(&mut self, abs_pos: usize, row: usize, tag: u8) {
         // `ROW_LOG` is the compile-time row width for this monomorphisation;
         // the dispatcher guarantees `ROW_LOG == self.row_log` so the table

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -306,28 +306,18 @@ macro_rules! greedy_parse_body {
                     None
                 };
 
-                // (2) Donor at `depth == 0` does `goto _storeSequence` on a
-                //     rep hit (commits without comparing against the regular
-                //     search). That trade-off is ratio-negative for us
-                //     because donor recovers the loss via other components
-                //     we don't replicate (smaller `mls=5`, block splitter,
-                //     better regular-search recall). To get the speed shape
-                //     of donor's greedy *without* its ratio cliff, we
-                //     compare both options and pick the longer match. On
-                //     ties / near-ties the rep wins by being cheaper to
-                //     encode (single-digit-bit offset code vs 9-13 bits for
-                //     a regular offset).
-                // Donor greedy (depth 0): a repcode hit commits immediately and
-                // SKIPS the regular row search (`zstd_lazy.c:2039`,
-                // `if (depth==0) goto _storeSequence`). The regular
-                // `row_candidate` (SIMD row scan + match extension) is the
-                // dominant per-position cost; running it on every rep hit made
-                // rep-dense inputs (repetitive logs) up to ~11x slower than the
-                // donor, which short-circuits. So only run the regular search
-                // when there is no rep to take. `row_candidate` is `&self` (a
-                // pure search, no table mutation), so skipping it drops no hash
-                // insert — the post-emit `insert_positions(abs_pos, ..)` still
-                // indexes the committed span.
+                // (2) Upstream zstd greedy (depth 0): a repcode hit commits
+                // immediately and SKIPS the regular row search
+                // (`zstd_lazy.c:2039`, `if (depth==0) goto _storeSequence`).
+                // The regular `row_candidate` (SIMD row scan + match
+                // extension) is the dominant per-position cost; running it on
+                // every rep hit made rep-dense inputs (repetitive logs) up to
+                // ~11x slower than upstream, which short-circuits. So only
+                // run the regular search when there is no rep to take.
+                // `row_candidate` is `&self` (a pure search, no table
+                // mutation), so skipping it drops no hash insert: the
+                // post-emit `insert_positions(abs_pos, ..)` still indexes the
+                // committed span.
                 let hash = match carried.take() {
                     Some((carried_pos, rt)) if carried_pos == abs_pos => Some(rt),
                     _ => None,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -442,9 +442,11 @@ macro_rules! greedy_parse_body {
 /// Rep + row best-of-two probe (the lazy search step) with the probe body
 /// expanded inline under the enclosing tier umbrella.
 macro_rules! row_best_match {
-    ($m:expr, $abs_pos:expr, $lit_len:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+    ($m:expr, $abs_pos:expr, $lit_len:expr, $hash:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         let rep = $m.repcode_candidate($abs_pos, $lit_len);
-        let row = row_probe_body!($m, $abs_pos, $lit_len, None, $rl, $use_mask, $maskmac, $cpl);
+        let row = row_probe_body!(
+            $m, $abs_pos, $lit_len, $hash, $rl, $use_mask, $maskmac, $cpl
+        );
         best_len_offset_candidate(rep, row)
     }};
 }
@@ -471,8 +473,9 @@ macro_rules! gen_row_find_monolith {
             &mut self,
             abs_pos: usize,
             lit_len: usize,
+            hash: Option<(usize, u8)>,
         ) -> Option<MatchCandidate> {
-            row_best_match!(self, abs_pos, lit_len, ROW_LOG, $use_mask, $maskmac, $cpl)
+            row_best_match!(self, abs_pos, lit_len, hash, ROW_LOG, $use_mask, $maskmac, $cpl)
         }
     };
 }
@@ -505,7 +508,12 @@ macro_rules! lazy_parse_body {
                 let abs_pos = current_abs_start + pos;
                 let lit_len = pos - literals_start;
 
-                let best = unsafe { $m.$find::<K, $rl>(abs_pos, lit_len) };
+                // Hash the position ONCE per iteration: the probe consumes it
+                // and the defer branch reuses it for the insert (upstream zstd
+                // hashes once per position — `ZSTD_RowFindBestMatch` updates
+                // the row as part of the search, `zstd_lazy.c`).
+                let hash = $m.hash_and_row(abs_pos);
+                let best = unsafe { $m.$find::<K, $rl>(abs_pos, lit_len, hash) };
                 let picked = pick_lazy_match_shared(
                     abs_pos,
                     lit_len,
@@ -519,7 +527,9 @@ macro_rules! lazy_parse_body {
                     // SAFETY: the enclosing kernel is only entered when its
                     // tier was runtime-detected, so the same-feature search
                     // fn's target_feature contract is upheld.
-                    |next_pos, next_lit_len| unsafe { $m.$find::<K, $rl>(next_pos, next_lit_len) },
+                    |next_pos, next_lit_len| unsafe {
+                        $m.$find::<K, $rl>(next_pos, next_lit_len, None)
+                    },
                 );
                 if let Some(candidate) = picked {
                     $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
@@ -539,7 +549,11 @@ macro_rules! lazy_parse_body {
                     pos = start + candidate.match_len;
                     literals_start = pos;
                 } else {
-                    $m.insert_position::<$rl>(abs_pos);
+                    // Reuse the iteration's hash for the defer-path insert
+                    // instead of rehashing the same position.
+                    if let Some((row, tag)) = hash {
+                        $m.insert_at::<$rl>(abs_pos, row, tag);
+                    }
                     pos += 1;
                 }
             }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -222,6 +222,24 @@ macro_rules! dispatch_tag_kernel {
     }};
 }
 
+/// Per-tier `#[target_feature]` umbrella over the greedy row kernel: with
+/// the umbrella's features a superset of the tier probe's, the
+/// `#[inline(always)]` loop body AND the tier's `row_probe_*` merge into ONE
+/// compiled function (donor `ZSTD_compressBlock_greedy_row` shape) instead
+/// of paying a non-inlinable `#[target_feature]` call per position.
+macro_rules! gen_greedy_kernel {
+    ($name:ident $(, $tf:literal)?) => {
+        $(#[target_feature(enable = $tf)])?
+        #[allow(unused_unsafe)]
+        unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
+            &mut self,
+            handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+        ) {
+            self.start_matching_greedy_rl::<K, ROW_LOG>(handle_sequence)
+        }
+    };
+}
+
 /// Bind the runtime `row_log` (clamped 4..=6) to the const `ROW_LOG` of a
 /// `*_rl::<K, ROW_LOG>` hot loop. Mirrors the donor's per-rowLog variant
 /// table; the branch is cold (once per block / call).
@@ -1149,6 +1167,7 @@ impl RowMatchGenerator {
     ///
     /// `pick_lazy_match` is intentionally not called here — depth == 0
     /// means "no lookahead", emit the first viable hit.
+    #[inline(always)]
     pub(crate) fn start_matching_greedy_rl<K: RowTags, const ROW_LOG: usize>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
@@ -1496,14 +1515,59 @@ impl RowMatchGenerator {
         &mut self,
         handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
-        dispatch_tag_kernel!(self.start_matching_greedy_k(handle_sequence))
+        // SAFETY: each `greedy_*` umbrella is entered only when its kernel
+        // was runtime-detected (`tag_kernel`), upholding the
+        // `#[target_feature]` contract; the wasm tier is compile-time.
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        {
+            // SAFETY: simd128 is a compile-time feature here; no runtime gate.
+            unsafe { dispatch_row_log!(self.greedy_simd128::<Simd128Tags>(handle_sequence)) }
+        }
+        #[cfg(not(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )))]
+        {
+            match self.tag_kernel {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Avx2Bmi2 => unsafe {
+                    dispatch_row_log!(self.greedy_avx2bmi2::<Avx2Bmi2Tags>(handle_sequence))
+                },
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Sse42 => unsafe {
+                    dispatch_row_log!(self.greedy_sse42::<Sse42Tags>(handle_sequence))
+                },
+                #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+                FastpathKernel::Neon => unsafe {
+                    dispatch_row_log!(self.greedy_neon::<NeonTags>(handle_sequence))
+                },
+                // SAFETY: the scalar kernel has no `#[target_feature]`; the
+                // fn is `unsafe` only for macro uniformity.
+                FastpathKernel::Scalar => unsafe {
+                    dispatch_row_log!(self.greedy_scalar::<ScalarTags>(handle_sequence))
+                },
+            }
+        }
     }
-    fn start_matching_greedy_k<K: RowTags>(
-        &mut self,
-        handle_sequence: impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        dispatch_row_log!(self.start_matching_greedy_rl::<K>(handle_sequence))
-    }
+
+    gen_greedy_kernel!(greedy_scalar);
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_greedy_kernel!(greedy_sse42, "sse4.2");
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_greedy_kernel!(greedy_avx2bmi2, "avx2,bmi2");
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    gen_greedy_kernel!(greedy_neon, "neon");
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    gen_greedy_kernel!(greedy_simd128);
 
     pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
         match self.row_log {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -39,6 +39,7 @@ use super::match_table::helpers::{
     INCOMPRESSIBLE_SKIP_STEP, LazyMatchConfig, best_len_offset_candidate, extend_backwards_shared,
     pick_lazy_match_shared, repcode_candidate_shared,
 };
+use super::match_table::storage::REBASE_RESET_FLOOR_CEILING;
 use super::opt::types::MatchCandidate;
 
 // The row probe reuses the shared `fastpath::FastpathKernel` selection so each
@@ -859,14 +860,33 @@ impl RowMatchGenerator {
     }
 
     pub(crate) fn reset(&mut self) {
+        // Floor-advance reset (same shape as the dfast/HC backends): instead
+        // of re-zeroing the row tables per frame (a multi-MiB memset that
+        // dominated small/medium-frame encode), advance the absolute
+        // coordinate floor past everything ever inserted. Stale entries all
+        // hold positions below the new floor, so the probes' existing
+        // `candidate_pos < self.history_abs_start` window check rejects them
+        // without any clearing — the donor's persistent-index design. Stale
+        // TAGS can still produce the occasional false mask hit whose
+        // candidate then fails the window check; the donor's tag table
+        // persists across frames with the same behaviour.
+        let next_floor = self.history_abs_start + (self.history.len() - self.history_start);
         self.window_size = 0;
         self.history.clear();
         self.history_start = 0;
-        self.history_abs_start = 0;
         self.offset_hist = [1, 4, 8];
-        self.row_heads.fill(0);
-        self.row_positions.fill(ROW_EMPTY_SLOT);
-        self.row_tags.fill(0);
+        if next_floor <= REBASE_RESET_FLOOR_CEILING && !self.row_positions.is_empty() {
+            self.history_abs_start = next_floor;
+        } else {
+            // Bounded fallback: rewind the coordinate space and zero the
+            // tables so the absolute cursor cannot climb without bound
+            // (mirrors dfast; the u32 packing is separately kept in range
+            // by `rebase_positions` in `add_data`).
+            self.history_abs_start = 0;
+            self.row_heads.fill(0);
+            self.row_positions.fill(ROW_EMPTY_SLOT);
+            self.row_tags.fill(0);
+        }
         // Block buffers are returned to the caller's pool per block in
         // `add_data`, so there is nothing window-side to recycle here.
         self.chunk_lens.clear();

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -543,6 +543,17 @@ macro_rules! lazy_parse_body {
 macro_rules! gen_lazy_monolith {
     ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
+        // wasm32+simd128 resolves the dispatch at compile time to the
+        // simd128 kernel, leaving the scalar monolith uncalled there
+        // (same shape as the `ScalarTags` allowance).
+        #[cfg_attr(
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ),
+            allow(dead_code)
+        )]
         #[allow(unused_unsafe)]
         unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
             &mut self,
@@ -559,6 +570,17 @@ macro_rules! gen_lazy_monolith {
 macro_rules! gen_greedy_monolith {
     ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
+        // wasm32+simd128 resolves the dispatch at compile time to the
+        // simd128 kernel, leaving the scalar monolith uncalled there
+        // (same shape as the `ScalarTags` allowance).
+        #[cfg_attr(
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ),
+            allow(dead_code)
+        )]
         #[allow(unused_unsafe)]
         unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
             &mut self,

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -449,11 +449,40 @@ macro_rules! row_best_match {
     }};
 }
 
+/// Per-tier standalone search function (upstream zstd's
+/// `ZSTD_RowFindBestMatch` shape, `zstd_lazy.c`): rep + row probe behind ONE
+/// symbol so the lazy parse's two probe sites (current position + lookahead)
+/// share a single copy instead of expanding the whole search body twice —
+/// the duplicated expansion doubled the kernel's icache footprint and left
+/// the lookahead copy as an outlined closure call.
+macro_rules! gen_row_find_monolith {
+    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+        $(#[target_feature(enable = $tf)])?
+        #[cfg_attr(
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ),
+            allow(dead_code)
+        )]
+        #[allow(unused_unsafe)]
+        unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
+            &mut self,
+            abs_pos: usize,
+            lit_len: usize,
+        ) -> Option<MatchCandidate> {
+            row_best_match!(self, abs_pos, lit_len, ROW_LOG, $use_mask, $maskmac, $cpl)
+        }
+    };
+}
+
 /// The lazy row parse BODY as a macro — same per-tier monolith shape as
 /// `greedy_parse_body!` for the lazy levels (lookahead via
-/// `pick_lazy_match_shared`, with both its probe sites expanded inline).
+/// `pick_lazy_match_shared`; both probe sites call the tier's shared
+/// `$find` search function).
 macro_rules! lazy_parse_body {
-    ($m:expr, $handle:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+    ($m:expr, $handle:expr, $rl:expr, $find:ident) => {{
         #[allow(unused_labels)]
         'parse: {
             debug_assert_eq!($rl, $m.row_log);
@@ -476,7 +505,7 @@ macro_rules! lazy_parse_body {
                 let abs_pos = current_abs_start + pos;
                 let lit_len = pos - literals_start;
 
-                let best = row_best_match!($m, abs_pos, lit_len, $rl, $use_mask, $maskmac, $cpl);
+                let best = unsafe { $m.$find::<K, $rl>(abs_pos, lit_len) };
                 let picked = pick_lazy_match_shared(
                     abs_pos,
                     lit_len,
@@ -487,9 +516,10 @@ macro_rules! lazy_parse_body {
                         lazy_depth: $m.lazy_depth,
                         history_abs_end: $m.history_abs_end(),
                     },
-                    |next_pos, next_lit_len| {
-                        row_best_match!($m, next_pos, next_lit_len, $rl, $use_mask, $maskmac, $cpl)
-                    },
+                    // SAFETY: the enclosing kernel is only entered when its
+                    // tier was runtime-detected, so the same-feature search
+                    // fn's target_feature contract is upheld.
+                    |next_pos, next_lit_len| unsafe { $m.$find::<K, $rl>(next_pos, next_lit_len) },
                 );
                 if let Some(candidate) = picked {
                     $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
@@ -531,7 +561,9 @@ macro_rules! lazy_parse_body {
 
 /// Per-tier lazy kernels (see `gen_greedy_monolith` — same SIMD pairing).
 macro_rules! gen_lazy_monolith {
-    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+    ($name:ident, $find:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+        gen_row_find_monolith!($find, $use_mask, $maskmac, $cpl $(, $tf)?);
+
         $(#[target_feature(enable = $tf)])?
         // wasm32+simd128 resolves the dispatch at compile time to the
         // simd128 kernel, leaving the scalar monolith uncalled there
@@ -549,7 +581,7 @@ macro_rules! gen_lazy_monolith {
             &mut self,
             mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
         ) {
-            lazy_parse_body!(self, handle_sequence, ROW_LOG, $use_mask, $maskmac, $cpl)
+            lazy_parse_body!(self, handle_sequence, ROW_LOG, $find)
         }
     };
 }
@@ -1670,6 +1702,7 @@ impl RowMatchGenerator {
 
     gen_lazy_monolith!(
         lazy_scalar,
+        find_best_scalar,
         false,
         row_tag_mask_scalar,
         crate::encoding::fastpath::scalar::common_prefix_len_ptr
@@ -1677,6 +1710,7 @@ impl RowMatchGenerator {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     gen_lazy_monolith!(
         lazy_sse42,
+        find_best_sse42,
         true,
         row_tag_mask_sse2,
         crate::encoding::fastpath::sse42::common_prefix_len_ptr,
@@ -1685,6 +1719,7 @@ impl RowMatchGenerator {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     gen_lazy_monolith!(
         lazy_avx2bmi2,
+        find_best_avx2bmi2,
         true,
         row_tag_mask_avx2,
         crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
@@ -1693,6 +1728,7 @@ impl RowMatchGenerator {
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     gen_lazy_monolith!(
         lazy_neon,
+        find_best_neon,
         true,
         row_tag_mask_neon,
         crate::encoding::fastpath::neon::common_prefix_len_ptr,
@@ -1705,6 +1741,7 @@ impl RowMatchGenerator {
     ))]
     gen_lazy_monolith!(
         lazy_simd128,
+        find_best_simd128,
         true,
         row_tag_mask_simd128,
         crate::encoding::fastpath::scalar::common_prefix_len_ptr

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -227,15 +227,15 @@ macro_rules! dispatch_tag_kernel {
 /// `#[inline(always)]` loop body AND the tier's `row_probe_*` merge into ONE
 /// compiled function (donor `ZSTD_compressBlock_greedy_row` shape) instead
 /// of paying a non-inlinable `#[target_feature]` call per position.
-macro_rules! gen_greedy_kernel {
-    ($name:ident $(, $tf:literal)?) => {
+macro_rules! gen_row_parse_kernel {
+    ($name:ident, $rl:ident $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
         #[allow(unused_unsafe)]
         unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
             &mut self,
             handle_sequence: impl for<'a> FnMut(Sequence<'a>),
         ) {
-            self.start_matching_greedy_rl::<K, ROW_LOG>(handle_sequence)
+            self.$rl::<K, ROW_LOG>(handle_sequence)
         }
     };
 }
@@ -1045,6 +1045,7 @@ impl RowMatchGenerator {
     /// row-hash machinery, which is wasteful. The `dead_code` allow is
     /// scoped to this method and its private helpers so any new
     /// caller will pick them up unmodified.
+    #[inline(always)]
     pub(crate) fn start_matching_rl<K: RowTags, const ROW_LOG: usize>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
@@ -1448,6 +1449,7 @@ impl RowMatchGenerator {
     /// Used only by the dead-code [`Self::start_matching`] (lazy-style
     /// row parse). Kept paired with that method so reviving the lazy
     /// path doesn't have to re-derive the rep+row best-of-two pick.
+    #[inline(always)]
     pub(crate) fn best_match_rl<K: RowTags, const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
@@ -1460,6 +1462,7 @@ impl RowMatchGenerator {
         best_len_offset_candidate(rep, row)
     }
 
+    #[inline(always)]
     pub(crate) fn pick_lazy_match_rl<K: RowTags, const ROW_LOG: usize>(
         &self,
         abs_pos: usize,
@@ -1505,11 +1508,57 @@ impl RowMatchGenerator {
     // siblings directly with the type and const already bound. `skip` does
     // no tag compare, so it dispatches on `row_log` only.
     pub(crate) fn start_matching(&mut self, handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
-        dispatch_tag_kernel!(self.start_matching_k(handle_sequence))
+        // SAFETY: same per-tier umbrella contract as `start_matching_greedy`.
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        ))]
+        {
+            // SAFETY: simd128 is a compile-time feature here; no runtime gate.
+            unsafe { dispatch_row_log!(self.lazy_simd128::<Simd128Tags>(handle_sequence)) }
+        }
+        #[cfg(not(all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )))]
+        {
+            match self.tag_kernel {
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Avx2Bmi2 => unsafe {
+                    dispatch_row_log!(self.lazy_avx2bmi2::<Avx2Bmi2Tags>(handle_sequence))
+                },
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                FastpathKernel::Sse42 => unsafe {
+                    dispatch_row_log!(self.lazy_sse42::<Sse42Tags>(handle_sequence))
+                },
+                #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+                FastpathKernel::Neon => unsafe {
+                    dispatch_row_log!(self.lazy_neon::<NeonTags>(handle_sequence))
+                },
+                // SAFETY: the scalar kernel has no `#[target_feature]`; the
+                // fn is `unsafe` only for macro uniformity.
+                FastpathKernel::Scalar => unsafe {
+                    dispatch_row_log!(self.lazy_scalar::<ScalarTags>(handle_sequence))
+                },
+            }
+        }
     }
-    fn start_matching_k<K: RowTags>(&mut self, handle_sequence: impl for<'a> FnMut(Sequence<'a>)) {
-        dispatch_row_log!(self.start_matching_rl::<K>(handle_sequence))
-    }
+
+    gen_row_parse_kernel!(lazy_scalar, start_matching_rl);
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_row_parse_kernel!(lazy_sse42, start_matching_rl, "sse4.2");
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    gen_row_parse_kernel!(lazy_avx2bmi2, start_matching_rl, "avx2,bmi2");
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    gen_row_parse_kernel!(lazy_neon, start_matching_rl, "neon");
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    gen_row_parse_kernel!(lazy_simd128, start_matching_rl);
 
     pub(crate) fn start_matching_greedy(
         &mut self,
@@ -1555,19 +1604,19 @@ impl RowMatchGenerator {
         }
     }
 
-    gen_greedy_kernel!(greedy_scalar);
+    gen_row_parse_kernel!(greedy_scalar, start_matching_greedy_rl);
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_greedy_kernel!(greedy_sse42, "sse4.2");
+    gen_row_parse_kernel!(greedy_sse42, start_matching_greedy_rl, "sse4.2");
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_greedy_kernel!(greedy_avx2bmi2, "avx2,bmi2");
+    gen_row_parse_kernel!(greedy_avx2bmi2, start_matching_greedy_rl, "avx2,bmi2");
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    gen_greedy_kernel!(greedy_neon, "neon");
+    gen_row_parse_kernel!(greedy_neon, start_matching_greedy_rl, "neon");
     #[cfg(all(
         target_arch = "wasm32",
         target_feature = "simd128",
         feature = "kernel_simd128"
     ))]
-    gen_greedy_kernel!(greedy_simd128);
+    gen_row_parse_kernel!(greedy_simd128, start_matching_greedy_rl);
 
     pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
         match self.row_log {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -416,6 +416,11 @@ macro_rules! row_tag_mask_simd128 {
 macro_rules! gen_row_probe {
     ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
+        // `#[inline]` hint (NOT always — forbidden with target_feature):
+        // the per-tier parse umbrella enables the same features, so the
+        // probe is inlinable there and LLVM takes the single-call-site
+        // hint, merging probe + parse loop into one body.
+        #[inline]
         #[allow(unused_unsafe)]
         // wasm32+simd128 selects `row_probe_simd128` at compile time, leaving
         // `row_probe_scalar` (the only other tier compiled on wasm) unused.

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -228,6 +228,227 @@ macro_rules! dispatch_tag_kernel {
 /// `#[inline(always)]` loop body AND the tier's `row_probe_*` merge into ONE
 /// compiled function (donor `ZSTD_compressBlock_greedy_row` shape) instead
 /// of paying a non-inlinable `#[target_feature]` call per position.
+/// The greedy row parse BODY as a macro: expanded per tier with the tier's
+/// own SIMD pairing (`$maskmac` tag-match + `$cpl` prefix kernel), with the
+/// probe body expanded inline at the search site — the full donor
+/// `ZSTD_compressBlock_greedy_row` monolith, one compiled function per tier.
+macro_rules! greedy_parse_body {
+    ($m:expr, $handle:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        #[allow(unused_labels)]
+        'parse: {
+            debug_assert_eq!($rl, $m.row_log);
+            $m.ensure_tables();
+
+            let current_len = *$m.chunk_lens.back().unwrap();
+            if current_len == 0 {
+                break 'parse;
+            }
+            let current_abs_start = $m.history_abs_start + $m.window_size - current_len;
+            let backfill_start = $m.backfill_start(current_abs_start);
+            if backfill_start < current_abs_start {
+                $m.insert_positions::<$rl>(backfill_start, current_abs_start);
+            }
+
+            // Donor mls for repcode probes is 4 (`MEM_read32` compare on
+            // `ip+1` against `ip+1-offset_1`, length extended by
+            // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 5`
+            // gates the *regular* search via the row-table layout; rep
+            // probes are independent of the row table and benefit from
+            // the lower donor threshold (a 4-byte rep is cheap to
+            // encode and frequently outperforms emitting the bytes as
+            // literals).
+            const REP_MIN_MATCH_LEN: usize = 4;
+            // Outer-loop lookahead floor: at least `REP_MIN_MATCH_LEN + 1`
+            // bytes left so the `abs_pos + 1` repcode probe can succeed even
+            // in the block tail (the rep probe needs `REP_MIN_MATCH_LEN`
+            // bytes one position ahead). This keeps the tail 4-byte rep-only
+            // case from falling through as literals.
+            const GREEDY_MIN_LOOKAHEAD: usize = REP_MIN_MATCH_LEN + 1;
+
+            let mut pos = 0usize;
+            let mut literals_start = 0usize;
+            // Software pipeline over the dependent row load: on a miss the next
+            // position's (row, tag) is computed ahead and its tag/position rows
+            // prefetched, so the probe's row loads (the hottest instructions of
+            // this loop — a hash-dependent cache miss per position) overlap the
+            // current iteration's tail instead of stalling the next probe.
+            // Donor `ZSTD_RowFindBestMatch` gets the same overlap from its
+            // hash-cache + `ZSTD_row_prefetch` pipeline.
+            let mut carried: Option<(usize, (usize, u8))> = None;
+
+            while pos + GREEDY_MIN_LOOKAHEAD <= current_len {
+                let abs_pos = current_abs_start + pos;
+                let lit_len = pos - literals_start;
+
+                // (1) Default start = abs_pos + 1: probe the repcode bank
+                //     at the next byte, treating one byte as already
+                //     committed to the literal run. Donor probes only
+                //     rep1 here; `repcode_candidate_shared` probes all three
+                //     plus the `ll0` fallback because the donor "ll0" trick
+                //     is already baked into our shared helper. The extra
+                //     probes only add candidates that have repcode encoding
+                //     costs (cheap), so the ratio direction is positive vs
+                //     donor while still landing in the "greedy via repcode"
+                //     algorithmic shape.
+                let rep_probe_pos = abs_pos + 1;
+                let rep_probe_lit_len = lit_len + 1;
+                let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= $m.history_abs_end() {
+                    repcode_candidate_shared(
+                        $m.hash_kernel,
+                        $m.live_history(),
+                        $m.history_abs_start,
+                        $m.offset_hist,
+                        rep_probe_pos,
+                        rep_probe_lit_len,
+                        REP_MIN_MATCH_LEN,
+                    )
+                } else {
+                    None
+                };
+
+                // (2) Donor at `depth == 0` does `goto _storeSequence` on a
+                //     rep hit (commits without comparing against the regular
+                //     search). That trade-off is ratio-negative for us
+                //     because donor recovers the loss via other components
+                //     we don't replicate (smaller `mls=5`, block splitter,
+                //     better regular-search recall). To get the speed shape
+                //     of donor's greedy *without* its ratio cliff, we
+                //     compare both options and pick the longer match. On
+                //     ties / near-ties the rep wins by being cheaper to
+                //     encode (single-digit-bit offset code vs 9-13 bits for
+                //     a regular offset).
+                // Donor greedy (depth 0): a repcode hit commits immediately and
+                // SKIPS the regular row search (`zstd_lazy.c:2039`,
+                // `if (depth==0) goto _storeSequence`). The regular
+                // `row_candidate` (SIMD row scan + match extension) is the
+                // dominant per-position cost; running it on every rep hit made
+                // rep-dense inputs (repetitive logs) up to ~11x slower than the
+                // donor, which short-circuits. So only run the regular search
+                // when there is no rep to take. `row_candidate` is `&self` (a
+                // pure search, no table mutation), so skipping it drops no hash
+                // insert — the post-emit `insert_positions(abs_pos, ..)` still
+                // indexes the committed span.
+                let hash = match carried.take() {
+                    Some((carried_pos, rt)) if carried_pos == abs_pos => Some(rt),
+                    _ => None,
+                };
+                let chosen = match rep_match {
+                    Some(rep) => Some(rep),
+                    // Probe body expanded inline (tier SIMD pairing via the
+                    // enclosing monolith macro), not a function call.
+                    None => {
+                        row_probe_body!($m, abs_pos, lit_len, hash, $rl, $use_mask, $maskmac, $cpl)
+                    }
+                };
+
+                let Some(candidate) = chosen else {
+                    // Donor `kSearchStrength = 8` shifts hard on miss
+                    // (step grows by `lit_len >> 8`). Empirically on our
+                    // corpus that recovers ~30% speed but costs ratio by
+                    // dropping hash inserts on long literal runs that
+                    // would have served future matches. Shift right by
+                    // `SKIP_STRENGTH = 10` instead — same shape, ~4×
+                    // rarer growth, so the step stays at 1 byte until the
+                    // literal run hits ~1 KiB and only then begins
+                    // skipping. Lets us keep most of donor's speed
+                    // characteristic without re-introducing the ratio
+                    // drain.
+                    const SKIP_STRENGTH: u32 = 10;
+                    let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
+                    // Reuse the probe's (row, tag) for the insert (the rep-hit
+                    // path never computed one, so fall back to the hashing
+                    // insert there — `hash` is `Some` exactly when the probe
+                    // ran on this position).
+                    match hash {
+                        Some((row, tag)) => $m.insert_at::<$rl>(abs_pos, row, tag),
+                        None => $m.insert_position::<$rl>(abs_pos),
+                    }
+                    if step == 1 {
+                        let next_abs = abs_pos + 1;
+                        if let Some((row, tag)) = $m.hash_and_row(next_abs) {
+                            $m.prefetch_row::<$rl>(row);
+                            carried = Some((next_abs, (row, tag)));
+                        }
+                    }
+                    pos += step;
+                    continue;
+                };
+
+                // Emit sequence.
+                let start = candidate.start - current_abs_start;
+                // Index `[abs_pos, candidate.start + match_len)`, NOT
+                // `[candidate.start, candidate.start + match_len)`.
+                // `extend_backwards_shared` can move `candidate.start`
+                // below `abs_pos` by absorbing literal bytes that the
+                // outer loop already indexed on earlier miss iterations
+                // via `insert_position(abs_pos)`. Re-indexing them here
+                // would write the same `abs_pos -> position` mapping
+                // into the row table a second time, evicting more recent
+                // / more useful slot tenants from the same row's chain.
+                // Measured on `decodecorpus-z000033`: the
+                // `candidate.start` lower bound regresses `rust_bytes` by
+                // ~+447 over `abs_pos` (537897 -> 538344), so the
+                // narrower range is intentional.
+                $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
+                let current = &$m.history[$m.history.len() - current_len..];
+                let literals = &current[literals_start..start];
+                $handle(Sequence::Triple {
+                    literals,
+                    offset: candidate.offset,
+                    match_len: candidate.match_len,
+                });
+                let _ = encode_offset_with_history(
+                    candidate.offset as u32,
+                    literals.len() as u32,
+                    &mut $m.offset_hist,
+                );
+                pos = start + candidate.match_len;
+                literals_start = pos;
+                // Same hash + row prefetch carry as the miss path: the next
+                // probe position is known here (right past the emitted match),
+                // and its row is otherwise guaranteed cold after the match-span
+                // insert walked other rows. The rep probe at the next iteration
+                // may consume the position without a row probe — then the
+                // carried hash is only reused by the insert-side, never wasted.
+                if pos + GREEDY_MIN_LOOKAHEAD <= current_len {
+                    let next_abs = current_abs_start + pos;
+                    if let Some((row, tag)) = $m.hash_and_row(next_abs) {
+                        $m.prefetch_row::<$rl>(row);
+                        carried = Some((next_abs, (row, tag)));
+                    }
+                }
+
+                // Donor's `lazy_generic` has an immediate-repcode loop here
+                // (probing `offset_2` after each main emit and swapping
+                // `offset_1 ↔ offset_2` on hit). It was implemented and
+                // shipped in earlier iterations of this method but never
+                // fired on any test or benchmark workload — the
+                // `repcode_candidate_shared` probe at the top of the main
+                // loop already evaluates all three rep slots (rep1, rep2,
+                // rep3 + the `ll0` fallback), and the immediate-rep slot
+                // (`offset_hist[1]` at `lit_len = 0`) is subsumed by the
+                // next main-loop iteration's rep probe of the same slot.
+                // Donor's version is single-rep, so the inner loop catches
+                // hits its main-loop probe wouldn't; ours is three-rep, so
+                // the inner loop is dead by construction. Removed to free
+                // the per-iteration check and keep the parser body lean.
+            }
+
+            while pos + ROW_HASH_KEY_LEN <= current_len {
+                $m.insert_position::<$rl>(current_abs_start + pos);
+                pos += 1;
+            }
+
+            if literals_start < current_len {
+                let current = &$m.history[$m.history.len() - current_len..];
+                $handle(Sequence::Literals {
+                    literals: &current[literals_start..],
+                });
+            }
+        }
+    }};
+}
+
 macro_rules! gen_row_parse_kernel {
     ($name:ident, $rl:ident $(, $tf:literal)?) => {
         $(#[target_feature(enable = $tf)])?
@@ -237,6 +458,22 @@ macro_rules! gen_row_parse_kernel {
             handle_sequence: impl for<'a> FnMut(Sequence<'a>),
         ) {
             self.$rl::<K, ROW_LOG>(handle_sequence)
+        }
+    };
+}
+
+/// Per-tier greedy kernels: the parse body AND its probe expand inline under
+/// the tier's `#[target_feature]` umbrella with the tier's own SIMD pairing
+/// (the `K` parameter is kept only so the dispatch site stays uniform).
+macro_rules! gen_greedy_monolith {
+    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+        $(#[target_feature(enable = $tf)])?
+        #[allow(unused_unsafe)]
+        unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
+            &mut self,
+            mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+        ) {
+            greedy_parse_body!(self, handle_sequence, ROW_LOG, $use_mask, $maskmac, $cpl)
         }
     };
 }
@@ -414,58 +651,45 @@ macro_rules! row_tag_mask_simd128 {
 /// the tier's `row_tag_mask_*!`; the optional `$tf` is the `target_feature`.
 /// Mirrors the former generic `row_candidate_rl`: live row probe, dict
 /// dual-probe, speculative tail gate.
-macro_rules! gen_row_probe {
-    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
-        $(#[target_feature(enable = $tf)])?
-        // `#[inline]` hint (NOT always — forbidden with target_feature):
-        // the per-tier parse umbrella enables the same features, so the
-        // probe is inlinable there and LLVM takes the single-call-site
-        // hint, merging probe + parse loop into one body.
-        #[inline]
-        #[allow(unused_unsafe)]
-        // wasm32+simd128 selects `row_probe_simd128` at compile time, leaving
-        // `row_probe_scalar` (the only other tier compiled on wasm) unused.
-        #[cfg_attr(
-            all(
-                target_arch = "wasm32",
-                target_feature = "simd128",
-                feature = "kernel_simd128"
-            ),
-            allow(dead_code)
-        )]
-        unsafe fn $name<const ROW_LOG: usize>(
-            &self,
-            abs_pos: usize,
-            lit_len: usize,
-            hash: Option<(usize, u8)>,
-        ) -> Option<MatchCandidate> {
-            debug_assert_eq!(ROW_LOG, self.row_log);
-            let mls = self.mls;
-            let concat = self.live_history();
-            let current_idx = abs_pos - self.history_abs_start;
+/// The row probe BODY as a macro, expanded both into the per-tier
+/// `row_probe_*` functions (non-kernel callers) and directly into the
+/// per-tier parse kernels (`greedy_*` / `lazy_*`) where a function-call
+/// boundary — non-inlinable across `#[target_feature]` without an
+/// `inline(always)` the compiler forbids there — cost a call with operand
+/// spills per position. Early exits use the labeled block (`break 'probe`)
+/// because a `return` inside a macro body would return from the EXPANSION
+/// SITE's function.
+macro_rules! row_probe_body {
+    ($m:expr, $abs_pos:expr, $lit_len:expr, $hash:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        #[allow(unused_labels)]
+        'probe: {
+            debug_assert_eq!($rl, $m.row_log);
+            let mls = $m.mls;
+            let concat = $m.live_history();
+            let current_idx = $abs_pos - $m.history_abs_start;
             if current_idx + mls > concat.len() {
-                return None;
+                break 'probe None;
             }
 
             // `hash` carries the (row, tag) the greedy loop already
             // computed for this position (and prefetched the row for);
             // recompute only on the uncarried paths.
-            let (row, tag) = match hash {
+            let (row, tag) = match $hash.or_else(|| $m.hash_and_row($abs_pos)) {
                 Some(rt) => rt,
-                None => self.hash_and_row(abs_pos)?,
+                None => break 'probe None,
             };
-            let row_entries = 1usize << ROW_LOG;
+            let row_entries = 1usize << $rl;
             let row_mask = row_entries - 1;
-            let row_base = row << ROW_LOG;
-            let head = self.row_heads[row] as usize;
-            let max_walk = self.search_depth.min(row_entries);
+            let row_base = row << $rl;
+            let head = $m.row_heads[row] as usize;
+            let max_walk = $m.search_depth.min(row_entries);
 
             // SIMD tiers precompute the full bitmask once (the tag-match
             // intrinsic inlines under this method's `#[target_feature]`); the
             // scalar tier (`USE_MASK == false`) const-folds this away and does
             // an on-the-fly per-slot byte compare in the loop.
             let tag_match = if $use_mask {
-                $maskmac!(&self.row_tags[row_base..row_base + row_entries], tag)
+                $maskmac!(&$m.row_tags[row_base..row_base + row_entries], tag)
             } else {
                 0
             };
@@ -516,7 +740,7 @@ macro_rules! gen_row_probe {
                     while scan < row_entries {
                         let s = (head + scan) & row_mask;
                         scan += 1;
-                        if self.row_tags[row_base + s] == tag {
+                        if $m.row_tags[row_base + s] == tag {
                             found = Some(s);
                             break;
                         }
@@ -526,24 +750,24 @@ macro_rules! gen_row_probe {
                 let Some(slot) = slot_opt else { break };
                 attempts += 1;
                 let idx = row_base + slot;
-                let raw_pos = self.row_positions[idx];
+                let raw_pos = $m.row_positions[idx];
                 if raw_pos == ROW_EMPTY_SLOT {
                     continue;
                 }
                 let candidate_pos = raw_pos as usize;
-                if candidate_pos < self.history_abs_start || candidate_pos >= abs_pos {
+                if candidate_pos < $m.history_abs_start || candidate_pos >= $abs_pos {
                     continue;
                 }
-                let candidate_idx = candidate_pos - self.history_abs_start;
+                let candidate_idx = candidate_pos - $m.history_abs_start;
                 // Speculative tail gate (HC `hash_chain_candidate` parity):
                 // a 4-byte compare at the length the candidate must reach to
                 // outgrow `best` proves whether the full `common_prefix_len`
                 // can pay off. Gated on offset-monotonicity since the row walk
                 // is not offset-ordered. Ratio-neutral.
                 if let Some(b) = best {
-                    let new_offset = abs_pos - candidate_pos;
+                    let new_offset = $abs_pos - candidate_pos;
                     if new_offset >= b.offset
-                        && let Some(tail_off) = b.match_len.checked_sub(lit_len + 3)
+                        && let Some(tail_off) = b.match_len.checked_sub($lit_len + 3)
                     {
                         let m_end = candidate_idx + tail_off + 4;
                         let i_end = current_idx + tail_off + 4;
@@ -569,19 +793,19 @@ macro_rules! gen_row_probe {
                 };
                 if match_len >= mls {
                     let candidate =
-                        self.extend_backwards(candidate_pos, abs_pos, match_len, lit_len);
+                        $m.extend_backwards(candidate_pos, $abs_pos, match_len, $lit_len);
                     best = best_len_offset_candidate(best, Some(candidate));
                     if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
-                        return best;
+                        break 'probe best;
                     }
                 }
             }
 
             // Dict dual-probe (donor `ZSTD_RowFindBestMatch` `dictMatchState`):
             // one bounded immutable dict row (concat-indexed positions).
-            if let Some(dict) = self.dict.table() {
-                let dict_end = self.dict.region_len();
-                let drow_base = row << ROW_LOG;
+            if let Some(dict) = $m.dict.table() {
+                let dict_end = $m.dict.region_len();
+                let drow_base = row << $rl;
                 let dhead = dict.heads[row] as usize;
                 let dtag_match = if $use_mask {
                     $maskmac!(&dict.tags[drow_base..drow_base + row_entries], tag)
@@ -635,11 +859,11 @@ macro_rules! gen_row_probe {
                     if dp >= dict_end || dp + mls > concat.len() {
                         continue;
                     }
-                    let cand_abs = self.history_abs_start + dp;
+                    let cand_abs = $m.history_abs_start + dp;
                     if let Some(b) = best {
-                        let new_offset = abs_pos - cand_abs;
+                        let new_offset = $abs_pos - cand_abs;
                         if new_offset >= b.offset
-                            && let Some(tail_off) = b.match_len.checked_sub(lit_len + 3)
+                            && let Some(tail_off) = b.match_len.checked_sub($lit_len + 3)
                         {
                             let m_end = dp + tail_off + 4;
                             let i_end = current_idx + tail_off + 4;
@@ -660,15 +884,46 @@ macro_rules! gen_row_probe {
                         )
                     };
                     if match_len >= mls {
-                        let candidate = self.extend_backwards(cand_abs, abs_pos, match_len, lit_len);
+                        let candidate =
+                            $m.extend_backwards(cand_abs, $abs_pos, match_len, $lit_len);
                         best = best_len_offset_candidate(best, Some(candidate));
                         if best.is_some_and(|b| current_idx + b.match_len >= concat.len()) {
-                            return best;
+                            break 'probe best;
                         }
                     }
                 }
             }
             best
+        }
+    }};
+}
+
+macro_rules! gen_row_probe {
+    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
+        $(#[target_feature(enable = $tf)])?
+        // `#[inline]` hint (NOT always — forbidden with target_feature):
+        // the per-tier parse umbrella enables the same features, so the
+        // probe is inlinable there and LLVM takes the single-call-site
+        // hint, merging probe + parse loop into one body.
+        #[inline]
+        #[allow(unused_unsafe)]
+        // wasm32+simd128 selects `row_probe_simd128` at compile time, leaving
+        // `row_probe_scalar` (the only other tier compiled on wasm) unused.
+        #[cfg_attr(
+            all(
+                target_arch = "wasm32",
+                target_feature = "simd128",
+                feature = "kernel_simd128"
+            ),
+            allow(dead_code)
+        )]
+        unsafe fn $name<const ROW_LOG: usize>(
+            &self,
+            abs_pos: usize,
+            lit_len: usize,
+            hash: Option<(usize, u8)>,
+        ) -> Option<MatchCandidate> {
+            row_probe_body!(self, abs_pos, lit_len, hash, ROW_LOG, $use_mask, $maskmac, $cpl)
         }
     };
 }
@@ -1193,220 +1448,6 @@ impl RowMatchGenerator {
     ///
     /// `pick_lazy_match` is intentionally not called here — depth == 0
     /// means "no lookahead", emit the first viable hit.
-    #[inline(always)]
-    pub(crate) fn start_matching_greedy_rl<K: RowTags, const ROW_LOG: usize>(
-        &mut self,
-        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        debug_assert_eq!(ROW_LOG, self.row_log);
-        self.ensure_tables();
-
-        let current_len = *self.chunk_lens.back().unwrap();
-        if current_len == 0 {
-            return;
-        }
-        let current_abs_start = self.history_abs_start + self.window_size - current_len;
-        let backfill_start = self.backfill_start(current_abs_start);
-        if backfill_start < current_abs_start {
-            self.insert_positions::<ROW_LOG>(backfill_start, current_abs_start);
-        }
-
-        // Donor mls for repcode probes is 4 (`MEM_read32` compare on
-        // `ip+1` against `ip+1-offset_1`, length extended by
-        // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 5`
-        // gates the *regular* search via the row-table layout; rep
-        // probes are independent of the row table and benefit from
-        // the lower donor threshold (a 4-byte rep is cheap to
-        // encode and frequently outperforms emitting the bytes as
-        // literals).
-        const REP_MIN_MATCH_LEN: usize = 4;
-        // Outer-loop lookahead floor: at least `REP_MIN_MATCH_LEN + 1`
-        // bytes left so the `abs_pos + 1` repcode probe can succeed even
-        // in the block tail (the rep probe needs `REP_MIN_MATCH_LEN`
-        // bytes one position ahead). This keeps the tail 4-byte rep-only
-        // case from falling through as literals.
-        const GREEDY_MIN_LOOKAHEAD: usize = REP_MIN_MATCH_LEN + 1;
-
-        let mut pos = 0usize;
-        let mut literals_start = 0usize;
-        // Software pipeline over the dependent row load: on a miss the next
-        // position's (row, tag) is computed ahead and its tag/position rows
-        // prefetched, so the probe's row loads (the hottest instructions of
-        // this loop — a hash-dependent cache miss per position) overlap the
-        // current iteration's tail instead of stalling the next probe.
-        // Donor `ZSTD_RowFindBestMatch` gets the same overlap from its
-        // hash-cache + `ZSTD_row_prefetch` pipeline.
-        let mut carried: Option<(usize, (usize, u8))> = None;
-
-        while pos + GREEDY_MIN_LOOKAHEAD <= current_len {
-            let abs_pos = current_abs_start + pos;
-            let lit_len = pos - literals_start;
-
-            // (1) Default start = abs_pos + 1: probe the repcode bank
-            //     at the next byte, treating one byte as already
-            //     committed to the literal run. Donor probes only
-            //     rep1 here; `repcode_candidate_shared` probes all three
-            //     plus the `ll0` fallback because the donor "ll0" trick
-            //     is already baked into our shared helper. The extra
-            //     probes only add candidates that have repcode encoding
-            //     costs (cheap), so the ratio direction is positive vs
-            //     donor while still landing in the "greedy via repcode"
-            //     algorithmic shape.
-            let rep_probe_pos = abs_pos + 1;
-            let rep_probe_lit_len = lit_len + 1;
-            let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= self.history_abs_end() {
-                repcode_candidate_shared(
-                    self.hash_kernel,
-                    self.live_history(),
-                    self.history_abs_start,
-                    self.offset_hist,
-                    rep_probe_pos,
-                    rep_probe_lit_len,
-                    REP_MIN_MATCH_LEN,
-                )
-            } else {
-                None
-            };
-
-            // (2) Donor at `depth == 0` does `goto _storeSequence` on a
-            //     rep hit (commits without comparing against the regular
-            //     search). That trade-off is ratio-negative for us
-            //     because donor recovers the loss via other components
-            //     we don't replicate (smaller `mls=5`, block splitter,
-            //     better regular-search recall). To get the speed shape
-            //     of donor's greedy *without* its ratio cliff, we
-            //     compare both options and pick the longer match. On
-            //     ties / near-ties the rep wins by being cheaper to
-            //     encode (single-digit-bit offset code vs 9-13 bits for
-            //     a regular offset).
-            // Donor greedy (depth 0): a repcode hit commits immediately and
-            // SKIPS the regular row search (`zstd_lazy.c:2039`,
-            // `if (depth==0) goto _storeSequence`). The regular
-            // `row_candidate` (SIMD row scan + match extension) is the
-            // dominant per-position cost; running it on every rep hit made
-            // rep-dense inputs (repetitive logs) up to ~11x slower than the
-            // donor, which short-circuits. So only run the regular search
-            // when there is no rep to take. `row_candidate` is `&self` (a
-            // pure search, no table mutation), so skipping it drops no hash
-            // insert — the post-emit `insert_positions(abs_pos, ..)` still
-            // indexes the committed span.
-            let hash = match carried.take() {
-                Some((carried_pos, rt)) if carried_pos == abs_pos => Some(rt),
-                _ => None,
-            };
-            let chosen = match rep_match {
-                Some(rep) => Some(rep),
-                // SAFETY: `K` selected by `dispatch_tag_kernel!` after `detect`
-                // confirmed its ISA; `K::probe` upholds the feature contract.
-                None => unsafe { K::probe::<ROW_LOG>(self, abs_pos, lit_len, hash) },
-            };
-
-            let Some(candidate) = chosen else {
-                // Donor `kSearchStrength = 8` shifts hard on miss
-                // (step grows by `lit_len >> 8`). Empirically on our
-                // corpus that recovers ~30% speed but costs ratio by
-                // dropping hash inserts on long literal runs that
-                // would have served future matches. Shift right by
-                // `SKIP_STRENGTH = 10` instead — same shape, ~4×
-                // rarer growth, so the step stays at 1 byte until the
-                // literal run hits ~1 KiB and only then begins
-                // skipping. Lets us keep most of donor's speed
-                // characteristic without re-introducing the ratio
-                // drain.
-                const SKIP_STRENGTH: u32 = 10;
-                let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
-                // Reuse the probe's (row, tag) for the insert (the rep-hit
-                // path never computed one, so fall back to the hashing
-                // insert there — `hash` is `Some` exactly when the probe
-                // ran on this position).
-                match hash {
-                    Some((row, tag)) => self.insert_at::<ROW_LOG>(abs_pos, row, tag),
-                    None => self.insert_position::<ROW_LOG>(abs_pos),
-                }
-                if step == 1 {
-                    let next_abs = abs_pos + 1;
-                    if let Some((row, tag)) = self.hash_and_row(next_abs) {
-                        self.prefetch_row::<ROW_LOG>(row);
-                        carried = Some((next_abs, (row, tag)));
-                    }
-                }
-                pos += step;
-                continue;
-            };
-
-            // Emit sequence.
-            let start = candidate.start - current_abs_start;
-            // Index `[abs_pos, candidate.start + match_len)`, NOT
-            // `[candidate.start, candidate.start + match_len)`.
-            // `extend_backwards_shared` can move `candidate.start`
-            // below `abs_pos` by absorbing literal bytes that the
-            // outer loop already indexed on earlier miss iterations
-            // via `insert_position(abs_pos)`. Re-indexing them here
-            // would write the same `abs_pos -> position` mapping
-            // into the row table a second time, evicting more recent
-            // / more useful slot tenants from the same row's chain.
-            // Measured on `decodecorpus-z000033`: the
-            // `candidate.start` lower bound regresses `rust_bytes` by
-            // ~+447 over `abs_pos` (537897 -> 538344), so the
-            // narrower range is intentional.
-            self.insert_match_span::<ROW_LOG>(abs_pos, candidate.start + candidate.match_len);
-            let current = &self.history[self.history.len() - current_len..];
-            let literals = &current[literals_start..start];
-            handle_sequence(Sequence::Triple {
-                literals,
-                offset: candidate.offset,
-                match_len: candidate.match_len,
-            });
-            let _ = encode_offset_with_history(
-                candidate.offset as u32,
-                literals.len() as u32,
-                &mut self.offset_hist,
-            );
-            pos = start + candidate.match_len;
-            literals_start = pos;
-            // Same hash + row prefetch carry as the miss path: the next
-            // probe position is known here (right past the emitted match),
-            // and its row is otherwise guaranteed cold after the match-span
-            // insert walked other rows. The rep probe at the next iteration
-            // may consume the position without a row probe — then the
-            // carried hash is only reused by the insert-side, never wasted.
-            if pos + GREEDY_MIN_LOOKAHEAD <= current_len {
-                let next_abs = current_abs_start + pos;
-                if let Some((row, tag)) = self.hash_and_row(next_abs) {
-                    self.prefetch_row::<ROW_LOG>(row);
-                    carried = Some((next_abs, (row, tag)));
-                }
-            }
-
-            // Donor's `lazy_generic` has an immediate-repcode loop here
-            // (probing `offset_2` after each main emit and swapping
-            // `offset_1 ↔ offset_2` on hit). It was implemented and
-            // shipped in earlier iterations of this method but never
-            // fired on any test or benchmark workload — the
-            // `repcode_candidate_shared` probe at the top of the main
-            // loop already evaluates all three rep slots (rep1, rep2,
-            // rep3 + the `ll0` fallback), and the immediate-rep slot
-            // (`offset_hist[1]` at `lit_len = 0`) is subsumed by the
-            // next main-loop iteration's rep probe of the same slot.
-            // Donor's version is single-rep, so the inner loop catches
-            // hits its main-loop probe wouldn't; ours is three-rep, so
-            // the inner loop is dead by construction. Removed to free
-            // the per-iteration check and keep the parser body lean.
-        }
-
-        while pos + ROW_HASH_KEY_LEN <= current_len {
-            self.insert_position::<ROW_LOG>(current_abs_start + pos);
-            pos += 1;
-        }
-
-        if literals_start < current_len {
-            let current = &self.history[self.history.len() - current_len..];
-            handle_sequence(Sequence::Literals {
-                literals: &current[literals_start..],
-            });
-        }
-    }
-
     pub(crate) fn ensure_tables(&mut self) {
         let row_count = 1usize << self.row_hash_log;
         let row_entries = 1usize << self.row_log;
@@ -1629,19 +1670,47 @@ impl RowMatchGenerator {
         }
     }
 
-    gen_row_parse_kernel!(greedy_scalar, start_matching_greedy_rl);
+    gen_greedy_monolith!(
+        greedy_scalar,
+        false,
+        row_tag_mask_scalar,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_row_parse_kernel!(greedy_sse42, start_matching_greedy_rl, "sse4.2");
+    gen_greedy_monolith!(
+        greedy_sse42,
+        true,
+        row_tag_mask_sse2,
+        crate::encoding::fastpath::sse42::common_prefix_len_ptr,
+        "sse4.2"
+    );
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_row_parse_kernel!(greedy_avx2bmi2, start_matching_greedy_rl, "avx2,bmi2");
+    gen_greedy_monolith!(
+        greedy_avx2bmi2,
+        true,
+        row_tag_mask_avx2,
+        crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
+        "avx2,bmi2"
+    );
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    gen_row_parse_kernel!(greedy_neon, start_matching_greedy_rl, "neon");
+    gen_greedy_monolith!(
+        greedy_neon,
+        true,
+        row_tag_mask_neon,
+        crate::encoding::fastpath::neon::common_prefix_len_ptr,
+        "neon"
+    );
     #[cfg(all(
         target_arch = "wasm32",
         target_feature = "simd128",
         feature = "kernel_simd128"
     ))]
-    gen_row_parse_kernel!(greedy_simd128, start_matching_greedy_rl);
+    gen_greedy_monolith!(
+        greedy_simd128,
+        true,
+        row_tag_mask_simd128,
+        crate::encoding::fastpath::scalar::common_prefix_len_ptr
+    );
 
     pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
         match self.row_log {

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1319,6 +1319,19 @@ impl RowMatchGenerator {
             );
             pos = start + candidate.match_len;
             literals_start = pos;
+            // Same hash + row prefetch carry as the miss path: the next
+            // probe position is known here (right past the emitted match),
+            // and its row is otherwise guaranteed cold after the match-span
+            // insert walked other rows. The rep probe at the next iteration
+            // may consume the position without a row probe — then the
+            // carried hash is only reused by the insert-side, never wasted.
+            if pos + GREEDY_MIN_LOOKAHEAD <= current_len {
+                let next_abs = current_abs_start + pos;
+                if let Some((row, tag)) = self.hash_and_row(next_abs) {
+                    self.prefetch_row::<ROW_LOG>(row);
+                    carried = Some((next_abs, (row, tag)));
+                }
+            }
 
             // Donor's `lazy_generic` has an immediate-repcode loop here
             // (probing `offset_2` after each main emit and swapping

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -62,6 +62,12 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     /// Dictionary applied to the frame (donor `ZSTD_CCtx_loadDictionary` on a
     /// streaming context). `None` = no dictionary. Set before the first write.
     dictionary: Option<EncoderDictionary>,
+    /// Whether the frame header records the attached dictionary's ID
+    /// (upstream `ZSTD_c_dictIDFlag`). Default `true`. Raw-content
+    /// dictionaries (upstream `ZSTD_CCtx_refPrefix`) carry a synthetic
+    /// non-zero ID that must not reach the wire, so their attach path
+    /// turns this off. See [`Self::set_dictionary_id_flag`].
+    dictionary_id_flag: bool,
     /// Encoder entropy tables (literals Huffman + LL/ML/OF FSE "previous"
     /// tables) the dictionary seeds into the first block, derived once when the
     /// dictionary is attached so each frame start is a cheap clone.
@@ -147,6 +153,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             magicless: false,
             content_checksum: false,
             dictionary: None,
+            dictionary_id_flag: true,
             dictionary_entropy_cache: None,
             #[cfg(feature = "hash")]
             hasher: XxHash64::with_seed(0),
@@ -282,6 +289,14 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         let dict = EncoderDictionary::from_bytes(raw_dictionary)
             .map_err(|err| invalid_input_error(&alloc::format!("invalid dictionary: {err:?}")))?;
         self.set_encoder_dictionary(dict)
+    }
+
+    /// Whether the frame header records the dictionary ID when a dictionary
+    /// is attached (upstream `ZSTD_c_dictIDFlag` semantics; default `true`).
+    /// Mirrors [`FrameCompressor::set_dictionary_id_flag`]. Decoders can still
+    /// decode such frames by supplying the dictionary explicitly.
+    pub fn set_dictionary_id_flag(&mut self, emit: bool) {
+        self.dictionary_id_flag = emit;
     }
 
     /// Attach an already-parsed [`EncoderDictionary`] to the frame. See
@@ -570,7 +585,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             },
             single_segment,
             content_checksum: cfg!(feature = "hash") && self.content_checksum,
-            dictionary_id: if use_dictionary_state {
+            dictionary_id: if use_dictionary_state && self.dictionary_id_flag {
                 self.dictionary.as_ref().map(|dict| dict.inner.id as u64)
             } else {
                 None

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -295,8 +295,15 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
     /// is attached (upstream `ZSTD_c_dictIDFlag` semantics; default `true`).
     /// Mirrors [`FrameCompressor::set_dictionary_id_flag`]. Decoders can still
     /// decode such frames by supplying the dictionary explicitly.
-    pub fn set_dictionary_id_flag(&mut self, emit: bool) {
+    pub fn set_dictionary_id_flag(&mut self, emit: bool) -> Result<(), Error> {
+        self.ensure_open()?;
+        if self.frame_started {
+            return Err(invalid_input_error(
+                "dictionary ID flag must be set before the first write",
+            ));
+        }
         self.dictionary_id_flag = emit;
+        Ok(())
     }
 
     /// Attach an already-parsed [`EncoderDictionary`] to the frame. See

--- a/zstd/src/huff0/huff0_decoder.rs
+++ b/zstd/src/huff0/huff0_decoder.rs
@@ -297,6 +297,7 @@ impl<'t> HuffmanDecoder<'t> {
 }
 
 /// A Huffman decoding table contains a list of Huffman prefix codes and their associated values
+#[derive(Clone)]
 pub struct HuffmanTable {
     /// Packed `symbol | (num_bits << 8)` per state index, exposed
     /// `pub(crate)` because the HUF 4-stream burst hot path in


### PR DESCRIPTION
## Summary

Completes the dictionary slice of #127 (v1.5.7 C ABI), adds a prepared-dictionary object to the npm/wasm package, and lands one confirmed perf gain on the largest dashboard outsider.

### 1. C ABI: dictionary attach surface (27 new symbols)

- **Attach family**: `ZSTD_CCtx_loadDictionary[_byReference/_advanced]`, `ZSTD_CCtx_refCDict`, `ZSTD_CCtx_refPrefix[_advanced]` and the `ZSTD_DCtx` mirror (`loadDictionary` ×3, `refDDict`, `refPrefix`). Attach state lives on the context and applies at every frame start across `compress2` / `compressStream2` / `decompressDCtx` / `decompressStream`; loads and refs are sticky, prefixes are single-use, `NULL` clears — upstream semantics.
- **Raw-content dictionaries** (no magic, and every prefix) model as a parsed dictionary with a synthetic non-zero ID suppressed on the wire; the codec's `StreamingEncoder` gains `set_dictionary_id_flag` for this.
- **One-shots**: `ZSTD_compress_usingDict` / `ZSTD_decompress_usingDict`.
- **Advanced creators**: `ZSTD_createCDict_advanced` / `ZSTD_createDDict_advanced` / `ZSTD_compress_usingCDict_advanced` with ABI-mirror `ZSTD_compressionParameters` / `ZSTD_frameParameters` / `ZSTD_customMem` (custom allocators rejected). A referenced CDict's parameters win over the context's sticky knobs (upstream rule); `refCDict` + `compress2` reuses the context's cached dict-compressor keyed by the CDict serial.
- **IDs**: `ZSTD_getDictID_fromDict` / `ZSTD_getDictID_fromFrame`.
- **Estimates**: `ZSTD_estimate{CCtx,DCtx,CStream,DStream}Size` + `_usingCParams`, backed by a new codec helper reading the real per-level tuning table (budgets track this library's actual allocations).
- **zdict**: `ZDICT_trainFromBuffer_fastCover` / `ZDICT_optimizeTrainFromBuffer_fastCover` with `ZDICT_fastCover_params_t` (optimize writes back the chosen k/d/f).
- Parity fixes found en route: plain `ZSTD_createCDict` now accepts raw-content bytes (upstream auto semantics); `ZSTD_decompress_usingDDict` reworked onto a parsed-handle cache, fixing raw-content DDicts failing at use.

### 2. npm/wasm: prepared dictionary (`ZstdDictionary` + TS `ZstdDict`)

The byte-taking dict API re-parsed the dictionary per call / per stream. The prepared object parses once and:
- one-shot `compress` keeps a cached frame compressor whose dictionary-primed match-finder snapshot is reused across calls (dominant per-frame cost for small payloads);
- one-shot `decompress` reuses one decoder workspace;
- compress streams seed via a table copy (`Clone` derived down the `Dictionary` chain), decode streams via an `Arc` refcount bump; the prepared decode stream also handles ID-less frames (raw-content dicts).

```ts
const dict = await ZstdDict.create(dictBytes);
const frame = dict.compress(payload, 19);
const back  = dict.decompress(frame);
const cs    = dict.compressStream(19);
```

### 3. Perf: row hash + prefetch pipeline (greedy levels)

`compress/level_5_greedy/decodecorpus-z000033` was the largest dashboard outsider (musl 5.3×; i9 3.66× — not musl-specific). Profile: the probe's hash-dependent tag-row load alone was ~26% of wall, and every miss position hashed twice (probe + insert). On a miss the next position's `(row, tag)` is now computed ahead and its rows prefetched, overlapping the dependent load; the insert reuses the probe's hash. Byte-identical output.

The track then continued slice-by-slice (each byte-identical, full suite green, i9 A/B with flat c_ffi controls):

| Slice | L5 effect | Notes |
|---|---|---|
| hash carry + row prefetch across miss iterations | −3.0% | donor hash-cache overlap shape |
| carry across match emissions | ~0 | structurally right, wide CI |
| force-inline per-position helpers (rep/hash/insert) | **−11.4%** | helpers showed as self-time = not inlined |
| greedy/lazy `target_feature` umbrellas | −1.8% (L8 −7.3%) | parse loop + probe under one feature scope |
| probe inline hint | ~−0.5% | LLVM declined full merge |
| **probe macro-expansion → per-tier monoliths** | **−2.8%** (L10 −3.1%) | probe body expands inline per tier with its own SIMD pairing (tag-mask + prefix kernel) — the literal donor `ZSTD_compressBlock_greedy_row` shape |
| floor-advance reset for row tables | reuse-loop −1.7% | last backend zeroing tables per frame (multi-MiB memset); output verified identical |
| one-u32 repcode gate (donor `MEM_read32`) | **−2.7%** (L8 −3.1%) | the 4-byte rep gate compared slice ranges, paying two bounds checks per input byte |
| mls-wide row hash key (donor `ZSTD_hashPtr` width) | L8 **−8.6%**, L10 **−11.3%** | 4-byte key admitted false tag hits; ratio improves at every row level and stays ahead of the donor everywhere (L5: 486 096 vs 513 921 B). L5 is arch-divergent (M1 −6.8%, i9 +2.9%); kept for donor parity + ratio. The shallow band gained more, so the `Best` alias moves to level 13, the first dominant point of the deep band, keeping the named-level ladder strictly monotone |

**Cumulative (i9, paired sessions):** L5 32.35 → ~24.7 ms (**−24%**, ratio 3.66× → ~2.8×), L8 −18%+, L10 −14%+. Diagnosis that drove the track: IPC parity with the donor (2.08 vs 2.04) but ~4× the instructions/byte — an abstraction-bloat gap, not a memory-bound one. Two negatives were measured and reverted (two-phase candidate prefetch; raw-pointer table hoist).

## Testing

- 906 workspace tests (9 new attach round-trips incl. prefix single-use, refCDict params-win, raw-content wire checks; estimates sanity; fastCover write-back)
- `c_consumer.c` extended to drive the attach surface end-to-end (train → loadDictionary/refCDict/refPrefix/usingDict → decode); built and run against the produced library
- CI exported-symbol gate covers all 27 new symbols
- wasm `test.mjs`: prepared-dict cached-path repeat calls, stream round-trips, raw content, and C-reference (bokuweb) interop for every produced frame — run locally, green
- clippy clean on host + wasm32 (simd128 and scalar); doctests green
- Row pipeline is byte-identical (output unchanged; hash just moves earlier)

Part of #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context-attached/referenceable dictionary APIs (sticky, prefix, by-reference and one-shot) for compress/decompress.
  * FastCOVER training/optimizer entry points.
  * Memory-estimate helpers for context/stream sizing.
  * Prepared-dictionary support in WASM/npm (ZstdDictionary/ZstdDict) with one-shot and stream helpers.
  * Streaming option to suppress dictionary-ID emission per stream.
  * Cloneable dictionary/scratch helpers and heap-size reporting.

* **Bug Fixes**
  * Corrected dictionary-ID emission/consumption and recovery across failure paths.

* **Tests**
  * Expanded end-to-end dictionary and interoperability coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

