### PR TITLE
perf(encode): close small-window dict compress gap (hash-chain matchfinder + borrowed dict kernel)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,10 +444,12 @@ jobs:
           for p in simd scalar; do
             sz=$(stat -c %s "zstd-wasm/npm/$p/structured_zstd_wasm_bg.wasm")
             echo "$p payload: $sz bytes"
-            # Generous ceiling (~768 KiB) over the ~550 KiB baseline; bump
-            # deliberately if a feature legitimately grows the module.
-            if [ "$sz" -gt 786432 ]; then
-              echo "::error::$p .wasm is $sz bytes, over the 768 KiB budget"
+            # Ceiling (~1 MiB) over the ~550 KiB baseline; bumped from 768 KiB
+            # when the per-tier match kernels (monomorphised per MLS + the
+            # simd128/scalar count tiers) legitimately grew the module, with
+            # headroom for the remaining backends gaining simd128 tiers.
+            if [ "$sz" -gt 1048576 ]; then
+              echo "::error::$p .wasm is $sz bytes, over the 1 MiB budget"
               exit 1
             fi
           done

--- a/zstd/examples/ffi_loop_dict.rs
+++ b/zstd/examples/ffi_loop_dict.rs
@@ -83,6 +83,13 @@ fn main() {
         core::hint::black_box(&dst);
     }
 
+    // Release the raw C contexts (zstd-sys exposes no Drop wrapper for the bare
+    // pointers). SAFETY: both were created above and not freed elsewhere.
+    unsafe {
+        zstd_sys::ZSTD_freeCCtx(cctx);
+        zstd_sys::ZSTD_freeCDict(cdict);
+    }
+
     eprintln!(
         "ffi encoded {} bytes x {} iters at level {} dict={}; last-out-sum={}",
         src.len(),

--- a/zstd/examples/ffi_loop_dict.rs
+++ b/zstd/examples/ffi_loop_dict.rs
@@ -1,0 +1,94 @@
+//! C-FFI counterpart of `encode_loop_dict` for a like-for-like perf profile:
+//! parse the dictionary into a `ZSTD_CDict` ONCE, then loop
+//! `ZSTD_compress_usingCDict` over a contiguous `&[u8]` at the given level with
+//! a reused `ZSTD_CCtx`. Lets `perf record` attribute time to libzstd's
+//! internal functions (ZSTD_compressBlock_lazy, HUF_compress, FSE_*, ...) so
+//! the per-function TIME graph can be compared directly against ours.
+//!
+//! Build: cargo build --profile flamegraph -p structured-zstd
+//!          --example ffi_loop_dict --features dict_builder
+//! Run:   ./target/flamegraph/examples/ffi_loop_dict <level> <iters> logs<N> <dict_path>
+
+use std::env;
+
+use zstd::zstd_safe::zstd_sys;
+
+/// Byte-for-byte the bench `repeated_log_lines(len)` fixture (same as
+/// `encode_loop_dict`) so a `logs<N>` input reproduces the `*-log-lines`
+/// scenario exactly.
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        for line in LINES {
+            if bytes.len() == len {
+                break;
+            }
+            let remaining = len - bytes.len();
+            bytes.extend_from_slice(&line.as_bytes()[..line.len().min(remaining)]);
+        }
+    }
+    bytes
+}
+
+fn resolve_input(spec: &str) -> Vec<u8> {
+    if let Some(rest) = spec.strip_prefix("logs") {
+        let n: usize = rest.parse().expect("logs<N>: N must be a byte count");
+        repeated_log_lines(n)
+    } else {
+        std::fs::read(spec).expect("read input file")
+    }
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(6);
+    let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(300_000);
+    let input_spec: &str = args.get(3).map(|s| s.as_str()).unwrap_or("logs4096");
+    let dict_path: &str = args.get(4).map(|s| s.as_str()).expect("dict path required");
+
+    let src = resolve_input(input_spec);
+    let dict = std::fs::read(dict_path).expect("read dict file");
+
+    let dst_cap = unsafe { zstd_sys::ZSTD_compressBound(src.len()) };
+    let mut dst: Vec<u8> = vec![0u8; dst_cap];
+
+    // Parse the dict into a CDict ONCE (mirrors our reused EncoderDictionary).
+    let cdict = unsafe {
+        zstd_sys::ZSTD_createCDict(dict.as_ptr() as *const core::ffi::c_void, dict.len(), level)
+    };
+    assert!(!cdict.is_null(), "ZSTD_createCDict failed");
+    let cctx = unsafe { zstd_sys::ZSTD_createCCtx() };
+    assert!(!cctx.is_null(), "ZSTD_createCCtx failed");
+
+    let mut sink: usize = 0;
+    for _ in 0..iters {
+        let rc = unsafe {
+            zstd_sys::ZSTD_compress_usingCDict(
+                cctx,
+                dst.as_mut_ptr() as *mut core::ffi::c_void,
+                dst_cap,
+                src.as_ptr() as *const core::ffi::c_void,
+                src.len(),
+                cdict,
+            )
+        };
+        assert_eq!(unsafe { zstd_sys::ZSTD_isError(rc) }, 0, "compress failed");
+        sink = sink.wrapping_add(rc);
+        core::hint::black_box(&dst);
+    }
+
+    eprintln!(
+        "ffi encoded {} bytes x {} iters at level {} dict={}; last-out-sum={}",
+        src.len(),
+        iters,
+        level,
+        dict_path,
+        sink
+    );
+}

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -975,11 +975,16 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
     /// The owned/evicting path keeps the scanned window bounded (positions
     /// stay small), so >4 GiB inputs fall back to it.
     fn borrowed_eligible(&self, input_len: usize, prep: &FramePrep) -> bool {
-        if prep.use_dictionary_state
-            || matches!(self.compression_level, CompressionLevel::Uncompressed)
+        if matches!(self.compression_level, CompressionLevel::Uncompressed)
             || input_len > u32::MAX as usize
         {
             return false;
+        }
+        if prep.use_dictionary_state {
+            // Dictionary frames: only the Simple (Fast) backend in attach mode
+            // has a borrowed (no input copy) dict scan. Copy-mode dict frames
+            // and the other backends still take the owned path.
+            return self.state.matcher.borrowed_dict_supported();
         }
         // The borrowed (no-copy, in-place over-window) scan exists for the
         // Simple (Fast), Dfast, and Row backends, and for the HashChain

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -981,6 +981,19 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             return false;
         }
         if prep.use_dictionary_state {
+            // The borrowed dict scan runs in VIRTUAL `[dict][input]` coordinates,
+            // so the position space is `dict_content.len() + input_len`, not just
+            // `input_len`. A large attached dictionary plus an otherwise-allowed
+            // input can exceed the `u32` floor the kernel asserts — fall back to
+            // the owned (copy) path in that case.
+            let fits_u32 = self
+                .dictionary
+                .as_ref()
+                .and_then(|dict| dict.inner.dict_content.len().checked_add(input_len))
+                .is_some_and(|virtual_len| virtual_len <= u32::MAX as usize);
+            if !fits_u32 {
+                return false;
+            }
             // Dictionary frames: only the Simple (Fast) backend in attach mode
             // has a borrowed (no input copy) dict scan. Copy-mode dict frames
             // and the other backends still take the owned path.

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2059,6 +2059,33 @@ impl Matcher for MatchGeneratorDriver {
                 hc.chain_log = dict_chain_log;
             }
         }
+        // upstream zstd `ZSTD_resolveRowMatchFinderMode` (zstd_compress.c:238-245):
+        // the row matchfinder is used for greedy/lazy/lazy2 ONLY when
+        // `windowLog > 14`; at or below that upstream runs the hash-chain
+        // matcher (`ZSTD_HcFindBestMatch`). We previously hardcoded the Row
+        // backend for these strategies regardless of window, sending every
+        // small-window frame (hinted floor = windowLog 14, e.g. the small-4k/10k
+        // fixtures) through Row where upstream uses HC. Match it: fall back to
+        // the hash-chain matcher (lazy/greedy parse via `lazy_depth`) when the
+        // resolved window is <= 14. The HC config is synthesised from the
+        // level's RowConfig (HC and Row share the same cParams; only the
+        // matchfinder differs) — `hash_log` / `chain_log` are
+        // clamped to the (<= 14) window inside the HashChain reset arm, so the
+        // nominal width here only sets the clamp ceiling.
+        if params.search == super::strategy::SearchMethod::RowHash && params.window_log <= 14 {
+            let row = params
+                .row
+                .expect("a RowHash level row must carry a RowConfig");
+            params.search = super::strategy::SearchMethod::HashChain;
+            params.hc = Some(HcConfig {
+                hash_log: row.hash_bits,
+                chain_log: row.hash_bits,
+                search_depth: row.search_depth,
+                target_len: row.target_len,
+                search_mls: 4,
+            });
+            params.row = None;
+        }
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
         self.dictionary_retained_budget = 0;
@@ -8311,27 +8338,39 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     // count is 1 << (ROW_L5.hash_bits - ROW_L5.row_log).
     assert_eq!(full_rows, 1 << (ROW_L5.hash_bits - ROW_L5.row_log));
 
-    driver.set_source_size_hint(1024);
+    // A hint that keeps the resolved window > 14 STILL uses the Row finder
+    // (upstream `ZSTD_resolveRowMatchFinderMode`: row mode on for windowLog > 14)
+    // and shrinks the row hash table to the source-derived width. 64 KiB →
+    // raw source log 16, so `row_hash_bits_for_window(1 << 16)` < the level's
+    // full hash_bits (19) and the row count drops.
+    driver.set_source_size_hint(1 << 16);
     driver.reset(CompressionLevel::Level(5));
     let mut space = driver.get_next_space();
     space[..12].copy_from_slice(b"xyzxyzxyzxyz");
     space.truncate(12);
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
-    let hinted_rows = driver.row_matcher().row_heads.len();
-
-    // Wire `window_log` stays floored, but the row hash table is sized from
-    // the RAW 1 KiB source: `table_window = 1 << 10`, so
-    // `row_hash_bits_for_window(1 << 10) = 11` (donor `hashLog <=
-    // windowLog + 1`) and the row count is `1 << (11 - ROW_L5.row_log)`.
-    assert_eq!(driver.window_size(), 1 << MIN_HINTED_WINDOW_LOG);
     assert_eq!(
-        hinted_rows,
-        1 << ((MIN_WINDOW_LOG as usize) + 1 - ROW_L5.row_log)
+        driver.active_backend(),
+        super::strategy::BackendTag::Row,
+        "windowLog > 14 keeps the upstream row matchfinder"
     );
+    let hinted_rows = driver.row_matcher().row_heads.len();
     assert!(
         hinted_rows < full_rows,
-        "tiny source hint should reduce row hash table footprint"
+        "a window>14 source hint should reduce the row hash table footprint"
+    );
+
+    // A tiny hint floors the resolved window at MIN_HINTED_WINDOW_LOG = 14;
+    // upstream uses the HASH-CHAIN matcher (not Row) at windowLog <= 14, so the
+    // driver must route greedy/lazy/lazy2 to the HashChain backend there.
+    driver.set_source_size_hint(1024);
+    driver.reset(CompressionLevel::Level(5));
+    assert_eq!(driver.window_size(), 1 << MIN_HINTED_WINDOW_LOG);
+    assert_eq!(
+        driver.active_backend(),
+        super::strategy::BackendTag::HashChain,
+        "windowLog <= 14 must fall back to the donor hash-chain matchfinder",
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1524,6 +1524,21 @@ impl MatchGeneratorDriver {
         }
     }
 
+    /// Whether a DICTIONARY frame can take the borrowed (no input copy) path.
+    /// Only the Simple (Fast) backend with the dictionary ATTACHED (not the
+    /// copy/merge regime) has a borrowed dict scan — `start_matching_borrowed_dict`
+    /// reads live matches from the borrowed input in place and dict matches
+    /// from the committed dict prefix via the 2-segment counter. Every other
+    /// backend, and copy-mode (large-input) dict frames, stay on the owned
+    /// path. Checked AFTER priming, so `is_attached()` reflects the resolved
+    /// attach-vs-copy decision.
+    pub(crate) fn borrowed_dict_supported(&self) -> bool {
+        matches!(
+            &self.storage,
+            MatcherStorage::Simple(m) if m.dict_is_attached()
+        )
+    }
+
     fn simple_mut(&mut self) -> &mut FastKernelMatcher {
         match &mut self.storage {
             MatcherStorage::Simple(m) => m,
@@ -2906,11 +2921,21 @@ impl Matcher for MatchGeneratorDriver {
         // and the stage is consumed so the next block re-stages.
         if let Some((block_start, block_end)) = self.borrowed_pending.take() {
             match self.active_backend() {
-                super::strategy::BackendTag::Simple => self.simple_mut().start_matching_borrowed(
-                    block_start,
-                    block_end,
-                    &mut handle_sequence,
-                ),
+                super::strategy::BackendTag::Simple => {
+                    let m = self.simple_mut();
+                    if m.dict_is_attached() {
+                        // Dict-attach borrowed scan: live matches read the
+                        // borrowed input in place, dict matches read the
+                        // committed dict prefix via the 2-segment counter.
+                        m.start_matching_borrowed_dict(
+                            block_start,
+                            block_end,
+                            &mut handle_sequence,
+                        );
+                    } else {
+                        m.start_matching_borrowed(block_start, block_end, &mut handle_sequence);
+                    }
+                }
                 super::strategy::BackendTag::Dfast => self
                     .dfast_matcher_mut()
                     .start_matching_borrowed(block_start, block_end, &mut handle_sequence),

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2077,9 +2077,26 @@ impl Matcher for MatchGeneratorDriver {
                 .row
                 .expect("a RowHash level row must carry a RowConfig");
             params.search = super::strategy::SearchMethod::HashChain;
+            // For a dict-bearing frame, downsize the synthesised HC logs to the
+            // dictionary's content tier via `cdict_table_logs` (the same
+            // correction the native HC dict-prime path applies above), so a dict
+            // much smaller than the window doesn't prime a needlessly sparse
+            // table. No-dict frames keep the level's `hash_bits` (clamped to the
+            // window in the reset arm). Row-finder levels are never BinaryTree,
+            // so `uses_bt = false`.
+            let (hash_log, chain_log) = match dict_hint.filter(|&size| size > 0) {
+                Some(dict_size) => cdict_table_logs(
+                    params.window_log,
+                    row.hash_bits,
+                    row.hash_bits,
+                    false,
+                    dict_size,
+                ),
+                None => (row.hash_bits, row.hash_bits),
+            };
             params.hc = Some(HcConfig {
-                hash_log: row.hash_bits,
-                chain_log: row.hash_bits,
+                hash_log,
+                chain_log,
                 search_depth: row.search_depth,
                 target_len: row.target_len,
                 search_mls: 4,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2516,7 +2516,16 @@ impl Matcher for MatchGeneratorDriver {
             if end - start < min_primed_tail {
                 break;
             }
-            let mut space = self.get_next_space();
+            // Stage the dict chunk WITHOUT `get_next_space`'s
+            // `resize(slice_size, 0)` zero-fill: that memsets a full
+            // block-sized buffer (up to ~128 KiB) every frame only to have it
+            // `clear()`-ed and overwritten by the dict bytes on the very next
+            // lines — pure waste (measured ~10% of the small dict encode).
+            // Reuse a pooled buffer's capacity if one is free (the prime/skip
+            // cycle recycles them back), else allocate exactly the chunk.
+            // Mirrors upstream zstd, which references the CDict content rather
+            // than zero-filling a fresh window per frame.
+            let mut space = self.vec_pool.pop().unwrap_or_default();
             space.clear();
             space.extend_from_slice(&dict_content[start..end]);
             self.commit_space(space);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2119,7 +2119,19 @@ impl Matcher for MatchGeneratorDriver {
             // override is range-validated to `ZSTD_HASHLOG_MIN = 6` at the
             // parameter API, so the value is always >= 6 here.
             //
-            let row_cdict_chain_bits = row_cdict_hash_bits - 1;
+            // A public `chain_log` override (#27) is dropped by the RowHash
+            // override arm (Row has no chain table), but once this frame falls
+            // back to HC the chain table is live and must honour it — mirror
+            // the native HC dict path, which feeds the override-applied
+            // `base_hc.chain_log` into `cdict_table_logs`. Use the explicit
+            // override (also API-validated to ZSTD_CHAINLOG_MIN = 6) when set,
+            // else the donor `hashLog - 1` relationship.
+            let explicit_chain_log = self
+                .param_overrides
+                .filter(|ov| !ov.is_empty())
+                .and_then(|ov| ov.chain_log)
+                .map(|chain_log| chain_log as usize);
+            let row_cdict_chain_bits = explicit_chain_log.unwrap_or(row_cdict_hash_bits - 1);
             let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
                 Some(dict_size) => cdict_table_logs(
                     params.window_log,
@@ -2128,7 +2140,10 @@ impl Matcher for MatchGeneratorDriver {
                     false,
                     dict_size,
                 ),
-                None => (row.hash_bits, row.hash_bits - 1),
+                None => (
+                    row.hash_bits,
+                    explicit_chain_log.unwrap_or(row.hash_bits - 1),
+                ),
             };
             // No-dict path: the HashChain reset arm only clamps the logs to the
             // window when `hinted`, but a public `window_log` override can lower

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2081,10 +2081,8 @@ impl Matcher for MatchGeneratorDriver {
             // dictionary's content tier via `cdict_table_logs` (the same
             // correction the native HC dict-prime path applies above), so a dict
             // much smaller than the window doesn't prime a needlessly sparse
-            // table. No-dict frames keep the level's `hash_bits` (clamped to the
-            // window in the reset arm). Row-finder levels are never BinaryTree,
-            // so `uses_bt = false`.
-            let (hash_log, chain_log) = match dict_hint.filter(|&size| size > 0) {
+            // table. Row-finder levels are never BinaryTree, so `uses_bt = false`.
+            let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
                 Some(dict_size) => cdict_table_logs(
                     params.window_log,
                     row.hash_bits,
@@ -2094,6 +2092,17 @@ impl Matcher for MatchGeneratorDriver {
                 ),
                 None => (row.hash_bits, row.hash_bits),
             };
+            // No-dict path: the HashChain reset arm only clamps the logs to the
+            // window when `hinted`, but a public `window_log` override can lower
+            // this level to <= 14 with no source hint — clamp the level's full
+            // Row `hash_bits` to the window here too (donor `ZSTD_adjustCParams`:
+            // hashLog <= windowLog + 1, chainLog <= windowLog) so a 16 KiB window
+            // doesn't allocate Row-sized HC tables.
+            if dict_hint.filter(|&size| size > 0).is_none() {
+                let wlog = params.window_log as usize;
+                hash_log = hash_log.min(wlog + 1);
+                chain_log = chain_log.min(wlog);
+            }
             params.hc = Some(HcConfig {
                 hash_log,
                 chain_log,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2383,7 +2383,15 @@ impl Matcher for MatchGeneratorDriver {
                 // allocation. Was the source of L10-lazy peak-alloc ~2.15x the
                 // donor on a 1 MiB input. Only applied when hinted; an
                 // unknown-size stream keeps the full level tables.
-                if hinted {
+                // Skip for dict-bearing frames: their `hc_cfg.{hash,chain}_log`
+                // were already sized to the dictionary content tier via
+                // `cdict_table_logs` (the dict supplies the long-distance
+                // matches, so upstream `ZSTD_createCDict` sizes the prepared
+                // tables to the dict, not the source window). Re-applying the
+                // source-window cap here would collapse those dict-tier logs
+                // back to the small hinted source — the same double-cap the
+                // synthesis sites avoid by using the un-hinted base width.
+                if hinted && !matches!(dict_hint, Some(size) if size > 0) {
                     let wlog = hc_hash_bits_for_window(table_window_size);
                     let uses_bt = matches!(
                         strategy_tag,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2107,15 +2107,27 @@ impl Matcher for MatchGeneratorDriver {
                 }
                 None => row.hash_bits,
             };
+            // Row-backed levels carry only `hash_bits`; the HC chain table they
+            // fall back to follows the donor cParams relationship `chainLog =
+            // hashLog - 1` for every Row level (L6 c18 h19 .. L12 c22 h23, see
+            // the ROW_L* tables). Synthesise the chain width as `hash_bits - 1`
+            // so the dict path doesn't leave the chain table one bit too wide
+            // (cdict_table_logs only downsizes, so passing the full hash width
+            // for both would keep a 2x-too-large chain table on dict frames).
+            // Raw `- 1` is underflow-safe: `hash_bits` is either a predefined
+            // ROW_L* width (>= 19) or a public `hash_log` override, and the
+            // override is range-validated to `ZSTD_HASHLOG_MIN = 6` at the
+            // parameter API, so the value is always >= 6 here.
+            let row_cdict_chain_bits = row_cdict_hash_bits - 1;
             let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
                 Some(dict_size) => cdict_table_logs(
                     params.window_log,
                     row_cdict_hash_bits,
-                    row_cdict_hash_bits,
+                    row_cdict_chain_bits,
                     false,
                     dict_size,
                 ),
-                None => (row.hash_bits, row.hash_bits),
+                None => (row.hash_bits, row.hash_bits - 1),
             };
             // No-dict path: the HashChain reset arm only clamps the logs to the
             // window when `hinted`, but a public `window_log` override can lower

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2118,6 +2118,7 @@ impl Matcher for MatchGeneratorDriver {
             // ROW_L* width (>= 19) or a public `hash_log` override, and the
             // override is range-validated to `ZSTD_HASHLOG_MIN = 6` at the
             // parameter API, so the value is always >= 6 here.
+            //
             let row_cdict_chain_bits = row_cdict_hash_bits - 1;
             let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
                 Some(dict_size) => cdict_table_logs(
@@ -8391,6 +8392,41 @@ fn driver_huge_source_hint_with_dict_does_not_overflow_hc_reserve() {
     space.truncate(12);
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
+}
+
+#[test]
+fn driver_chain_log_override_survives_row_to_hc_fallback() {
+    // Regression: when a RowHash level is forced onto the HashChain backend
+    // (resolved window <= 14, upstream `ZSTD_resolveRowMatchFinderMode`), the
+    // synthesised HC chain table must honour an explicit `chain_log` override.
+    // The RowHash override arm drops `chain_log` (Row has no chain table), so
+    // the synthesis previously replaced the caller's `chain_log` with the donor
+    // `hashLog - 1`, silently ignoring it on small-window frames.
+    let chain_log_override = 10u32;
+    let ov = super::parameters::ParamOverrides {
+        chain_log: Some(chain_log_override),
+        ..Default::default()
+    };
+    let mut driver = MatchGeneratorDriver::new(32, 2);
+    // Small source hint pins the window to the hinted floor (16 KiB =
+    // windowLog 14), so the Level 6 Row finder falls back to HashChain.
+    driver.set_source_size_hint(1 << 12);
+    driver.set_param_overrides(Some(ov));
+    driver.reset(CompressionLevel::Level(6));
+    let mut space = driver.get_next_space();
+    space[..12].copy_from_slice(b"abcabcabcabc");
+    space.truncate(12);
+    driver.commit_space(space);
+    driver.skip_matching_with_hint(None);
+    // The override (10) is below the window cap (14), so the resolved HC chain
+    // table must reflect it — NOT the donor `hashLog - 1` (18, clamped to the
+    // window 14). Pre-fix this resolved to 14.
+    assert_eq!(
+        driver.hc_matcher().table.chain_log,
+        chain_log_override as usize,
+        "explicit chain_log override must survive the Row->HC fallback, got {}",
+        driver.hc_matcher().table.chain_log
+    );
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2082,11 +2082,36 @@ impl Matcher for MatchGeneratorDriver {
             // correction the native HC dict-prime path applies above), so a dict
             // much smaller than the window doesn't prime a needlessly sparse
             // table. Row-finder levels are never BinaryTree, so `uses_bt = false`.
+            //
+            // Feed `cdict_table_logs` the UN-hinted base Row width, not the
+            // resolved `row.hash_bits`: the latter is already source-capped on a
+            // hinted reset (the `row_cap = table_log + 1` clamp), so passing it
+            // here would double-cap exactly as the native HC dict path warns
+            // above — a small hinted source with a large dictionary would
+            // collapse the prepared table below what the dict needs.
+            // `cdict_table_logs` only ever downsizes, so deriving the ceiling
+            // from the un-hinted base (plus active public overrides) keeps the
+            // dict-tier geometry intact. No source hint => `row.hash_bits` is
+            // already the level's full width, so reuse it directly.
+            let row_cdict_hash_bits = match dict_hint.filter(|&size| size > 0) {
+                Some(_) => {
+                    let mut base_params = Self::level_params(level, None);
+                    if let Some(ov) = self.param_overrides
+                        && !ov.is_empty()
+                    {
+                        apply_param_overrides(&mut base_params, &ov);
+                    }
+                    base_params
+                        .row
+                        .map_or(row.hash_bits, |base_row| base_row.hash_bits)
+                }
+                None => row.hash_bits,
+            };
             let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
                 Some(dict_size) => cdict_table_logs(
                     params.window_log,
-                    row.hash_bits,
-                    row.hash_bits,
+                    row_cdict_hash_bits,
+                    row_cdict_hash_bits,
                     false,
                     dict_size,
                 ),

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -169,6 +169,48 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
     (ip as usize) - (p_start as usize)
 }
 
+/// Forward match length for a candidate whose bytes begin in the dictionary
+/// prefix and may continue into the active input, compared against the current
+/// input position. This is the 2-segment count the borrowed dict-attach path
+/// needs: the dictionary lives in a buffer SEPARATE from the borrowed input,
+/// so the flat single-base [`count_forward`] cannot reach across the
+/// dict/input boundary. The candidate side reads `dict[cand..]` and, once the
+/// dictionary is exhausted, continues at `inp[0..]` (the logical `[dict][input]`
+/// window); the current side reads `inp[cur..]`. Mirrors upstream zstd
+/// `ZSTD_count_2segments` for a dict-prefix match that extends past the
+/// dictionary boundary into the active input.
+///
+/// Scalar by design: a dict-prefix match is the fallback probe (recent input
+/// wins first), and crossing the dictionary boundary is rare for the short
+/// Fast-strategy matches, so the per-byte boundary check is off the hot path.
+pub(crate) fn count_forward_dict_2segment(
+    dict: &[u8],
+    cand: usize,
+    inp: &[u8],
+    cur: usize,
+) -> usize {
+    let limit = inp.len() - cur;
+    let dict_len = dict.len();
+    let mut k = 0usize;
+    while k < limit {
+        let cand_idx = cand + k;
+        // Candidate reads the dictionary first, then the input that logically
+        // follows it. `cand < dict_len` initially and `cand < cur + dict_len`
+        // (candidate precedes the current position in the `[dict][input]`
+        // window), so the `inp` index here stays `< k <= limit`, in bounds.
+        let cand_byte = if cand_idx < dict_len {
+            dict[cand_idx]
+        } else {
+            inp[cand_idx - dict_len]
+        };
+        if cand_byte != inp[cur + k] {
+            break;
+        }
+        k += 1;
+    }
+    k
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,5 +313,32 @@ mod tests {
         let a = [0u8, 1, 2, 3, 4, 5, 6, 7];
         let b = [9u8, 1, 2, 3, 4, 5, 6, 7];
         assert_eq!(count(&a, &b), 0);
+    }
+
+    #[test]
+    fn dict_2segment_within_dict_only() {
+        // Candidate fully inside the dict; current input matches the dict tail.
+        let dict = [10u8, 20, 30, 40];
+        let inp = [30u8, 40, 99];
+        // cand=2: dict[2]=30 vs inp[0]=30 ✓; dict[3]=40 vs inp[1]=40 ✓;
+        // cand_idx=4 == dict.len() → inp[0]=30 vs inp[2]=99 ✗ → len 2.
+        assert_eq!(count_forward_dict_2segment(&dict, 2, &inp, 0), 2);
+    }
+
+    #[test]
+    fn dict_2segment_crosses_boundary_into_input() {
+        // Match starts in the dict and continues past the boundary into the
+        // input (the logical [dict][input] window), then stops at a mismatch.
+        let dict = [1u8, 2, 3];
+        let inp = [1u8, 2, 3, 1, 2, 3, 9]; // cur=3 → [1,2,3,9...]
+        // cand=0: dict[0..3] match inp[3..6]; cand_idx=3 → inp[0]=1 vs inp[6]=9 ✗ → 3.
+        assert_eq!(count_forward_dict_2segment(&dict, 0, &inp, 3), 3);
+    }
+
+    #[test]
+    fn dict_2segment_stops_at_input_end() {
+        let dict = [7u8, 7];
+        let inp = [7u8, 7, 7, 7]; // cur=2 → only 2 bytes left
+        assert_eq!(count_forward_dict_2segment(&dict, 0, &inp, 2), 2);
     }
 }

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -191,6 +191,11 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
 ///
 /// `cand < dict.len()` is required (a dict-prefix candidate); the kernel only
 /// calls this for `cand_abs < dict_end`.
+///
+/// `#[inline]` so the shared 2-segment primitive folds into each backend's
+/// borrowed dual-base dict kernel (Fast/Dfast/Row) rather than paying an
+/// out-of-line call on the dict-match path.
+#[inline]
 pub(crate) fn count_forward_dict_2segment(
     dict: &[u8],
     cand: usize,

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -180,35 +180,63 @@ pub(crate) unsafe fn count_forward(ip: *const u8, match_ptr: *const u8, iend: *c
 /// `ZSTD_count_2segments` for a dict-prefix match that extends past the
 /// dictionary boundary into the active input.
 ///
-/// Scalar by design: a dict-prefix match is the fallback probe (recent input
-/// wins first), and crossing the dictionary boundary is rare for the short
-/// Fast-strategy matches, so the per-byte boundary check is off the hot path.
+/// Word-at-a-time per segment, mirroring upstream zstd `ZSTD_count_2segments`
+/// (it calls `ZSTD_count` on each side of the split): the candidate's dict
+/// remainder is counted against the current input with [`count_forward`], and
+/// if the candidate exhausts the dict still matching, a second [`count_forward`]
+/// continues from the input start. A dict-attach match on dictionary-trained
+/// data hits the dict on nearly every position, so the dict segment is on the
+/// HOT path — a per-byte boundary loop here was the dominant cost of the
+/// borrowed dict kernel; the segmented word-at-a-time count removes it.
+///
+/// `cand < dict.len()` is required (a dict-prefix candidate); the kernel only
+/// calls this for `cand_abs < dict_end`.
 pub(crate) fn count_forward_dict_2segment(
     dict: &[u8],
     cand: usize,
     inp: &[u8],
     cur: usize,
 ) -> usize {
-    let limit = inp.len() - cur;
     let dict_len = dict.len();
-    let mut k = 0usize;
-    while k < limit {
-        let cand_idx = cand + k;
-        // Candidate reads the dictionary first, then the input that logically
-        // follows it. `cand < dict_len` initially and `cand < cur + dict_len`
-        // (candidate precedes the current position in the `[dict][input]`
-        // window), so the `inp` index here stays `< k <= limit`, in bounds.
-        let cand_byte = if cand_idx < dict_len {
-            dict[cand_idx]
-        } else {
-            inp[cand_idx - dict_len]
-        };
-        if cand_byte != inp[cur + k] {
-            break;
-        }
-        k += 1;
+    let inp_len = inp.len();
+    let cur_avail = inp_len - cur;
+    if cur_avail == 0 {
+        return 0;
     }
-    k
+    // Segment 1: candidate reads `dict[cand..dict_len]`, current reads
+    // `inp[cur..]`. Bounded by whichever side runs out first.
+    let seg1 = (dict_len - cand).min(cur_avail);
+    // SAFETY: reads `inp[cur..cur+seg1]` and `dict[cand..cand+seg1]`; `seg1 <=
+    // cur_avail` keeps the current side in bounds and `seg1 <= dict_len - cand`
+    // keeps the candidate side within the dict.
+    let m1 = unsafe {
+        count_forward(
+            inp.as_ptr().add(cur),
+            dict.as_ptr().add(cand),
+            inp.as_ptr().add(cur + seg1),
+        )
+    };
+    // Mismatch inside the dict segment, or the current input is exhausted →
+    // the match ends here.
+    if m1 < seg1 || seg1 == cur_avail {
+        return m1;
+    }
+    // The candidate exhausted the dict (`m1 == dict_len - cand`) and the current
+    // input still has bytes left. Segment 2: the candidate logically continues
+    // at `inp[0..]` (the input directly follows the dict in the `[dict][input]`
+    // window); the current side continues at `inp[cur + m1..]`.
+    let cur2 = cur + m1;
+    // SAFETY: reads `inp[cur2..inp_len]` (current) and `inp[0..inp_len-cur2]`
+    // (candidate); both stay within `inp`. `count_forward`'s `iend` caps the
+    // current side at the input end.
+    let m2 = unsafe {
+        count_forward(
+            inp.as_ptr().add(cur2),
+            inp.as_ptr(),
+            inp.as_ptr().add(inp_len),
+        )
+    };
+    m1 + m2
 }
 
 #[cfg(test)]
@@ -333,6 +361,17 @@ mod tests {
         let inp = [1u8, 2, 3, 1, 2, 3, 9]; // cur=3 → [1,2,3,9...]
         // cand=0: dict[0..3] match inp[3..6]; cand_idx=3 → inp[0]=1 vs inp[6]=9 ✗ → 3.
         assert_eq!(count_forward_dict_2segment(&dict, 0, &inp, 3), 3);
+    }
+
+    #[test]
+    fn dict_2segment_continues_word_at_a_time_past_boundary() {
+        // Candidate exhausts the dict mid-match and keeps matching into the
+        // input segment — exercises the segment-2 count_forward path.
+        let dict = [1u8, 2, 3];
+        let inp = [1u8, 2, 3, 1, 2, 3, 1, 2]; // cur=3 → [1,2,3,1,2]
+        // seg1: dict[0..3]=[1,2,3] vs inp[3..6]=[1,2,3] → m1=3 (dict exhausted).
+        // seg2: inp[0..]=[1,2,...] vs inp[6..]=[1,2] → m2=2. total 5.
+        assert_eq!(count_forward_dict_2segment(&dict, 0, &inp, 3), 5);
     }
 
     #[test]

--- a/zstd/src/encoding/simple/fast_kernel/count.rs
+++ b/zstd/src/encoding/simple/fast_kernel/count.rs
@@ -202,6 +202,20 @@ pub(crate) fn count_forward_dict_2segment(
     inp: &[u8],
     cur: usize,
 ) -> usize {
+    // Release assertions: this is a safe `pub(crate)` fn that does raw pointer
+    // math below. `cand >= dict.len()` would make the dict segment read OOB and
+    // `cur > inp.len()` would underflow `cur_avail`; enforce the kernel's
+    // contract here so a future caller can't silently corrupt memory.
+    assert!(
+        cand < dict.len(),
+        "count_forward_dict_2segment requires cand ({cand}) < dict.len() ({})",
+        dict.len(),
+    );
+    assert!(
+        cur <= inp.len(),
+        "count_forward_dict_2segment requires cur ({cur}) <= inp.len() ({})",
+        inp.len(),
+    );
     let dict_len = dict.len();
     let inp_len = inp.len();
     let cur_avail = inp_len - cur;

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1286,7 +1286,7 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
 /// and, for an input candidate, `cand_off + 4 <= block_end`. `dict` covers the
 /// `[0, dict_end)` prefix and `inp` covers `[0, block_end)`.
 #[inline(always)]
-unsafe fn borrowed_candidate_len(
+unsafe fn borrowed_candidate_len<C: Fn(*const u8, *const u8, usize) -> usize>(
     cand_abs: usize,
     cur_off: usize,
     dict_end: usize,
@@ -1294,20 +1294,24 @@ unsafe fn borrowed_candidate_len(
     inp: &[u8],
     inp_base: *const u8,
     block_end: usize,
+    cpl: &C,
 ) -> usize {
     if cand_abs >= dict_end {
         let cand_off = cand_abs - dict_end;
         // SAFETY: caller guarantees `cur_off + 4 <= block_end` and
-        // `cand_off + 4 <= block_end` (cand_off < cur_off); `count_forward`
-        // is bounded by `inp_base.add(block_end)`.
+        // `cand_off + 4 <= block_end` (cand_off < cur_off). `cpl` (the active
+        // tier's `common_prefix_len_ptr`) is bounded by `max = block_end -
+        // (cur_off + 4)`, so the current side reads `inp[cur_off+4 ..
+        // block_end]` and the candidate side `cand_off < cur_off` more bytes
+        // — both within `inp`.
         if unsafe { read32(inp_base.add(cur_off)) != read32(inp_base.add(cand_off)) } {
             return 0;
         }
         4 + unsafe {
-            count_forward(
+            cpl(
                 inp_base.add(cur_off + 4),
                 inp_base.add(cand_off + 4),
-                inp_base.add(block_end),
+                block_end - (cur_off + 4),
             )
         }
     } else {
@@ -1337,8 +1341,13 @@ unsafe fn borrowed_candidate_len(
 /// [`borrowed_candidate_len`], which routes dict-prefix candidates (the rep
 /// state after dict priming, and the dict-table fallback) through the 2-segment
 /// counter while keeping input candidates on the fast flat path.
+#[inline(always)]
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: bool>(
+fn compress_block_fast_dict_borrowed_impl<
+    const MLS: u32,
+    const USE_CMOV: bool,
+    C: Fn(*const u8, *const u8, usize) -> usize,
+>(
     inp: &[u8],
     dict: &[u8],
     block_start: usize,
@@ -1349,6 +1358,7 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
     rep: [u32; 2],
     step_size: usize,
     mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    cpl: C,
 ) -> FastBlockResult {
     assert!(
         block_start <= block_end && block_end <= inp.len(),
@@ -1434,6 +1444,7 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
                         inp,
                         inp_base,
                         block_end,
+                        &cpl,
                     )
                 };
                 if m_len >= 4 {
@@ -1511,10 +1522,10 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
                 let mut match_ip = ip0;
                 let mut match_pos = main_idx as usize - dict_end;
                 let mut m_len = 4 + unsafe {
-                    count_forward(
+                    cpl(
                         inp_base.add(ip0 + 4),
                         inp_base.add(match_pos + 4),
-                        inp_base.add(block_end),
+                        block_end - (ip0 + 4),
                     )
                 };
                 while match_ip > anchor
@@ -1577,7 +1588,9 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
             {
                 let rep_abs = dict_end + ip0 - offset_2 as usize;
                 let r_len = unsafe {
-                    borrowed_candidate_len(rep_abs, ip0, dict_end, dict, inp, inp_base, block_end)
+                    borrowed_candidate_len(
+                        rep_abs, ip0, dict_end, dict, inp, inp_base, block_end, &cpl,
+                    )
                 };
                 if r_len < 4 {
                     break;
@@ -1602,6 +1615,226 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
     FastBlockResult {
         rep: [offset_1, offset_2],
         tail_literals_len: block_end - anchor,
+    }
+}
+
+// Per-tier `#[target_feature]` wrappers around the borrowed dual-base dict
+// kernel. Each carries the tier's umbrella so the inlined `_impl` (and the
+// `common_prefix_len_ptr` it calls for the hot input-match extension) compiles
+// with that tier's SIMD — the 32-byte AVX2 / 16-byte SSE4.2 / NEON /
+// wasm-simd128 compare instead of the generic word-at-a-time scalar count.
+// Same pattern the Dfast / Row backends use. The dict-prefix 2-segment count
+// (cold fallback) stays scalar inside `_impl`.
+macro_rules! fast_dict_borrowed_wrapper {
+    ($(#[$attr:meta])* $name:ident, $cpl:path) => {
+        $(#[$attr])*
+        #[allow(clippy::too_many_arguments)]
+        unsafe fn $name<const MLS: u32, const USE_CMOV: bool>(
+            inp: &[u8],
+            dict: &[u8],
+            block_start: usize,
+            block_end: usize,
+            main_table: &mut FastHashTable,
+            dict_table: &FastHashTable,
+            bounds: PrefixBounds,
+            rep: [u32; 2],
+            step_size: usize,
+            handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+        ) -> FastBlockResult {
+            compress_block_fast_dict_borrowed_impl::<MLS, USE_CMOV, _>(
+                inp,
+                dict,
+                block_start,
+                block_end,
+                main_table,
+                dict_table,
+                bounds,
+                rep,
+                step_size,
+                handle_sequence,
+                // SAFETY: only invoked from within this `#[target_feature]`
+                // umbrella, so the tier's CPU features are guaranteed present.
+                |l, r, m| unsafe { $cpl(l, r, m) },
+            )
+        }
+    };
+}
+
+fast_dict_borrowed_wrapper!(
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "avx2,bmi2")]
+    cbfd_borrowed_avx2_bmi2,
+    crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr
+);
+
+fast_dict_borrowed_wrapper!(
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "sse4.2")]
+    cbfd_borrowed_sse42,
+    crate::encoding::fastpath::sse42::common_prefix_len_ptr
+);
+
+fast_dict_borrowed_wrapper!(
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    #[target_feature(enable = "neon")]
+    cbfd_borrowed_neon,
+    crate::encoding::fastpath::neon::common_prefix_len_ptr
+);
+
+fast_dict_borrowed_wrapper!(
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    #[target_feature(enable = "simd128")]
+    cbfd_borrowed_simd128,
+    crate::encoding::fastpath::simd128::common_prefix_len_ptr
+);
+
+/// Dispatch the borrowed dual-base dict kernel to the resolved per-tier SIMD
+/// wrapper. `kernel` is the matcher's once-resolved [`FastpathKernel`]; the
+/// scalar arm carries no `#[target_feature]` (generic word-at-a-time count).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: bool>(
+    inp: &[u8],
+    dict: &[u8],
+    block_start: usize,
+    block_end: usize,
+    main_table: &mut FastHashTable,
+    dict_table: &FastHashTable,
+    bounds: PrefixBounds,
+    rep: [u32; 2],
+    step_size: usize,
+    handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    kernel: crate::encoding::fastpath::FastpathKernel,
+) -> FastBlockResult {
+    use crate::encoding::fastpath::FastpathKernel;
+    // The scalar fallback: generic word-at-a-time `count_forward` for the input
+    // match extension, no SIMD umbrella.
+    let scalar = |inp: &[u8],
+                  dict: &[u8],
+                  main_table: &mut FastHashTable,
+                  dict_table: &FastHashTable,
+                  handle_sequence: &mut dyn for<'a> FnMut(Sequence<'a>)|
+     -> FastBlockResult {
+        compress_block_fast_dict_borrowed_impl::<MLS, USE_CMOV, _>(
+            inp,
+            dict,
+            block_start,
+            block_end,
+            main_table,
+            dict_table,
+            bounds,
+            rep,
+            step_size,
+            handle_sequence,
+            // SAFETY: `count_forward` is a safe word-at-a-time count; the
+            // pointer/length contract is identical to the SIMD tiers.
+            |l, r, m| unsafe { count_forward(l, r, l.add(m)) },
+        )
+    };
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        match kernel {
+            FastpathKernel::Avx2Bmi2 => unsafe {
+                cbfd_borrowed_avx2_bmi2::<MLS, USE_CMOV>(
+                    inp,
+                    dict,
+                    block_start,
+                    block_end,
+                    main_table,
+                    dict_table,
+                    bounds,
+                    rep,
+                    step_size,
+                    handle_sequence,
+                )
+            },
+            FastpathKernel::Sse42 => unsafe {
+                cbfd_borrowed_sse42::<MLS, USE_CMOV>(
+                    inp,
+                    dict,
+                    block_start,
+                    block_end,
+                    main_table,
+                    dict_table,
+                    bounds,
+                    rep,
+                    step_size,
+                    handle_sequence,
+                )
+            },
+            FastpathKernel::Scalar => {
+                let mut hs = handle_sequence;
+                scalar(inp, dict, main_table, dict_table, &mut hs)
+            }
+        }
+    }
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    {
+        match kernel {
+            FastpathKernel::Neon => unsafe {
+                cbfd_borrowed_neon::<MLS, USE_CMOV>(
+                    inp,
+                    dict,
+                    block_start,
+                    block_end,
+                    main_table,
+                    dict_table,
+                    bounds,
+                    rep,
+                    step_size,
+                    handle_sequence,
+                )
+            },
+            FastpathKernel::Scalar => {
+                let mut hs = handle_sequence;
+                scalar(inp, dict, main_table, dict_table, &mut hs)
+            }
+        }
+    }
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_feature = "simd128",
+        feature = "kernel_simd128"
+    ))]
+    {
+        match kernel {
+            FastpathKernel::Simd128 => unsafe {
+                cbfd_borrowed_simd128::<MLS, USE_CMOV>(
+                    inp,
+                    dict,
+                    block_start,
+                    block_end,
+                    main_table,
+                    dict_table,
+                    bounds,
+                    rep,
+                    step_size,
+                    handle_sequence,
+                )
+            },
+            FastpathKernel::Scalar => {
+                let mut hs = handle_sequence;
+                scalar(inp, dict, main_table, dict_table, &mut hs)
+            }
+        }
+    }
+    #[cfg(not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(
+            target_arch = "wasm32",
+            target_feature = "simd128",
+            feature = "kernel_simd128"
+        )
+    )))]
+    {
+        let _ = kernel;
+        let mut hs = handle_sequence;
+        scalar(inp, dict, main_table, dict_table, &mut hs)
     }
 }
 

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -8,7 +8,7 @@
 //! (`ZSTD_match4Found_branch` + `ZSTD_match4Found_cmov`) selected
 //! per-call via the `USE_CMOV` const generic.
 
-use super::count::count_forward;
+use super::count::{count_forward, count_forward_dict_2segment};
 use super::hash_table::{FastHashTable, hash_ptr_raw};
 use crate::encoding::Sequence;
 
@@ -1267,6 +1267,341 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     FastBlockResult {
         rep: [offset_1, offset_2],
         tail_literals_len: data.len() - anchor,
+    }
+}
+
+/// Forward match length for a candidate at virtual position `cand_abs` in the
+/// logical `[dict][input]` window, compared against the current input at offset
+/// `cur_off`, for the borrowed dual-base dict kernel. Dispatches ONCE on which
+/// buffer the candidate lives in (never per byte): an input candidate
+/// (`cand_abs >= dict_end`) takes the `read32` 4-byte gate + word-at-a-time
+/// [`count_forward`] hot path over the borrowed input; a dict-prefix candidate
+/// (`cand_abs < dict_end`) falls to the scalar [`count_forward_dict_2segment`]
+/// that crosses the dict→input boundary (the cold fallback, mirroring upstream
+/// zstd's `repBase`/`dictBase` candidate split). Returns 0 when the 4-byte gate
+/// fails so the caller's `>= 4` check rejects it in one place.
+///
+/// # Safety
+/// `inp_base` must have `block_end` readable bytes; `cur_off + 4 <= block_end`
+/// and, for an input candidate, `cand_off + 4 <= block_end`. `dict` covers the
+/// `[0, dict_end)` prefix and `inp` covers `[0, block_end)`.
+#[inline(always)]
+unsafe fn borrowed_candidate_len(
+    cand_abs: usize,
+    cur_off: usize,
+    dict_end: usize,
+    dict: &[u8],
+    inp: &[u8],
+    inp_base: *const u8,
+    block_end: usize,
+) -> usize {
+    if cand_abs >= dict_end {
+        let cand_off = cand_abs - dict_end;
+        // SAFETY: caller guarantees `cur_off + 4 <= block_end` and
+        // `cand_off + 4 <= block_end` (cand_off < cur_off); `count_forward`
+        // is bounded by `inp_base.add(block_end)`.
+        if unsafe { read32(inp_base.add(cur_off)) != read32(inp_base.add(cand_off)) } {
+            return 0;
+        }
+        4 + unsafe {
+            count_forward(
+                inp_base.add(cur_off + 4),
+                inp_base.add(cand_off + 4),
+                inp_base.add(block_end),
+            )
+        }
+    } else {
+        let l = count_forward_dict_2segment(dict, cand_abs, inp, cur_off);
+        if l >= 4 { l } else { 0 }
+    }
+}
+
+/// Dual-base port of [`compress_block_fast_dict`] for the *borrowed* dict-attach
+/// path: the dictionary lives in a buffer (`dict`, the `[0, dict_end)` prefix)
+/// SEPARATE from the borrowed frame input (`inp`, read in place), so the flat
+/// single-base kernel above cannot be used. Positions live in the logical
+/// `[dict][input]` window: a dict byte `d` has virtual position `d`; an input
+/// byte at offset `i` has virtual position `dict_end + i`. The main hash table
+/// stores virtual input positions (`dict_end + i`); the immutable `dict_table`
+/// stores dict positions (`< dict_end`). An emitted offset is `cur_abs -
+/// cand_abs`.
+///
+/// Monomorphised on `MLS` + `USE_CMOV` exactly like the owned kernel, so it
+/// keeps that path's full machinery — `read32` 4-byte gate, word-at-a-time
+/// [`count_forward`], the step-ramped `ip0`/`ip1` two-position lookahead, the
+/// repcode-at-`ip0+1` probe, post-match dense fills, backward catch-up
+/// extension and the immediate repcode-2 loop — none of which the prior scalar
+/// greedy scan had (it was +68% slower than this owned-kernel shape). The only
+/// dual-base divergences: current-position reads are always input
+/// (`inp_base.add(off)`); a candidate's match length goes through
+/// [`borrowed_candidate_len`], which routes dict-prefix candidates (the rep
+/// state after dict priming, and the dict-table fallback) through the 2-segment
+/// counter while keeping input candidates on the fast flat path.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: bool>(
+    inp: &[u8],
+    dict: &[u8],
+    block_start: usize,
+    block_end: usize,
+    main_table: &mut FastHashTable,
+    dict_table: &FastHashTable,
+    bounds: PrefixBounds,
+    rep: [u32; 2],
+    step_size: usize,
+    mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+) -> FastBlockResult {
+    assert!(
+        block_start <= block_end && block_end <= inp.len(),
+        "borrowed dict block bounds out of range: start={block_start} end={block_end} inp_len={}",
+        inp.len(),
+    );
+    let dict_end = dict.len();
+    assert!(
+        dict_end >= 1,
+        "borrowed dict kernel requires a non-empty dictionary (sentinel-0 safety)",
+    );
+    assert!(
+        dict_end + block_end <= u32::MAX as usize,
+        "FastKernel does not support dict_end + block_end ({}) > u32::MAX",
+        dict_end + block_end,
+    );
+    debug_assert_eq!(MLS, main_table.mls());
+    debug_assert_eq!(MLS, dict_table.mls());
+    debug_assert_eq!(main_table.hash_log(), dict_table.hash_log());
+
+    // Window bounds in VIRTUAL `[dict][input]` coords, so the gates match the
+    // owned flat kernel: `window_low` is the absolute floor, `prefix_start_index`
+    // the sentinel-aware floor for the hash-slot filter.
+    let prefix_start_index = bounds.prefix_start_index;
+    let window_low = bounds.window_low as usize;
+
+    if block_end < block_start + HASH_READ_SIZE {
+        return FastBlockResult {
+            rep,
+            tail_literals_len: block_end - block_start,
+        };
+    }
+
+    let inp_base = inp.as_ptr();
+    // Last input offset with HASH_READ_SIZE readable bytes ahead.
+    let ilimit = block_end - HASH_READ_SIZE;
+
+    let mut anchor: usize = block_start;
+    // Input offset 0 maps to virtual `dict_end >= 1`, so it never aliases the
+    // empty-slot sentinel 0 — no `ip0 == 0` fixup needed (unlike the owned flat
+    // kernel where position 0 is the dict's first byte).
+    let mut ip0: usize = block_start;
+    let mut ip1 = ip0 + step_size;
+
+    let mut offset_1: u32 = rep[0];
+    let mut offset_2: u32 = rep[1];
+
+    // Inner-loop result: literals end (input offset), raw match offset, match
+    // length, and the donor `curr` probe offset for the post-match `curr + 2`
+    // fill. `None` → drain to cleanup.
+    struct DictMatch {
+        lit_end: usize,
+        offset: usize,
+        m_len: usize,
+        curr: usize,
+    }
+
+    'outer: while ip1 <= ilimit {
+        // SAFETY: ip0 < ip1 <= ilimit = block_end - 8 ⇒ ≥ 8 readable bytes at ip0.
+        let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
+        let mut main_idx = unsafe { main_table.get(hash0) };
+        let mut dict_idx = unsafe { dict_table.get(hash0) };
+        let mut curr = ip0;
+
+        let found: Option<DictMatch> = loop {
+            // SAFETY: ip1 <= ilimit ⇒ ≥ 8 readable bytes at ip1.
+            let hash1 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip1)) };
+            let cur_abs = dict_end + curr;
+            // Insert current virtual position into the MAIN table.
+            unsafe { main_table.put(hash0, cur_abs as u32) };
+
+            // Repcode probe for a match starting at curr + 1. The rep candidate
+            // may sit in the dict (offsets primed from the dictionary's
+            // repToConfirm) or in the input; `borrowed_candidate_len` routes it.
+            if offset_1 > 0 && cur_abs + 1 >= offset_1 as usize + window_low {
+                let rep_abs = cur_abs + 1 - offset_1 as usize;
+                let m_len = unsafe {
+                    borrowed_candidate_len(
+                        rep_abs,
+                        curr + 1,
+                        dict_end,
+                        dict,
+                        inp,
+                        inp_base,
+                        block_end,
+                    )
+                };
+                if m_len >= 4 {
+                    break Some(DictMatch {
+                        lit_end: curr + 1,
+                        offset: offset_1 as usize,
+                        m_len,
+                        curr,
+                    });
+                }
+            }
+
+            // Dictionary match — taken ONLY when the main candidate is below the
+            // window floor (exactly the indices the main probe rejects), keeping
+            // "recent input wins, dict is the fallback".
+            if main_idx < prefix_start_index {
+                let dpos = dict_idx as usize;
+                if dict_idx >= 1 && dpos < dict_end && dpos >= window_low {
+                    let m0 = count_forward_dict_2segment(dict, dpos, inp, curr);
+                    if m0 >= 4 {
+                        let mut match_ip = curr;
+                        let mut match_pos = dpos;
+                        let mut m_len = m0;
+                        // Backward catch-up into the dict (current side in input,
+                        // candidate side in the dict prefix).
+                        while match_ip > anchor
+                            && match_pos > window_low
+                            && unsafe { *inp_base.add(match_ip - 1) == dict[match_pos - 1] }
+                        {
+                            match_ip -= 1;
+                            match_pos -= 1;
+                            m_len += 1;
+                        }
+                        if m_len >= MIN_DICT_MATCH_LEN {
+                            let offset = (dict_end + match_ip) - match_pos;
+                            offset_2 = offset_1;
+                            offset_1 = offset as u32;
+                            break Some(DictMatch {
+                                lit_end: match_ip,
+                                offset,
+                                m_len,
+                                curr,
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Main match (recent input) — `main_idx` is a virtual input position
+            // (`>= dict_end`); the candidate read is at input offset
+            // `main_idx - dict_end`.
+            let main_valid = if USE_CMOV {
+                let in_range = main_idx >= prefix_start_index;
+                // SAFETY: when `in_range`, `main_idx >= prefix_start_index >= 1`
+                // and the main table only ever stores `>= dict_end`, so
+                // `main_idx - dict_end` is a valid input offset with ≥ 4 readable
+                // bytes; otherwise `CMOV_DUMMY` (4 bytes) is read instead.
+                let mval_addr = if in_range {
+                    unsafe { inp_base.add(main_idx as usize - dict_end) }
+                } else {
+                    CMOV_DUMMY.as_ptr()
+                };
+                let bytes_match = unsafe { read32(inp_base.add(ip0)) == read32(mval_addr) };
+                #[allow(clippy::needless_bitwise_bool)]
+                let r = bytes_match & in_range;
+                r
+            } else {
+                main_idx >= prefix_start_index
+                    && unsafe {
+                        read32(inp_base.add(ip0))
+                            == read32(inp_base.add(main_idx as usize - dict_end))
+                    }
+            };
+            if main_valid {
+                let mut match_ip = ip0;
+                let mut match_pos = main_idx as usize - dict_end;
+                let mut m_len = 4 + unsafe {
+                    count_forward(
+                        inp_base.add(ip0 + 4),
+                        inp_base.add(match_pos + 4),
+                        inp_base.add(block_end),
+                    )
+                };
+                while match_ip > anchor
+                    && match_pos > 0
+                    && (dict_end + match_pos) > window_low
+                    && unsafe { *inp_base.add(match_ip - 1) == *inp_base.add(match_pos - 1) }
+                {
+                    match_ip -= 1;
+                    match_pos -= 1;
+                    m_len += 1;
+                }
+                let offset = match_ip - match_pos;
+                offset_2 = offset_1;
+                offset_1 = offset as u32;
+                break Some(DictMatch {
+                    lit_end: match_ip,
+                    offset,
+                    m_len,
+                    curr,
+                });
+            }
+
+            // Prepare next iteration.
+            dict_idx = unsafe { dict_table.get(hash1) };
+            main_idx = unsafe { main_table.get(hash1) };
+            ip0 = ip1;
+            ip1 += step_size;
+            if ip1 > ilimit {
+                break None;
+            }
+            curr = ip0;
+            hash0 = hash1;
+        };
+
+        let Some(m) = found else {
+            break 'outer;
+        };
+
+        handle_sequence(Sequence::Triple {
+            literals: &inp[anchor..m.lit_end],
+            offset: m.offset,
+            match_len: m.m_len,
+        });
+        ip0 = m.lit_end + m.m_len;
+        anchor = ip0;
+
+        if ip0 <= ilimit {
+            // Post-match dense fills (virtual positions).
+            if m.curr + 2 + HASH_READ_SIZE <= block_end {
+                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(m.curr + 2)) };
+                unsafe { main_table.put(h, (dict_end + m.curr + 2) as u32) };
+            }
+            if ip0 >= 2 {
+                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0 - 2)) };
+                unsafe { main_table.put(h, (dict_end + ip0 - 2) as u32) };
+            }
+            // Immediate repcode-2 loop. The rep candidate may straddle into the
+            // dict; `borrowed_candidate_len` routes it.
+            while ip0 <= ilimit && offset_2 > 0 && dict_end + ip0 >= offset_2 as usize + window_low
+            {
+                let rep_abs = dict_end + ip0 - offset_2 as usize;
+                let r_len = unsafe {
+                    borrowed_candidate_len(rep_abs, ip0, dict_end, dict, inp, inp_base, block_end)
+                };
+                if r_len < 4 {
+                    break;
+                }
+                let r_off = offset_2 as usize;
+                core::mem::swap(&mut offset_1, &mut offset_2);
+                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
+                unsafe { main_table.put(h, (dict_end + ip0) as u32) };
+                handle_sequence(Sequence::Triple {
+                    literals: &inp[anchor..ip0],
+                    offset: r_off,
+                    match_len: r_len,
+                });
+                ip0 += r_len;
+                anchor = ip0;
+            }
+        }
+
+        ip1 = ip0 + step_size;
+    }
+
+    FastBlockResult {
+        rep: [offset_1, offset_2],
+        tail_literals_len: block_end - anchor,
     }
 }
 

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1371,14 +1371,25 @@ fn compress_block_fast_dict_borrowed_impl<
         dict_end >= 1,
         "borrowed dict kernel requires a non-empty dictionary (sentinel-0 safety)",
     );
+    // Checked virtual-length bound: the [dict][input] coordinate floor relies on
+    // `dict_end + block_end` fitting `u32`; validate with `checked_add` rather
+    // than adding then checking after (which could itself overflow `usize`).
     assert!(
-        dict_end + block_end <= u32::MAX as usize,
-        "FastKernel does not support dict_end + block_end ({}) > u32::MAX",
-        dict_end + block_end,
+        dict_end
+            .checked_add(block_end)
+            .is_some_and(|v| v <= u32::MAX as usize),
+        "FastKernel does not support dict_end + block_end > u32::MAX (dict_end={dict_end}, block_end={block_end})",
     );
-    debug_assert_eq!(MLS, main_table.mls());
-    debug_assert_eq!(MLS, dict_table.mls());
-    debug_assert_eq!(main_table.hash_log(), dict_table.hash_log());
+    // Release checks (not debug_assert): these guard UNCHECKED table access in
+    // the hot loop — a mismatched hash_log would hash with `main_table` then
+    // index past `dict_table`, and `step_size < 2` would stall the scan.
+    assert!(
+        step_size >= 2,
+        "borrowed dict kernel requires step_size >= 2 (got {step_size})",
+    );
+    assert_eq!(MLS, main_table.mls());
+    assert_eq!(MLS, dict_table.mls());
+    assert_eq!(main_table.hash_log(), dict_table.hash_log());
 
     // Window bounds in VIRTUAL `[dict][input]` coords, so the gates match the
     // owned flat kernel: `window_low` is the absolute floor, `prefix_start_index`
@@ -1497,14 +1508,23 @@ fn compress_block_fast_dict_borrowed_impl<
             // Main match (recent input) — `main_idx` is a virtual input position
             // (`>= dict_end`); the candidate read is at input offset
             // `main_idx - dict_end`.
+            // A main-table entry is only a usable candidate when it is a VIRTUAL
+            // input position: `>= dict_end` (so `main_idx - dict_end` does not
+            // underflow) AND strictly before the current position (`< dict_end +
+            // ip0`). `main_idx >= prefix_start_index` alone is not sufficient —
+            // the borrowed skip-priming path can write raw input offsets (`<
+            // dict_end`) into the main table, and a stale entry in
+            // `[prefix_start_index, dict_end)` would otherwise underflow the
+            // subtraction and feed a bogus pointer to `read32`.
+            let main_abs = main_idx as usize;
+            let main_is_input = main_abs >= dict_end && main_abs < dict_end + ip0;
             let main_valid = if USE_CMOV {
-                let in_range = main_idx >= prefix_start_index;
-                // SAFETY: when `in_range`, `main_idx >= prefix_start_index >= 1`
-                // and the main table only ever stores `>= dict_end`, so
+                let in_range = main_idx >= prefix_start_index && main_is_input;
+                // SAFETY: when `in_range`, `main_abs >= dict_end`, so
                 // `main_idx - dict_end` is a valid input offset with ≥ 4 readable
                 // bytes; otherwise `CMOV_DUMMY` (4 bytes) is read instead.
                 let mval_addr = if in_range {
-                    unsafe { inp_base.add(main_idx as usize - dict_end) }
+                    unsafe { inp_base.add(main_abs - dict_end) }
                 } else {
                     CMOV_DUMMY.as_ptr()
                 };
@@ -1514,9 +1534,9 @@ fn compress_block_fast_dict_borrowed_impl<
                 r
             } else {
                 main_idx >= prefix_start_index
+                    && main_is_input
                     && unsafe {
-                        read32(inp_base.add(ip0))
-                            == read32(inp_base.add(main_idx as usize - dict_end))
+                        read32(inp_base.add(ip0)) == read32(inp_base.add(main_abs - dict_end))
                     }
             };
             if main_valid {

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -2452,4 +2452,106 @@ mod tests {
              ip bytes coincide with CMOV_DUMMY",
         );
     }
+
+    /// Drive the borrowed dual-base dict kernel directly (Scalar tier — always
+    /// available, deterministic) over a crafted `(dict, input)` pair that
+    /// exercises the dict-match (2-segment + backward extension), input-match,
+    /// repcode and tail-literal branches. Reconstruct against the logical
+    /// `[dict][input]` window to prove every emitted offset is valid, and check
+    /// the byte-accounting invariant.
+    #[test]
+    fn borrowed_dict_kernel_reconstructs_via_dual_base() {
+        use crate::encoding::fastpath::FastpathKernel;
+
+        let hash_log = 12u32;
+        const MLS: u32 = 4;
+        // Distinct dict bytes so each 4-byte key hashes uniquely; the input
+        // both matches the dict prefix (dict match) and repeats itself
+        // (input match + repcode), then ends in a literal tail.
+        let dict: Vec<u8> = (0u8..40).collect();
+        let mut inp: Vec<u8> = Vec::new();
+        inp.extend_from_slice(&dict[0..20]); // dict match against dict[0..]
+        inp.extend_from_slice(&dict[0..20]); // input match against the first copy
+        inp.extend_from_slice(&dict[4..24]); // dict match at a non-zero dict pos
+        inp.extend_from_slice(b"tail-literals-xyz"); // terminal literals
+
+        let dict_end = dict.len();
+
+        // main table (filled during the scan) + immutable dict table primed
+        // over every hashable dict position.
+        let mut main_table = FastHashTable::new(hash_log, MLS);
+        let mut dict_table = FastHashTable::new(hash_log, MLS);
+        for pos in 0..=dict.len() - HASH_READ_SIZE {
+            // SAFETY: pos + 8 <= dict.len(); MLS matches the table.
+            let h = unsafe { dict_table.hash_ptr::<MLS>(dict.as_ptr().add(pos)) };
+            unsafe { dict_table.put(h, pos as u32) };
+        }
+
+        let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();
+        let mut handle = |seq: Sequence<'_>| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => tuples.push((literals.to_vec(), offset, match_len)),
+            Sequence::Literals { literals } => tuples.push((literals.to_vec(), 0, 0)),
+        };
+
+        let result = compress_block_fast_dict_borrowed::<MLS, false>(
+            &inp,
+            &dict,
+            0,
+            inp.len(),
+            &mut main_table,
+            &dict_table,
+            PrefixBounds {
+                prefix_start_index: 1,
+                window_low: 0,
+            },
+            [0, 0],
+            2,
+            &mut handle,
+            FastpathKernel::Scalar,
+        );
+
+        // Reconstruct against the logical [dict][input] window: start from the
+        // dictionary, then replay each sequence. A Triple's offset references
+        // `current_len - offset` in this combined buffer, so a valid dual-base
+        // offset reproduces the original input exactly.
+        let mut window = dict.clone();
+        let mut saw_dict_region_match = false;
+        for (literals, offset, match_len) in &tuples {
+            window.extend_from_slice(literals);
+            if *match_len > 0 {
+                let start = window.len() - offset;
+                // A match whose source lands in the dictionary prefix exercised
+                // the dual-base / 2-segment path (not a plain input back-ref).
+                if start < dict_end {
+                    saw_dict_region_match = true;
+                }
+                for i in 0..*match_len {
+                    let b = window[start + i];
+                    window.push(b);
+                }
+            }
+        }
+        // Append the terminal tail the kernel reports separately.
+        let tail_start = inp.len() - result.tail_literals_len;
+        window.extend_from_slice(&inp[tail_start..]);
+
+        assert_eq!(
+            &window[dict_end..],
+            &inp[..],
+            "borrowed dict kernel must reconstruct the input from the [dict][input] window",
+        );
+
+        assert!(
+            tuples.iter().any(|(_, _, m)| *m >= 4),
+            "expected at least one match Triple",
+        );
+        assert!(
+            saw_dict_region_match,
+            "expected at least one match reading from the dictionary region (dual-base path)",
+        );
+    }
 }

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1286,6 +1286,7 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
 /// and, for an input candidate, `cand_off + 4 <= block_end`. `dict` covers the
 /// `[0, dict_end)` prefix and `inp` covers `[0, block_end)`.
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 unsafe fn borrowed_candidate_len<C: Fn(*const u8, *const u8, usize) -> usize>(
     cand_abs: usize,
     cur_off: usize,

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1508,23 +1508,25 @@ fn compress_block_fast_dict_borrowed_impl<
             // Main match (recent input) — `main_idx` is a virtual input position
             // (`>= dict_end`); the candidate read is at input offset
             // `main_idx - dict_end`.
-            // A main-table entry is only a usable candidate when it is a VIRTUAL
-            // input position: `>= dict_end` (so `main_idx - dict_end` does not
-            // underflow) AND strictly before the current position (`< dict_end +
-            // ip0`). `main_idx >= prefix_start_index` alone is not sufficient —
-            // the borrowed skip-priming path can write raw input offsets (`<
-            // dict_end`) into the main table, and a stale entry in
-            // `[prefix_start_index, dict_end)` would otherwise underflow the
-            // subtraction and feed a bogus pointer to `read32`.
-            let main_abs = main_idx as usize;
-            let main_is_input = main_abs >= dict_end && main_abs < dict_end + ip0;
+            // INVARIANT: every main-table entry is either the empty sentinel 0
+            // or a VIRTUAL input position `>= dict_end` — the scan stores
+            // `dict_end + off` and the borrowed priming rebases primed offsets by
+            // `dict_end` too (no raw offsets in `[1, dict_end)`). So
+            // `main_idx >= prefix_start_index` (which is `>= 1`) already implies
+            // `main_idx >= dict_end`, and `main_idx - dict_end` cannot underflow
+            // — no per-candidate range check is needed on the hot path.
+            debug_assert!(
+                main_idx == 0 || main_idx as usize >= dict_end,
+                "main-table entry must be the sentinel or a virtual input position (>= dict_end)",
+            );
             let main_valid = if USE_CMOV {
-                let in_range = main_idx >= prefix_start_index && main_is_input;
-                // SAFETY: when `in_range`, `main_abs >= dict_end`, so
-                // `main_idx - dict_end` is a valid input offset with ≥ 4 readable
-                // bytes; otherwise `CMOV_DUMMY` (4 bytes) is read instead.
+                let in_range = main_idx >= prefix_start_index;
+                // SAFETY: when `in_range`, `main_idx >= prefix_start_index >= 1`
+                // and (per the invariant) `>= dict_end`, so `main_idx - dict_end`
+                // is a valid input offset with ≥ 4 readable bytes; otherwise
+                // `CMOV_DUMMY` (4 bytes) is read instead.
                 let mval_addr = if in_range {
-                    unsafe { inp_base.add(main_abs - dict_end) }
+                    unsafe { inp_base.add(main_idx as usize - dict_end) }
                 } else {
                     CMOV_DUMMY.as_ptr()
                 };
@@ -1534,9 +1536,9 @@ fn compress_block_fast_dict_borrowed_impl<
                 r
             } else {
                 main_idx >= prefix_start_index
-                    && main_is_input
                     && unsafe {
-                        read32(inp_base.add(ip0)) == read32(inp_base.add(main_abs - dict_end))
+                        read32(inp_base.add(ip0))
+                            == read32(inp_base.add(main_idx as usize - dict_end))
                     }
             };
             if main_valid {

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1710,6 +1710,10 @@ pub(crate) fn compress_block_fast_dict_borrowed<const MLS: u32, const USE_CMOV: 
     handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     kernel: crate::encoding::fastpath::FastpathKernel,
 ) -> FastBlockResult {
+    // Used by the per-tier match arms below; on a target with no SIMD tier
+    // (e.g. wasm32 without simd128) only the scalar fallback compiles and the
+    // import is unused.
+    #[allow(unused_imports)]
     use crate::encoding::fastpath::FastpathKernel;
     // The scalar fallback: generic word-at-a-time `count_forward` for the input
     // match extension, no SIMD umbrella.

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -569,15 +569,18 @@ impl FastKernelMatcher {
         );
         self.borrowed = Some((buffer.as_ptr(), buffer.len()));
         self.last_borrowed_block = None;
-        // Any hash-table entries left from a prior window are absolute
-        // positions into THAT buffer; once we switch the window backing
-        // to `buffer`, a `start_matching_borrowed` scan would read them
-        // as indices into the new buffer — out of bounds / memory-unsafe.
-        // Today the caller (`compress_oneshot_borrowed`) always resets
-        // first, but make the borrowed-window registration self-contained:
-        // clear the table and re-floor `prefix_start_index` so the window
-        // starts from a clean match state regardless of prior history.
-        self.hash_table.clear();
+        // Stale hash-table entries from a prior window are invalidated by the
+        // `reset()` the caller (`run_borrowed_block_loop` via
+        // `compress_oneshot_borrowed`) ALWAYS runs immediately before this
+        // call — `reset` either memsets the table (no-dict / copy frames) or
+        // epoch-advances the bias past every prior position (dict-attach
+        // frames, donor `ZSTD_continueCCtx`). Re-clearing here would memset the
+        // whole table a SECOND time per frame and, on the dict-attach path,
+        // throw away the epoch advance the reset just performed (measured: the
+        // redundant clear was ~12% of the borrowed-dict encode). The
+        // mode-switch precondition (no stale owned `pending`) is asserted
+        // above. Re-flooring `prefix_start_index` is a single store (not a
+        // memset), so keep it for self-containment.
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
     }
 
@@ -586,18 +589,20 @@ impl FastKernelMatcher {
     pub(crate) fn clear_borrowed_window(&mut self) {
         self.borrowed = None;
         self.last_borrowed_block = None;
-        // The hash table still holds absolute positions into the
-        // now-detached borrowed buffer. An owned-path scan would read
-        // them as offsets into `self.history` — out of bounds once the
-        // borrowed buffer is gone (memory-unsafe). Today every frame
-        // begins with `reset` (which clears the table), so an owned
-        // scan never observes the stale entries; but the docstring
-        // promises a return to the owned path, so restore that
-        // invariant here too rather than relying on the caller always
-        // resetting first. Mirrors `reset` / `drain_real_prefix`:
-        // clear the table and re-floor `prefix_start_index` at the
-        // sentinel-0 baseline.
-        self.hash_table.clear();
+        // Detach the window pointer only — do NOT memset the table. The hash
+        // table still holds absolute positions into the now-detached borrowed
+        // buffer, but every frame begins with `reset()` (which memsets the
+        // table for no-dict / copy frames, or epoch-advances the bias for
+        // dict-attach frames) BEFORE any subsequent scan reads it, so an
+        // owned- or borrowed-path scan never observes the stale entries. The
+        // prior unconditional `hash_table.clear()` here was a second
+        // full-table memset per borrowed frame (this runs on the
+        // `ClearBorrowedOnDrop` guard at every frame exit) on top of the next
+        // frame's reset — measured at ~12% of the borrowed-dict encode — with
+        // no correctness role the reset does not already cover. `start_matching`
+        // (the owned path) additionally asserts `borrowed.is_none()`, which the
+        // `self.borrowed = None` above satisfies. Re-floor the sentinel-0
+        // baseline (a single store, not a memset).
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
     }
 
@@ -1053,9 +1058,15 @@ impl FastKernelMatcher {
             "borrowed block bounds out of range: start={block_start} end={block_end} total={total_len}",
         );
         self.last_borrowed_block = Some((block_start, block_end));
-        self.table_pos_high_water = self.table_pos_high_water.max(block_end);
 
         let dict_end = self.dict.region_len();
+        // The dual-base kernel stores VIRTUAL positions `dict_end + input_off`
+        // (up to ~`dict_end + block_end`) into the main table, so the next
+        // frame's epoch advance must span past `dict_end + block_end` — NOT
+        // just `block_end` — or stale entries in `[block_end, dict_end +
+        // block_end)` would survive the bias advance and alias as bogus
+        // low positions.
+        self.table_pos_high_water = self.table_pos_high_water.max(dict_end + block_end);
         let advertised_window = 1usize << self.window_log;
         let mls = self.hash_table.mls();
         let use_cmov = self.use_cmov;

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1122,6 +1122,12 @@ impl FastKernelMatcher {
         // likewise reborrows through a raw ptr (immutable, built once in
         // `prime_dict_table_*`).
         let inp: &[u8] = unsafe { core::slice::from_raw_parts(ptr, block_end) };
+        debug_assert!(
+            dict_end <= self.history.len(),
+            "dict region_len ({dict_end}) exceeds history.len() ({}) — \
+             dictionary bytes must be committed before borrowed-dict scan",
+            self.history.len(),
+        );
         let dict: &[u8] = unsafe { core::slice::from_raw_parts(self.history.as_ptr(), dict_end) };
         let dict_tab_ptr: *const FastHashTable = self
             .dict

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -578,6 +578,18 @@ impl FastKernelMatcher {
             self.pending.is_none(),
             "set_borrowed_window requires no staged owned block; reset before switching to a borrowed window",
         );
+        // A live borrowed window at entry means a prior frame's window was never
+        // cleared by a `reset()` — and since `clear_borrowed_window` no longer
+        // memsets the table (it relies on the next reset to do so), the table
+        // would still hold the prior scan's virtual `dict_end + input_off`
+        // positions. The borrowed-dict kernel would then read those as current
+        // offsets (`main_idx - dict_end` underflowing to a huge pointer). Catch
+        // that missing-reset regression here rather than letting it silently
+        // corrupt memory; the production caller always resets first.
+        debug_assert!(
+            self.borrowed.is_none(),
+            "set_borrowed_window called without a preceding reset()/clear_borrowed_window",
+        );
         self.borrowed = Some((buffer.as_ptr(), buffer.len()));
         self.last_borrowed_block = None;
         // Stale hash-table entries from a prior window are invalidated by the

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1302,12 +1302,16 @@ impl FastKernelMatcher {
         let (base, _len) = self
             .borrowed
             .expect("prime_hash_table_for_range_borrowed requires a registered borrowed window");
+        // Store primed input positions in VIRTUAL `[dict][input]` coords so they
+        // match what the dual-base dict kernel reads from the main table; 0 when
+        // no dict is attached.
+        let base_offset = self.dict.region_len();
         match self.hash_table.mls() {
-            4 => self.prime_hash_table_impl::<4>(base, backfill_start, last_hashable),
-            5 => self.prime_hash_table_impl::<5>(base, backfill_start, last_hashable),
-            6 => self.prime_hash_table_impl::<6>(base, backfill_start, last_hashable),
-            7 => self.prime_hash_table_impl::<7>(base, backfill_start, last_hashable),
-            8 => self.prime_hash_table_impl::<8>(base, backfill_start, last_hashable),
+            4 => self.prime_hash_table_impl::<4>(base, backfill_start, last_hashable, base_offset),
+            5 => self.prime_hash_table_impl::<5>(base, backfill_start, last_hashable, base_offset),
+            6 => self.prime_hash_table_impl::<6>(base, backfill_start, last_hashable, base_offset),
+            7 => self.prime_hash_table_impl::<7>(base, backfill_start, last_hashable, base_offset),
+            8 => self.prime_hash_table_impl::<8>(base, backfill_start, last_hashable, base_offset),
             _ => unreachable!("FastHashTable construction rejects mls outside 4..=8"),
         }
     }
@@ -1393,12 +1397,15 @@ impl FastKernelMatcher {
         }
 
         let base = self.history.as_ptr();
+        // Owned path: history offsets are already the flat `[dict][input]`
+        // coordinate (input is appended after the dict in `history`), so no
+        // virtual rebase is needed.
         match self.hash_table.mls() {
-            4 => self.prime_hash_table_impl::<4>(base, backfill_start, last_hashable),
-            5 => self.prime_hash_table_impl::<5>(base, backfill_start, last_hashable),
-            6 => self.prime_hash_table_impl::<6>(base, backfill_start, last_hashable),
-            7 => self.prime_hash_table_impl::<7>(base, backfill_start, last_hashable),
-            8 => self.prime_hash_table_impl::<8>(base, backfill_start, last_hashable),
+            4 => self.prime_hash_table_impl::<4>(base, backfill_start, last_hashable, 0),
+            5 => self.prime_hash_table_impl::<5>(base, backfill_start, last_hashable, 0),
+            6 => self.prime_hash_table_impl::<6>(base, backfill_start, last_hashable, 0),
+            7 => self.prime_hash_table_impl::<7>(base, backfill_start, last_hashable, 0),
+            8 => self.prime_hash_table_impl::<8>(base, backfill_start, last_hashable, 0),
             _ => unreachable!("FastHashTable construction rejects mls outside 4..=8"),
         }
     }
@@ -1408,11 +1415,20 @@ impl FastKernelMatcher {
     /// [`Self::skip_matching_borrowed`] dict-priming paths. `base` is the
     /// window base pointer (owned `history` or the borrowed input
     /// buffer); positions are absolute window offsets in both.
+    /// `base_offset` is added to every stored position so the main table holds
+    /// the SAME coordinate space the active kernel reads. The owned path passes
+    /// 0 (history offsets are already the flat `[dict][input]` coordinate). The
+    /// borrowed dict path passes `dict_end` so a primed input position `pos` is
+    /// stored as the VIRTUAL `dict_end + pos` the dual-base kernel expects —
+    /// without this, a primed raw offset in `[1, dict_end)` would underflow the
+    /// kernel's `main_idx - dict_end`. No-dict borrowed frames pass 0
+    /// (`region_len() == 0`), so their raw offsets are unchanged.
     fn prime_hash_table_impl<const MLS: u32>(
         &mut self,
         base: *const u8,
         range_start: usize,
         last_hashable: usize,
+        base_offset: usize,
     ) {
         for pos in range_start..=last_hashable {
             // SAFETY: pos < history_len (by loop bound), and the load
@@ -1424,7 +1440,7 @@ impl FastKernelMatcher {
             // constant-folded per MLS.
             let ptr = unsafe { base.add(pos) };
             let hash = unsafe { self.hash_table.hash_ptr::<MLS>(ptr) };
-            unsafe { self.hash_table.put(hash, pos as u32) };
+            unsafe { self.hash_table.put(hash, (base_offset + pos) as u32) };
         }
     }
 

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -179,6 +179,14 @@ pub(crate) struct FastKernelMatcher {
     /// `adjust_params_for_source_size` clamps `window_log` below
     /// the donor default of 19, flipping `use_cmov` on).
     use_cmov: bool,
+    /// Cached per-tier SIMD kernel selection (resolved once via
+    /// [`crate::encoding::fastpath::select_kernel`] at construction / reset),
+    /// mirroring the Dfast/Row backends. Drives the `#[target_feature]`
+    /// umbrella dispatch in the borrowed dual-base dict scan so the
+    /// match-length `common_prefix_len_ptr` is the tier's 32-byte AVX2 /
+    /// 16-byte SSE4.2 / NEON / wasm-simd128 compare instead of the generic
+    /// word-at-a-time `count_forward`.
+    kernel: crate::encoding::fastpath::FastpathKernel,
     /// Initial step the kernel uses for the 4-cursor body's skip
     /// schedule. Donor `stepSize = targetLength + !(targetLength) +
     /// 1` (min 2). Negative-level frames set this to 2..8 to
@@ -265,6 +273,7 @@ impl Clone for FastKernelMatcher {
             max_window_size: self.max_window_size,
             window_log: self.window_log,
             use_cmov: self.use_cmov,
+            kernel: self.kernel,
             step_size: self.step_size,
             pending: self.pending.clone(),
             last_block_start: self.last_block_start,
@@ -289,6 +298,7 @@ impl Clone for FastKernelMatcher {
         self.max_window_size = source.max_window_size;
         self.window_log = source.window_log;
         self.use_cmov = source.use_cmov;
+        self.kernel = source.kernel;
         self.step_size = source.step_size;
         self.pending.clone_from(&source.pending);
         self.last_block_start = source.last_block_start;
@@ -388,6 +398,7 @@ impl FastKernelMatcher {
             max_window_size: 1usize << window_log,
             window_log,
             use_cmov: window_log < 19,
+            kernel: crate::encoding::fastpath::select_kernel(),
             step_size,
             pending: None,
             borrowed: None,
@@ -1072,6 +1083,7 @@ impl FastKernelMatcher {
         let use_cmov = self.use_cmov;
         let step_size = self.step_size;
         let rep_in = self.rep;
+        let kernel = self.kernel;
 
         // Window bounds in VIRTUAL `[dict][input]` coords (length `dict_end +
         // block_end`), so the kernel's gates match the owned flat dict kernel:
@@ -1118,6 +1130,7 @@ impl FastKernelMatcher {
                     rep_in,
                     step_size,
                     &mut handle_sequence,
+                    kernel,
                 )
             };
         }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1029,21 +1029,22 @@ impl FastKernelMatcher {
     ///
     /// Live (input) candidates read from the borrowed window and count flat;
     /// dictionary candidates read from `history[0..dict_end]` and extend across
-    /// the dict→input boundary via [`count_forward_dict_2segment`] — the
-    /// 2-segment count C performs with `dictBase` / `ZSTD_count_2segments`,
-    /// which the flat single-base path cannot. Correctness-first scalar greedy
-    /// scan (no repcode / step-ramp / interior inserts yet); validated by
-    /// roundtrip + cross-validation + the FFI ratio gate, not byte-identity to
-    /// the owned SIMD kernel.
+    /// the dict→input boundary via the 2-segment counter — the 2-segment count
+    /// C performs with `dictBase` / `ZSTD_count_2segments`, which the flat
+    /// single-base path cannot. Dispatches the active `(mls, use_cmov)` pair to
+    /// the monomorphised dual-base kernel
+    /// [`compress_block_fast_dict_borrowed`], which carries the owned dict
+    /// kernel's full machinery (repcode probe, step-ramp two-position
+    /// lookahead, dense fills, backward extension, immediate repcode-2 loop) —
+    /// the prior scalar greedy scan had none of these and was +68% slower.
+    /// Validated by roundtrip + cross-validation + the FFI ratio gate.
     pub(crate) fn start_matching_borrowed_dict(
         &mut self,
         block_start: usize,
         block_end: usize,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
-        use super::fast_kernel::count::{count_forward, count_forward_dict_2segment};
-        use super::fast_kernel::hash_table::hash_ptr_raw;
-        const HASH_READ: usize = 8;
+        use super::fast_kernel::kernel::{PrefixBounds, compress_block_fast_dict_borrowed};
         let (ptr, total_len) = self
             .borrowed
             .expect("start_matching_borrowed_dict requires a registered borrowed window");
@@ -1056,15 +1057,31 @@ impl FastKernelMatcher {
 
         let dict_end = self.dict.region_len();
         let advertised_window = 1usize << self.window_log;
-        let hash_log = self.hash_table.hash_log();
         let mls = self.hash_table.mls();
+        let use_cmov = self.use_cmov;
+        let step_size = self.step_size;
+        let rep_in = self.rep;
+
+        // Window bounds in VIRTUAL `[dict][input]` coords (length `dict_end +
+        // block_end`), so the kernel's gates match the owned flat dict kernel:
+        // `window_low` is the absolute floor; `prefix_start_index` the
+        // sentinel-aware floor (`>= 1`) for the hash-slot filter.
+        let virtual_len = dict_end + block_end;
+        let window_low = virtual_len.saturating_sub(advertised_window);
+        let prefix_start_index = window_low.max(self.prefix_start_index as usize) as u32;
+        let bounds = PrefixBounds {
+            prefix_start_index,
+            window_low: window_low as u32,
+        };
+
         // SAFETY: `block_end <= total_len` (asserted) and the borrowed window is
         // live for the call; `ptr` is `Copy`d out so `inp` holds no `&self`
         // borrow. The dict slice reborrows `history`'s base through a raw ptr so
-        // it coexists with the `&mut self.hash_table` writes below — disjoint
-        // memory (the dict content is committed at `history[0..dict_end]` and is
-        // not mutated during the scan). The dict hash table likewise reborrows
-        // through a raw ptr (immutable, built once in `prime_dict_table_*`).
+        // it coexists with the `&mut self.hash_table` writes inside the kernel —
+        // disjoint memory (the dict content is committed at `history[0..
+        // dict_end]` and is not mutated during the scan). The dict hash table
+        // likewise reborrows through a raw ptr (immutable, built once in
+        // `prime_dict_table_*`).
         let inp: &[u8] = unsafe { core::slice::from_raw_parts(ptr, block_end) };
         let dict: &[u8] = unsafe { core::slice::from_raw_parts(self.history.as_ptr(), dict_end) };
         let dict_tab_ptr: *const FastHashTable = self
@@ -1073,85 +1090,47 @@ impl FastKernelMatcher {
             .expect("start_matching_borrowed_dict requires an attached dict table");
         // SAFETY: reborrow the immutable dict table (built once in
         // `prime_dict_table_*`, not mutated during the scan) detached from
-        // `&self` so it coexists with the `&mut self.hash_table` writes below.
+        // `&self` so it coexists with the `&mut self.hash_table` borrow below.
         let dict_tab: &FastHashTable = unsafe { &*dict_tab_ptr };
+        let main_table = &mut self.hash_table;
 
-        // Hash the 8 bytes at input offset `p` with the active `mls`
-        // (monomorphised per supported value, matching the table layout).
-        macro_rules! hash_at {
-            ($p:expr) => {{
-                let hp = unsafe { inp.as_ptr().add($p) };
-                match mls {
-                    4 => unsafe { hash_ptr_raw::<4>(hp, hash_log) },
-                    5 => unsafe { hash_ptr_raw::<5>(hp, hash_log) },
-                    6 => unsafe { hash_ptr_raw::<6>(hp, hash_log) },
-                    7 => unsafe { hash_ptr_raw::<7>(hp, hash_log) },
-                    _ => unsafe { hash_ptr_raw::<8>(hp, hash_log) },
-                }
-            }};
+        macro_rules! run {
+            ($mls:literal, $cmov:literal) => {
+                compress_block_fast_dict_borrowed::<$mls, $cmov>(
+                    inp,
+                    dict,
+                    block_start,
+                    block_end,
+                    main_table,
+                    dict_tab,
+                    bounds,
+                    rep_in,
+                    step_size,
+                    &mut handle_sequence,
+                )
+            };
         }
-
-        let mut anchor = block_start;
-        let mut ip = block_start;
-        while ip + HASH_READ <= block_end {
-            let cur_abs = dict_end + ip;
-            let hash = hash_at!(ip);
-            // Prior position stored at this hash, then insert the current one
-            // (absolute coords) so a candidate is always strictly earlier.
-            let live_abs = unsafe { self.hash_table.get(hash) } as usize;
-            unsafe { self.hash_table.put(hash, cur_abs as u32) };
-
-            // Live (input) candidate: real positions are `>= dict_end >= 1`, so
-            // the empty sentinel 0 is naturally distinct.
-            let mut best_len = 0usize;
-            let mut best_off = 0usize;
-            if live_abs >= dict_end && live_abs < cur_abs && cur_abs - live_abs <= advertised_window
-            {
-                let cand = live_abs - dict_end; // input offset
-                if inp[ip..ip + 4] == inp[cand..cand + 4] {
-                    let ext = unsafe {
-                        count_forward(
-                            inp.as_ptr().add(ip + 4),
-                            inp.as_ptr().add(cand + 4),
-                            inp.as_ptr().add(block_end),
-                        )
-                    };
-                    best_len = 4 + ext;
-                    best_off = cur_abs - live_abs;
-                }
+        let result = match (mls, use_cmov) {
+            (4, false) => run!(4, false),
+            (4, true) => run!(4, true),
+            (5, false) => run!(5, false),
+            (5, true) => run!(5, true),
+            (6, false) => run!(6, false),
+            (6, true) => run!(6, true),
+            (7, false) => run!(7, false),
+            (7, true) => run!(7, true),
+            (8, false) => run!(8, false),
+            (8, true) => run!(8, true),
+            _ => {
+                unreachable!("FastHashTable construction rejects mls outside 4..=8 — got mls={mls}")
             }
+        };
+        self.rep = result.rep;
 
-            // Dictionary candidate (fallback): the dict probe is keyed by the
-            // same hash/mls. A dict position `d` is valid when in range and the
-            // emitted offset stays within the advertised window. Extend across
-            // the dict→input boundary with the 2-segment counter.
-            if best_len < 4 {
-                let d = unsafe { dict_tab.get(hash) } as usize;
-                if d != 0 && d < dict_end && cur_abs - d <= advertised_window {
-                    let dlen = count_forward_dict_2segment(dict, d, inp, ip);
-                    if dlen >= 4 {
-                        best_len = dlen;
-                        best_off = cur_abs - d;
-                    }
-                }
-            }
-
-            if best_len >= 4 {
-                handle_sequence(Sequence::Triple {
-                    literals: &inp[anchor..ip],
-                    offset: best_off,
-                    match_len: best_len,
-                });
-                ip += best_len;
-                anchor = ip;
-            } else {
-                ip += 1;
-            }
-        }
-
-        if anchor < block_end {
+        if result.tail_literals_len > 0 {
+            let tail_start = block_end - result.tail_literals_len;
             handle_sequence(Sequence::Literals {
-                literals: &inp[anchor..block_end],
+                literals: &inp[tail_start..block_end],
             });
         }
     }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -330,6 +330,13 @@ impl FastKernelMatcher {
         self.hash_table.hash_log()
     }
 
+    /// Whether a dictionary table is attached (drives the dual-probe dispatch:
+    /// the borrowed scan must consult the dict when set). Mirrors the owned
+    /// path's `self.dict.is_attached()` gate.
+    pub(crate) fn dict_is_attached(&self) -> bool {
+        self.dict.is_attached()
+    }
+
     /// Hash table `mls` (delegates to the inner table). Test-only
     /// crate helper for verifying driver wiring.
     #[cfg(test)]
@@ -1010,6 +1017,143 @@ impl FastKernelMatcher {
         // Record the scanned range so `last_committed_space` can return
         // this block's bytes (`borrowed[start..end]`) for the emit path.
         self.last_borrowed_block = Some((block_start, block_end));
+    }
+
+    /// Borrowed in-place scan WITH an attached dictionary (the dict-attach
+    /// counterpart of [`Self::start_matching_borrowed`]). The dictionary
+    /// content sits in `history[0..dict_end]`; the frame input is read in
+    /// place from the borrowed window, never copied after it. Positions live
+    /// in the logical `[dict][input]` window: a dict byte `d` has absolute
+    /// position `d`; an input byte `i` has absolute position `dict_end + i`
+    /// (the dict precedes the input). A match offset is `cur_abs - cand_abs`.
+    ///
+    /// Live (input) candidates read from the borrowed window and count flat;
+    /// dictionary candidates read from `history[0..dict_end]` and extend across
+    /// the dict→input boundary via [`count_forward_dict_2segment`] — the
+    /// 2-segment count C performs with `dictBase` / `ZSTD_count_2segments`,
+    /// which the flat single-base path cannot. Correctness-first scalar greedy
+    /// scan (no repcode / step-ramp / interior inserts yet); validated by
+    /// roundtrip + cross-validation + the FFI ratio gate, not byte-identity to
+    /// the owned SIMD kernel.
+    pub(crate) fn start_matching_borrowed_dict(
+        &mut self,
+        block_start: usize,
+        block_end: usize,
+        mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        use super::fast_kernel::count::{count_forward, count_forward_dict_2segment};
+        use super::fast_kernel::hash_table::hash_ptr_raw;
+        const HASH_READ: usize = 8;
+        let (ptr, total_len) = self
+            .borrowed
+            .expect("start_matching_borrowed_dict requires a registered borrowed window");
+        assert!(
+            block_start <= block_end && block_end <= total_len,
+            "borrowed block bounds out of range: start={block_start} end={block_end} total={total_len}",
+        );
+        self.last_borrowed_block = Some((block_start, block_end));
+        self.table_pos_high_water = self.table_pos_high_water.max(block_end);
+
+        let dict_end = self.dict.region_len();
+        let advertised_window = 1usize << self.window_log;
+        let hash_log = self.hash_table.hash_log();
+        let mls = self.hash_table.mls();
+        // SAFETY: `block_end <= total_len` (asserted) and the borrowed window is
+        // live for the call; `ptr` is `Copy`d out so `inp` holds no `&self`
+        // borrow. The dict slice reborrows `history`'s base through a raw ptr so
+        // it coexists with the `&mut self.hash_table` writes below — disjoint
+        // memory (the dict content is committed at `history[0..dict_end]` and is
+        // not mutated during the scan). The dict hash table likewise reborrows
+        // through a raw ptr (immutable, built once in `prime_dict_table_*`).
+        let inp: &[u8] = unsafe { core::slice::from_raw_parts(ptr, block_end) };
+        let dict: &[u8] = unsafe { core::slice::from_raw_parts(self.history.as_ptr(), dict_end) };
+        let dict_tab_ptr: *const FastHashTable = self
+            .dict
+            .table()
+            .expect("start_matching_borrowed_dict requires an attached dict table");
+        // SAFETY: reborrow the immutable dict table (built once in
+        // `prime_dict_table_*`, not mutated during the scan) detached from
+        // `&self` so it coexists with the `&mut self.hash_table` writes below.
+        let dict_tab: &FastHashTable = unsafe { &*dict_tab_ptr };
+
+        // Hash the 8 bytes at input offset `p` with the active `mls`
+        // (monomorphised per supported value, matching the table layout).
+        macro_rules! hash_at {
+            ($p:expr) => {{
+                let hp = unsafe { inp.as_ptr().add($p) };
+                match mls {
+                    4 => unsafe { hash_ptr_raw::<4>(hp, hash_log) },
+                    5 => unsafe { hash_ptr_raw::<5>(hp, hash_log) },
+                    6 => unsafe { hash_ptr_raw::<6>(hp, hash_log) },
+                    7 => unsafe { hash_ptr_raw::<7>(hp, hash_log) },
+                    _ => unsafe { hash_ptr_raw::<8>(hp, hash_log) },
+                }
+            }};
+        }
+
+        let mut anchor = block_start;
+        let mut ip = block_start;
+        while ip + HASH_READ <= block_end {
+            let cur_abs = dict_end + ip;
+            let hash = hash_at!(ip);
+            // Prior position stored at this hash, then insert the current one
+            // (absolute coords) so a candidate is always strictly earlier.
+            let live_abs = unsafe { self.hash_table.get(hash) } as usize;
+            unsafe { self.hash_table.put(hash, cur_abs as u32) };
+
+            // Live (input) candidate: real positions are `>= dict_end >= 1`, so
+            // the empty sentinel 0 is naturally distinct.
+            let mut best_len = 0usize;
+            let mut best_off = 0usize;
+            if live_abs >= dict_end && live_abs < cur_abs && cur_abs - live_abs <= advertised_window
+            {
+                let cand = live_abs - dict_end; // input offset
+                if inp[ip..ip + 4] == inp[cand..cand + 4] {
+                    let ext = unsafe {
+                        count_forward(
+                            inp.as_ptr().add(ip + 4),
+                            inp.as_ptr().add(cand + 4),
+                            inp.as_ptr().add(block_end),
+                        )
+                    };
+                    best_len = 4 + ext;
+                    best_off = cur_abs - live_abs;
+                }
+            }
+
+            // Dictionary candidate (fallback): the dict probe is keyed by the
+            // same hash/mls. A dict position `d` is valid when in range and the
+            // emitted offset stays within the advertised window. Extend across
+            // the dict→input boundary with the 2-segment counter.
+            if best_len < 4 {
+                let d = unsafe { dict_tab.get(hash) } as usize;
+                if d != 0 && d < dict_end && cur_abs - d <= advertised_window {
+                    let dlen = count_forward_dict_2segment(dict, d, inp, ip);
+                    if dlen >= 4 {
+                        best_len = dlen;
+                        best_off = cur_abs - d;
+                    }
+                }
+            }
+
+            if best_len >= 4 {
+                handle_sequence(Sequence::Triple {
+                    literals: &inp[anchor..ip],
+                    offset: best_off,
+                    match_len: best_len,
+                });
+                ip += best_len;
+                anchor = ip;
+            } else {
+                ip += 1;
+            }
+        }
+
+        if anchor < block_end {
+            handle_sequence(Sequence::Literals {
+                literals: &inp[anchor..block_end],
+            });
+        }
     }
 
     /// Make `[block_start, block_end)` the block `last_committed_space`

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1083,13 +1083,18 @@ impl FastKernelMatcher {
         self.last_borrowed_block = Some((block_start, block_end));
 
         let dict_end = self.dict.region_len();
-        // The dual-base kernel stores VIRTUAL positions `dict_end + input_off`
-        // (up to ~`dict_end + block_end`) into the main table, so the next
-        // frame's epoch advance must span past `dict_end + block_end` — NOT
-        // just `block_end` — or stale entries in `[block_end, dict_end +
-        // block_end)` would survive the bias advance and alias as bogus
-        // low positions.
-        self.table_pos_high_water = self.table_pos_high_water.max(dict_end + block_end);
+        // Single checked virtual length of the [dict][input] window. The dual-base
+        // kernel stores VIRTUAL positions `dict_end + input_off` (up to
+        // `virtual_len`) into the main table, so the next frame's epoch advance
+        // must span past it — NOT just `block_end` — or stale entries in
+        // `[block_end, virtual_len)` would survive the bias advance and alias as
+        // bogus low positions. Checked so the `as u32` casts below cannot
+        // truncate (the kernel asserts the same bound).
+        let virtual_len = dict_end
+            .checked_add(block_end)
+            .filter(|&v| v <= u32::MAX as usize)
+            .expect("dict_end + block_end exceeds the u32 FastKernel position space");
+        self.table_pos_high_water = self.table_pos_high_water.max(virtual_len);
         let advertised_window = 1usize << self.window_log;
         let mls = self.hash_table.mls();
         let use_cmov = self.use_cmov;
@@ -1097,11 +1102,10 @@ impl FastKernelMatcher {
         let rep_in = self.rep;
         let kernel = self.kernel;
 
-        // Window bounds in VIRTUAL `[dict][input]` coords (length `dict_end +
-        // block_end`), so the kernel's gates match the owned flat dict kernel:
-        // `window_low` is the absolute floor; `prefix_start_index` the
-        // sentinel-aware floor (`>= 1`) for the hash-slot filter.
-        let virtual_len = dict_end + block_end;
+        // Window bounds in VIRTUAL `[dict][input]` coords, so the kernel's gates
+        // match the owned flat dict kernel: `window_low` is the absolute floor;
+        // `prefix_start_index` the sentinel-aware floor (`>= 1`) for the
+        // hash-slot filter. `virtual_len` was checked above.
         let window_low = virtual_len.saturating_sub(advertised_window);
         let prefix_start_index = window_low.max(self.prefix_start_index as usize) as u32;
         let bounds = PrefixBounds {

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1306,6 +1306,12 @@ impl FastKernelMatcher {
         // match what the dual-base dict kernel reads from the main table; 0 when
         // no dict is attached.
         let base_offset = self.dict.region_len();
+        debug_assert!(
+            base_offset
+                .checked_add(block_end)
+                .is_some_and(|v| v <= u32::MAX as usize),
+            "virtual position overflow: dict.region_len()={base_offset} + block_end={block_end} exceeds u32",
+        );
         match self.hash_table.mls() {
             4 => self.prime_hash_table_impl::<4>(base, backfill_start, last_hashable, base_offset),
             5 => self.prime_hash_table_impl::<5>(base, backfill_start, last_hashable, base_offset),


### PR DESCRIPTION
## Summary

Closes the large small-window dictionary-compress gap vs C zstd, driven by two root causes plus supporting per-frame overhead removals. All numbers i9-9900K (BMI2+AVX2), `compare_ffi`, c_ffi control flat.

### 1. Match the upstream matchfinder selection (biggest win)
We hardcoded the Row matchfinder for every greedy/lazy/lazy2 level. upstream zstd (`ZSTD_resolveRowMatchFinderMode`, `zstd_compress.c:238-245`) uses the row matchfinder ONLY when `windowLog > 14`; at or below that it runs the hash-chain matcher (`ZSTD_HcFindBestMatch`). Every small-window frame (the hinted window floor is `windowLog 14`, e.g. all small-4k/10k fixtures) went through Row where upstream uses HC.

Resolve it like upstream: at `windowLog <= 14`, greedy/lazy/lazy2 fall back to the HashChain backend (parse via `lazy_depth`); the HC config is synthesised from the level's RowConfig (HC and Row share cParams, only the matchfinder differs). Unhinted / `window>14` frames keep Row unchanged.

- `compress-dict` L6 lazy small-4k-log-lines: **13.09µs → 4.03µs (−70.6%)**, rust/C **3.56× → 1.09×**, compressed bytes identical (48 == 48).
- Fixes all small-window greedy/lazy/lazy2 frames (dict + no-dict).

### 2. Borrowed dual-base dict kernel for the Fast backend (per-tier SIMD)
In-place dict-attach compression that reads the frame input from the caller's buffer (no per-block copy) and the dictionary from the committed prefix, with a 2-segment match counter across the boundary. Monomorphised per `(MLS, USE_CMOV)` and wrapped in per-tier `#[target_feature]` umbrellas (AVX2+BMI2 / SSE4.2 / NEON / wasm-simd128 / scalar) so the hot match extension uses the tier's `common_prefix_len`.

- `compress-dict` Fast band small-4k-log-lines: **−12-13% vs main**, rust/C 2.2× → ~1.78×.

### 3. Per-frame overhead removals (shared)
- Drop the redundant double hash-table memset on the borrowed dict path (`set_borrowed_window` + the drop guard re-cleared on top of reset's epoch advance).
- Drop the `slice_size` zero-fill (~128 KiB) when staging dictionary chunks in `prime_with_dictionary` — the buffer was cleared and overwritten on the next line. Benefits every backend's dict-prime.
- Inline the shared 2-segment dict-prefix match counter.

## Testing
- `cargo nextest run -p structured-zstd --features dict_builder`: **844 passed**, incl. cross-validation (rust-encode → C-decode + ratio bounds) and the borrowed-oneshot / roundtrip suites.
- Paired i9 benches (`compare_ffi`, `encode_loop_dict`, plus `ffi_loop_dict` added for like-for-like C-internals profiling).

## Notes
- No public API change.
- Distinct internal block/sequence shapes below the bt strategies are algorithmic freedom (drop-in replacement, not binary parity); compressed sizes verified `<=` c_ffi on the affected fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dictionary-attached support for borrowed-window mode in the fast compression path.
  * Added a Rust C-FFI benchmark example for dictionary-based workloads.
* **Improvements**
  * Refined dictionary-aware borrowed eligibility and matching dispatch, including small-window backend routing.
  * Improved fast matching across dictionary-to-input boundaries with virtual coordinate correctness.
  * Reduced dictionary priming overhead and improved handling for borrowed-window hash-table priming.
  * Slightly increased the wasm payload size budget to 1 MiB.
* **Tests**
  * Added unit tests covering dictionary↔input boundary matching and reconstruction correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->