### PR TITLE
perf(hc): lazy-skip + separate dictMatchState beat C on small-window dict compress

### DIFF
--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -45,6 +45,13 @@ pub(crate) struct BtMatcher {
     /// boxed slice (no `cap` field, no in-parse `resize`/realloc) sized to
     /// `HC_OPT_NODE_LEN`, mirroring upstream zstd's fixed `opt[ZSTD_OPT_NUM]`.
     pub(crate) opt_nodes_scratch: alloc::boxed::Box<[HcOptimalNode]>,
+    /// SoA companion to `opt_nodes_scratch`: the running DP price for each
+    /// node, split out of `HcOptimalNode` into its own contiguous `u32`
+    /// array so the optimal-parser inner price-set loop can SIMD-compare a
+    /// run of consecutive node prices with a single vector load (the 28-byte
+    /// AoS node stride would otherwise force a strided gather). Same length
+    /// as `opt_nodes_scratch`; index `i` is the price of node `i`.
+    pub(crate) opt_node_prices_scratch: alloc::boxed::Box<[u32]>,
     /// Per-frame scratch for collected match candidates.
     pub(crate) opt_candidates_scratch: Vec<MatchCandidate>,
     /// Per-frame scratch for the final emitted node stream.
@@ -150,6 +157,7 @@ impl BtMatcher {
             // first runs (non-BT strategies never touch these), matching
             // the prior lazy `Vec::new()` + grow behaviour.
             opt_nodes_scratch: alloc::boxed::Box::default(),
+            opt_node_prices_scratch: alloc::boxed::Box::default(),
             opt_candidates_scratch: Vec::new(),
             opt_store_scratch: Vec::new(),
             opt_segment_plan_scratch: Vec::new(),
@@ -171,6 +179,7 @@ impl BtMatcher {
     /// (counted by the owner's `size_of`), so only the `Vec` fields contribute.
     pub(crate) fn heap_size(&self) -> usize {
         let scratch = self.opt_nodes_scratch.len() * core::mem::size_of::<HcOptimalNode>()
+            + self.opt_node_prices_scratch.len() * core::mem::size_of::<u32>()
             + self.opt_candidates_scratch.capacity() * core::mem::size_of::<MatchCandidate>()
             + self.opt_store_scratch.capacity() * core::mem::size_of::<HcOptimalNode>()
             + (self.opt_segment_plan_scratch.capacity() + self.opt_seed_plan_scratch.capacity())
@@ -360,12 +369,14 @@ impl BtMatcher {
     ) -> (u32, [u32; 3], usize, usize) {
         let HcOptimalPlanBuffers {
             nodes,
+            node_prices,
             mut candidates,
             store,
             price_arena,
         } = buffers;
         candidates.clear();
         self.opt_nodes_scratch = nodes;
+        self.opt_node_prices_scratch = node_prices;
         self.opt_candidates_scratch = candidates;
         self.opt_store_scratch = store;
         self.opt_price_arena = price_arena;
@@ -600,9 +611,17 @@ impl BtMatcher {
     }
 
     #[inline(always)]
-    pub(crate) fn reset_opt_nodes(nodes: &mut [HcOptimalNode], start: usize, end: usize) {
+    pub(crate) fn reset_opt_nodes(
+        nodes: &mut [HcOptimalNode],
+        node_prices: &mut [u32],
+        start: usize,
+        end: usize,
+    ) {
         for node in &mut nodes[start..=end] {
             Self::reset_opt_node(node);
+        }
+        for price in &mut node_prices[start..=end] {
+            *price = u32::MAX;
         }
     }
 

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -629,9 +629,9 @@ impl BtMatcher {
 
     #[inline(always)]
     pub(crate) fn reset_opt_node(node: &mut HcOptimalNode) {
-        node.price = u32::MAX;
-        // Donor only marks the slot as unreachable and not end-of-match here;
-        // stale mlen is ignored while price is MAX and litlen is non-zero.
+        // Price is reset separately via `node_prices` (see `reset_opt_nodes`);
+        // here we only mark the slot not end-of-match. Donor parity: stale mlen
+        // is ignored while the (separately-held) price is MAX and litlen != 0.
         node.litlen = u32::MAX;
     }
 

--- a/zstd/src/encoding/bt/mod.rs
+++ b/zstd/src/encoding/bt/mod.rs
@@ -111,7 +111,8 @@ impl BtMatcher {
     /// payload (`HcOptState` cost tables, lit-price arrays) plus the
     /// retained scratch arenas at their growth bounds — node frontier and
     /// emitted store (`HC_OPT_NODE_LEN` nodes each, including the `+2`
-    /// lookahead slack), the consolidated price arena (two frontier-sized
+    /// lookahead slack), the SoA node-price companion (`HC_OPT_NODE_LEN`
+    /// `u32`s), the consolidated price arena (two frontier-sized
     /// `[price, generation]` pair regions, LL and ML), the per-segment plan
     /// buffers, and the candidate ladder (`MAX_HC_SEARCH_DEPTH`). LDM is
     /// opt-in and excluded (`ldm_sequences` stays empty on every level
@@ -123,6 +124,7 @@ impl BtMatcher {
         let frontier = HC_OPT_NUM + 1;
         core::mem::size_of::<Self>()
             + 2 * HC_OPT_NODE_LEN * core::mem::size_of::<HcOptimalNode>()
+            + HC_OPT_NODE_LEN * core::mem::size_of::<u32>()
             + 2 * frontier * core::mem::size_of::<[u32; 2]>()
             + 2 * frontier * core::mem::size_of::<HcOptimalSequence>()
             + MAX_HC_SEARCH_DEPTH * core::mem::size_of::<MatchCandidate>()

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -228,7 +228,7 @@ impl HcMatcher {
     /// [`Self::chain_candidates`], extends each survivor backwards
     /// over the literal run, and short-circuits as soon as a
     /// candidate crosses `target_len`.
-    pub(crate) fn hash_chain_candidate(
+    pub(crate) fn hash_chain_candidate<const DICT: bool>(
         &self,
         table: &MatchTable,
         abs_pos: usize,
@@ -440,97 +440,136 @@ impl HcMatcher {
             cur = next;
         }
 
-        // Separate dictionary match state (upstream `ZSTD_dictMatchState` HC4
-        // loop, `zstd_lazy.c:748-770`). FUSED into this function and sharing the
-        // SAME `steps` / `max_chain_steps` budget as the live walk above — donor
-        // decrements ONE `nbAttempts` across the live chain then the dms chain,
-        // so the two together are a single bounded operation, not two
-        // full-budget walks. The dict sits at the front of the concat buffer
-        // (`[0, region)`); a dms candidate is a concat index < `current_idx`, so
-        // the offset / extension logic matches the live walk. Inert when no dms
-        // is primed (no-dict frames, or copy-mode where the dict was merged into
-        // the live chain above).
-        if let Some(dms) = table.dms.table()
-            && !dms.hash_table.is_empty()
-        {
-            let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
-            let mut dcur = dms.hash_table[dms_hash];
-            while steps < max_chain_steps {
-                if dcur == 0 {
-                    break;
-                }
-                // Dict position is a concat index in `[0, region)`; the dict is
-                // at the front so `dict_idx < current_idx` always.
-                let dict_idx = (dcur - 1) as usize;
-                let dnext = dms.chain_table[dict_idx];
-                steps += 1;
-                let new_offset = current_idx - dict_idx;
-                // Out-of-window dict positions are unreachable to the decoder.
-                if new_offset <= table.max_window_size {
-                    let mut skip = false;
-                    if let Some(best_ref) = best
-                        && new_offset >= best_ref.offset
-                        && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
-                    {
-                        let m_end = dict_idx + tail_off + 4;
-                        let i_end = current_idx + tail_off + 4;
-                        if i_end > history_tail || m_end > history_tail {
-                            skip = true;
-                        } else {
-                            let m = unsafe {
-                                MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx + tail_off))
-                            };
-                            let i = unsafe {
-                                MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
-                            };
-                            skip = m != i;
-                        }
-                    }
-                    let four_byte_ok = dict_idx + 4 > history_tail
-                        || current_idx + 4 > history_tail
-                        || unsafe {
-                            MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx))
-                                == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
-                        };
-                    if !skip && four_byte_ok {
-                        let match_len =
-                            common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
-                        if match_len >= HC_MIN_MATCH_LEN {
-                            let candidate = Self::extend_backwards(
-                                table,
-                                dict_idx + history_abs_start,
-                                abs_pos,
-                                match_len,
-                                lit_len,
-                            );
-                            best = Self::better_candidate(best, Some(candidate));
-                            if best.is_some_and(|b| b.match_len >= self.target_len) {
-                                return best;
-                            }
-                        }
-                    }
-                }
-                // Chain links are strictly decreasing (head insert); `dnext == 0`
-                // ends the walk at the loop top.
-                if dnext == dcur {
-                    break;
-                }
-                dcur = dnext;
+        // Separate dictionary match state (upstream `ZSTD_dictMatchState`). The
+        // walk is OUT-OF-LINE (`dms_chain_walk`, `#[inline(never)]`) so the
+        // dict-only code never bloats this hot function on no-dict frames, where
+        // the `is_some` guard is a single not-taken branch. `dms_chain_walk`
+        // continues the SAME `steps` budget, so live + dms stay one bounded
+        // operation (donor's single `nbAttempts`).
+        if DICT && table.dms.table().is_some_and(|d| !d.hash_table.is_empty()) {
+            best = self.dms_chain_walk(
+                table,
+                concat,
+                abs_pos,
+                lit_len,
+                current_idx,
+                history_abs_start,
+                history_tail,
+                max_chain_steps,
+                steps,
+                best,
+            );
+        }
+        best
+    }
+
+    /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
+    /// `zstd_lazy.c:748-770`). Split from [`Self::hash_chain_candidate`] so the
+    /// no-dict hot path keeps its small body / register budget. Continues the
+    /// caller's `steps` against the shared `max_chain_steps` so the live + dms
+    /// search is one bounded operation. The dict sits at the front of `concat`
+    /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
+    /// the offset / extension logic matches the live walk.
+    #[inline(never)]
+    fn dms_chain_walk(
+        &self,
+        table: &MatchTable,
+        concat: &[u8],
+        abs_pos: usize,
+        lit_len: usize,
+        current_idx: usize,
+        history_abs_start: usize,
+        history_tail: usize,
+        max_chain_steps: usize,
+        mut steps: usize,
+        mut best: Option<MatchCandidate>,
+    ) -> Option<MatchCandidate> {
+        let dms = match table.dms.table() {
+            Some(d) => d,
+            None => return best,
+        };
+        let base_ptr = concat.as_ptr();
+        let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
+        let mut dcur = dms.hash_table[dms_hash];
+        while steps < max_chain_steps {
+            if dcur == 0 {
+                break;
             }
+            // Dict position is a concat index in `[0, region)`; the dict is at
+            // the front so `dict_idx < current_idx` always.
+            let dict_idx = (dcur - 1) as usize;
+            let dnext = dms.chain_table[dict_idx];
+            steps += 1;
+            let new_offset = current_idx - dict_idx;
+            // Out-of-window dict positions are unreachable to the decoder.
+            if new_offset <= table.max_window_size {
+                let mut skip = false;
+                if let Some(best_ref) = best
+                    && new_offset >= best_ref.offset
+                    && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
+                {
+                    let m_end = dict_idx + tail_off + 4;
+                    let i_end = current_idx + tail_off + 4;
+                    if i_end > history_tail || m_end > history_tail {
+                        skip = true;
+                    } else {
+                        let m = unsafe {
+                            MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx + tail_off))
+                        };
+                        let i = unsafe {
+                            MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
+                        };
+                        skip = m != i;
+                    }
+                }
+                let four_byte_ok = dict_idx + 4 > history_tail
+                    || current_idx + 4 > history_tail
+                    || unsafe {
+                        MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx))
+                            == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
+                    };
+                if !skip && four_byte_ok {
+                    let match_len = common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
+                    if match_len >= HC_MIN_MATCH_LEN {
+                        let candidate = Self::extend_backwards(
+                            table,
+                            dict_idx + history_abs_start,
+                            abs_pos,
+                            match_len,
+                            lit_len,
+                        );
+                        best = Self::better_candidate(best, Some(candidate));
+                        if best.is_some_and(|b| b.match_len >= self.target_len) {
+                            return best;
+                        }
+                    }
+                }
+            }
+            // Chain links are strictly decreasing (head insert); `dnext == 0`
+            // ends the walk at the loop top.
+            if dnext == dcur {
+                break;
+            }
+            dcur = dnext;
         }
         best
     }
 
     /// Combine the rep-code and chain-walk candidates and pick the
-    /// better of the two.
-    pub(crate) fn find_best_match(
+    /// better of the two. Monomorphised over `DICT` (upstream's compile-time
+    /// `dictMode` template param): the `DICT = false` instance compiles WITHOUT
+    /// any dms code so the no-dict hot path keeps its tight body, while the
+    /// `DICT = true` instance dual-probes the separate dictMatchState. The
+    /// dispatcher in `start_matching_lazy` picks the instance from whether a dms
+    /// is primed.
+    pub(crate) fn find_best_match<const DICT: bool>(
         &self,
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
         let rep = Self::repcode_candidate(table, abs_pos, lit_len);
-        let hash = self.hash_chain_candidate(table, abs_pos, lit_len);
+        let hash = self.hash_chain_candidate::<DICT>(table, abs_pos, lit_len);
         Self::better_candidate(rep, hash)
     }
 
@@ -543,7 +582,7 @@ impl HcMatcher {
     /// inserted into the hash tables — matching the C zstd ordering.
     /// Seeding before comparing would let a position match against
     /// itself, changing semantics.
-    pub(crate) fn pick_lazy_match(
+    pub(crate) fn pick_lazy_match<const DICT: bool>(
         &self,
         table: &MatchTable,
         abs_pos: usize,
@@ -559,7 +598,7 @@ impl HcMatcher {
 
         let current_gain = Self::match_gain(best.match_len, best.offset) + 4;
 
-        let next = self.find_best_match(table, abs_pos + 1, lit_len + 1);
+        let next = self.find_best_match::<DICT>(table, abs_pos + 1, lit_len + 1);
         if let Some(next) = next {
             let next_gain = Self::match_gain(next.match_len, next.offset);
             if next_gain > current_gain {
@@ -568,7 +607,7 @@ impl HcMatcher {
         }
 
         if self.lazy_depth >= 2 && abs_pos + 2 + HC_MIN_MATCH_LEN <= table.history_abs_end() {
-            let next2 = self.find_best_match(table, abs_pos + 2, lit_len + 2);
+            let next2 = self.find_best_match::<DICT>(table, abs_pos + 2, lit_len + 2);
             if let Some(next2) = next2 {
                 let next2_gain = Self::match_gain(next2.match_len, next2.offset);
                 if next2_gain > current_gain + 4 {
@@ -918,7 +957,7 @@ mod hc_tests {
     fn find_best_match_returns_none_for_short_suffix() {
         let hc = HcMatcher::new(2, 4, 32);
         let t = table_with_history(b"abc");
-        assert!(hc.find_best_match(&t, 0, 1).is_none());
+        assert!(hc.find_best_match::<false>(&t, 0, 1).is_none());
     }
 
     /// Regression test for the speculative tail check's
@@ -993,7 +1032,7 @@ mod hc_tests {
         // candidate can grow past its forward match length, so the
         // best wins at forward-only length 8. Both pre-fix and
         // post-fix gates produce the same answer here.
-        let result_lit0 = hc.hash_chain_candidate(&t, 24, 0);
+        let result_lit0 = hc.hash_chain_candidate::<false>(&t, 24, 0);
         let len0 = result_lit0.map(|c| c.match_len).unwrap_or(0);
         assert_eq!(
             len0, 8,
@@ -1004,7 +1043,7 @@ mod hc_tests {
         // `lit_len = 3`: the second candidate (`idx 3`) can extend 3
         // bytes backwards, giving a total length of 9. Pre-fix gate
         // would skip it; post-fix gate lets it through.
-        let result_lit3 = hc.hash_chain_candidate(&t, 24, 3);
+        let result_lit3 = hc.hash_chain_candidate::<false>(&t, 24, 3);
         let len3 = result_lit3.map(|c| c.match_len).unwrap_or(0);
         assert_eq!(
             len3, 9,
@@ -1113,7 +1152,7 @@ mod hc_tests {
         t.chain_table[18 & chain_mask] = HC_EMPTY;
 
         let hc = HcMatcher::new(2, 16, 64);
-        let result = hc.hash_chain_candidate(&t, abs_pos, 0);
+        let result = hc.hash_chain_candidate::<false>(&t, abs_pos, 0);
         let cand = result.expect("non-monotonic walk must still produce a match");
         assert_eq!(
             cand.match_len, 8,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -439,6 +439,85 @@ impl HcMatcher {
             }
             cur = next;
         }
+
+        // Separate dictionary match state (upstream `ZSTD_dictMatchState` HC4
+        // loop, `zstd_lazy.c:748-770`). FUSED into this function and sharing the
+        // SAME `steps` / `max_chain_steps` budget as the live walk above — donor
+        // decrements ONE `nbAttempts` across the live chain then the dms chain,
+        // so the two together are a single bounded operation, not two
+        // full-budget walks. The dict sits at the front of the concat buffer
+        // (`[0, region)`); a dms candidate is a concat index < `current_idx`, so
+        // the offset / extension logic matches the live walk. Inert when no dms
+        // is primed (no-dict frames, or copy-mode where the dict was merged into
+        // the live chain above).
+        if let Some(dms) = table.dms.table()
+            && !dms.hash_table.is_empty()
+        {
+            let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
+            let mut dcur = dms.hash_table[dms_hash];
+            while steps < max_chain_steps {
+                if dcur == 0 {
+                    break;
+                }
+                // Dict position is a concat index in `[0, region)`; the dict is
+                // at the front so `dict_idx < current_idx` always.
+                let dict_idx = (dcur - 1) as usize;
+                let dnext = dms.chain_table[dict_idx];
+                steps += 1;
+                let new_offset = current_idx - dict_idx;
+                // Out-of-window dict positions are unreachable to the decoder.
+                if new_offset <= table.max_window_size {
+                    let mut skip = false;
+                    if let Some(best_ref) = best
+                        && new_offset >= best_ref.offset
+                        && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
+                    {
+                        let m_end = dict_idx + tail_off + 4;
+                        let i_end = current_idx + tail_off + 4;
+                        if i_end > history_tail || m_end > history_tail {
+                            skip = true;
+                        } else {
+                            let m = unsafe {
+                                MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx + tail_off))
+                            };
+                            let i = unsafe {
+                                MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
+                            };
+                            skip = m != i;
+                        }
+                    }
+                    let four_byte_ok = dict_idx + 4 > history_tail
+                        || current_idx + 4 > history_tail
+                        || unsafe {
+                            MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx))
+                                == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
+                        };
+                    if !skip && four_byte_ok {
+                        let match_len =
+                            common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
+                        if match_len >= HC_MIN_MATCH_LEN {
+                            let candidate = Self::extend_backwards(
+                                table,
+                                dict_idx + history_abs_start,
+                                abs_pos,
+                                match_len,
+                                lit_len,
+                            );
+                            best = Self::better_candidate(best, Some(candidate));
+                            if best.is_some_and(|b| b.match_len >= self.target_len) {
+                                return best;
+                            }
+                        }
+                    }
+                }
+                // Chain links are strictly decreasing (head insert); `dnext == 0`
+                // ends the walk at the loop top.
+                if dnext == dcur {
+                    break;
+                }
+                dcur = dnext;
+            }
+        }
         best
     }
 

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -316,6 +316,9 @@ impl HcMatcher {
         //   walks we fall through to the full `common_prefix_len` so
         //   the offset-bits advantage is given a chance to win.
         let history_tail = concat.len();
+        // Raw base pointer for the donor-style `MEM_read32` 4-byte gates below
+        // (single unaligned load each, no per-candidate slice bounds check).
+        let base_ptr = concat.as_ptr();
         while steps < max_chain_steps {
             if cur == HC_EMPTY {
                 break;
@@ -357,12 +360,21 @@ impl HcMatcher {
                     // gate's git history. Briefly: under the monotonicity
                     // precondition above, bounds-fail proves no in-range
                     // candidate at this `current_idx` can outscore `best`.
-                    if i_end > history_tail
-                        || m_end > history_tail
-                        || concat[candidate_idx + tail_off..m_end]
-                            != concat[current_idx + tail_off..i_end]
-                    {
+                    // Raw unaligned `u32` load+compare (donor `MEM_read32`)
+                    // instead of a bounds-checked slice equality — same 4-byte
+                    // tail test, one load each, no `[a..b]` bounds panic path.
+                    if i_end > history_tail || m_end > history_tail {
                         skip = true;
+                    } else {
+                        // SAFETY: both `+ tail_off` reads are `<= history_tail`
+                        // (checked above), so 4 bytes are in range.
+                        let m = unsafe {
+                            MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx + tail_off))
+                        };
+                        let i = unsafe {
+                            MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
+                        };
+                        skip = m != i;
                     }
                 }
 
@@ -374,13 +386,19 @@ impl HcMatcher {
                 // (random) input, where `best` stays `None` so the speculative
                 // tail gate above never fires, this rejects the bulk of chain
                 // candidates on a scalar compare instead of a full
-                // `common_prefix_len`. Falls through to the full count when
-                // either side lacks a 4-byte lookahead (the count handles short
-                // tails), so the accepted set is byte-identical.
+                // `common_prefix_len`. Raw unaligned `u32` load+compare (donor
+                // `MEM_read32`), not a bounds-checked slice equality. Falls
+                // through to the full count when either side lacks a 4-byte
+                // lookahead (the count handles short tails), so the accepted
+                // set is byte-identical.
                 let four_byte_ok = candidate_idx + 4 > history_tail
                     || current_idx + 4 > history_tail
-                    || concat[candidate_idx..candidate_idx + 4]
-                        == concat[current_idx..current_idx + 4];
+                    || unsafe {
+                        // SAFETY: both `+ 4` reads are `<= history_tail` (checked
+                        // above), so 4 bytes are in range.
+                        MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx))
+                            == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
+                    };
                 if !skip && four_byte_ok {
                     let match_len =
                         common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -319,33 +319,44 @@ impl HcMatcher {
         // Raw base pointer for the donor-style `MEM_read32` 4-byte gates below
         // (single unaligned load each, no per-candidate slice bounds check).
         let base_ptr = concat.as_ptr();
+        // Loop-invariant precompute, hoisted out of the chain walk (donor:
+        // `lowLimit` + base pointers are set once before the loop). Candidates
+        // are tracked in history-RELATIVE index space so each step is a single
+        // `add` + range check + 4-byte gate, mirroring `ZSTD_HcFindBestMatch`'s
+        // tight body (`matchIndex >= lowLimit`; `NEXT_IN_CHAIN`) instead of an
+        // `Option`-returning absolute-position decode plus a per-candidate
+        // `.max()/.saturating_sub()` window-floor recompute.
+        let floor_idx = current_idx.saturating_sub(table.max_window_size);
+        // `candidate_idx = position_base + (cur-1) - index_shift -
+        // history_abs_start`, folded into one wrapping bias so the per-step cost
+        // is `cur + idx_bias`. Stale / sub-floor chain entries wrap to a huge
+        // index and are rejected by the `< current_idx` upper bound — the
+        // accepted set is identical to the `stored_abs_position_fast` decode
+        // (which returned `None` for the same sub-floor entries).
+        let idx_bias = table
+            .position_base
+            .wrapping_sub(1)
+            .wrapping_sub(table.index_shift)
+            .wrapping_sub(history_abs_start);
         while steps < max_chain_steps {
             if cur == HC_EMPTY {
                 break;
             }
             let candidate_rel = cur.wrapping_sub(1) as usize;
-            let candidate_abs_opt =
-                super::match_table::storage::MatchTable::stored_abs_position_fast(
-                    cur,
-                    table.position_base,
-                    table.index_shift,
-                );
             let next = table.chain_table[candidate_rel & chain_mask];
             steps += 1;
             // Self-loop: two positions share `candidate_rel & chain_mask`;
             // stop after processing this slot.
             let self_loop = next == cur;
 
-            // Only process candidates in the live window [history_abs_start, abs_pos).
-            if let Some(candidate_abs) = candidate_abs_opt
-                && candidate_abs
-                    >= history_abs_start.max(abs_pos.saturating_sub(table.max_window_size))
-                && candidate_abs < abs_pos
-            {
-                let candidate_idx = candidate_abs - history_abs_start;
-                // `abs_pos > candidate_abs` is invariant under the bounds check
-                // above, so the subtraction never underflows.
-                let new_offset = abs_pos - candidate_abs;
+            // Only process candidates in the live window, in relative space:
+            // `floor_idx <= candidate_idx < current_idx`.
+            let candidate_idx = (cur as usize).wrapping_add(idx_bias);
+            if candidate_idx >= floor_idx && candidate_idx < current_idx {
+                // `candidate_idx < current_idx` (checked above), so the
+                // subtraction never underflows. `new_offset == abs_pos -
+                // candidate_abs`.
+                let new_offset = current_idx - candidate_idx;
                 // Speculative tail gate — full rationale (backward-extension
                 // bound + walk-order/offset-monotonicity precondition) is in
                 // the comment block right above this loop.
@@ -403,6 +414,11 @@ impl HcMatcher {
                     let match_len =
                         common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
                     if match_len >= HC_MIN_MATCH_LEN {
+                        // Rare accept path: recover the absolute position only
+                        // here (the hot per-candidate body stays in relative
+                        // space). `candidate_abs == candidate_idx +
+                        // history_abs_start`.
+                        let candidate_abs = candidate_idx + history_abs_start;
                         let candidate = Self::extend_backwards(
                             table,
                             candidate_abs,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -470,7 +470,13 @@ impl HcMatcher {
     /// search is one bounded operation. The dict sits at the front of `concat`
     /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
     /// the offset / extension logic matches the live walk.
-    #[inline(never)]
+    ///
+    /// `#[inline]`: with the `DICT` split the `DICT = false` monomorph never
+    /// references this (the `if DICT &&` gate is a compile-time false), so it is
+    /// dropped from the no-dict path entirely; the `DICT = true` monomorph
+    /// inlines it into the dict hot path.
+    #[inline]
+    #[allow(clippy::too_many_arguments)]
     fn dms_chain_walk(
         &self,
         table: &MatchTable,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -446,7 +446,7 @@ impl HcMatcher {
         // the `is_some` guard is a single not-taken branch. `dms_chain_walk`
         // continues the SAME `steps` budget, so live + dms stay one bounded
         // operation (donor's single `nbAttempts`).
-        if DICT && table.dms.table().is_some_and(|d| !d.hash_table.is_empty()) {
+        if DICT && table.dms.is_primed() {
             best = self.dms_chain_walk(
                 table,
                 concat,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -685,12 +685,12 @@ const DFAST_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
 /// `row_candidate_rl`), larger known-size inputs dense-COPY into the live rows.
 const ROW_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
 
-/// 16 KiB (`2^14`, donor `attachDictSizeCutoffs[ZSTD_lazy2]`): small /
+/// 32 KiB (`2^15`, upstream zstd `attachDictSizeCutoffs[ZSTD_lazy2]`): small /
 /// unknown-size inputs ATTACH the dict as a separate hash-chain dms (the dual
 /// search in `find_best_match` walks the live input chain + the dms), larger
 /// known-size inputs dense-COPY (merge the dict into the live chain and search
 /// the one combined chain).
-const HC_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
+const HC_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
 
 // Source-size cap for the dfast hash bits when a size hint is present: a tiny
 // input needs no larger hash than its window. The donor `cParams.hashLog` /
@@ -10215,11 +10215,13 @@ fn primed_snapshot_not_restored_across_fast_attach_copy_boundary() {
 #[test]
 fn primed_snapshot_fast_attach_does_not_over_key_non_simple_backends() {
     // `fast_attach` is a Simple/Fast-backend concept (the 8 KiB attach-vs-copy
-    // table split). Dfast/Row prime the dictionary one way; HashChain has its
-    // OWN attach/copy split (`HC_ATTACH_DICT_CUTOFF_LOG`) but deliberately keeps
-    // it OUT of the snapshot key — both HC modes share the same window geometry,
-    // so a cross-mode restore is decodable (see `prime_with_dictionary` and
-    // `primed_snapshot_hc_cross_mode_roundtrips`). Either way the `fast_attach`
+    // table split). Dfast/Row/HashChain each have their OWN attach/copy regime
+    // (`DFAST_ATTACH_DICT_CUTOFF_LOG`, `ROW_ATTACH_DICT_CUTOFF_LOG`,
+    // `HC_ATTACH_DICT_CUTOFF_LOG`) but those are deliberately kept OUT of the
+    // `fast_attach` key, which only models the Fast table split. Their snapshots
+    // are keyed by the resolved matcher geometry instead, and the HC modes share
+    // one window geometry so an HC cross-mode restore stays decodable (see
+    // `prime_with_dictionary`). Either way the `fast_attach`
     // bit must NOT enter a non-Simple snapshot key — otherwise an unhinted
     // capture (which would record `fast_attach = true`) and a hinted reset that
     // resolves to the IDENTICAL `LevelParams` would key differently and force a

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4540,11 +4540,44 @@ macro_rules! build_optimal_plan_impl_body {
                             break;
                         }
                     }
+                } else if max_match_len + 1 - start_len < 16 {
+                    // btultra / btultra2 SHORT range: stay inline-scalar (forward,
+                    // simplified `next_cost < node_prices[next]` compare — the
+                    // `next > last_pos` term is subsumed because reset set
+                    // beyond-frontier cells to MAX). No fn-call / vectorisation
+                    // overhead on the short loops that dominate by count.
+                    for match_len in start_len..=max_match_len {
+                        let next = pos + match_len;
+                        let ml_price = BtMatcher::cached_match_length_price(
+                            profile,
+                            $stats,
+                            match_len,
+                            &mut ml_cache,
+                            ml_price_stamp,
+                        );
+                        let seq_cost = BtMatcher::add_prices(
+                            ll0_price,
+                            profile.match_price_from_parts(off_price, ml_price, $stats),
+                        );
+                        let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
+                        if next_cost < unsafe { *node_prices.get_unchecked(next) } {
+                            let slot = unsafe { nodes.get_unchecked_mut(next) };
+                            *slot = HcOptimalNode {
+                                price: next_cost,
+                                off: candidate.offset as u32,
+                                mlen: match_len as u32,
+                                litlen: 0,
+                                reps: base_reps,
+                            };
+                            unsafe { *node_prices.get_unchecked_mut(next) = next_cost };
+                            if next > last_pos {
+                                last_pos = next;
+                            }
+                        }
+                    }
                 } else {
-                    // btultra / btultra2 (OPT_LEVEL >= 2): no abort, each
-                    // match_len writes a distinct node => order-independent =>
-                    // SIMD-vectorised price-set (compare against the contiguous
-                    // node_prices SoA array).
+                    // btultra / btultra2 LONG range: SIMD-vectorised price-set
+                    // (compare against the contiguous node_prices SoA array).
                     last_pos = last_pos.max(priceset_range_nonabort(
                         &mut node_prices,
                         &mut nodes,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -692,6 +692,19 @@ const ROW_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
 /// the one combined chain).
 const HC_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
 
+/// BT/optimal attach cutoff for `btlazy2` + `btopt`: 32 KiB (`2^15`, upstream
+/// zstd `attachDictSizeCutoffs[ZSTD_btlazy2]` == `[ZSTD_btopt]`). Small /
+/// unknown-size inputs ATTACH the dict as a separate DUBT dms; larger known-size
+/// inputs COPY the dict into the LIVE binary tree (donor
+/// `ZSTD_resetCCtx_byCopyingCDict`).
+const BT_OPT_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
+
+/// BT/optimal attach cutoff for `btultra` + `btultra2`: 8 KiB (`2^13`, upstream
+/// zstd `attachDictSizeCutoffs[ZSTD_btultra]` == `[ZSTD_btultra2]`). The deepest
+/// parses copy the dict into the live tree past a much smaller source than the
+/// `btopt` tier, matching upstream's per-strategy cutoff table.
+const BT_ULTRA_ATTACH_DICT_CUTOFF_LOG: u8 = 13;
+
 // Source-size cap for the dfast hash bits when a size hint is present: a tiny
 // input needs no larger hash than its window. The donor `cParams.hashLog` /
 // `chainLog` (from `DfastConfig`) caps it from above at the call site.
@@ -1832,6 +1845,35 @@ impl MatchGeneratorDriver {
         }
     }
 
+    /// ATTACH (`true`) vs COPY (`false`) decision for the dms-bearing HashChain
+    /// backend (lazy hash-chain AND binary-tree/optimal levels), mirroring
+    /// upstream `ZSTD_shouldAttachDict` and its per-strategy `attachDictSizeCutoffs`:
+    /// a small / unknown source ATTACHES the dict as a separate dms (hash-chain
+    /// dms for lazy, DUBT dms for BT); a large known source COPIES it into the
+    /// live chain / tree. The cutoff is the lazy/lazy2 value for HC, the
+    /// btlazy2/btopt value for Bt{Opt}, and the smaller btultra/btultra2 value for
+    /// the deepest parses. Both `skip_matching_for_dictionary_priming` (which
+    /// stages the dict) and `prime_with_dictionary` (which builds-or-drops the
+    /// dms) read this so the two stay in lock-step.
+    fn hc_dict_attach_mode(&self) -> bool {
+        // Only the HashChain backend (lazy hash-chain + BT/optimal) routes here;
+        // a non-HashChain storage has no dms decision, so default to attach.
+        let MatcherStorage::HashChain(hc) = &self.storage else {
+            return true;
+        };
+        let cutoff = if hc.table.uses_bt {
+            match hc.strategy_tag {
+                super::strategy::StrategyTag::BtUltra | super::strategy::StrategyTag::BtUltra2 => {
+                    BT_ULTRA_ATTACH_DICT_CUTOFF_LOG
+                }
+                _ => BT_OPT_ATTACH_DICT_CUTOFF_LOG,
+            }
+        } else {
+            HC_ATTACH_DICT_CUTOFF_LOG
+        };
+        self.reset_size_log.is_none_or(|log| log <= cutoff)
+    }
+
     fn skip_matching_for_dictionary_priming(&mut self) {
         match self.active_backend() {
             super::strategy::BackendTag::Simple => {
@@ -1895,28 +1937,20 @@ impl MatchGeneratorDriver {
                 }
             }
             super::strategy::BackendTag::HashChain => {
-                let table = &mut self.hc_matcher_mut().table;
-                if table.uses_bt {
-                    // BT / optimal levels: keep the dict in history for the dms
-                    // but do NOT insert it into the live tree (donor separate
-                    // dictMatchState). The dms-BT is built in
-                    // `prime_with_dictionary`.
-                    table.skip_matching_dict_bt();
+                // Lazy-HC AND BT/optimal both follow donor `ZSTD_shouldAttachDict`
+                // per-strategy: ATTACH (a separate dms — hash-chain dms for lazy,
+                // DUBT dms for BT) for small / unknown inputs, COPY (merge the dict
+                // into the live chain/tree) for large known inputs. ATTACH keeps
+                // the dict in history but out of the live structure via
+                // `skip_matching_dict_bt` (the cursor advance is shared by both
+                // arms); COPY routes through the normal `skip_matching` (its
+                // `uses_bt` branch fills the live tree, the lazy branch the live
+                // chain). The dms is built-or-dropped to match in
+                // `prime_with_dictionary`.
+                if self.hc_dict_attach_mode() {
+                    self.hc_matcher_mut().table.skip_matching_dict_bt();
                 } else {
-                    // Lazy-HC: ATTACH (separate dms hash-chain) for small /
-                    // unknown inputs like the Fast/Dfast/Row backends; COPY
-                    // (merge into the live chain) for large known inputs. Attach
-                    // keeps the dict in history but out of the live chain (same
-                    // insert-cursor advance as the BT arm); the dms hash-chain is
-                    // built in `prime_with_dictionary`.
-                    let attach = self
-                        .reset_size_log
-                        .is_none_or(|log| log <= HC_ATTACH_DICT_CUTOFF_LOG);
-                    if attach {
-                        self.hc_matcher_mut().table.skip_matching_dict_bt();
-                    } else {
-                        self.hc_matcher_mut().skip_matching(Some(false));
-                    }
+                    self.hc_matcher_mut().skip_matching(Some(false));
                 }
             }
         }
@@ -2732,22 +2766,22 @@ impl Matcher for MatchGeneratorDriver {
             // that same-mode reuse decodes; the driver-level cross-mode restore is
             // accepted (not refused) per
             // `primed_snapshot_fast_attach_does_not_over_key_non_simple_backends`.
-            let hc_attach = self
-                .reset_size_log
-                .is_none_or(|log| log <= HC_ATTACH_DICT_CUTOFF_LOG);
+            let attach = self.hc_dict_attach_mode();
             let table = &mut self.hc_matcher_mut().table;
             table.set_dictionary_limit_from_primed_bytes(committed_dict_budget);
-            // Build the dictMatchState over the committed dict (front of
-            // history) so `find_best_match` dual-probes it with its own compare
-            // budget. BT/optimal → DUBT dms; lazy-HC attach → single-link
-            // hash-chain dms. Copy-mode lazy-HC merged the dict into the live
-            // chain instead, so drop any stale dms.
-            if table.uses_bt {
-                table.prime_dms_bt(committed_dict_budget);
-            } else if hc_attach {
-                table.prime_dms_hc(committed_dict_budget);
-            } else {
+            // Build the dictMatchState over the committed dict (front of history)
+            // so `find_best_match` dual-probes it with its own compare budget —
+            // but ONLY in ATTACH mode. BT/optimal attach → DUBT dms; lazy-HC
+            // attach → single-link hash-chain dms. COPY mode (large known source,
+            // both BT and lazy-HC) already merged the dict into the live tree /
+            // chain in `skip_matching_for_dictionary_priming`, so it carries no
+            // separate dms — drop any stale one.
+            if !attach {
                 table.dms.invalidate();
+            } else if table.uses_bt {
+                table.prime_dms_bt(committed_dict_budget);
+            } else {
+                table.prime_dms_hc(committed_dict_budget);
             }
         }
         // CDict-equivalent: now that every dict chunk is indexed, mark the
@@ -2819,16 +2853,18 @@ impl Matcher for MatchGeneratorDriver {
             }
             (live, snapshot_storage) => {
                 let mut storage = snapshot_storage.clone();
-                // A binary-tree snapshot is stored WITHOUT its live hash /
-                // chain / hash3 tables (they hold no dictionary entries — the
-                // dict lives in `dms` + history; see
-                // `capture_primed_dictionary`). Re-allocate them zeroed to the
-                // snapshot's geometry, exactly reproducing the post-prime
-                // state (all `HC_EMPTY`). This is a full storage replace, so
-                // no stale live-table entry from a prior frame can survive —
-                // `ensure_tables` only allocates when the length mismatches,
-                // so a full (HC / non-BT) snapshot whose tables are already
-                // present is left untouched.
+                // This arm handles the binary-tree backend. In ATTACH mode the
+                // snapshot was stored WITHOUT its live hash / chain / hash3
+                // tables (they hold no dictionary entries — the dict lives in
+                // `dms` + history; see `capture_primed_dictionary`), so
+                // `ensure_tables` re-allocates them zeroed to the snapshot's
+                // geometry, exactly reproducing the post-prime state (all
+                // `HC_EMPTY`). In COPY mode the snapshot retained its FULL live
+                // tree (the dict was merged into it, no `dms`), so the tables are
+                // already present at the right length and `ensure_tables` — which
+                // only allocates on a length mismatch — leaves them untouched.
+                // Either way this is a full storage replace, so no stale
+                // live-table entry from a prior frame can survive.
                 if let MatcherStorage::HashChain(hc) = &mut storage {
                     hc.table.ensure_tables();
                 }
@@ -2869,9 +2905,9 @@ impl Matcher for MatchGeneratorDriver {
             fast_attach,
             ldm,
         };
-        // Donor CDict-equivalent retained state. On the binary-tree backend the
-        // dictionary is decoupled into `dms` (the donor `dictMatchState`); the
-        // live hash / chain / hash3 tables carry NO dict entries at capture
+        // CDict-equivalent retained state. A binary-tree level in ATTACH mode
+        // decouples the dictionary into `dms` (the donor `dictMatchState`); its
+        // live hash / chain / hash3 tables carry NO dict entries
         // (`skip_matching_dict_bt` keeps the dict out of the live tree), so they
         // are pure zeros. Storing them in the snapshot wastes the full table
         // footprint (a second window-tier table set resident for the whole
@@ -2879,11 +2915,16 @@ impl Matcher for MatchGeneratorDriver {
         // clone only the dict-state (history + `dms` + window/offset/dict-limit),
         // then move the live tables back — the snapshot keeps just what donor's
         // CDict keeps, and `restore_primed_dictionary` re-allocates the zeroed
-        // live tables. HC / lazy levels keep the dict IN the live chain (no
-        // `dms`), so their snapshot must retain the full tables: full clone.
+        // live tables. Every other case keeps the dict IN the live structure and
+        // carries no usable `dms`, so the snapshot must retain the full tables
+        // (full clone): lazy-HC (attach hash-chain dms aside, the live chain is
+        // still the search structure) and COPY mode for BOTH BT and lazy-HC
+        // (`dms` invalidated, dict merged into the live tree / chain). `dms`
+        // being primed is the exact "decoupled" signal — it is set only by the BT
+        // attach prime and dropped in copy mode.
         let bt_decoupled = matches!(
             &self.storage,
-            MatcherStorage::HashChain(hc) if hc.table.uses_bt
+            MatcherStorage::HashChain(hc) if hc.table.uses_bt && hc.table.dms.is_primed()
         );
         if bt_decoupled {
             let MatcherStorage::HashChain(hc) = &mut self.storage else {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2546,11 +2546,13 @@ impl Matcher for MatchGeneratorDriver {
         // here (post-resolution, after the test-only param override) so the key
         // reflects exactly the geometry the restored `storage` must match. The
         // Fast attach-vs-copy mode is part of the shape ONLY for the Simple
-        // backend (it decides whether a separate dict table is built); the other
-        // backends prime the dictionary the same way regardless, so including
-        // the bit there would over-key identical resolved shapes. When it
-        // applies it matches the decision `prime_with_dictionary` makes from the
-        // same `reset_size_log`.
+        // backend (it decides the distinct dict-table shape that backend builds).
+        // Dfast/Row/HashChain have their OWN attach/copy regimes, but this bit
+        // models only the Fast table split; those backends are keyed by the
+        // resolved matcher geometry instead, so folding the Fast bit into their
+        // key would over-key identical resolved shapes. When it applies it
+        // matches the decision `prime_with_dictionary` makes from the same
+        // `reset_size_log`.
         let fast_attach = matches!(next_backend, super::strategy::BackendTag::Simple)
             && self
                 .reset_size_log
@@ -2915,13 +2917,14 @@ impl Matcher for MatchGeneratorDriver {
         // clone only the dict-state (history + `dms` + window/offset/dict-limit),
         // then move the live tables back — the snapshot keeps just what donor's
         // CDict keeps, and `restore_primed_dictionary` re-allocates the zeroed
-        // live tables. Every other case keeps the dict IN the live structure and
-        // carries no usable `dms`, so the snapshot must retain the full tables
-        // (full clone): lazy-HC (attach hash-chain dms aside, the live chain is
-        // still the search structure) and COPY mode for BOTH BT and lazy-HC
-        // (`dms` invalidated, dict merged into the live tree / chain). `dms`
-        // being primed is the exact "decoupled" signal — it is set only by the BT
-        // attach prime and dropped in copy mode.
+        // live tables. Every other case keeps the dict reachable through the live
+        // structure, so the snapshot must retain the full tables (full clone):
+        // lazy-HC attach (it DOES prime a hash-chain `dms`, but the live chain is
+        // still the search structure, so the tables must travel) and COPY mode for
+        // BOTH BT and lazy-HC (`dms` invalidated, dict merged into the live tree /
+        // chain). `uses_bt && dms.is_primed()` is therefore the exact "decoupled"
+        // signal — true only for the BT attach prime; lazy-HC attach primes `dms`
+        // too but is intentionally NOT decoupled.
         let bt_decoupled = matches!(
             &self.storage,
             MatcherStorage::HashChain(hc) if hc.table.uses_bt && hc.table.dms.is_primed()
@@ -4826,6 +4829,9 @@ macro_rules! build_optimal_plan_impl_body {
                 last_pos = (min_match_len - 1).min(frontier_limit);
                 for p in 1..min_match_len.min(frontier_buffer_size) {
                     BtMatcher::reset_opt_node(&mut nodes[p]);
+                    // Keep the SoA `node_prices` sidecar in lockstep with the AoS
+                    // `nodes[p].price` the price-set paths compare against.
+                    node_prices[p] = u32::MAX;
                     // `initial_litlen` is the litlen carried from prior
                     // optimal-plan segments — its real bound is the
                     // current block length (the frame compressor caps
@@ -4874,6 +4880,9 @@ macro_rules! build_optimal_plan_impl_body {
                     };
                     if longest_len < frontier_buffer_size && forced_price < nodes[longest_len].price {
                         nodes[longest_len] = forced_state;
+                        // Mirror into the SoA sidecar so the price-set loop sees
+                        // the forced seed as the baseline (lockstep invariant).
+                        node_prices[longest_len] = forced_price;
                     }
                     forced_end = Some(longest_len);
                     forced_end_state = Some(forced_state);
@@ -6520,6 +6529,13 @@ impl HcMatchGenerator {
                 // run). Ratio follows upstream (not byte-identical).
                 let step = ((pos - literals_start) >> 8) + 1;
                 pos += step;
+                // No clamp needed before the tail loop: the search bound and the
+                // hashable bound are both `pos + HC_MIN_MATCH_LEN <= current_len`
+                // (HC_MIN_MATCH_LEN == 4 == the insert width), so there is no
+                // non-searchable-but-hashable anchor to miss. Positions the skip
+                // jumps over inside the searchable region are intentionally not
+                // inserted — same as upstream zstd, which advances past them via
+                // the identical `ip += step` and never hashes them either.
             }
         }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3791,6 +3791,134 @@ macro_rules! start_matching_btlazy2_body {
     }};
 }
 
+/// 8-lane `next_cost < node_price` mask for the optimal-parser price-set
+/// loop. AVX2 lacks an unsigned `cmplt`, so derive `nc < np` from
+/// `min_epu32`: `nc <= np` iff `min(nc,np) == nc`, then exclude equality.
+/// Returns a bitmask (bit `k` set => lane `k` improves). Scalar fallback
+/// for non-x86 / no-AVX2.
+#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+#[target_feature(enable = "avx2")]
+unsafe fn priceset_improved_mask8_avx2(next_cost: &[u32; 8], node_price: &[u32]) -> u8 {
+    use core::arch::x86_64::{
+        __m256i, _mm256_andnot_si256, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256,
+        _mm256_min_epu32, _mm256_movemask_ps,
+    };
+    let nc = unsafe { _mm256_loadu_si256(next_cost.as_ptr() as *const __m256i) };
+    let np = unsafe { _mm256_loadu_si256(node_price.as_ptr() as *const __m256i) };
+    let min = _mm256_min_epu32(nc, np);
+    let le = _mm256_cmpeq_epi32(min, nc); // nc <= np
+    let eq = _mm256_cmpeq_epi32(nc, np); // nc == np
+    let lt = _mm256_andnot_si256(eq, le); // nc < np
+    _mm256_movemask_ps(_mm256_castsi256_ps(lt)) as u8
+}
+
+#[inline]
+fn priceset_improved_mask8(next_cost: &[u32; 8], node_price: &[u32]) -> u8 {
+    #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            // SAFETY: avx2 confirmed at runtime; both slices are >= 8 u32.
+            return unsafe { priceset_improved_mask8_avx2(next_cost, node_price) };
+        }
+    }
+    let mut mask = 0u8;
+    for k in 0..8 {
+        if next_cost[k] < node_price[k] {
+            mask |= 1 << k;
+        }
+    }
+    mask
+}
+
+/// Vectorised price-set over the match-length range `[start, max]` for the
+/// NON-abort optimal modes (btultra / btultra2, `OPT_LEVEL >= 2`). Each
+/// `match_len` writes a distinct node `pos + match_len`, so iteration order
+/// is irrelevant and the loop vectorises; the scalar abort path (btopt,
+/// `OPT_LEVEL == 0`) keeps its reverse-iterate-then-break form. `next_cost`
+/// is computed with the same `add_prices` / `match_price_from_parts` chain
+/// as the scalar loop (byte-identical), and the improvement test reduces to
+/// `next_cost < node_prices[next]` because `reset_opt_nodes` set every
+/// beyond-frontier cell to `u32::MAX` (so `next > last_pos` is subsumed).
+/// Returns the highest written `next` (the caller folds it into `last_pos`).
+#[allow(clippy::too_many_arguments)]
+fn priceset_range_nonabort(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+) -> usize {
+    let mut new_last = last_pos;
+    let mut buf = [0u32; 8];
+    let mut ml = start;
+    while ml + 8 <= max + 1 {
+        for (k, slot) in buf.iter_mut().enumerate() {
+            let ml_price =
+                BtMatcher::cached_match_length_price(profile, stats, ml + k, ml_cache, ml_stamp);
+            let seq_cost = BtMatcher::add_prices(
+                ll0_price,
+                profile.match_price_from_parts(off_price, ml_price, stats),
+            );
+            *slot = BtMatcher::add_prices(base_cost, seq_cost);
+        }
+        let base_next = pos + ml;
+        let mask = priceset_improved_mask8(&buf, &node_prices[base_next..base_next + 8]);
+        if mask != 0 {
+            for k in 0..8 {
+                if mask & (1 << k) != 0 {
+                    let next = base_next + k;
+                    node_prices[next] = buf[k];
+                    nodes[next] = HcOptimalNode {
+                        price: buf[k],
+                        off,
+                        mlen: (ml + k) as u32,
+                        litlen: 0,
+                        reps,
+                    };
+                    if next > new_last {
+                        new_last = next;
+                    }
+                }
+            }
+        }
+        ml += 8;
+    }
+    while ml <= max {
+        let ml_price = BtMatcher::cached_match_length_price(profile, stats, ml, ml_cache, ml_stamp);
+        let seq_cost = BtMatcher::add_prices(
+            ll0_price,
+            profile.match_price_from_parts(off_price, ml_price, stats),
+        );
+        let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
+        let next = pos + ml;
+        if next_cost < node_prices[next] {
+            node_prices[next] = next_cost;
+            nodes[next] = HcOptimalNode {
+                price: next_cost,
+                off,
+                mlen: ml as u32,
+                litlen: 0,
+                reps,
+            };
+            if next > new_last {
+                new_last = next;
+            }
+        }
+        ml += 1;
+    }
+    new_last
+}
+
 macro_rules! build_optimal_plan_impl_body {
     (
         $self:expr,
@@ -4376,38 +4504,64 @@ macro_rules! build_optimal_plan_impl_body {
                 let off_price = profile
                     .offset_price_for::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>($stats, off_base);
                 debug_assert!(pos + max_match_len < frontier_buffer_size);
-                for match_len in (start_len..=max_match_len).rev() {
-                    let next = pos + match_len;
-                    let ml_price = BtMatcher::cached_match_length_price(
+                if abort_on_worse_match {
+                    // btopt (OPT_LEVEL == 0): reverse-iterate with early break —
+                    // once a longer match stops improving, shorter ones are
+                    // skipped. Order-dependent, stays scalar.
+                    for match_len in (start_len..=max_match_len).rev() {
+                        let next = pos + match_len;
+                        let ml_price = BtMatcher::cached_match_length_price(
+                            profile,
+                            $stats,
+                            match_len,
+                            &mut ml_cache,
+                            ml_price_stamp,
+                        );
+                        let seq_cost = BtMatcher::add_prices(
+                            ll0_price,
+                            profile.match_price_from_parts(off_price, ml_price, $stats),
+                        );
+                        let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
+                        let node_next_price = unsafe { *node_prices.get_unchecked(next) };
+                        if next > last_pos || next_cost < node_next_price {
+                            let slot = unsafe { nodes.get_unchecked_mut(next) };
+                            *slot = HcOptimalNode {
+                                price: next_cost,
+                                off: candidate.offset as u32,
+                                mlen: match_len as u32,
+                                litlen: 0,
+                                reps: base_reps,
+                            };
+                            unsafe { *node_prices.get_unchecked_mut(next) = next_cost };
+                            if next > last_pos {
+                                last_pos = next;
+                            }
+                        } else {
+                            break;
+                        }
+                    }
+                } else {
+                    // btultra / btultra2 (OPT_LEVEL >= 2): no abort, each
+                    // match_len writes a distinct node => order-independent =>
+                    // SIMD-vectorised price-set (compare against the contiguous
+                    // node_prices SoA array).
+                    last_pos = last_pos.max(priceset_range_nonabort(
+                        &mut node_prices,
+                        &mut nodes,
+                        ml_cache,
+                        ml_price_stamp,
                         profile,
                         $stats,
-                        match_len,
-                        &mut ml_cache,
-                        ml_price_stamp,
-                    );
-                    let seq_cost = BtMatcher::add_prices(
+                        pos,
+                        start_len,
+                        max_match_len,
                         ll0_price,
-                        profile.match_price_from_parts(off_price, ml_price, $stats),
-                    );
-                    let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
-                    let node_next_price = unsafe { *node_prices.get_unchecked(next) };
-                    let improved = next > last_pos || next_cost < node_next_price;
-                    if improved {
-                        let slot = unsafe { nodes.get_unchecked_mut(next) };
-                        *slot = HcOptimalNode {
-                            price: next_cost,
-                            off: candidate.offset as u32,
-                            mlen: match_len as u32,
-                            litlen: 0,
-                            reps: base_reps,
-                        };
-                        unsafe { *node_prices.get_unchecked_mut(next) = next_cost };
-                        if next > last_pos {
-                            last_pos = next;
-                        }
-                    } else if abort_on_worse_match {
-                        break;
-                    }
+                        off_price,
+                        base_cost,
+                        candidate.offset as u32,
+                        base_reps,
+                        last_pos,
+                    ));
                 }
                 prev_max_len = prev_max_len.max(max_match_len);
             }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3828,6 +3828,7 @@ unsafe fn priceset_improved_mask8_avx2(next_cost: &[u32; 8], node_price: &[u32])
 /// for one match length — the exact `add_prices` chain the scalar loop uses,
 /// so the SoA vector path stays byte-identical.
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn priceset_next_cost(
     profile: HcOptimalCostProfile,
     stats: &HcOptState,
@@ -3896,13 +3897,53 @@ fn priceset_range_nonabort_scalar(
     new_last
 }
 
-/// AVX2 counterpart of [`priceset_range_nonabort_scalar`]: process the range
-/// in 8-lane chunks (scalar `next_cost`, same byte-identical chain; AVX2
-/// unsigned compare against the contiguous `node_prices` SoA array; scalar
-/// write of the improving lanes), scalar remainder tail. `#[target_feature]`
-/// + `#[inline]` so it folds into the avx2 optimal-parser wrapper's
-/// `target_feature` umbrella — no runtime feature detection, no call ABI,
-/// `cached_match_length_price` inlines.
+/// Vector-load 8 cached ml-prices for the optimal parser's price-set, given a
+/// run of 8 contiguous `[price, generation]` cells. Returns `Some(prices)`
+/// only when ALL eight cells are warm (`generation == stamp`) — the common
+/// (~91-98%) case — so the caller can fold them with one broadcast constant;
+/// any cold cell returns `None` to route the chunk through the scalar fill
+/// (which recomputes + repopulates the misses). Deinterleaves the price (even)
+/// and generation (odd) lanes with two `permutevar8x32` + a `permute2x128`.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+#[inline]
+unsafe fn priceset_cached_prices8_avx2(cells: &[[u32; 2]], stamp: u32) -> Option<[u32; 8]> {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256, _mm256_movemask_ps,
+        _mm256_permute2x128_si256, _mm256_permutevar8x32_epi32, _mm256_set1_epi32,
+        _mm256_setr_epi32, _mm256_storeu_si256,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+        __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256, _mm256_movemask_ps,
+        _mm256_permute2x128_si256, _mm256_permutevar8x32_epi32, _mm256_set1_epi32,
+        _mm256_setr_epi32, _mm256_storeu_si256,
+    };
+    debug_assert!(cells.len() >= 8);
+    let base = cells.as_ptr() as *const __m256i;
+    // v0 = [p0 g0 p1 g1 p2 g2 p3 g3], v1 = [p4 g4 .. p7 g7] (contiguous pairs).
+    let v0 = unsafe { _mm256_loadu_si256(base) };
+    let v1 = unsafe { _mm256_loadu_si256(base.add(1)) };
+    let idx_even = _mm256_setr_epi32(0, 2, 4, 6, 0, 2, 4, 6);
+    let idx_odd = _mm256_setr_epi32(1, 3, 5, 7, 1, 3, 5, 7);
+    // Gather the 8 generation stamps (odd lanes) and require an all-hit chunk.
+    let g_lo = _mm256_permutevar8x32_epi32(v0, idx_odd);
+    let g_hi = _mm256_permutevar8x32_epi32(v1, idx_odd);
+    let gens = _mm256_permute2x128_si256(g_lo, g_hi, 0x20);
+    let eq = _mm256_cmpeq_epi32(gens, _mm256_set1_epi32(stamp as i32));
+    if _mm256_movemask_ps(_mm256_castsi256_ps(eq)) as u8 != 0xFF {
+        return None;
+    }
+    // All hit: deinterleave the 8 cached prices (even lanes) in order.
+    let p_lo = _mm256_permutevar8x32_epi32(v0, idx_even);
+    let p_hi = _mm256_permutevar8x32_epi32(v1, idx_even);
+    let prices = _mm256_permute2x128_si256(p_lo, p_hi, 0x20);
+    let mut out = [0u32; 8];
+    unsafe { _mm256_storeu_si256(out.as_mut_ptr() as *mut __m256i, prices) };
+    Some(out)
+}
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 #[inline]
@@ -3926,19 +3967,44 @@ unsafe fn priceset_range_nonabort_avx2(
 ) -> usize {
     let mut new_last = last_pos;
     let mut buf = [0u32; 8];
+    // Loop-invariant constant of the byte-identical next_cost chain:
+    // next_cost = add_prices(base_cost, add_prices(ll0_price,
+    //   match_price_from_parts(off_price, ml_price))) = c_base + ml_price,
+    // with c_base = base_cost + ll0_price + match_price_from_parts(off_price, 0)
+    // (folds the off_price + non-Predefined bias). Lets the all-hit chunk add
+    // the vector-loaded cached prices to one broadcast constant.
+    let c_base = base_cost
+        .wrapping_add(ll0_price)
+        .wrapping_add(profile.match_price_from_parts(off_price, 0, stats));
     let mut ml = start;
     while ml + 8 <= max + 1 {
-        for (k, slot) in buf.iter_mut().enumerate() {
-            *slot = priceset_next_cost(
-                profile,
-                stats,
-                ml_cache,
-                ml_stamp,
-                ml + k,
-                ll0_price,
-                off_price,
-                base_cost,
-            );
+        // Fast path: all 8 ml-price cells are warm (gen == stamp, ~91-98% of
+        // chunks) — vector-load + deinterleave the cached prices and fold the
+        // constant, instead of 8 scalar cache probes. Cold/out-of-cache chunks
+        // fall back to the scalar `next_cost` (which fills the cache).
+        let vectorised = if ml + 8 <= ml_cache.len() {
+            // SAFETY: avx2 umbrella; slice is >= 8 cells.
+            unsafe { priceset_cached_prices8_avx2(&ml_cache[ml..ml + 8], ml_stamp) }
+        } else {
+            None
+        };
+        if let Some(prices) = vectorised {
+            for (k, slot) in buf.iter_mut().enumerate() {
+                *slot = c_base.wrapping_add(prices[k]);
+            }
+        } else {
+            for (k, slot) in buf.iter_mut().enumerate() {
+                *slot = priceset_next_cost(
+                    profile,
+                    stats,
+                    ml_cache,
+                    ml_stamp,
+                    ml + k,
+                    ll0_price,
+                    off_price,
+                    base_cost,
+                );
+            }
         }
         let base_next = pos + ml;
         // SAFETY: caller's `target_feature(avx2)` umbrella covers this; both

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6453,7 +6453,7 @@ impl HcMatchGenerator {
         &mut self,
         handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
-        if self.table.dms.table().is_some() {
+        if self.table.dms.is_primed() {
             self.start_matching_lazy_impl::<true>(handle_sequence);
         } else {
             self.start_matching_lazy_impl::<false>(handle_sequence);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3903,6 +3903,98 @@ fn priceset_range_nonabort_scalar(
     new_last
 }
 
+/// Per-tier deinterleave + improve-mask correctness vs a scalar reference.
+/// Each tier's dispatch only fires on matching hardware (i9 picks AVX2 over
+/// SSE4.1, M1 picks NEON), so the non-dispatched tiers never run in the
+/// roundtrip suite; this exercises the deinterleave/mask helpers directly on
+/// whatever ISA the test host exposes (AVX2 + SSE4.1 on x86, NEON on aarch64).
+#[cfg(test)]
+#[test]
+fn priceset_tier_helpers_match_scalar() {
+    // Reference: gen-stamped contiguous cells -> ordered prices on all-warm.
+    fn scalar_deint<const W: usize>(cells: &[[u32; 2]], stamp: u32) -> Option<[u32; W]> {
+        let mut out = [0u32; W];
+        for k in 0..W {
+            if cells[k][1] != stamp {
+                return None;
+            }
+            out[k] = cells[k][0];
+        }
+        Some(out)
+    }
+    fn scalar_mask<const W: usize>(nc: &[u32; W], np: &[u32]) -> u8 {
+        let mut m = 0u8;
+        for k in 0..W {
+            if nc[k] < np[k] {
+                m |= 1 << k;
+            }
+        }
+        m
+    }
+    const S: u32 = 0x55;
+    let warm: [[u32; 2]; 4] = [[11, S], [22, S], [33, S], [44, S]];
+    let mut cold = warm;
+    cold[2][1] = S ^ 1; // one stale cell -> must yield None
+    let nc4: [u32; 4] = [10, 99, 30, 41];
+    let np4: [u32; 4] = [20, 21, 30, 99]; // lt: lane0 (10<20), lane3 (41<99)
+
+    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+    unsafe {
+        assert_eq!(
+            priceset_cached_prices4_neon(&warm, S),
+            scalar_deint::<4>(&warm, S)
+        );
+        assert_eq!(priceset_cached_prices4_neon(&cold, S), None);
+        assert_eq!(
+            priceset_improved_mask4_neon(&nc4, &np4),
+            scalar_mask::<4>(&nc4, &np4)
+        );
+    }
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        if std::is_x86_feature_detected!("sse4.2") {
+            unsafe {
+                assert_eq!(
+                    priceset_cached_prices4_sse41(&warm, S),
+                    scalar_deint::<4>(&warm, S)
+                );
+                assert_eq!(priceset_cached_prices4_sse41(&cold, S), None);
+                assert_eq!(
+                    priceset_improved_mask4_sse41(&nc4, &np4),
+                    scalar_mask::<4>(&nc4, &np4)
+                );
+            }
+        }
+        if std::is_x86_feature_detected!("avx2") {
+            let warm8: [[u32; 2]; 8] = [
+                [11, S],
+                [22, S],
+                [33, S],
+                [44, S],
+                [55, S],
+                [66, S],
+                [77, S],
+                [88, S],
+            ];
+            let mut cold8 = warm8;
+            cold8[5][1] = S ^ 1;
+            let nc8: [u32; 8] = [10, 99, 30, 41, 99, 60, 99, 80];
+            let np8: [u32; 8] = [20, 21, 30, 99, 50, 99, 70, 99];
+            unsafe {
+                assert_eq!(
+                    priceset_cached_prices8_avx2(&warm8, S),
+                    scalar_deint::<8>(&warm8, S)
+                );
+                assert_eq!(priceset_cached_prices8_avx2(&cold8, S), None);
+                assert_eq!(
+                    priceset_improved_mask8_avx2(&nc8, &np8),
+                    scalar_mask::<8>(&nc8, &np8)
+                );
+            }
+        }
+    }
+}
+
 /// Shared vectorised price-set loop body, generic over the SIMD width `W`.
 /// The per-tier `deint` (vector-load plus deinterleave of `W` cached prices,
 /// returning `Some` only on an all-warm chunk) and `mask` (per-tier
@@ -4185,6 +4277,111 @@ unsafe fn priceset_range_nonabort_neon(
         // SAFETY: both closures run inside this fn's neon target_feature umbrella.
         |cells, stamp| unsafe { priceset_cached_prices4_neon(cells, stamp) },
         |nc, np| unsafe { priceset_improved_mask4_neon(nc, np) },
+    )
+}
+
+/// SSE4.1 4-lane vector-load + deinterleave of cached ml-prices. Two 128-bit
+/// loads of `[price, gen]` pairs, `shuffle_epi32(0xD8)` groups prices then gens
+/// within each, `unpacklo/hi_epi64` separates them. `Some(prices)` only when
+/// all 4 generations equal `stamp`.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse4.2")]
+#[inline]
+unsafe fn priceset_cached_prices4_sse41(cells: &[[u32; 2]], stamp: u32) -> Option<[u32; 4]> {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        __m128i, _mm_castsi128_ps, _mm_cmpeq_epi32, _mm_loadu_si128, _mm_movemask_ps,
+        _mm_set1_epi32, _mm_shuffle_epi32, _mm_storeu_si128, _mm_unpackhi_epi64,
+        _mm_unpacklo_epi64,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+        __m128i, _mm_castsi128_ps, _mm_cmpeq_epi32, _mm_loadu_si128, _mm_movemask_ps,
+        _mm_set1_epi32, _mm_shuffle_epi32, _mm_storeu_si128, _mm_unpackhi_epi64,
+        _mm_unpacklo_epi64,
+    };
+    debug_assert!(cells.len() >= 4);
+    let base = cells.as_ptr() as *const __m128i;
+    let v0 = unsafe { _mm_loadu_si128(base) }; // [p0 g0 p1 g1]
+    let v1 = unsafe { _mm_loadu_si128(base.add(1)) }; // [p2 g2 p3 g3]
+    let s0 = _mm_shuffle_epi32(v0, 0xD8); // [p0 p1 g0 g1]
+    let s1 = _mm_shuffle_epi32(v1, 0xD8); // [p2 p3 g2 g3]
+    let gens = _mm_unpackhi_epi64(s0, s1); // [g0 g1 g2 g3]
+    let eq = _mm_cmpeq_epi32(gens, _mm_set1_epi32(stamp as i32));
+    if _mm_movemask_ps(_mm_castsi128_ps(eq)) as u8 & 0x0F != 0x0F {
+        return None;
+    }
+    let prices = _mm_unpacklo_epi64(s0, s1); // [p0 p1 p2 p3]
+    let mut out = [0u32; 4];
+    unsafe { _mm_storeu_si128(out.as_mut_ptr() as *mut __m128i, prices) };
+    Some(out)
+}
+
+/// SSE4.1 4-lane `next_cost < node_price` bitmask (unsigned compare via
+/// `min_epu32`, like the AVX2 path).
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse4.2")]
+#[inline]
+unsafe fn priceset_improved_mask4_sse41(next_cost: &[u32; 4], node_price: &[u32]) -> u8 {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        __m128i, _mm_andnot_si128, _mm_castsi128_ps, _mm_cmpeq_epi32, _mm_loadu_si128,
+        _mm_min_epu32, _mm_movemask_ps,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+        __m128i, _mm_andnot_si128, _mm_castsi128_ps, _mm_cmpeq_epi32, _mm_loadu_si128,
+        _mm_min_epu32, _mm_movemask_ps,
+    };
+    let nc = unsafe { _mm_loadu_si128(next_cost.as_ptr() as *const __m128i) };
+    let np = unsafe { _mm_loadu_si128(node_price.as_ptr() as *const __m128i) };
+    let min = _mm_min_epu32(nc, np);
+    let le = _mm_cmpeq_epi32(min, nc);
+    let eq = _mm_cmpeq_epi32(nc, np);
+    let lt = _mm_andnot_si128(eq, le);
+    (_mm_movemask_ps(_mm_castsi128_ps(lt)) as u8) & 0x0F
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "sse4.2")]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+unsafe fn priceset_range_nonabort_sse41(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+) -> usize {
+    priceset_range_vec::<4>(
+        node_prices,
+        nodes,
+        ml_cache,
+        ml_stamp,
+        profile,
+        stats,
+        pos,
+        start,
+        max,
+        ll0_price,
+        off_price,
+        base_cost,
+        off,
+        reps,
+        last_pos,
+        // SAFETY: both closures run inside this fn's sse4.2 target_feature umbrella.
+        |cells, stamp| unsafe { priceset_cached_prices4_sse41(cells, stamp) },
+        |nc, np| unsafe { priceset_improved_mask4_sse41(nc, np) },
     )
 }
 
@@ -6596,7 +6793,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_sse42,
-            priceset_range_nonabort_scalar,
+            priceset_range_nonabort_sse41,
         )
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2739,6 +2739,23 @@ impl Matcher for MatchGeneratorDriver {
             (MatcherStorage::Simple(live), MatcherStorage::Simple(snap)) => {
                 live.clone_from(snap);
             }
+            // Same-variant HC lazy/greedy restore (non-BT): the snapshot keeps
+            // the full primed hash/chain tables (capture's non-BT full clone),
+            // so `clone_from` reuses the live history/hash/chain/dms buffers in
+            // place — donor reuses the CDict tables rather than reallocating
+            // them. This is the per-frame allocate+copy+drop that dominated
+            // small `compress-dict` HC frames (5-7x vs C). BT (`uses_bt`)
+            // snapshots drop their live tables, so they stay on the realloc
+            // path below.
+            (MatcherStorage::HashChain(live), MatcherStorage::HashChain(snap))
+                if !snap.table.uses_bt =>
+            {
+                live.table.clone_from(&snap.table);
+                live.hc.clone_from(&snap.hc);
+                live.strategy_tag = snap.strategy_tag;
+                // backend is `HcBackend::Hc` (zero-sized) for non-BT levels;
+                // the live one is already correct for this resolved key.
+            }
             (live, snapshot_storage) => {
                 let mut storage = snapshot_storage.clone();
                 // A binary-tree snapshot is stored WITHOUT its live hash /

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3902,8 +3902,11 @@ fn priceset_range_nonabort_scalar(
 /// only when ALL eight cells are warm (`generation == stamp`) — the common
 /// (~91-98%) case — so the caller can fold them with one broadcast constant;
 /// any cold cell returns `None` to route the chunk through the scalar fill
-/// (which recomputes + repopulates the misses). Deinterleaves the price (even)
-/// and generation (odd) lanes with two `permutevar8x32` + a `permute2x128`.
+/// (which recomputes + repopulates the misses). Deinterleaves with cheap
+/// in-128-lane ops (`shuffle_epi32` + `unpack*_epi64`) and a single cross-lane
+/// `permute4x64` for the ordered prices — avoiding the latency-bound chain of
+/// cross-lane `permutevar8x32`s that lost to pipelined scalar loads on
+/// high-chunk-count fixtures.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 #[inline]
@@ -3911,34 +3914,34 @@ unsafe fn priceset_cached_prices8_avx2(cells: &[[u32; 2]], stamp: u32) -> Option
     #[cfg(target_arch = "x86")]
     use core::arch::x86::{
         __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256, _mm256_movemask_ps,
-        _mm256_permute2x128_si256, _mm256_permutevar8x32_epi32, _mm256_set1_epi32,
-        _mm256_setr_epi32, _mm256_storeu_si256,
+        _mm256_permute4x64_epi64, _mm256_set1_epi32, _mm256_shuffle_epi32, _mm256_storeu_si256,
+        _mm256_unpackhi_epi64, _mm256_unpacklo_epi64,
     };
     #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{
         __m256i, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256, _mm256_movemask_ps,
-        _mm256_permute2x128_si256, _mm256_permutevar8x32_epi32, _mm256_set1_epi32,
-        _mm256_setr_epi32, _mm256_storeu_si256,
+        _mm256_permute4x64_epi64, _mm256_set1_epi32, _mm256_shuffle_epi32, _mm256_storeu_si256,
+        _mm256_unpackhi_epi64, _mm256_unpacklo_epi64,
     };
     debug_assert!(cells.len() >= 8);
     let base = cells.as_ptr() as *const __m256i;
-    // v0 = [p0 g0 p1 g1 p2 g2 p3 g3], v1 = [p4 g4 .. p7 g7] (contiguous pairs).
+    // v0 = [p0 g0 p1 g1 | p2 g2 p3 g3], v1 = [p4 g4 p5 g5 | p6 g6 p7 g7].
     let v0 = unsafe { _mm256_loadu_si256(base) };
     let v1 = unsafe { _mm256_loadu_si256(base.add(1)) };
-    let idx_even = _mm256_setr_epi32(0, 2, 4, 6, 0, 2, 4, 6);
-    let idx_odd = _mm256_setr_epi32(1, 3, 5, 7, 1, 3, 5, 7);
-    // Gather the 8 generation stamps (odd lanes) and require an all-hit chunk.
-    let g_lo = _mm256_permutevar8x32_epi32(v0, idx_odd);
-    let g_hi = _mm256_permutevar8x32_epi32(v1, idx_odd);
-    let gens = _mm256_permute2x128_si256(g_lo, g_hi, 0x20);
+    // In-128-lane group prices then gens: [p g p g] -> [p p g g] (control 0xD8).
+    let s0 = _mm256_shuffle_epi32(v0, 0xD8); // [p0 p1 g0 g1 | p2 p3 g2 g3]
+    let s1 = _mm256_shuffle_epi32(v1, 0xD8); // [p4 p5 g4 g5 | p6 p7 g6 g7]
+    // Gens (hi 64 of each 128-lane) — order irrelevant for the all-equal test.
+    let gens = _mm256_unpackhi_epi64(s0, s1);
     let eq = _mm256_cmpeq_epi32(gens, _mm256_set1_epi32(stamp as i32));
     if _mm256_movemask_ps(_mm256_castsi256_ps(eq)) as u8 != 0xFF {
         return None;
     }
-    // All hit: deinterleave the 8 cached prices (even lanes) in order.
-    let p_lo = _mm256_permutevar8x32_epi32(v0, idx_even);
-    let p_hi = _mm256_permutevar8x32_epi32(v1, idx_even);
-    let prices = _mm256_permute2x128_si256(p_lo, p_hi, 0x20);
+    // Prices (lo 64 of each 128-lane): [p0 p1 p4 p5 | p2 p3 p6 p7] as 64-bit
+    // chunks [c0 c1 c2 c3] = [p0p1 p4p5 p2p3 p6p7]; reorder to [c0 c2 c1 c3]
+    // (control 0xD8) for in-order [p0..p7].
+    let p_scrambled = _mm256_unpacklo_epi64(s0, s1);
+    let prices = _mm256_permute4x64_epi64(p_scrambled, 0xD8);
     let mut out = [0u32; 8];
     unsafe { _mm256_storeu_si256(out.as_mut_ptr() as *mut __m256i, prices) };
     Some(out)

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2703,6 +2703,35 @@ impl Matcher for MatchGeneratorDriver {
             // Recompute the lazy-HC attach decision made per-chunk in
             // `skip_matching_for_dictionary_priming` (stable across the prime —
             // `reset_size_log` does not change here).
+            //
+            // The HC attach/copy mode is deliberately NOT folded into `PrimedKey`
+            // (unlike Fast `fast_attach`). Fast attach builds a separate dict
+            // table whose dimensions differ from the copy-mode live table, so a
+            // cross-mode restore would install mismatched table geometry and the
+            // encoder could search past the frame window (undecodable). The two
+            // HC modes share identical window geometry: `max_window_size` and the
+            // dictionary limit are both set ABOVE this branch (the same value in
+            // either mode), and the live chain table dimensions come from the
+            // resolved `params` the key already pins. The modes differ only in
+            // WHERE the committed dict lives — a single-link `dms` (attach) vs
+            // merged into the live chain (copy) — both producing valid matches at
+            // in-window offsets. Upstream zstd makes the same observation: attach
+            // (`ZSTD_resetCCtx_byAttachingCDict`) and copy
+            // (`ZSTD_resetCCtx_byCopyingCDict`) both keep the caller's
+            // `windowLog`; the choice is a memory/speed trade-off, not a wire
+            // contract. So restoring an attach snapshot where this frame would
+            // have copied (or vice versa) yields a decodable frame that may only
+            // differ in which matches are found (ratio) — algorithmic freedom, not
+            // a defect. Keying on the mode would instead force a re-prime across
+            // the cutoff, re-adding the per-frame cost this snapshot path removes.
+            //
+            // In practice the public reuse path (`compress_independent_frame`)
+            // only ever captures AND restores the COPY-mode snapshot — capture is
+            // gated on the above-cutoff source size, so a restored frame always
+            // matches the captured mode. `hc_dict_snapshot_reuse_roundtrips` pins
+            // that same-mode reuse decodes; the driver-level cross-mode restore is
+            // accepted (not refused) per
+            // `primed_snapshot_fast_attach_does_not_over_key_non_simple_backends`.
             let hc_attach = self
                 .reset_size_log
                 .is_none_or(|log| log <= HC_ATTACH_DICT_CUTOFF_LOG);
@@ -4098,6 +4127,18 @@ fn priceset_range_vec<const W: usize>(
     // next_cost = add_prices(base_cost, add_prices(ll0_price,
     //   match_price_from_parts(off_price, ml_price))) = c_base + ml_price,
     // c_base = base_cost + ll0_price + match_price_from_parts(off_price, 0).
+    //
+    // This stays bit-exact with the scalar `priceset_next_cost` because both
+    // helpers are affine in `ml_price`: `BtMatcher::add_prices(a, b) = a + b`
+    // and `match_price_from_parts(off, ml) = off + ml + bias` are plain integer
+    // additions, so `match_price_from_parts(off, ml) = match_price_from_parts(
+    // off, 0) + ml` and the whole chain collapses to `c_base + ml_price`. The
+    // `wrapping_add` here matches the scalar `+` under the cost model's
+    // no-overflow invariant (the `debug_assert`s in both helpers). Factoring the
+    // combine into one helper per the review suggestion would force a per-lane
+    // `match_price_from_parts(off, ml_price)` recompute instead of hoisting the
+    // ml-independent `c_base` once — a regression on this hot DP loop — so the
+    // hoist is kept and the equivalence documented here instead.
     let c_base = base_cost
         .wrapping_add(ll0_price)
         .wrapping_add(profile.match_price_from_parts(off_price, 0, stats));
@@ -10174,11 +10215,15 @@ fn primed_snapshot_not_restored_across_fast_attach_copy_boundary() {
 #[test]
 fn primed_snapshot_fast_attach_does_not_over_key_non_simple_backends() {
     // `fast_attach` is a Simple/Fast-backend concept (the 8 KiB attach-vs-copy
-    // table split). On the HashChain/Dfast/Row backends the dictionary is
-    // always primed the same way, so the bit must NOT enter their snapshot key
-    // — otherwise an unhinted capture (which would record `fast_attach = true`)
-    // and a hinted reset that resolves to the IDENTICAL `LevelParams` would key
-    // differently and force a needless re-prime. `Best` is a Row-backend lazy
+    // table split). Dfast/Row prime the dictionary one way; HashChain has its
+    // OWN attach/copy split (`HC_ATTACH_DICT_CUTOFF_LOG`) but deliberately keeps
+    // it OUT of the snapshot key — both HC modes share the same window geometry,
+    // so a cross-mode restore is decodable (see `prime_with_dictionary` and
+    // `primed_snapshot_hc_cross_mode_roundtrips`). Either way the `fast_attach`
+    // bit must NOT enter a non-Simple snapshot key — otherwise an unhinted
+    // capture (which would record `fast_attach = true`) and a hinted reset that
+    // resolves to the IDENTICAL `LevelParams` would key differently and force a
+    // needless re-prime. `Best` is a Row-backend lazy
     // level; this also pins the Row arm recording its RESOLVED hash width on
     // the unhinted path (a 0 default there keyed unhinted-vs-hinted apart).
     // An explicit Row-backend level: `Best` now sits on level 13 (Btlazy2),

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6354,7 +6354,22 @@ impl HcMatchGenerator {
         }
     }
 
+    /// Dispatcher: pick the dict-aware monomorph when a separate dms is primed
+    /// (attach-mode dictionary), else the no-dict monomorph. Mirrors upstream's
+    /// compile-time `dictMode` split — the `DICT = false` body carries no dms
+    /// code at all, so the no-dict hot path is unaffected by the dict search.
     pub(crate) fn start_matching_lazy(
+        &mut self,
+        handle_sequence: impl for<'a> FnMut(Sequence<'a>),
+    ) {
+        if self.table.dms.table().is_some() {
+            self.start_matching_lazy_impl::<true>(handle_sequence);
+        } else {
+            self.start_matching_lazy_impl::<false>(handle_sequence);
+        }
+    }
+
+    fn start_matching_lazy_impl<const DICT: bool>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
@@ -6385,8 +6400,13 @@ impl HcMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            let best = self.hc.find_best_match(&self.table, abs_pos, lit_len);
-            if let Some(candidate) = self.hc.pick_lazy_match(&self.table, abs_pos, lit_len, best) {
+            let best = self
+                .hc
+                .find_best_match::<DICT>(&self.table, abs_pos, lit_len);
+            if let Some(candidate) =
+                self.hc
+                    .pick_lazy_match::<DICT>(&self.table, abs_pos, lit_len, best)
+            {
                 self.table
                     .insert_match_span(abs_pos, candidate.start + candidate.match_len);
                 let start = candidate.start - current_abs_start;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -685,6 +685,13 @@ const DFAST_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
 /// `row_candidate_rl`), larger known-size inputs dense-COPY into the live rows.
 const ROW_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
 
+/// 16 KiB (`2^14`, donor `attachDictSizeCutoffs[ZSTD_lazy2]`): small /
+/// unknown-size inputs ATTACH the dict as a separate hash-chain dms (the dual
+/// search in `find_best_match` walks the live input chain + the dms), larger
+/// known-size inputs dense-COPY (merge the dict into the live chain and search
+/// the one combined chain).
+const HC_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
+
 // Source-size cap for the dfast hash bits when a size hint is present: a tiny
 // input needs no larger hash than its window. The donor `cParams.hashLog` /
 // `chainLog` (from `DfastConfig`) caps it from above at the call site.
@@ -1892,11 +1899,24 @@ impl MatchGeneratorDriver {
                 if table.uses_bt {
                     // BT / optimal levels: keep the dict in history for the dms
                     // but do NOT insert it into the live tree (donor separate
-                    // dictMatchState). Lazy-HC levels still index the dict into
-                    // the live chain (they have no dms).
+                    // dictMatchState). The dms-BT is built in
+                    // `prime_with_dictionary`.
                     table.skip_matching_dict_bt();
                 } else {
-                    self.hc_matcher_mut().skip_matching(Some(false));
+                    // Lazy-HC: ATTACH (separate dms hash-chain) for small /
+                    // unknown inputs like the Fast/Dfast/Row backends; COPY
+                    // (merge into the live chain) for large known inputs. Attach
+                    // keeps the dict in history but out of the live chain (same
+                    // insert-cursor advance as the BT arm); the dms hash-chain is
+                    // built in `prime_with_dictionary`.
+                    let attach = self
+                        .reset_size_log
+                        .is_none_or(|log| log <= HC_ATTACH_DICT_CUTOFF_LOG);
+                    if attach {
+                        self.hc_matcher_mut().table.skip_matching_dict_bt();
+                    } else {
+                        self.hc_matcher_mut().skip_matching(Some(false));
+                    }
                 }
             }
         }
@@ -2680,13 +2700,25 @@ impl Matcher for MatchGeneratorDriver {
                 .saturating_add(granted_retained_budget);
         }
         if self.active_backend() == super::strategy::BackendTag::HashChain {
+            // Recompute the lazy-HC attach decision made per-chunk in
+            // `skip_matching_for_dictionary_priming` (stable across the prime —
+            // `reset_size_log` does not change here).
+            let hc_attach = self
+                .reset_size_log
+                .is_none_or(|log| log <= HC_ATTACH_DICT_CUTOFF_LOG);
             let table = &mut self.hc_matcher_mut().table;
             table.set_dictionary_limit_from_primed_bytes(committed_dict_budget);
-            // Build the dictMatchState chain for BT/optimal levels so the
-            // collect dual-probes the dictionary with its own compare budget
-            // (the dict bytes were just committed to the front of history).
+            // Build the dictMatchState over the committed dict (front of
+            // history) so `find_best_match` dual-probes it with its own compare
+            // budget. BT/optimal → DUBT dms; lazy-HC attach → single-link
+            // hash-chain dms. Copy-mode lazy-HC merged the dict into the live
+            // chain instead, so drop any stale dms.
             if table.uses_bt {
                 table.prime_dms_bt(committed_dict_budget);
+            } else if hc_attach {
+                table.prime_dms_hc(committed_dict_budget);
+            } else {
+                table.dms.invalidate();
             }
         }
         // CDict-equivalent: now that every dict chunk is indexed, mark the

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3857,6 +3857,12 @@ fn priceset_next_cost(
 /// (no call overhead). Returns the highest written `next`.
 #[inline]
 #[allow(clippy::too_many_arguments)]
+// Used by the scalar / sse42 / wasm DP wrappers; on aarch64 the dispatch only
+// reaches the neon wrapper, so this is cfg-dead there.
+#[cfg_attr(
+    all(target_arch = "aarch64", target_endian = "little"),
+    allow(dead_code)
+)]
 fn priceset_range_nonabort_scalar(
     node_prices: &mut [u32],
     nodes: &mut [HcOptimalNode],
@@ -3893,6 +3899,115 @@ fn priceset_range_nonabort_scalar(
                 new_last = next;
             }
         }
+    }
+    new_last
+}
+
+/// Shared vectorised price-set loop body, generic over the SIMD width `W`.
+/// The per-tier `deint` (vector-load plus deinterleave of `W` cached prices,
+/// returning `Some` only on an all-warm chunk) and `mask` (per-tier
+/// `next_cost` less-than `node_price` bitmask) are passed as zero-sized
+/// `impl Fn`s. `#[inline(always)]` plus monomorphisation folds `deint` and
+/// `mask` directly into each per-tier wrapper's `target_feature` umbrella, so
+/// the intrinsics inline with no call ABI and no runtime feature detection.
+/// Cold or out-of-cache chunks, and the sub-`W` remainder, fall back to the
+/// scalar `priceset_next_cost` (which fills the cache); writes are
+/// scalar-scatter on the improving lanes (1-8% of compares, per the
+/// improve-ratio probe). Same signature tail as the scalar variant.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn priceset_range_vec<const W: usize>(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+    deint: impl Fn(&[[u32; 2]], u32) -> Option<[u32; W]>,
+    mask: impl Fn(&[u32; W], &[u32]) -> u8,
+) -> usize {
+    let mut new_last = last_pos;
+    let mut buf = [0u32; W];
+    // Loop-invariant constant of the byte-identical next_cost chain:
+    // next_cost = add_prices(base_cost, add_prices(ll0_price,
+    //   match_price_from_parts(off_price, ml_price))) = c_base + ml_price,
+    // c_base = base_cost + ll0_price + match_price_from_parts(off_price, 0).
+    let c_base = base_cost
+        .wrapping_add(ll0_price)
+        .wrapping_add(profile.match_price_from_parts(off_price, 0, stats));
+    let mut ml = start;
+    while ml + W <= max + 1 {
+        let vectorised = if ml + W <= ml_cache.len() {
+            deint(&ml_cache[ml..ml + W], ml_stamp)
+        } else {
+            None
+        };
+        if let Some(prices) = vectorised {
+            for (k, slot) in buf.iter_mut().enumerate() {
+                *slot = c_base.wrapping_add(prices[k]);
+            }
+        } else {
+            for (k, slot) in buf.iter_mut().enumerate() {
+                *slot = priceset_next_cost(
+                    profile,
+                    stats,
+                    ml_cache,
+                    ml_stamp,
+                    ml + k,
+                    ll0_price,
+                    off_price,
+                    base_cost,
+                );
+            }
+        }
+        let base_next = pos + ml;
+        let mut bits = mask(&buf, &node_prices[base_next..base_next + W]);
+        while bits != 0 {
+            let k = bits.trailing_zeros() as usize;
+            bits &= bits - 1;
+            let next = base_next + k;
+            node_prices[next] = buf[k];
+            nodes[next] = HcOptimalNode {
+                price: buf[k],
+                off,
+                mlen: (ml + k) as u32,
+                litlen: 0,
+                reps,
+            };
+            if next > new_last {
+                new_last = next;
+            }
+        }
+        ml += W;
+    }
+    while ml <= max {
+        let next_cost = priceset_next_cost(
+            profile, stats, ml_cache, ml_stamp, ml, ll0_price, off_price, base_cost,
+        );
+        let next = pos + ml;
+        if next_cost < node_prices[next] {
+            node_prices[next] = next_cost;
+            nodes[next] = HcOptimalNode {
+                price: next_cost,
+                off,
+                mlen: ml as u32,
+                litlen: 0,
+                reps,
+            };
+            if next > new_last {
+                new_last = next;
+            }
+        }
+        ml += 1;
     }
     new_last
 }
@@ -3968,92 +4083,109 @@ unsafe fn priceset_range_nonabort_avx2(
     reps: [u32; 3],
     last_pos: usize,
 ) -> usize {
-    let mut new_last = last_pos;
-    let mut buf = [0u32; 8];
-    // Loop-invariant constant of the byte-identical next_cost chain:
-    // next_cost = add_prices(base_cost, add_prices(ll0_price,
-    //   match_price_from_parts(off_price, ml_price))) = c_base + ml_price,
-    // with c_base = base_cost + ll0_price + match_price_from_parts(off_price, 0)
-    // (folds the off_price + non-Predefined bias). Lets the all-hit chunk add
-    // the vector-loaded cached prices to one broadcast constant.
-    let c_base = base_cost
-        .wrapping_add(ll0_price)
-        .wrapping_add(profile.match_price_from_parts(off_price, 0, stats));
-    let mut ml = start;
-    while ml + 8 <= max + 1 {
-        // Fast path: all 8 ml-price cells are warm (gen == stamp, ~91-98% of
-        // chunks) — vector-load + deinterleave the cached prices and fold the
-        // constant, instead of 8 scalar cache probes. Cold/out-of-cache chunks
-        // fall back to the scalar `next_cost` (which fills the cache).
-        let vectorised = if ml + 8 <= ml_cache.len() {
-            // SAFETY: avx2 umbrella; slice is >= 8 cells.
-            unsafe { priceset_cached_prices8_avx2(&ml_cache[ml..ml + 8], ml_stamp) }
-        } else {
-            None
-        };
-        if let Some(prices) = vectorised {
-            for (k, slot) in buf.iter_mut().enumerate() {
-                *slot = c_base.wrapping_add(prices[k]);
-            }
-        } else {
-            for (k, slot) in buf.iter_mut().enumerate() {
-                *slot = priceset_next_cost(
-                    profile,
-                    stats,
-                    ml_cache,
-                    ml_stamp,
-                    ml + k,
-                    ll0_price,
-                    off_price,
-                    base_cost,
-                );
-            }
-        }
-        let base_next = pos + ml;
-        // SAFETY: caller's `target_feature(avx2)` umbrella covers this; both
-        // slices are exactly 8 u32 wide.
-        let mask =
-            unsafe { priceset_improved_mask8_avx2(&buf, &node_prices[base_next..base_next + 8]) };
-        let mut bits = mask;
-        while bits != 0 {
-            let k = bits.trailing_zeros() as usize;
-            bits &= bits - 1;
-            let next = base_next + k;
-            node_prices[next] = buf[k];
-            nodes[next] = HcOptimalNode {
-                price: buf[k],
-                off,
-                mlen: (ml + k) as u32,
-                litlen: 0,
-                reps,
-            };
-            if next > new_last {
-                new_last = next;
-            }
-        }
-        ml += 8;
+    priceset_range_vec::<8>(
+        node_prices,
+        nodes,
+        ml_cache,
+        ml_stamp,
+        profile,
+        stats,
+        pos,
+        start,
+        max,
+        ll0_price,
+        off_price,
+        base_cost,
+        off,
+        reps,
+        last_pos,
+        // SAFETY: both closures run inside this fn's avx2 target_feature umbrella.
+        |cells, stamp| unsafe { priceset_cached_prices8_avx2(cells, stamp) },
+        |nc, np| unsafe { priceset_improved_mask8_avx2(nc, np) },
+    )
+}
+
+/// NEON 4-lane vector-load + deinterleave of cached ml-prices. `vld2q_u32`
+/// deinterleaves the 4 contiguous `[price, generation]` pairs natively into
+/// two registers (prices, gens) — no shuffle chain. `Some(prices)` only when
+/// all 4 generations equal `stamp` (`vminvq` of the equality mask is all-ones).
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+#[inline]
+unsafe fn priceset_cached_prices4_neon(cells: &[[u32; 2]], stamp: u32) -> Option<[u32; 4]> {
+    use core::arch::aarch64::{vceqq_u32, vdupq_n_u32, vld2q_u32, vminvq_u32, vst1q_u32};
+    debug_assert!(cells.len() >= 4);
+    // SAFETY: caller's neon umbrella; `cells` is >= 4 pairs = 8 contiguous u32.
+    let pair = unsafe { vld2q_u32(cells.as_ptr() as *const u32) };
+    let eq = vceqq_u32(pair.1, vdupq_n_u32(stamp));
+    if vminvq_u32(eq) != u32::MAX {
+        return None;
     }
-    while ml <= max {
-        let next_cost = priceset_next_cost(
-            profile, stats, ml_cache, ml_stamp, ml, ll0_price, off_price, base_cost,
-        );
-        let next = pos + ml;
-        if next_cost < node_prices[next] {
-            node_prices[next] = next_cost;
-            nodes[next] = HcOptimalNode {
-                price: next_cost,
-                off,
-                mlen: ml as u32,
-                litlen: 0,
-                reps,
-            };
-            if next > new_last {
-                new_last = next;
-            }
-        }
-        ml += 1;
-    }
-    new_last
+    let mut out = [0u32; 4];
+    unsafe { vst1q_u32(out.as_mut_ptr(), pair.0) };
+    Some(out)
+}
+
+/// NEON 4-lane `next_cost < node_price` bitmask. NEON has an unsigned compare
+/// (`vcltq_u32`) but no movemask; AND the all-ones lane mask with lane weights
+/// `[1,2,4,8]` and horizontal-add (`vaddvq_u32`) to pack the 4 bits.
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+#[inline]
+unsafe fn priceset_improved_mask4_neon(next_cost: &[u32; 4], node_price: &[u32]) -> u8 {
+    use core::arch::aarch64::{vaddvq_u32, vandq_u32, vcltq_u32, vld1q_u32, vst1q_u32};
+    // SAFETY: neon umbrella; both spans are 4 u32 wide.
+    let nc = unsafe { vld1q_u32(next_cost.as_ptr()) };
+    let np = unsafe { vld1q_u32(node_price.as_ptr()) };
+    let lt = vcltq_u32(nc, np);
+    let weights: [u32; 4] = [1, 2, 4, 8];
+    let w = unsafe { vld1q_u32(weights.as_ptr()) };
+    let bits = vandq_u32(lt, w);
+    let _ = vst1q_u32; // silence unused import on some toolchains
+    vaddvq_u32(bits) as u8
+}
+
+#[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+#[target_feature(enable = "neon")]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+unsafe fn priceset_range_nonabort_neon(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+) -> usize {
+    priceset_range_vec::<4>(
+        node_prices,
+        nodes,
+        ml_cache,
+        ml_stamp,
+        profile,
+        stats,
+        pos,
+        start,
+        max,
+        ll0_price,
+        off_price,
+        base_cost,
+        off,
+        reps,
+        last_pos,
+        // SAFETY: both closures run inside this fn's neon target_feature umbrella.
+        |cells, stamp| unsafe { priceset_cached_prices4_neon(cells, stamp) },
+        |nc, np| unsafe { priceset_improved_mask4_neon(nc, np) },
+    )
 }
 
 macro_rules! build_optimal_plan_impl_body {
@@ -6435,7 +6567,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_neon,
-            priceset_range_nonabort_scalar,
+            priceset_range_nonabort_neon,
         )
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3831,6 +3831,7 @@ macro_rules! build_optimal_plan_impl_body {
             <$strategy_ty as super::strategy::Strategy>::OPT_LEVEL == 0;
         let opt_level: bool = <$strategy_ty as super::strategy::Strategy>::OPT_LEVEL >= 2;
         let mut nodes = core::mem::take(&mut $self.backend.bt_mut().opt_nodes_scratch);
+        let mut node_prices = core::mem::take(&mut $self.backend.bt_mut().opt_node_prices_scratch);
         // `frontier_limit + 2 <= HC_OPT_NODE_LEN` — bounded by const.
         let frontier_buffer_size = frontier_limit + 2;
         if nodes.len() < HC_OPT_NODE_LEN {
@@ -3838,6 +3839,13 @@ macro_rules! build_optimal_plan_impl_body {
             // buffer: allocate the fixed upstream-zstd-sized frontier once. The DP
             // overwrites the active prefix before reading it.
             nodes = alloc::vec![HcOptimalNode::default(); HC_OPT_NODE_LEN].into_boxed_slice();
+        }
+        // SoA price companion, same fixed length as `nodes`. Initialised to
+        // u32::MAX so unwritten frontier cells compare as "unreachable",
+        // mirroring `HcOptimalNode::default().price`. Kept in lockstep with
+        // every `nodes[i].price` write below.
+        if node_prices.len() < HC_OPT_NODE_LEN {
+            node_prices = alloc::vec![u32::MAX; HC_OPT_NODE_LEN].into_boxed_slice();
         }
         let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
         candidates.clear();
@@ -3892,18 +3900,20 @@ macro_rules! build_optimal_plan_impl_body {
             .wrapping_add(1)
             .max(1);
         let ml_price_stamp = $self.backend.bt_mut().opt_ml_price_stamp;
+        let node0_price = BtMatcher::cached_lit_length_price(
+            profile,
+            $stats,
+            initial_litlen,
+            &mut ll_cache,
+            ll_price_stamp,
+        );
         nodes[0] = HcOptimalNode {
-            price: BtMatcher::cached_lit_length_price(
-                profile,
-                $stats,
-                initial_litlen,
-                &mut ll_cache,
-                ll_price_stamp,
-            ),
+            price: node0_price,
             litlen: initial_litlen as u32,
             reps: initial_reps,
             ..HcOptimalNode::default()
         };
+        node_prices[0] = node0_price;
         let sufficient_len = profile.sufficient_match_len;
         let ll0_price = BtMatcher::cached_lit_length_price(
             profile,
@@ -4059,7 +4069,12 @@ macro_rules! build_optimal_plan_impl_body {
                         continue;
                     }
                     if max_match_len > last_pos {
-                        BtMatcher::reset_opt_nodes(&mut nodes, last_pos + 1, max_match_len);
+                        BtMatcher::reset_opt_nodes(
+                            &mut nodes,
+                            &mut node_prices,
+                            last_pos + 1,
+                            max_match_len,
+                        );
                     }
                     let off_base = BtMatcher::encode_offset_base_with_reps(
                         candidate.offset as u32,
@@ -4083,7 +4098,7 @@ macro_rules! build_optimal_plan_impl_body {
                             profile.match_price_from_parts(off_price, ml_price, $stats),
                         );
                         let next_cost = BtMatcher::add_prices(nodes0_price, seq_cost);
-                        let node_price = unsafe { nodes.get_unchecked(match_len).price };
+                        let node_price = unsafe { *node_prices.get_unchecked(match_len) };
                         if match_len > last_pos || next_cost < node_price {
                             let slot = unsafe { nodes.get_unchecked_mut(match_len) };
                             *slot = HcOptimalNode {
@@ -4093,6 +4108,7 @@ macro_rules! build_optimal_plan_impl_body {
                                 litlen: 0,
                                 reps: initial_reps,
                             };
+                            unsafe { *node_prices.get_unchecked_mut(match_len) = next_cost };
                             if match_len > last_pos {
                                 last_pos = match_len;
                             }
@@ -4104,6 +4120,7 @@ macro_rules! build_optimal_plan_impl_body {
                 }
                 if last_pos + 1 < frontier_buffer_size {
                     nodes[last_pos + 1].price = u32::MAX;
+                    node_prices[last_pos + 1] = u32::MAX;
                 }
             }
         }
@@ -4138,6 +4155,7 @@ macro_rules! build_optimal_plan_impl_body {
                     *slot = prev_node;
                     slot.litlen = lit_len as u32;
                     slot.price = lit_cost;
+                    node_prices[pos] = lit_cost;
                     #[allow(clippy::collapsible_if)]
                     if opt_level
                         && prev_match.mlen > 0
@@ -4188,6 +4206,7 @@ macro_rules! build_optimal_plan_impl_body {
                                     slot.reps = reps_after_match;
                                     slot.litlen = 1;
                                     slot.price = with1literal;
+                                    node_prices[next] = with1literal;
                                     if next > last_pos {
                                         last_pos = next;
                                     }
@@ -4341,7 +4360,12 @@ macro_rules! build_optimal_plan_impl_body {
                 }
                 let max_next = pos + max_match_len;
                 if max_next > last_pos {
-                    BtMatcher::reset_opt_nodes(&mut nodes, last_pos + 1, max_next);
+                    BtMatcher::reset_opt_nodes(
+                        &mut nodes,
+                        &mut node_prices,
+                        last_pos + 1,
+                        max_next,
+                    );
                 }
                 let lit_len = base_litlen;
                 let off_base = BtMatcher::encode_offset_base_with_reps(
@@ -4366,7 +4390,7 @@ macro_rules! build_optimal_plan_impl_body {
                         profile.match_price_from_parts(off_price, ml_price, $stats),
                     );
                     let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
-                    let node_next_price = unsafe { nodes.get_unchecked(next).price };
+                    let node_next_price = unsafe { *node_prices.get_unchecked(next) };
                     let improved = next > last_pos || next_cost < node_next_price;
                     if improved {
                         let slot = unsafe { nodes.get_unchecked_mut(next) };
@@ -4377,6 +4401,7 @@ macro_rules! build_optimal_plan_impl_body {
                             litlen: 0,
                             reps: base_reps,
                         };
+                        unsafe { *node_prices.get_unchecked_mut(next) = next_cost };
                         if next > last_pos {
                             last_pos = next;
                         }
@@ -4390,6 +4415,7 @@ macro_rules! build_optimal_plan_impl_body {
             if last_pos + 1 < frontier_buffer_size {
                 unsafe {
                     nodes.get_unchecked_mut(last_pos + 1).price = u32::MAX;
+                    *node_prices.get_unchecked_mut(last_pos + 1) = u32::MAX;
                 }
             }
             pos += 1;
@@ -4401,6 +4427,7 @@ macro_rules! build_optimal_plan_impl_body {
                 return $self.backend.bt_mut().finish_optimal_plan(
                     HcOptimalPlanBuffers {
                         nodes,
+                        node_prices,
                         candidates,
                         store,
                         price_arena,
@@ -4439,6 +4466,7 @@ macro_rules! build_optimal_plan_impl_body {
             return $self.backend.bt_mut().finish_optimal_plan(
                 HcOptimalPlanBuffers {
                     nodes,
+                    node_prices,
                     candidates,
                     store,
                     price_arena,
@@ -4457,6 +4485,7 @@ macro_rules! build_optimal_plan_impl_body {
             return $self.backend.bt_mut().finish_optimal_plan(
                 HcOptimalPlanBuffers {
                     nodes,
+                    node_prices,
                     candidates,
                     store,
                     price_arena,
@@ -4469,6 +4498,7 @@ macro_rules! build_optimal_plan_impl_body {
             return $self.backend.bt_mut().finish_optimal_plan(
                 HcOptimalPlanBuffers {
                     nodes,
+                    node_prices,
                     candidates,
                     store,
                     price_arena,
@@ -4497,6 +4527,7 @@ macro_rules! build_optimal_plan_impl_body {
                 return $self.backend.bt_mut().finish_optimal_plan(
                     HcOptimalPlanBuffers {
                         nodes,
+                        node_prices,
                         candidates,
                         store,
                         price_arena,
@@ -4590,6 +4621,7 @@ macro_rules! build_optimal_plan_impl_body {
         $self.backend.bt_mut().finish_optimal_plan(
             HcOptimalPlanBuffers {
                 nodes,
+                node_prices,
                 candidates,
                 store,
                 price_arena,

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6373,7 +6373,19 @@ impl HcMatchGenerator {
                 literals_start = pos;
             } else {
                 self.table.insert_position(abs_pos);
-                pos += 1;
+                // Lazy skipping (upstream zstd `ZSTD_compressBlock_lazy_generic`,
+                // zstd_lazy.c:1614): advance faster over runs with no match.
+                // `step = ((ip - anchor) >> kSearchStrength) + 1` with
+                // kSearchStrength = 8, where `ip - anchor` is the current
+                // literal-run length. On compressible input the run stays short
+                // (step == 1, identical to a 1-byte advance); on incompressible
+                // / dict-over-random input the run grows so the parser skips
+                // ahead (one search per `step` positions) instead of searching
+                // every byte. Skipped positions are not inserted, mirroring
+                // upstream (it inserts only searched positions during a no-match
+                // run). Ratio follows upstream (not byte-identical).
+                let step = ((pos - literals_start) >> 8) + 1;
+                pos += step;
             }
         }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -4015,7 +4015,6 @@ fn priceset_range_nonabort_scalar(
         if next_cost < node_prices[next] {
             node_prices[next] = next_cost;
             nodes[next] = HcOptimalNode {
-                price: next_cost,
                 off,
                 mlen: ml as u32,
                 litlen: 0,
@@ -4219,7 +4218,6 @@ fn priceset_range_vec<const W: usize>(
             let next = base_next + k;
             node_prices[next] = buf[k];
             nodes[next] = HcOptimalNode {
-                price: buf[k],
                 off,
                 mlen: (ml + k) as u32,
                 litlen: 0,
@@ -4239,7 +4237,6 @@ fn priceset_range_vec<const W: usize>(
         if next_cost < node_prices[next] {
             node_prices[next] = next_cost;
             nodes[next] = HcOptimalNode {
-                price: next_cost,
                 off,
                 mlen: ml as u32,
                 litlen: 0,
@@ -4667,10 +4664,10 @@ macro_rules! build_optimal_plan_impl_body {
             // overwrites the active prefix before reading it.
             nodes = alloc::vec![HcOptimalNode::default(); HC_OPT_NODE_LEN].into_boxed_slice();
         }
-        // SoA price companion, same fixed length as `nodes`. Initialised to
-        // u32::MAX so unwritten frontier cells compare as "unreachable",
-        // mirroring `HcOptimalNode::default().price`. Kept in lockstep with
-        // every `nodes[i].price` write below.
+        // The DP price array, same fixed length as `nodes`. This is the SOLE
+        // home of each position's price (the node struct carries no price), so
+        // the SIMD price-set vector-loads it directly. Initialised to u32::MAX
+        // so unwritten frontier cells compare as "unreachable".
         if node_prices.len() < HC_OPT_NODE_LEN {
             node_prices = alloc::vec![u32::MAX; HC_OPT_NODE_LEN].into_boxed_slice();
         }
@@ -4735,7 +4732,6 @@ macro_rules! build_optimal_plan_impl_body {
             ll_price_stamp,
         );
         nodes[0] = HcOptimalNode {
-            price: node0_price,
             litlen: initial_litlen as u32,
             reps: initial_reps,
             ..HcOptimalNode::default()
@@ -4760,6 +4756,9 @@ macro_rules! build_optimal_plan_impl_body {
         let mut last_pos = 0usize;
         let mut forced_end: Option<usize> = None;
         let mut forced_end_state: Option<HcOptimalNode> = None;
+        // Price companion of `forced_end_state` (price no longer lives in the
+        // node struct; tracked alongside the forced-seed node).
+        let mut forced_end_price: Option<u32> = None;
         let mut seed_forced_shortest_path = false;
         let mut opt_ldm = HcOptLdmState {
             seq_store: HcRawSeqStore {
@@ -4829,8 +4828,7 @@ macro_rules! build_optimal_plan_impl_body {
                 last_pos = (min_match_len - 1).min(frontier_limit);
                 for p in 1..min_match_len.min(frontier_buffer_size) {
                     BtMatcher::reset_opt_node(&mut nodes[p]);
-                    // Keep the SoA `node_prices` sidecar in lockstep with the AoS
-                    // `nodes[p].price` the price-set paths compare against.
+                    // Reset the price (sole home; the node carries none).
                     node_prices[p] = u32::MAX;
                     // `initial_litlen` is the litlen carried from prior
                     // optimal-plan segments — its real bound is the
@@ -4870,22 +4868,20 @@ macro_rules! build_optimal_plan_impl_body {
                         ll0_price,
                         profile.match_price_from_parts(off_price, ml_price, $stats),
                     );
-                    let forced_price = BtMatcher::add_prices(nodes[0].price, seq_cost);
+                    let forced_price = BtMatcher::add_prices(node_prices[0], seq_cost);
                     let forced_state = HcOptimalNode {
-                        price: forced_price,
                         off: candidate.offset as u32,
                         mlen: longest_len as u32,
                         litlen: 0,
                         reps: initial_reps,
                     };
-                    if longest_len < frontier_buffer_size && forced_price < nodes[longest_len].price {
+                    if longest_len < frontier_buffer_size && forced_price < node_prices[longest_len] {
                         nodes[longest_len] = forced_state;
-                        // Mirror into the SoA sidecar so the price-set loop sees
-                        // the forced seed as the baseline (lockstep invariant).
                         node_prices[longest_len] = forced_price;
                     }
                     forced_end = Some(longest_len);
                     forced_end_state = Some(forced_state);
+                    forced_end_price = Some(forced_price);
                     seed_forced_shortest_path = true;
                 }
             }
@@ -4917,7 +4913,7 @@ macro_rules! build_optimal_plan_impl_body {
                     let off_price = profile
                         .offset_price_for::<ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>($stats, off_base);
                     debug_assert!(max_match_len < frontier_buffer_size);
-                    let nodes0_price = nodes[0].price;
+                    let nodes0_price = node_prices[0];
                     for match_len in (start_len..=max_match_len).rev() {
                         let ml_price = BtMatcher::cached_match_length_price(
                             profile,
@@ -4935,7 +4931,6 @@ macro_rules! build_optimal_plan_impl_body {
                         if match_len > last_pos || next_cost < node_price {
                             let slot = unsafe { nodes.get_unchecked_mut(match_len) };
                             *slot = HcOptimalNode {
-                                price: next_cost,
                                 off: candidate.offset as u32,
                                 mlen: match_len as u32,
                                 litlen: 0,
@@ -4952,7 +4947,6 @@ macro_rules! build_optimal_plan_impl_body {
                     prev_max_len = prev_max_len.max(max_match_len);
                 }
                 if last_pos + 1 < frontier_buffer_size {
-                    nodes[last_pos + 1].price = u32::MAX;
                     node_prices[last_pos + 1] = u32::MAX;
                 }
             }
@@ -4960,7 +4954,8 @@ macro_rules! build_optimal_plan_impl_body {
         while !seed_forced_shortest_path && pos <= last_pos && pos <= frontier_limit {
             debug_assert!(pos + 1 < frontier_buffer_size);
             let prev_node = unsafe { *nodes.get_unchecked(pos - 1) };
-            if prev_node.price != u32::MAX {
+            let prev_node_price = unsafe { *node_prices.get_unchecked(pos - 1) };
+            if prev_node_price != u32::MAX {
                 let lit_len = prev_node.litlen as usize + 1;
                 let lit_price = {
                     let bt = $self.backend.bt_mut();
@@ -4980,14 +4975,15 @@ macro_rules! build_optimal_plan_impl_body {
                     &mut ll_cache,
                     ll_price_stamp,
                 );
-                let lit_cost = BtMatcher::add_price_delta(prev_node.price, lit_price, ll_delta);
-                let node_pos_price = unsafe { nodes.get_unchecked(pos).price };
+                let lit_cost = BtMatcher::add_price_delta(prev_node_price, lit_price, ll_delta);
+                // `node_pos_price` is the OLD price at `pos` (before the write
+                // below) — also the price of `prev_match`, the pre-overwrite copy.
+                let node_pos_price = unsafe { *node_prices.get_unchecked(pos) };
                 if lit_cost <= node_pos_price {
                     let prev_match = unsafe { *nodes.get_unchecked(pos) };
                     let slot = unsafe { nodes.get_unchecked_mut(pos) };
                     *slot = prev_node;
                     slot.litlen = lit_len as u32;
-                    slot.price = lit_cost;
                     node_prices[pos] = lit_cost;
                     #[allow(clippy::collapsible_if)]
                     if opt_level
@@ -5008,7 +5004,7 @@ macro_rules! build_optimal_plan_impl_body {
                                 )
                             };
                             let with1literal = BtMatcher::add_price_delta(
-                                prev_match.price,
+                                node_pos_price,
                                 next_lit_price,
                                 ll1_price as i32 - ll0_price as i32,
                             );
@@ -5022,7 +5018,7 @@ macro_rules! build_optimal_plan_impl_body {
                             let with_more_literals =
                                 BtMatcher::add_price_delta(lit_cost, next_lit_price, ll_delta_next);
                             let next = pos + 1;
-                            let next_price = unsafe { nodes.get_unchecked(next).price };
+                            let next_price = unsafe { *node_prices.get_unchecked(next) };
                             if with1literal < with_more_literals && with1literal < next_price {
                                 // Donor parity (zstd_opt.c:1232): `cur >= prevMatch.mlen`.
                                 debug_assert!(pos >= prev_match.mlen as usize);
@@ -5038,7 +5034,6 @@ macro_rules! build_optimal_plan_impl_body {
                                     *slot = prev_match;
                                     slot.reps = reps_after_match;
                                     slot.litlen = 1;
-                                    slot.price = with1literal;
                                     node_prices[next] = with1literal;
                                     if next > last_pos {
                                         last_pos = next;
@@ -5057,7 +5052,7 @@ macro_rules! build_optimal_plan_impl_body {
             // reading the fields fresh on each side keeps them out of the
             // cross-call live set. `nodes[pos]` is stable across `$collect`
             // (it only fills `candidates`), so post-call reads are identical.
-            let base_cost = unsafe { nodes.get_unchecked(pos).price };
+            let base_cost = unsafe { *node_prices.get_unchecked(pos) };
             if base_cost == u32::MAX {
                 pos += 1;
                 continue;
@@ -5087,7 +5082,7 @@ macro_rules! build_optimal_plan_impl_body {
                 break;
             }
 
-            let next_price = unsafe { nodes.get_unchecked(pos + 1).price };
+            let next_price = unsafe { *node_prices.get_unchecked(pos + 1) };
             // `saturating_add` is REQUIRED here, not a masked bug: `base_cost`
             // is a node price that can be the `u32::MAX` "unreachable" sentinel,
             // and saturating keeps `base_cost + margin` pinned at MAX so the
@@ -5163,12 +5158,12 @@ macro_rules! build_optimal_plan_impl_body {
                     let end_pos = (pos + longest_len).min($current_len);
                     forced_end = Some(end_pos);
                     forced_end_state = Some(HcOptimalNode {
-                        price: forced_price,
                         off: candidate.offset as u32,
                         mlen: longest_len as u32,
                         litlen: 0,
                         reps: base_reps,
                     });
+                    forced_end_price = Some(forced_price);
                     break;
                 }
             }
@@ -5231,7 +5226,6 @@ macro_rules! build_optimal_plan_impl_body {
                         if next > last_pos || next_cost < node_next_price {
                             let slot = unsafe { nodes.get_unchecked_mut(next) };
                             *slot = HcOptimalNode {
-                                price: next_cost,
                                 off: candidate.offset as u32,
                                 mlen: match_len as u32,
                                 litlen: 0,
@@ -5280,7 +5274,6 @@ macro_rules! build_optimal_plan_impl_body {
 
             if last_pos + 1 < frontier_buffer_size {
                 unsafe {
-                    nodes.get_unchecked_mut(last_pos + 1).price = u32::MAX;
                     *node_prices.get_unchecked_mut(last_pos + 1) = u32::MAX;
                 }
             }
@@ -5289,7 +5282,7 @@ macro_rules! build_optimal_plan_impl_body {
 
         if last_pos == 0 {
             if $current_len == 0 {
-                let price = nodes[0].price;
+                let price = node_prices[0];
                 return $self.backend.bt_mut().finish_optimal_plan(
                     HcOptimalPlanBuffers {
                         nodes,
@@ -5328,7 +5321,7 @@ macro_rules! build_optimal_plan_impl_body {
                 &mut ll_cache,
                 ll_price_stamp,
             );
-            let price = BtMatcher::add_price_delta(nodes[0].price, lit_price, ll_delta);
+            let price = BtMatcher::add_price_delta(node_prices[0], lit_price, ll_delta);
             return $self.backend.bt_mut().finish_optimal_plan(
                 HcOptimalPlanBuffers {
                     nodes,
@@ -5342,12 +5335,15 @@ macro_rules! build_optimal_plan_impl_body {
         }
 
         let target_pos = forced_end.unwrap_or(last_pos.min(frontier_limit));
-        let last_stretch = if let Some(forced_state) = forced_end_state {
-            forced_state
+        // Price lives in `node_prices`, not the node struct, so carry the
+        // final-stretch price alongside its node (forced-seed companion or the
+        // frontier price at `target_pos`).
+        let (last_stretch, last_stretch_price) = if let Some(forced_state) = forced_end_state {
+            (forced_state, forced_end_price.expect("forced state has a price"))
         } else {
-            nodes[target_pos]
+            (nodes[target_pos], node_prices[target_pos])
         };
-        if last_stretch.price == u32::MAX {
+        if last_stretch_price == u32::MAX {
             return $self.backend.bt_mut().finish_optimal_plan(
                 HcOptimalPlanBuffers {
                     nodes,
@@ -5370,7 +5366,7 @@ macro_rules! build_optimal_plan_impl_body {
                     price_arena,
                 },
                 (
-                    last_stretch.price,
+                    last_stretch_price,
                     last_stretch.reps,
                     last_stretch.litlen as usize,
                     target_pos.min($current_len),
@@ -5399,7 +5395,7 @@ macro_rules! build_optimal_plan_impl_body {
                         price_arena,
                     },
                     (
-                        last_stretch.price,
+                        last_stretch_price,
                         last_stretch.reps,
                         tail_literals,
                         target_pos.min($current_len),
@@ -5475,7 +5471,7 @@ macro_rules! build_optimal_plan_impl_body {
             store_pos += 1;
         }
         let result = (
-            last_stretch.price,
+            last_stretch_price,
             end_reps,
             if last_stretch.litlen > 0 {
                 last_stretch.litlen as usize

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3796,9 +3796,21 @@ macro_rules! start_matching_btlazy2_body {
 /// `min_epu32`: `nc <= np` iff `min(nc,np) == nc`, then exclude equality.
 /// Returns a bitmask (bit `k` set => lane `k` improves). Scalar fallback
 /// for non-x86 / no-AVX2.
-#[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
+/// 8-lane `next_cost < node_price` mask for the optimal-parser price-set
+/// loop. AVX2 lacks an unsigned `cmplt`, so derive `nc < np` from
+/// `min_epu32`: `nc <= np` iff `min(nc,np) == nc`, then exclude equality.
+/// Returns a bitmask (bit `k` set => lane `k` improves). Compiled on every
+/// x86 target (same as the avx2 collect kernel); the cargo `kernel_avx2`
+/// feature only gates the runtime dispatch, not compilation.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx2")]
 unsafe fn priceset_improved_mask8_avx2(next_cost: &[u32; 8], node_price: &[u32]) -> u8 {
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+        __m256i, _mm256_andnot_si256, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256,
+        _mm256_min_epu32, _mm256_movemask_ps,
+    };
+    #[cfg(target_arch = "x86_64")]
     use core::arch::x86_64::{
         __m256i, _mm256_andnot_si256, _mm256_castsi256_ps, _mm256_cmpeq_epi32, _mm256_loadu_si256,
         _mm256_min_epu32, _mm256_movemask_ps,
@@ -3812,36 +3824,90 @@ unsafe fn priceset_improved_mask8_avx2(next_cost: &[u32; 8], node_price: &[u32])
     _mm256_movemask_ps(_mm256_castsi256_ps(lt)) as u8
 }
 
-#[inline]
-fn priceset_improved_mask8(next_cost: &[u32; 8], node_price: &[u32]) -> u8 {
-    #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
-    {
-        if std::is_x86_feature_detected!("avx2") {
-            // SAFETY: avx2 confirmed at runtime; both slices are >= 8 u32.
-            return unsafe { priceset_improved_mask8_avx2(next_cost, node_price) };
-        }
-    }
-    let mut mask = 0u8;
-    for k in 0..8 {
-        if next_cost[k] < node_price[k] {
-            mask |= 1 << k;
-        }
-    }
-    mask
+/// Inline `next_cost = base_cost + ll0_price + match_price_from_parts(off,ml)`
+/// for one match length — the exact `add_prices` chain the scalar loop uses,
+/// so the SoA vector path stays byte-identical.
+#[inline(always)]
+fn priceset_next_cost(
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    match_len: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+) -> u32 {
+    let ml_price =
+        BtMatcher::cached_match_length_price(profile, stats, match_len, ml_cache, ml_stamp);
+    let seq_cost = BtMatcher::add_prices(
+        ll0_price,
+        profile.match_price_from_parts(off_price, ml_price, stats),
+    );
+    BtMatcher::add_prices(base_cost, seq_cost)
 }
 
-/// Vectorised price-set over the match-length range `[start, max]` for the
-/// NON-abort optimal modes (btultra / btultra2, `OPT_LEVEL >= 2`). Each
-/// `match_len` writes a distinct node `pos + match_len`, so iteration order
-/// is irrelevant and the loop vectorises; the scalar abort path (btopt,
-/// `OPT_LEVEL == 0`) keeps its reverse-iterate-then-break form. `next_cost`
-/// is computed with the same `add_prices` / `match_price_from_parts` chain
-/// as the scalar loop (byte-identical), and the improvement test reduces to
-/// `next_cost < node_prices[next]` because `reset_opt_nodes` set every
-/// beyond-frontier cell to `u32::MAX` (so `next > last_pos` is subsumed).
-/// Returns the highest written `next` (the caller folds it into `last_pos`).
+/// Scalar price-set over the match-length range `[start, max]` for the
+/// NON-abort optimal modes (btultra / btultra2). Each `match_len` writes a
+/// distinct node `pos + match_len`, so order is irrelevant; the improvement
+/// test reduces to `next_cost < node_prices[next]` (`reset_opt_nodes` set
+/// every beyond-frontier cell to `u32::MAX`, subsuming `next > last_pos`).
+/// `#[inline]` so it folds into each per-tier optimal-parser monomorphisation
+/// (no call overhead). Returns the highest written `next`.
+#[inline]
 #[allow(clippy::too_many_arguments)]
-fn priceset_range_nonabort(
+fn priceset_range_nonabort_scalar(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+) -> usize {
+    let mut new_last = last_pos;
+    for ml in start..=max {
+        let next_cost = priceset_next_cost(
+            profile, stats, ml_cache, ml_stamp, ml, ll0_price, off_price, base_cost,
+        );
+        let next = pos + ml;
+        if next_cost < node_prices[next] {
+            node_prices[next] = next_cost;
+            nodes[next] = HcOptimalNode {
+                price: next_cost,
+                off,
+                mlen: ml as u32,
+                litlen: 0,
+                reps,
+            };
+            if next > new_last {
+                new_last = next;
+            }
+        }
+    }
+    new_last
+}
+
+/// AVX2 counterpart of [`priceset_range_nonabort_scalar`]: process the range
+/// in 8-lane chunks (scalar `next_cost`, same byte-identical chain; AVX2
+/// unsigned compare against the contiguous `node_prices` SoA array; scalar
+/// write of the improving lanes), scalar remainder tail. `#[target_feature]`
+/// + `#[inline]` so it folds into the avx2 optimal-parser wrapper's
+/// `target_feature` umbrella — no runtime feature detection, no call ABI,
+/// `cached_match_length_price` inlines.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx2")]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+unsafe fn priceset_range_nonabort_avx2(
     node_prices: &mut [u32],
     nodes: &mut [HcOptimalNode],
     ml_cache: &mut [[u32; 2]],
@@ -3863,43 +3929,45 @@ fn priceset_range_nonabort(
     let mut ml = start;
     while ml + 8 <= max + 1 {
         for (k, slot) in buf.iter_mut().enumerate() {
-            let ml_price =
-                BtMatcher::cached_match_length_price(profile, stats, ml + k, ml_cache, ml_stamp);
-            let seq_cost = BtMatcher::add_prices(
+            *slot = priceset_next_cost(
+                profile,
+                stats,
+                ml_cache,
+                ml_stamp,
+                ml + k,
                 ll0_price,
-                profile.match_price_from_parts(off_price, ml_price, stats),
+                off_price,
+                base_cost,
             );
-            *slot = BtMatcher::add_prices(base_cost, seq_cost);
         }
         let base_next = pos + ml;
-        let mask = priceset_improved_mask8(&buf, &node_prices[base_next..base_next + 8]);
-        if mask != 0 {
-            for k in 0..8 {
-                if mask & (1 << k) != 0 {
-                    let next = base_next + k;
-                    node_prices[next] = buf[k];
-                    nodes[next] = HcOptimalNode {
-                        price: buf[k],
-                        off,
-                        mlen: (ml + k) as u32,
-                        litlen: 0,
-                        reps,
-                    };
-                    if next > new_last {
-                        new_last = next;
-                    }
-                }
+        // SAFETY: caller's `target_feature(avx2)` umbrella covers this; both
+        // slices are exactly 8 u32 wide.
+        let mask =
+            unsafe { priceset_improved_mask8_avx2(&buf, &node_prices[base_next..base_next + 8]) };
+        let mut bits = mask;
+        while bits != 0 {
+            let k = bits.trailing_zeros() as usize;
+            bits &= bits - 1;
+            let next = base_next + k;
+            node_prices[next] = buf[k];
+            nodes[next] = HcOptimalNode {
+                price: buf[k],
+                off,
+                mlen: (ml + k) as u32,
+                litlen: 0,
+                reps,
+            };
+            if next > new_last {
+                new_last = next;
             }
         }
         ml += 8;
     }
     while ml <= max {
-        let ml_price = BtMatcher::cached_match_length_price(profile, stats, ml, ml_cache, ml_stamp);
-        let seq_cost = BtMatcher::add_prices(
-            ll0_price,
-            profile.match_price_from_parts(off_price, ml_price, stats),
+        let next_cost = priceset_next_cost(
+            profile, stats, ml_cache, ml_stamp, ml, ll0_price, off_price, base_cost,
         );
-        let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
         let next = pos + ml;
         if next_cost < node_prices[next] {
             node_prices[next] = next_cost;
@@ -3929,7 +3997,8 @@ macro_rules! build_optimal_plan_impl_body {
         $initial_state:ident,
         $stats:ident,
         $out:ident,
-        $collect:ident $(,)?
+        $collect:ident,
+        $priceset:path $(,)?
     ) => {{
         let current_abs_end = $current_abs_start + $current_len;
         let min_match_len = HC_OPT_MIN_MATCH_LEN;
@@ -4540,61 +4609,35 @@ macro_rules! build_optimal_plan_impl_body {
                             break;
                         }
                     }
-                } else if max_match_len + 1 - start_len < 16 {
-                    // btultra / btultra2 SHORT range: stay inline-scalar (forward,
-                    // simplified `next_cost < node_prices[next]` compare — the
-                    // `next > last_pos` term is subsumed because reset set
-                    // beyond-frontier cells to MAX). No fn-call / vectorisation
-                    // overhead on the short loops that dominate by count.
-                    for match_len in start_len..=max_match_len {
-                        let next = pos + match_len;
-                        let ml_price = BtMatcher::cached_match_length_price(
-                            profile,
-                            $stats,
-                            match_len,
-                            &mut ml_cache,
-                            ml_price_stamp,
-                        );
-                        let seq_cost = BtMatcher::add_prices(
-                            ll0_price,
-                            profile.match_price_from_parts(off_price, ml_price, $stats),
-                        );
-                        let next_cost = BtMatcher::add_prices(base_cost, seq_cost);
-                        if next_cost < unsafe { *node_prices.get_unchecked(next) } {
-                            let slot = unsafe { nodes.get_unchecked_mut(next) };
-                            *slot = HcOptimalNode {
-                                price: next_cost,
-                                off: candidate.offset as u32,
-                                mlen: match_len as u32,
-                                litlen: 0,
-                                reps: base_reps,
-                            };
-                            unsafe { *node_prices.get_unchecked_mut(next) = next_cost };
-                            if next > last_pos {
-                                last_pos = next;
-                            }
-                        }
-                    }
                 } else {
-                    // btultra / btultra2 LONG range: SIMD-vectorised price-set
-                    // (compare against the contiguous node_prices SoA array).
-                    last_pos = last_pos.max(priceset_range_nonabort(
-                        &mut node_prices,
-                        &mut nodes,
-                        ml_cache,
-                        ml_price_stamp,
-                        profile,
-                        $stats,
-                        pos,
-                        start_len,
-                        max_match_len,
-                        ll0_price,
-                        off_price,
-                        base_cost,
-                        candidate.offset as u32,
-                        base_reps,
-                        last_pos,
-                    ));
+                    // btultra / btultra2 (OPT_LEVEL >= 2): no abort, each
+                    // match_len writes a distinct node => order-independent.
+                    // Dispatch to the per-tier price-set ($priceset is the
+                    // tier's fn: AVX2 SoA-vector compare for the avx2 wrapper,
+                    // inline scalar otherwise) — it folds into this wrapper's
+                    // monomorphisation, so no call ABI / runtime feature check.
+                    #[allow(unused_unsafe)]
+                    {
+                        last_pos = last_pos.max(unsafe {
+                            $priceset(
+                                &mut node_prices,
+                                &mut nodes,
+                                ml_cache,
+                                ml_price_stamp,
+                                profile,
+                                $stats,
+                                pos,
+                                start_len,
+                                max_match_len,
+                                ll0_price,
+                                off_price,
+                                base_cost,
+                                candidate.offset as u32,
+                                base_reps,
+                                last_pos,
+                            )
+                        });
+                    }
                 }
                 prev_max_len = prev_max_len.max(max_match_len);
             }
@@ -6323,6 +6366,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_neon,
+            priceset_range_nonabort_scalar,
         )
     }
 
@@ -6351,6 +6395,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_sse42,
+            priceset_range_nonabort_scalar,
         )
     }
 
@@ -6379,6 +6424,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_avx2_bmi2,
+            priceset_range_nonabort_avx2,
         )
     }
 
@@ -6410,6 +6456,7 @@ impl HcMatchGenerator {
             stats,
             out,
             collect_optimal_candidates_initialized_scalar,
+            priceset_range_nonabort_scalar,
         )
     }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3857,10 +3857,14 @@ fn priceset_next_cost(
 /// (no call overhead). Returns the highest written `next`.
 #[inline]
 #[allow(clippy::too_many_arguments)]
-// Used by the scalar / sse42 / wasm DP wrappers; on aarch64 the dispatch only
-// reaches the neon wrapper, so this is cfg-dead there.
+// Used by the scalar / sse42 DP wrappers; on aarch64 the dispatch only reaches
+// the neon wrapper and on wasm+simd128 only the simd128 wrapper, so this is
+// cfg-dead on those targets.
 #[cfg_attr(
-    all(target_arch = "aarch64", target_endian = "little"),
+    any(
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "wasm32", target_feature = "simd128")
+    ),
     allow(dead_code)
 )]
 fn priceset_range_nonabort_scalar(
@@ -4008,6 +4012,18 @@ fn priceset_tier_helpers_match_scalar() {
 /// improve-ratio probe). Same signature tail as the scalar variant.
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
+// Instantiated only by a vector tier wrapper (avx2/sse4.1 on x86, neon on
+// aarch64, simd128 on wasm+simd128); a target with none of those (e.g.
+// wasm without +simd128) uses only the scalar range, leaving this generic dead.
+#[cfg_attr(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        all(target_arch = "aarch64", target_endian = "little"),
+        all(target_arch = "wasm32", target_feature = "simd128")
+    )),
+    allow(dead_code)
+)]
 fn priceset_range_vec<const W: usize>(
     node_prices: &mut [u32],
     nodes: &mut [HcOptimalNode],
@@ -4382,6 +4398,88 @@ unsafe fn priceset_range_nonabort_sse41(
         // SAFETY: both closures run inside this fn's sse4.2 target_feature umbrella.
         |cells, stamp| unsafe { priceset_cached_prices4_sse41(cells, stamp) },
         |nc, np| unsafe { priceset_improved_mask4_sse41(nc, np) },
+    )
+}
+
+/// wasm `simd128` 4-lane vector-load + deinterleave of cached ml-prices.
+/// `u32x4_shuffle` selects the price (even) and gen (odd) lanes across the two
+/// loaded vectors natively. `Some(prices)` only when all 4 gens equal `stamp`
+/// (`u32x4_all_true` of the equality vector).
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[target_feature(enable = "simd128")]
+#[inline]
+unsafe fn priceset_cached_prices4_simd128(cells: &[[u32; 2]], stamp: u32) -> Option<[u32; 4]> {
+    use core::arch::wasm32::{
+        u32x4_all_true, u32x4_eq, u32x4_shuffle, u32x4_splat, v128, v128_load, v128_store,
+    };
+    debug_assert!(cells.len() >= 4);
+    let base = cells.as_ptr() as *const v128;
+    let v0 = unsafe { v128_load(base) }; // [p0 g0 p1 g1]
+    let v1 = unsafe { v128_load(base.add(1)) }; // [p2 g2 p3 g3]
+    // Lanes 0..3 index v0, 4..7 index v1.
+    let gens = u32x4_shuffle::<1, 3, 5, 7>(v0, v1); // [g0 g1 g2 g3]
+    let eq = u32x4_eq(gens, u32x4_splat(stamp));
+    if !u32x4_all_true(eq) {
+        return None;
+    }
+    let prices = u32x4_shuffle::<0, 2, 4, 6>(v0, v1); // [p0 p1 p2 p3]
+    let mut out = [0u32; 4];
+    unsafe { v128_store(out.as_mut_ptr() as *mut v128, prices) };
+    Some(out)
+}
+
+/// wasm `simd128` 4-lane `next_cost < node_price` bitmask. wasm has a native
+/// unsigned compare (`u32x4_lt`) and `u32x4_bitmask` to pack the lanes.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[target_feature(enable = "simd128")]
+#[inline]
+unsafe fn priceset_improved_mask4_simd128(next_cost: &[u32; 4], node_price: &[u32]) -> u8 {
+    use core::arch::wasm32::{u32x4_bitmask, u32x4_lt, v128, v128_load};
+    let nc = unsafe { v128_load(next_cost.as_ptr() as *const v128) };
+    let np = unsafe { v128_load(node_price.as_ptr() as *const v128) };
+    u32x4_bitmask(u32x4_lt(nc, np))
+}
+
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[target_feature(enable = "simd128")]
+#[inline]
+#[allow(clippy::too_many_arguments)]
+unsafe fn priceset_range_nonabort_simd128(
+    node_prices: &mut [u32],
+    nodes: &mut [HcOptimalNode],
+    ml_cache: &mut [[u32; 2]],
+    ml_stamp: u32,
+    profile: HcOptimalCostProfile,
+    stats: &HcOptState,
+    pos: usize,
+    start: usize,
+    max: usize,
+    ll0_price: u32,
+    off_price: u32,
+    base_cost: u32,
+    off: u32,
+    reps: [u32; 3],
+    last_pos: usize,
+) -> usize {
+    priceset_range_vec::<4>(
+        node_prices,
+        nodes,
+        ml_cache,
+        ml_stamp,
+        profile,
+        stats,
+        pos,
+        start,
+        max,
+        ll0_price,
+        off_price,
+        base_cost,
+        off,
+        reps,
+        last_pos,
+        // SAFETY: both closures run inside this fn's simd128 target_feature umbrella.
+        |cells, stamp| unsafe { priceset_cached_prices4_simd128(cells, stamp) },
+        |nc, np| unsafe { priceset_improved_mask4_simd128(nc, np) },
     )
 }
 
@@ -6719,10 +6817,23 @@ impl HcMatchGenerator {
                     ),
             }
         }
+        // wasm with simd128: route through the simd128 DP body (4-lane price-set).
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        unsafe {
+            self.build_optimal_plan_impl_simd128::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
+                current,
+                current_abs_start,
+                current_len,
+                initial_state,
+                stats,
+                out,
+            )
+        }
         #[cfg(not(any(
             all(target_arch = "aarch64", target_endian = "little"),
             target_arch = "x86",
-            target_arch = "x86_64"
+            target_arch = "x86_64",
+            all(target_arch = "wasm32", target_feature = "simd128")
         )))]
         {
             self.build_optimal_plan_impl_scalar::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
@@ -6831,6 +6942,13 @@ impl HcMatchGenerator {
     // variants where callees are `unsafe fn`. The scalar wrappers route
     // through safe fns, so those blocks are redundant on this path.
     #[allow(unused_unsafe)]
+    // The dispatch reaches this only on non-SIMD x86 (Scalar tier) and the
+    // portable fallback; on wasm+simd128 the simd128 wrapper is selected, so
+    // this is cfg-dead there.
+    #[cfg_attr(
+        all(target_arch = "wasm32", target_feature = "simd128"),
+        allow(dead_code)
+    )]
     fn build_optimal_plan_impl_scalar<
         S: super::strategy::Strategy,
         const ACCURATE_PRICE: bool,
@@ -6855,6 +6973,41 @@ impl HcMatchGenerator {
             out,
             collect_optimal_candidates_initialized_scalar,
             priceset_range_nonabort_scalar,
+        )
+    }
+
+    /// wasm `simd128`-umbrella DP body: scalar candidate collection (no wasm
+    /// collect kernel) but the simd128 4-lane price-set.
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    #[target_feature(enable = "simd128")]
+    // With `+simd128` in the wasm baseline the shared body macro's `unsafe`
+    // blocks (needed by the safe scalar wrapper) are redundant inside this
+    // target_feature fn.
+    #[allow(unused_unsafe)]
+    unsafe fn build_optimal_plan_impl_simd128<
+        S: super::strategy::Strategy,
+        const ACCURATE_PRICE: bool,
+        const FAVOR_SMALL_OFFSETS: bool,
+    >(
+        &mut self,
+        current: &[u8],
+        current_abs_start: usize,
+        current_len: usize,
+        initial_state: HcOptimalPlanState,
+        stats: &HcOptState,
+        out: &mut Vec<HcOptimalSequence>,
+    ) -> (u32, [u32; 3], usize, usize) {
+        build_optimal_plan_impl_body!(
+            self,
+            S,
+            current,
+            current_abs_start,
+            current_len,
+            initial_state,
+            stats,
+            out,
+            collect_optimal_candidates_initialized_scalar,
+            priceset_range_nonabort_simd128,
         )
     }
 

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -412,11 +412,21 @@ impl MatchTable {
     #[inline]
     pub(crate) fn insert_position_no_rebase(&mut self, abs_pos: usize) {
         let idx = abs_pos.wrapping_sub(self.history_abs_start);
-        let concat = &self.history[self.history_start..];
-        if idx + 4 > concat.len() {
-            return;
-        }
-        let hash = Self::hash_position_at(concat, idx, self.hash_log, 4);
+        // Borrowed-aware: read the SAME bytes the finder hashes via
+        // `live_history()` (borrowed window in no-copy mode, owned mirror
+        // otherwise). Reading `self.history[history_start..]` directly would
+        // hash the empty owned mirror on the borrowed HC lazy/greedy path
+        // (live=input, mirror=0) — the insert would skip or hash garbage while
+        // the finder hashes the real input, so the chain stays empty and no
+        // matches are ever found. `hash` is the only value needed past this
+        // borrow, so it ends before the table mutation below.
+        let hash = {
+            let concat = self.live_history();
+            if idx + 4 > concat.len() {
+                return;
+            }
+            Self::hash_position_at(concat, idx, self.hash_log, 4)
+        };
         let Some(relative_pos) = self.relative_position(abs_pos) else {
             return;
         };
@@ -1719,15 +1729,17 @@ impl MatchTable {
         let index_shift = self.index_shift;
         let hash_log = self.hash_log;
         let chain_mask = (1usize << self.chain_log) - 1;
-        let hist_start = self.history_start;
-        let concat_len = self.history.len() - hist_start;
-        // Raw base pointers hoisted once: the loop reads `history` and
-        // writes `hash_table` / `chain_table`, which are disjoint fields, so
-        // raw pointers let the writes proceed without re-borrowing `self`
-        // each iteration. `ensure_tables` (run before any matching pass)
-        // guarantees `hash_table.len() == 1 << hash_log` and
-        // `chain_table.len() == 1 << chain_log`.
-        let concat_ptr = self.history.as_ptr();
+        // Borrowed-aware source: `live_history()` is the borrowed input window
+        // in no-copy mode (owned mirror empty) and `history[history_start..]`
+        // otherwise. Reading `self.history` directly would hash the empty
+        // mirror on the borrowed HC lazy/greedy path. The raw ptr is copied
+        // out so it holds no borrow across the `hash_table` / `chain_table`
+        // mutations below; the window stays valid for the loop (borrowed input
+        // is live by contract, owned `history` is not realloc'd mid-fill).
+        let (concat_ptr, concat_len) = {
+            let live = self.live_history();
+            (live.as_ptr(), live.len())
+        };
         let hash_ptr = self.hash_table.as_mut_ptr();
         let chain_ptr = self.chain_table.as_mut_ptr();
         debug_assert!(self.hash_table.len() == 1usize << hash_log);
@@ -1743,7 +1755,7 @@ impl MatchTable {
         // Hoist the source pointer and relative index out of the loop and
         // advance both by one per iteration, mirroring the donor's
         // `ip++ / idx++` fill rather than recomputing them from `pos`.
-        let mut src = unsafe { concat_ptr.add(hist_start + (start - history_abs_start)) };
+        let mut src = unsafe { concat_ptr.add(start - history_abs_start) };
         // `rel` cannot reach `u32::MAX` because the caller proved
         // `!needs_rebase(end - 1)`; `wrapping_add` keeps the overflow branch
         // off this per-byte hot loop.

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -244,7 +244,6 @@ pub(crate) struct DmsDictTables {
 /// tables. Methods on this struct contain only logic that's identical
 /// between HC and BT modes — backend-specific table interpretation
 /// lives in the matcher modules.
-#[derive(Clone)]
 pub(crate) struct MatchTable {
     pub(crate) max_window_size: usize,
     /// Per-chunk lengths of the live window, in add order. The bytes
@@ -306,6 +305,79 @@ pub(crate) struct MatchTable {
     /// Active borrowed block range `[start, end)` within `borrowed_input`,
     /// staged before each borrowed scan.
     pub(crate) borrowed_block: Option<(usize, usize)>,
+}
+
+// Manual `Clone` (not derived) so the per-frame dictionary-snapshot restore can
+// `clone_from` the retained `history` / hash / chain / hash3 / dms buffers
+// in place — the derived `clone_from` is `*self = source.clone()`, a full
+// per-frame allocate+copy+drop that dominated small `compress-dict` HC/lazy
+// frames (donor reuses the CDict tables in place). `clone()` is the obvious
+// field-wise copy; `clone_from()` reuses every heap buffer.
+impl Clone for MatchTable {
+    fn clone(&self) -> Self {
+        Self {
+            max_window_size: self.max_window_size,
+            chunk_lens: self.chunk_lens.clone(),
+            window_size: self.window_size,
+            history: self.history.clone(),
+            history_start: self.history_start,
+            history_abs_start: self.history_abs_start,
+            position_base: self.position_base,
+            index_shift: self.index_shift,
+            offset_hist: self.offset_hist,
+            hash_table: self.hash_table.clone(),
+            hash3_table: self.hash3_table.clone(),
+            chain_table: self.chain_table.clone(),
+            hash_log: self.hash_log,
+            chain_log: self.chain_log,
+            hash3_log: self.hash3_log,
+            next_to_update3: self.next_to_update3,
+            skip_insert_until_abs: self.skip_insert_until_abs,
+            dictionary_limit_abs: self.dictionary_limit_abs,
+            dictionary_primed_for_frame: self.dictionary_primed_for_frame,
+            allow_zero_relative_position: self.allow_zero_relative_position,
+            search_depth: self.search_depth,
+            is_btultra2: self.is_btultra2,
+            uses_bt: self.uses_bt,
+            search_mls: self.search_mls,
+            dms: self.dms.clone(),
+            borrowed_input: self.borrowed_input,
+            borrowed_block: self.borrowed_block,
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        // Heap buffers: reuse the existing allocation (Vec/VecDeque/DictAttach
+        // `clone_from` keep capacity and overwrite in place).
+        self.chunk_lens.clone_from(&source.chunk_lens);
+        self.history.clone_from(&source.history);
+        self.hash_table.clone_from(&source.hash_table);
+        self.hash3_table.clone_from(&source.hash3_table);
+        self.chain_table.clone_from(&source.chain_table);
+        self.dms.clone_from(&source.dms);
+        // Scalars / Copy fields.
+        self.max_window_size = source.max_window_size;
+        self.window_size = source.window_size;
+        self.history_start = source.history_start;
+        self.history_abs_start = source.history_abs_start;
+        self.position_base = source.position_base;
+        self.index_shift = source.index_shift;
+        self.offset_hist = source.offset_hist;
+        self.hash_log = source.hash_log;
+        self.chain_log = source.chain_log;
+        self.hash3_log = source.hash3_log;
+        self.next_to_update3 = source.next_to_update3;
+        self.skip_insert_until_abs = source.skip_insert_until_abs;
+        self.dictionary_limit_abs = source.dictionary_limit_abs;
+        self.dictionary_primed_for_frame = source.dictionary_primed_for_frame;
+        self.allow_zero_relative_position = source.allow_zero_relative_position;
+        self.search_depth = source.search_depth;
+        self.is_btultra2 = source.is_btultra2;
+        self.uses_bt = source.uses_bt;
+        self.search_mls = source.search_mls;
+        self.borrowed_input = source.borrowed_input;
+        self.borrowed_block = source.borrowed_block;
+    }
 }
 
 impl MatchTable {

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -222,8 +222,27 @@ pub(crate) const HC3_HASH_LOG: usize = 17;
 /// with its OWN compare budget so dictionary candidates are reachable even
 /// when the live tree's budget is spent on recent positions. Slots store
 /// `dict_rel + 1` (dictionary-relative concat index); `0` is empty.
+/// Which matcher built a [`DmsDictTables`]: the hash-chain (`prime_dms_hc`) and
+/// the binary-tree (`prime_dms_bt`) populate `hash_table` / `chain_table` with
+/// incompatible meanings, so a cached dms must only be reused by the SAME
+/// builder. Part of the cache-reuse key alongside `mls` / `hash_log` / region so
+/// a reused compressor that switches level across the HC↔BT boundary (same
+/// `mls` / `hash_log`) rebuilds instead of reinterpreting the other layout.
+#[derive(Clone, Copy, PartialEq, Eq, Default, Debug)]
+pub(crate) enum DmsDictLayout {
+    /// Unbuilt / invalidated — never matches a reuse probe.
+    #[default]
+    None,
+    /// Hash-chain dms (`prime_dms_hc`): single-link chain for the lazy backend.
+    Hc,
+    /// Binary-tree dms (`prime_dms_bt`): unsorted DUBT for the optimal backend.
+    Bt,
+}
+
 #[derive(Clone, Default)]
 pub(crate) struct DmsDictTables {
+    /// Builder that populated the tables (HC vs BT), part of the reuse key.
+    pub(crate) layout: DmsDictLayout,
     /// Per-hash-bucket binary-tree root (`1 << hash_log` entries), packed
     /// `dict_rel + 1` (`0` = empty).
     pub(crate) hash_table: Vec<u32>,
@@ -698,10 +717,9 @@ impl MatchTable {
         // change lands here with a different shape and rebuilds.
         if self.dms.is_primed()
             && self.dms.region_len() == region
-            && self
-                .dms
-                .table()
-                .is_some_and(|t| t.mls == mls && t.hash_log == dms_hash_log)
+            && self.dms.table().is_some_and(|t| {
+                t.layout == DmsDictLayout::Bt && t.mls == mls && t.hash_log == dms_hash_log
+            })
         {
             return;
         }
@@ -775,6 +793,7 @@ impl MatchTable {
         }
         // `concat`'s borrow of `self` ends above; now mutate `self.dms`.
         let tables = self.dms.table_mut_or_init(DmsDictTables::default);
+        tables.layout = DmsDictLayout::Bt;
         tables.hash_table = hash_table;
         tables.chain_table = chain_table;
         tables.hash_log = dms_hash_log;
@@ -807,10 +826,9 @@ impl MatchTable {
             (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
         if self.dms.is_primed()
             && self.dms.region_len() == region
-            && self
-                .dms
-                .table()
-                .is_some_and(|t| t.mls == mls && t.hash_log == dms_hash_log)
+            && self.dms.table().is_some_and(|t| {
+                t.layout == DmsDictLayout::Hc && t.mls == mls && t.hash_log == dms_hash_log
+            })
         {
             return;
         }
@@ -837,6 +855,7 @@ impl MatchTable {
             current += 1;
         }
         let tables = self.dms.table_mut_or_init(DmsDictTables::default);
+        tables.layout = DmsDictLayout::Hc;
         tables.hash_table = hash_table;
         tables.chain_table = chain_table;
         tables.hash_log = dms_hash_log;
@@ -2306,6 +2325,44 @@ mod storage_tests {
         t.history_abs_start = 100;
         t.set_dictionary_limit_from_primed_bytes(40);
         assert_eq!(t.dictionary_limit_abs, Some(140));
+    }
+
+    #[test]
+    fn dms_cache_rebuilds_across_hc_bt_layout_switch() {
+        // A reused compressor that changes level across the HC↔BT boundary lands
+        // back in prime_dms_* with the SAME (region, mls, hash_log) but the OTHER
+        // builder. Without a layout discriminator in the cache key, the second
+        // prime would reuse the first builder's tables verbatim (HC single-link
+        // chain reinterpreted as a BT DUBT, or vice versa) — a silent corruption.
+        // The cache key must include the layout so the switch forces a rebuild.
+        let mut t = new_table(64);
+        // dms_hash_log clamps to [10, hash_log]; keep hash_log above the floor.
+        t.hash_log = 12;
+        // Match HC's fixed mls (HC_MIN_MATCH_LEN == 4) so the BT prime resolves
+        // the SAME (region, mls, hash_log) as the HC prime — then the LAYOUT field
+        // is the only differing key, which is exactly what this test guards. With
+        // search_mls != 4 the rebuild would happen via the mls mismatch and the
+        // test would pass even without the layout discriminator.
+        t.search_mls = 4;
+        t.push_test_chunk(vec![7u8; 48]);
+        t.ensure_tables();
+        let region = 48;
+
+        t.prime_dms_hc(region);
+        assert_eq!(t.dms.table().unwrap().layout, DmsDictLayout::Hc);
+        // HC chain has one `next` per dict position.
+        assert_eq!(t.dms.table().unwrap().chain_table.len(), region);
+
+        // Same region/mls/hash_log, but the BT builder must NOT reuse the HC
+        // tables: it rebuilds to the BT layout (2 children per dict position).
+        t.prime_dms_bt(region);
+        assert_eq!(t.dms.table().unwrap().layout, DmsDictLayout::Bt);
+        assert_eq!(t.dms.table().unwrap().chain_table.len(), 2 * region);
+
+        // And back to HC rebuilds again.
+        t.prime_dms_hc(region);
+        assert_eq!(t.dms.table().unwrap().layout, DmsDictLayout::Hc);
+        assert_eq!(t.dms.table().unwrap().chain_table.len(), region);
     }
 
     #[test]

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -783,6 +783,68 @@ impl MatchTable {
         self.dms.mark_primed();
     }
 
+    /// Build a SEPARATE dictionary match state for the lazy hash-chain path
+    /// (upstream `ZSTD_dictMatchState`, the dms HC4 walk in
+    /// `ZSTD_HcFindBestMatch` `zstd_lazy.c:748-770`) over the first `region_len`
+    /// bytes of the live history (the dictionary at the front). Unlike
+    /// [`Self::prime_dms_bt`] this is a single-link hash chain (one `next` entry
+    /// per dict position, like the live HC chain), not a binary tree: the lazy
+    /// parser walks it with a bounded compare budget rather than descending to
+    /// the longest match. `hash_table` holds per-bucket chain heads, packed
+    /// `dict_rel + 1` (`0` = empty); `chain_table[dict_rel]` is the previous
+    /// dict position in the same bucket, same packing. Dict positions are concat
+    /// indices at the front of the shared buffer, so the offset is `idx -
+    /// dict_idx` directly. Hashed at `HC_MIN_MATCH_LEN` (4), matching the live
+    /// chain. Cached across frames via `DictAttach::is_primed`.
+    pub(crate) fn prime_dms_hc(&mut self, region_len: usize) {
+        let mls = HC_MIN_MATCH_LEN;
+        let region = region_len.min(self.live_history().len());
+        if region < mls {
+            self.dms.invalidate();
+            return;
+        }
+        let dms_hash_log =
+            (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
+        if self.dms.is_primed()
+            && self.dms.region_len() == region
+            && self
+                .dms
+                .table()
+                .is_some_and(|t| t.mls == mls && t.hash_log == dms_hash_log)
+        {
+            return;
+        }
+        let (mut hash_table, mut chain_table) = match self.dms.table_mut() {
+            Some(t) => (
+                core::mem::take(&mut t.hash_table),
+                core::mem::take(&mut t.chain_table),
+            ),
+            None => (Vec::new(), Vec::new()),
+        };
+        hash_table.clear();
+        hash_table.resize(1usize << dms_hash_log, 0u32);
+        // Single `next` link per dict position (HC4 chain, not the BT's 2/pos).
+        chain_table.clear();
+        chain_table.resize(region, 0u32);
+        let concat = self.live_history();
+        let mut current = 0usize;
+        while current + mls <= region {
+            let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
+            // Prepend `current` to its bucket chain (donor
+            // `ZSTD_insertAndFindFirstIndex` head insert).
+            chain_table[current] = hash_table[h];
+            hash_table[h] = (current + 1) as u32;
+            current += 1;
+        }
+        let tables = self.dms.table_mut_or_init(DmsDictTables::default);
+        tables.hash_table = hash_table;
+        tables.chain_table = chain_table;
+        tables.hash_log = dms_hash_log;
+        tables.mls = mls;
+        self.dms.set_region_len(region);
+        self.dms.mark_primed();
+    }
+
     /// Append a freshly committed buffer to the rolling window. Drops
     /// chunk-length entries for the oldest slices until the new total
     /// fits inside `max_window_size`, extends the contiguous `history`

--- a/zstd/src/encoding/opt/types.rs
+++ b/zstd/src/encoding/opt/types.rs
@@ -90,6 +90,10 @@ pub(crate) struct HcOptimalPlanState {
 /// scaffolding.
 pub(crate) struct HcOptimalPlanBuffers {
     pub(crate) nodes: alloc::boxed::Box<[HcOptimalNode]>,
+    /// SoA price companion to `nodes` (see `BtMatcher::opt_node_prices_scratch`):
+    /// `node_prices[i]` mirrors node `i`'s running DP price as a contiguous
+    /// `u32` so the inner price-set loop can SIMD-compare a run of node prices.
+    pub(crate) node_prices: alloc::boxed::Box<[u32]>,
     pub(crate) candidates: Vec<MatchCandidate>,
     pub(crate) store: Vec<HcOptimalNode>,
     /// Single backing allocation for the LL/ML price caches as `[price,

--- a/zstd/src/encoding/opt/types.rs
+++ b/zstd/src/encoding/opt/types.rs
@@ -22,12 +22,16 @@ pub(crate) struct MatchCandidate {
     pub(crate) match_len: usize,
 }
 
-/// DP cell in the optimal parser table. Stores the running price, the
-/// chosen offset/match-length, the literal-run length, and the rep-code
-/// history that would be active after committing this cell.
+/// DP cell in the optimal parser table. Stores the chosen offset/match-length,
+/// the literal-run length, and the rep-code history that would be active after
+/// committing this cell.
+///
+/// The running PRICE is NOT stored here: it lives solely in the parallel
+/// `node_prices: Box<[u32]>` (one `u32` per position), so the SIMD price-set
+/// can vector-load consecutive prices and there is a SINGLE source of truth for
+/// each price (no AoS/SoA duplication to keep in lockstep).
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct HcOptimalNode {
-    pub(crate) price: u32,
     pub(crate) off: u32,
     pub(crate) mlen: u32,
     pub(crate) litlen: u32,
@@ -37,7 +41,6 @@ pub(crate) struct HcOptimalNode {
 impl Default for HcOptimalNode {
     fn default() -> Self {
         Self {
-            price: u32::MAX,
             off: 0,
             mlen: 0,
             // Donor parity: uninitialized DP slots use litlen != 0

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -91,6 +91,68 @@ fn test_dictionary_handle_from_dictionary_roundtrips() {
 }
 
 #[test]
+fn hc_dict_snapshot_reuse_roundtrips() {
+    // The lazy hash-chain dict path captures a CDict-equivalent prime snapshot on
+    // the first above-cutoff frame and restores it (a table copy) on later frames
+    // instead of re-hashing the dictionary. This pins that a frame compressed
+    // AFTER a snapshot restore still decodes against the dictionary — the reuse
+    // must reproduce the post-prime matcher exactly, not a stale or wrong-mode
+    // shape. Both frames are > 32 KiB so the lazy attach cutoff routes them
+    // through capture (frame 1) + restore (frame 2) on the same compressor.
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    // Deterministic ~2 KiB dictionary content (LCG, so the test is hermetic).
+    let dict_id = 0x5A5A_1234u32;
+    let mut dict_content = Vec::with_capacity(2048);
+    let mut s = 0x1234_5678u32;
+    while dict_content.len() < 2048 {
+        s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        dict_content.push((s >> 24) as u8);
+    }
+
+    let enc_dict = Dictionary::from_raw_content(dict_id, dict_content.clone())
+        .expect("encoder dict should build");
+    let dec_handle = DictionaryHandle::from_dictionary(
+        Dictionary::from_raw_content(dict_id, dict_content.clone())
+            .expect("decoder dict should build"),
+    );
+
+    // Two distinct > 32 KiB inputs that embed the dictionary content, so dict
+    // matches actually fire through the restored tables on the second frame.
+    let make_input = |salt: u8| {
+        let mut data = Vec::with_capacity(48 * 1024);
+        while data.len() < 48 * 1024 {
+            data.extend_from_slice(&dict_content);
+            data.push(salt);
+        }
+        data
+    };
+    let input_a = make_input(0xAA);
+    let input_b = make_input(0xBB);
+
+    let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(12));
+    cctx.set_dictionary(enc_dict).expect("attach dict");
+
+    // Frame 1 primes + captures the copy-mode snapshot; frame 2 restores it.
+    let frame_a = cctx.compress_independent_frame(&input_a);
+    let frame_b = cctx.compress_independent_frame(&input_b);
+
+    for (frame, original) in [(&frame_a, &input_a), (&frame_b, &input_b)] {
+        let mut output = vec![0u8; original.len()];
+        let mut decoder = FrameDecoder::new();
+        let written = decoder
+            .decode_all_with_dict_handle(frame.as_slice(), &mut output, &dec_handle)
+            .expect("decode with dict should succeed");
+        assert_eq!(written, original.len());
+        assert_eq!(&output, original, "snapshot-reuse frame must round-trip");
+    }
+}
+
+#[test]
 fn test_dict_decoding() {
     extern crate std;
     use crate::decoding::BlockDecodingStrategy;

--- a/zstd/src/tests/roundtrip_integrity.rs
+++ b/zstd/src/tests/roundtrip_integrity.rs
@@ -301,6 +301,39 @@ fn repetitive_data_compresses_better_than_random() {
     );
 }
 
+/// Regression: small repetitive inputs at the greedy/lazy levels (5-12) take
+/// the borrowed (no-copy) one-shot path, where the resolved window is <= 14 and
+/// the matchfinder falls back to HashChain (donor `ZSTD_resolveRowMatchFinderMode`).
+/// The HC `insert_position` must hash the borrowed input window, not the empty
+/// owned history mirror — otherwise the chain stays empty, no matches are found,
+/// and a trivially-compressible repeated block balloons (was 4 KiB -> 2549 B,
+/// ~16x the donor's 154 B). Assert the borrowed-HC band still finds the repeats.
+#[test]
+fn small_repetitive_compresses_on_borrowed_hashchain_band() {
+    // ~96-byte repeating record, 4 KiB total: the exact small-log-lines shape
+    // that resolves to windowLog 14 -> HashChain on the borrowed path.
+    let line = b"ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n";
+    let mut data = Vec::with_capacity(4096);
+    while data.len() < 4096 {
+        let take = line.len().min(4096 - data.len());
+        data.extend_from_slice(&line[..take]);
+    }
+    for level in [5i32, 6, 7, 10, 12] {
+        let compressed = compress_to_vec(&data[..], CompressionLevel::Level(level));
+        let roundtrip = roundtrip_at_level(&data, CompressionLevel::Level(level));
+        assert_eq!(data, roundtrip, "L{level} borrowed-HC roundtrip mismatch");
+        // The repeats are found: output is a small fraction of the input, not
+        // the near-incompressible ~62% the empty-mirror bug produced.
+        assert!(
+            compressed.len() < data.len() / 4,
+            "L{level} small repetitive input must compress well on the borrowed \
+             HashChain band (matches found), got {} bytes for {} input",
+            compressed.len(),
+            data.len()
+        );
+    }
+}
+
 /// Multi-block data exercises FSE table reuse across blocks and offset history
 /// persistence across block boundaries.
 #[test]

--- a/zstd/src/tests/roundtrip_integrity.rs
+++ b/zstd/src/tests/roundtrip_integrity.rs
@@ -318,7 +318,7 @@ fn small_repetitive_compresses_on_borrowed_hashchain_band() {
         let take = line.len().min(4096 - data.len());
         data.extend_from_slice(&line[..take]);
     }
-    for level in [5i32, 6, 7, 10, 12] {
+    for level in 5i32..=12 {
         // Compress via the one-shot slice entry (the borrowed in-place scan this
         // regression guards), then decode THIS exact frame — not a separately
         // recompressed one — so the round-trip validates the same bytes the ratio

--- a/zstd/src/tests/roundtrip_integrity.rs
+++ b/zstd/src/tests/roundtrip_integrity.rs
@@ -319,8 +319,15 @@ fn small_repetitive_compresses_on_borrowed_hashchain_band() {
         data.extend_from_slice(&line[..take]);
     }
     for level in [5i32, 6, 7, 10, 12] {
-        let compressed = compress_to_vec(&data[..], CompressionLevel::Level(level));
-        let roundtrip = roundtrip_at_level(&data, CompressionLevel::Level(level));
+        // Compress via the one-shot slice entry (the borrowed in-place scan this
+        // regression guards), then decode THIS exact frame — not a separately
+        // recompressed one — so the round-trip validates the same bytes the ratio
+        // assertion below measures, and keeps guarding the borrowed-HC path even
+        // if wrapper routing changes.
+        let compressed = compress_slice_to_vec(&data[..], CompressionLevel::Level(level));
+        let mut decoder = StreamingDecoder::new(compressed.as_slice()).unwrap();
+        let mut roundtrip = Vec::new();
+        decoder.read_to_end(&mut roundtrip).unwrap();
         assert_eq!(data, roundtrip, "L{level} borrowed-HC roundtrip mismatch");
         // The repeats are found: output is a small fraction of the input, not
         // the near-incompressible ~62% the empty-mirror bug produced.


### PR DESCRIPTION
## Summary

Closes the small-window dictionary `compress-dict` throughput gap for the lazy hash-chain levels (L6–L12) and ships the optimal-parser SIMD price-set vectorisation.

On `small-10k-random` `compress-dict` (i9, flat `c_ffi` control) the lazy levels now **beat C zstd** across the board, where they were ~7–9× behind:

| level | before | after | vs C |
|-------|--------|-------|------|
| L6 | — | 67 µs | **0.47×** |
| L7 | 1025 µs | 98 µs | **0.69×** |
| L8 | — | 98 µs | **0.68×** |
| L9 | — | 98 µs | **0.45×** |
| L10 | 928 µs | 156 µs | **0.71×** |
| L11 | — | 297 µs | **0.87×** |
| L12 | 1390 µs | 297 µs | **0.75×** |

No-dict `decodecorpus-z000033` L10 lazy: no regression. `decompress-dict` round-trips correctly at every level.

## What changed

**Dictionary lazy hash-chain (the headline):**
- **Lazy skipping** — the lazy parser advanced one byte per no-match position; upstream `ZSTD_compressBlock_lazy_generic` advances `step = ((ip - anchor) >> kSearchStrength) + 1`, skipping faster over matchless runs. Instrumenting both sides showed our `find_best_match` call count was 9136 vs C's 6107 on the target frame; with skipping it is 6103.
- **Separate dictMatchState** — dict frames merged the dictionary into the live chain, so every input-position walk dragged dict candidates out of the shared buckets. Mirror upstream's separate `dictMatchState`: attach mode (small/unknown inputs) builds a single-link hash-chain dms over the committed dict and keeps it out of the live chain; large known inputs keep the copy/merge path. The dms walk is **fused** into the chain walk sharing one bounded `nbAttempts` budget (not two full-budget walks).
- **`DICT` monomorphisation** — `find_best_match` / `pick_lazy_match` / `hash_chain_candidate` are generic over `const DICT: bool` (upstream's compile-time `dictMode` template). The no-dict instance carries zero dms code; the dict instance inlines it. This keeps the no-dict hot path untouched.
- Per-candidate codegen: raw `MEM_read32`-style `u32` gates instead of bounds-checked slice equality, history-relative index space with hoisted loop invariants.
- Ratio fix: hash the borrowed window (not the empty owned mirror) in the HashChain insert paths.

**Optimal-parser SIMD price-set:** SoA node-price array + per-CPU-tier vectorised price-set compare (AVX2/BMI2, NEON, SSE4.1, wasm simd128) gated to long ranges, macro-expanded per tier.

## Testing
- `cargo nextest run -p structured-zstd --features dict_builder`: 848 passed
- `cargo test --doc`: 22 passed
- `cargo clippy --all-targets`: clean
- i9 paired before/after with flat `c_ffi` control arms for every number above

Output is ratio-equivalent to upstream (not byte-identical) on the lazy dict path, by design — it follows upstream's match decisions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dictionary-aware behavior across HashChain/Binary Tree tiers, including improved attach/copy handling and snapshot reuse correctness.
* **Bug Fixes**
  * Fixed borrowed-history hashing to use the correct live bytes.
  * Prevented incorrect cache reuse across HC↔BT dictionary layouts.
* **Performance Improvements**
  * Improved optimal-planning DP with dedicated per-node price tracking and faster non-aborting implementations (including SIMD where available).
  * Refined lazy matching/candidate advancement and dictionary-aware hot-path dispatch.
* **Tests**
  * Added regressions for small repetitive inputs and dictionary snapshot reuse roundtrips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->