### PR TITLE
perf(encode): cap row match-finder table to upstream hashLog

### DIFF
--- a/zstd/examples/donor_cparams_check.rs
+++ b/zstd/examples/donor_cparams_check.rs
@@ -8,8 +8,9 @@
 use zstd::zstd_safe::zstd_sys;
 
 fn main() {
-    let src_size = 1022035u64; // bytes in zstd/decodecorpus_files/z000033
-    let level = 1i32;
+    let args: Vec<String> = std::env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1);
+    let src_size: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1022035);
     let dict_size = 0usize;
 
     // SAFETY: standard libzstd query.

--- a/zstd/examples/donor_cparams_check.rs
+++ b/zstd/examples/donor_cparams_check.rs
@@ -1,9 +1,13 @@
-//! One-shot diagnostic: ask donor what cParams it selects for our exact
-//! (level, srcSize, dictSize) tuple. Confirms whether donor's L1 path
-//! uses mls=7 vs mls=4/6 for the 1MB decodecorpus-z000033 fixture.
+//! One-shot diagnostic: ask upstream zstd which cParams it selects for a
+//! given (level, srcSize, dictSize=0) tuple via `ZSTD_getCParams`. Useful
+//! for checking our per-level table widths (windowLog / hashLog / chainLog)
+//! against upstream's source-size-adjusted values.
 //!
 //! Build: cargo build --release -p structured-zstd --example donor_cparams_check
-//! Run:   ./target/release/examples/donor_cparams_check
+//! Run:   ./target/release/examples/donor_cparams_check [level] [src_size]
+//!        level    compression level (default 1)
+//!        src_size source size in bytes for the size hint (default 1022035,
+//!                 the decodecorpus-z000033 fixture; 0 = unknown/unbounded)
 
 use zstd::zstd_safe::zstd_sys;
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -270,10 +270,13 @@ const ROW_CONFIG: RowConfig = RowConfig {
 // The shared `ROW_CONFIG` (row_log=5, search_depth=16, target_len=48) ran a
 // level-12-grade search here: 16 slots per row, never early-exiting until a
 // 48-byte match. That exhaustive walk was the dominant cost in greedy L5's
-// encode-speed regression vs FFI. `hash_bits` stays at the `ROW_HASH_BITS`
-// cap (the row table size is a separate budget).
+// encode-speed regression vs FFI. `hash_bits` matches upstream zstd's
+// `ZSTD_getCParams(5, .., 0).hashLog` = 19 (verified via
+// `donor_cparams_check 5`), so the row table is the same width as upstream's
+// (2^19 slots); the previous `ROW_HASH_BITS` (20) doubled both row tables vs
+// upstream, the dominant peak-memory excess on the greedy band.
 const ROW_L5: RowConfig = RowConfig {
-    hash_bits: ROW_HASH_BITS,
+    hash_bits: 19,
     row_log: 4,
     search_depth: 8,
     target_len: 2,
@@ -878,9 +881,9 @@ fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> Leve
     // zeroing a window-sized table per frame; large inputs keep the level's
     // widths. The cap is applied with the same per-backend headroom the
     // level table uses, so the load factor (and match quality) is unchanged.
-    // The Row / Dfast backends derive their table widths from the source in
-    // `reset` (their `set_hash_bits` recomputes there), so they are not
-    // adjusted here.
+    // The Dfast backend derives its table widths from the source in `reset`
+    // (`set_hash_bits` recomputes there), so it is not adjusted here. The Row
+    // backend's width IS capped here, mirroring the donor (see the Row branch).
     let table_log = raw_src_log.max(MIN_WINDOW_LOG);
     let backend = params.backend();
     if backend == super::strategy::BackendTag::HashChain {
@@ -893,6 +896,22 @@ fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> Leve
         }
         if (table_log + 1) < hc.chain_log as u8 {
             hc.chain_log = (table_log + 1) as usize;
+        }
+    } else if backend == super::strategy::BackendTag::Row {
+        let row = params
+            .row
+            .as_mut()
+            .expect("Row level row carries a RowConfig");
+        // Upstream zstd `ZSTD_adjustCParams_internal` (zstd_compress.c): once
+        // the window is source-capped, `hashLog <= windowLog + 1`. The row
+        // table is `2^hash_bits` slots, exactly upstream's row hashTable
+        // `2^hashLog` slots, so the same cap applies. Without it the row table
+        // stays at the level's unbounded width (e.g. L12 hash_bits 23 = 4x
+        // upstream's source-capped 21), the dominant peak-memory excess on the
+        // row band.
+        let row_cap = (table_log + 1) as usize;
+        if row_cap < row.hash_bits {
+            row.hash_bits = row_cap;
         }
     } else if backend == super::strategy::BackendTag::Simple {
         let fast = params
@@ -8048,9 +8067,10 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
     let full_rows = driver.row_matcher().row_heads.len();
-    // Level 5 uses the donor row_log (clamp(searchLog=3, 4, 6) = 4), not the
-    // shared ROW_LOG, so the row count is 1 << (hash_bits - ROW_L5.row_log).
-    assert_eq!(full_rows, 1 << (ROW_HASH_BITS - ROW_L5.row_log));
+    // Level 5 uses the upstream row_log (clamp(searchLog=3, 4, 6) = 4) and the
+    // upstream L5 hashLog (`ZSTD_getCParams(5,..).hashLog` = 19), so the row
+    // count is 1 << (ROW_L5.hash_bits - ROW_L5.row_log).
+    assert_eq!(full_rows, 1 << (ROW_L5.hash_bits - ROW_L5.row_log));
 
     driver.set_source_size_hint(1024);
     driver.reset(CompressionLevel::Level(5));


### PR DESCRIPTION
## Summary

The Row match-finder backend (greedy L5 + lazy L6-L12) sized its hash/tag
tables from the level's unbounded `hashLog`, ignoring the source-size cap
upstream zstd applies in `ZSTD_adjustCParams_internal`: once the window is
source-capped, `hashLog <= windowLog + 1`. On a 1 MiB source the L12 row
table was `2^23` slots vs upstream's source-capped `2^21` (4x), the
dominant peak-memory excess on the row band.

`adjust_params_for_source_size` previously capped only the HashChain / Fast
backends and explicitly skipped Row. This adds the same `hashLog <=
windowLog + 1` cap to the Row backend, and corrects `ROW_L5.hash_bits`
(20 -> 19) which was a generic constant one bit wider than
`ZSTD_getCParams(5,..).hashLog` even unbounded.

## Results (i9 x86_64, `compare_ffi_memory`, peak alloc vs C FFI)

| fixture | level | before | after |
|---|---|---|---|
| z000033 | L5 greedy | 1.50x | **0.98x** |
| low-entropy-1m | L5 greedy | 1.52x | **0.94x** |
| large-log-stream | L5 greedy | 1.79x | **1.32x** |
| z000033 | L10-L12 lazy | ~1.0-2.0x | **~0.59x** |

Universal across targets (the dashboard's per-target i686/gnu/musl memory
bands all flagged this same gap).

## Ratio / speed

- Ratio gate (`compare_ffi`): compressed size still smaller than C FFI at
  every affected level (e.g. z000033 L5 485967 vs 513921 bytes).
- Speed (paired criterion, flat C control): L5 greedy compress +3.0%
  (a denser table sees more tag collisions -> more match verification;
  this is upstream's own `hashLog=19` cost). L10-L12 lazy neutral
  (depth-bound search is insensitive to table width). L5 is not a
  compress-speed band outlier.

## Testing

- `cargo nextest run -p structured-zstd --features dict_builder`: 838 pass.
- Memory + ratio + paired-speed verified on the i9 bench host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated compression parameter example to accept command-line arguments for configurable `level` and source size settings

* **Chores**
  * Optimized compression parameter configuration to improve behavior consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->