### PR TITLE
fix(c-api): build and test the C ABI on 32-bit targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,18 @@ jobs:
         run: cargo clippy -p structured-zstd-c --all-targets -- -D warnings
       - name: Unit + ABI tests
         run: cargo test -p structured-zstd-c
+      - name: 32-bit toolchain (i686)
+        # Upstream libzstd ships on 32-bit platforms; the drop-in C ABI must
+        # keep building and passing there too (size_t error encoding, struct
+        # layouts, and overflow guards all change shape at 32-bit usize).
+        run: |
+          rustup target add i686-unknown-linux-gnu
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+      - name: Clippy (c-api, i686)
+        run: cargo clippy -p structured-zstd-c --all-targets --target i686-unknown-linux-gnu -- -D warnings
+      - name: Unit + ABI tests (i686)
+        run: cargo test -p structured-zstd-c --target i686-unknown-linux-gnu
       - name: Vendored headers match upstream verbatim
         # The headers are copied byte-for-byte from the pinned upstream tag; a
         # diff means someone edited a vendored header (forbidden) or the pin

--- a/c-api/src/simple.rs
+++ b/c-api/src/simple.rs
@@ -24,8 +24,11 @@ const CONTENTSIZE_UNKNOWN: u64 = u64::MAX;
 const CONTENTSIZE_ERROR: u64 = u64::MAX - 1;
 
 /// `ZSTD_MAX_INPUT_SIZE`: above this `ZSTD_compressBound` reports an error.
+/// The 64-bit value is spelled as a `u64` literal because both arms of a
+/// const `if` are type-checked even on targets where only the 32-bit arm is
+/// live — a bare `usize` literal would fail to compile on 32-bit.
 const MAX_INPUT_SIZE: usize = if usize::BITS >= 64 {
-    0xFF00_FF00_FF00_FF00
+    0xFF00_FF00_FF00_FF00u64 as usize
 } else {
     0xFF00_FF00
 };

--- a/c-api/src/tests.rs
+++ b/c-api/src/tests.rs
@@ -298,6 +298,13 @@ fn frame_header_abi_layout_is_stable() {
         assert_eq!(size_of::<ZSTD_FrameHeader>(), 48);
         assert_eq!(align_of::<ZSTD_FrameHeader>(), 8);
     }
+    // i386 ABI aligns u64 to 4, so the struct loses the trailing pad and
+    // the 8-byte alignment; the field offsets above stay identical.
+    #[cfg(target_pointer_width = "32")]
+    {
+        assert_eq!(size_of::<ZSTD_FrameHeader>(), 44);
+        assert_eq!(align_of::<ZSTD_FrameHeader>(), 4);
+    }
 }
 
 #[test]
@@ -582,14 +589,22 @@ use crate::streaming::{
 };
 use core::ffi::c_int;
 
-// ABI invariants: struct sizes match upstream `sizeof` on 64-bit (on
-// 32-bit targets `size_t` / pointers halve the layouts).
+// ABI invariants: struct sizes match upstream `sizeof` per pointer width
+// (`size_t` / pointers halve the layouts on 32-bit).
 #[test]
-#[cfg(target_pointer_width = "64")]
 fn streaming_buffer_abi_sizes() {
-    assert_eq!(core::mem::size_of::<ZSTD_inBuffer>(), 24);
-    assert_eq!(core::mem::size_of::<ZSTD_outBuffer>(), 24);
-    assert_eq!(core::mem::size_of::<ZSTD_bounds>(), 16);
+    #[cfg(target_pointer_width = "64")]
+    {
+        assert_eq!(core::mem::size_of::<ZSTD_inBuffer>(), 24);
+        assert_eq!(core::mem::size_of::<ZSTD_outBuffer>(), 24);
+        assert_eq!(core::mem::size_of::<ZSTD_bounds>(), 16);
+    }
+    #[cfg(target_pointer_width = "32")]
+    {
+        assert_eq!(core::mem::size_of::<ZSTD_inBuffer>(), 12);
+        assert_eq!(core::mem::size_of::<ZSTD_outBuffer>(), 12);
+        assert_eq!(core::mem::size_of::<ZSTD_bounds>(), 12);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `ZSTD_MAX_INPUT_SIZE` spells its 64-bit arm as a `u64` literal: both arms of a const `if` are type-checked even where only the 32-bit arm is live, so the bare `usize` literal failed to compile on i686. The `size_t` error encoding itself was already pointer-width-correct (`wrapping_sub`-based, mirroring upstream's `(size_t)-code`).
- The ABI layout tests gain 32-bit arms instead of being cfg'd out: `ZSTD_FrameHeader` is 44 bytes / align 4 under the i386 u64-align-4 ABI (field offsets unchanged), and `ZSTD_inBuffer` / `ZSTD_outBuffer` / `ZSTD_bounds` are 12 bytes each.
- CI's `c-abi` job now clippy-checks and runs the full c-api test suite for `i686-unknown-linux-gnu` (gcc-multilib), so the 32-bit build can't silently regress.

## Testing

Verified on a real 32-bit target (i686-unknown-linux-gnu): all 56 c-api tests pass, including the cParams-estimate overflow regression test from #409, which until now could not exercise live 32-bit behavior. Host suite: 916 workspace tests + doc tests + clippy clean.

Closes #410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * CI now includes testing for 32-bit (i686) platform compatibility
  * Expanded ABI stability assertions for 32-bit targets to ensure consistency

* **Chores**
  * Improved type safety for cross-platform constant definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->