### PR TITLE
perf(encode): cap dfast history buffer near the live window

### DIFF
--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -424,6 +424,18 @@ impl DfastMatchGenerator {
             // dict bytes — drop the attach (dict ratio benefit lost once the
             // dict slides out of the window, like the Fast backend).
             self.dict.invalidate();
+            // Cap the history buffer near the live window: reserve exactly
+            // (window + window/4 + one block) once eviction starts so the Vec
+            // grows linearly to that ceiling instead of power-of-two doubling
+            // to ~2x window; `compact_history`'s quarter-window drain keeps len
+            // under it, so the Vec never reallocates again. Small frames that
+            // never fill the window keep their tight data-sized buffer.
+            let target = self.max_window_size
+                + (self.max_window_size >> 2)
+                + crate::common::MAX_BLOCK_SIZE as usize;
+            if target > self.history.len() && self.history.capacity() < target {
+                self.history.reserve_exact(target - self.history.len());
+            }
         }
         while self.window_size + data.len() > self.max_window_size {
             let removed_len = self.window_blocks.pop_front().unwrap();
@@ -1350,7 +1362,10 @@ impl DfastMatchGenerator {
         if self.history_start == 0 {
             return;
         }
-        if self.history_start >= self.max_window_size
+        // Drain the dead prefix at a quarter window (paired with the one-time
+        // `reserve_exact` in `add_data`) so the buffer stays near
+        // `window + window/4` instead of doubling to ~2x window on long streams.
+        if self.history_start >= (self.max_window_size >> 2)
             || self.history_start * 2 >= self.history.len()
         {
             self.history.drain(..self.history_start);


### PR DESCRIPTION
## Summary

Mirror of #418 for the dfast (L3/L4) match finder. On long streams the
dfast history `Vec` power-of-two doubled to ~2x the window, inflating L3/L4
compress peak memory.

Once eviction starts, reserve exactly `window + window/4 + one block` so
the buffer grows linearly to that ceiling, and drain the dead prefix at a
quarter window so the `Vec` never reallocates again. Small frames (window
never fills) keep their tight data-sized buffer. Byte-identical (buffer
management only — no match-decision change).

## Results (i9 x86_64)

Peak alloc vs C FFI (`compare_ffi_memory`), large-log-stream:

| level | before | after |
|---|---|---|
| L3 dfast | 5.59 MB (1.47x) | **4.15 MB (1.09x)** |
| L4 dfast | 6.90 MB (1.35x) | **5.46 MB (1.067x)** |

z000033 / low-entropy-1m peak unchanged (1 MiB < window -> no eviction,
already tight; no small-frame regression).

## Throughput (clean win, not a trade)

Paired `perf stat -e cycles` (11.5 MiB corpus): L3 **-2.48%**, L4 **-1.94%**
— *faster*. The smaller, fixed-size history buffer improves cache locality
for the dfast hash tables, so this lowers peak memory AND cycles.

## Testing

- `cargo nextest run -p structured-zstd --features dict_builder`: 838 pass
  (incl cross_validation byte-identity).
- Peak + paired-cycles verified on the i9 bench host.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory efficiency during long compression streams by optimizing buffer management and earlier cleanup of obsolete data, preventing excessive memory growth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->