### PR TITLE
perf(encode): cap row history buffer near the live window

### DIFF
--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1424,6 +1424,20 @@ impl RowMatchGenerator {
             // Eviction advances `history_start`, staling the dict row index's
             // concat positions — drop the attach (dict slid within/out window).
             self.dict.invalidate();
+            // Cap the history buffer near the live window instead of letting
+            // the Vec power-of-two double to ~2x window on long streams. Once
+            // eviction starts, reserve exactly (window + window/4 + one block)
+            // so the buffer grows linearly to that ceiling; `compact_history`'s
+            // quarter-window drain then keeps `len` under it, so the Vec never
+            // reallocates again. Only fires in the eviction regime (large
+            // inputs that fill the window) — small frames keep their tight
+            // data-sized buffer untouched.
+            let target = self.max_window_size
+                + (self.max_window_size >> 2)
+                + crate::common::MAX_BLOCK_SIZE as usize;
+            if target > self.history.len() && self.history.capacity() < target {
+                self.history.reserve_exact(target - self.history.len());
+            }
         }
         while self.window_size + data.len() > self.max_window_size {
             let removed_len = self.chunk_lens.pop_front().unwrap();
@@ -1646,7 +1660,14 @@ impl RowMatchGenerator {
         if self.history_start == 0 {
             return;
         }
-        if self.history_start >= self.max_window_size
+        // Drain the (unreachable) dead prefix once it reaches a quarter window
+        // so the buffer stays near `window + window/4` rather than growing to
+        // ~2x window before the old full-window trigger fired. Paired with the
+        // one-time `reserve_exact` in `add_data`, this keeps the Vec at a fixed
+        // ~1.25x-window capacity on long streams. The drain memmoves the live
+        // window, so a quarter-window trigger bounds the write amplification
+        // (~4x the eviction stride) while closing most of the peak gap.
+        if self.history_start >= (self.max_window_size >> 2)
             || self.history_start * 2 >= self.history.len()
         {
             self.history.drain(..self.history_start);


### PR DESCRIPTION
## Summary

On long streams the row match-finder's history `Vec` power-of-two doubled
to ~2x the window (a 2 MiB window peaked at a 4 MiB buffer), inflating
compress peak memory on the greedy/lazy band.

Once eviction starts, reserve exactly `window + window/4 + one block` so
the buffer grows linearly to that ceiling, and drain the dead prefix at a
quarter window so `len` stays under it. The `Vec` then never reallocates
and peak residency sits near 1.25x the window instead of 2x. Small frames
(window never fills) keep their tight data-sized buffer untouched.

Byte-identical (buffer management only — no match-decision change).

## Results (i9 x86_64)

Peak alloc vs C FFI (`compare_ffi_memory`), large-log-stream:

| level | before | after |
|---|---|---|
| L5 greedy | 7.45 MB (1.32x) | **6.01 MB (1.065x)** |
| L7 lazy | 10.1 MB (1.22x) | **8.66 MB (1.05x)** |
| L10-L12 lazy | already < C | further reduced |

z000033 / low-entropy-1m peak unchanged (1 MiB < window -> no eviction ->
no overshoot; already tight, no regression on small frames).

## Throughput

Paired `perf stat -e cycles` (11.5 MiB corpus): L10 lazy neutral
(-0.36%); L5 greedy +2.3% (the dead-prefix drain memmoves the live window,
and on the shallow greedy path that is a larger fraction). The trade is
confined to large-log L5 greedy throughput (not a flagged band) in
exchange for closing the flagged large-log L5 memory band.

## Testing

- `cargo nextest run -p structured-zstd --features dict_builder`: 838 pass
  (incl cross_validation byte-identity checks).
- Peak + paired-cycles verified on the i9 bench host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Efficiency**
  * Optimized memory allocation strategy to reduce overhead during compression operations.
  * Improved handling of extended data streams with more consistent memory usage and better performance on long-running compressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->