### PR TITLE
ci(release-plz): register ffi-bench with a private tag namespace

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -47,6 +47,20 @@ name = "structured-zstd-c"
 release = false
 git_tag_name = "structured-zstd-c-v{{ version }}"
 
+# Non-published bench/test crate: holds the libzstd-linking comparison benches,
+# FFI parity tests, and diagnostic examples (`publish = false` in
+# ffi-bench/Cargo.toml). It never releases anywhere. Same baseline-diff trap as
+# the wasm and c-api crates above: added after the last shared `v*` tag, so
+# resolving its "last release" against the shared `v{{ version }}` pattern
+# checks out an old worktree where this package does not exist and crashes
+# `release-pr` with "Failed to find package ffi-bench". A private tag namespace
+# with no matching tag makes release-plz treat it as unreleased and skip the
+# broken baseline diff.
+[[package]]
+name = "ffi-bench"
+release = false
+git_tag_name = "ffi-bench-v{{ version }}"
+
 [changelog]
 commit_parsers = [
     { message = "^chore", skip = true },


### PR DESCRIPTION
## Summary

The `release-plz` job on `main` started failing after #430 merged:

```
get cargo package ffi-bench from worktree ...
Failed to find package "ffi-bench"
```

#430 added the non-published `ffi-bench` workspace member, but it was added after the last shared `v*` release tag. release-plz resolves each package's "last release" against the shared `v{{ version }}` tag pattern, checks out that tag's worktree (where `ffi-bench` does not exist), and crashes.

## Fix

Register `ffi-bench` in `.release-plz.toml` with `release = false` and a private `ffi-bench-v{{ version }}` tag namespace that has no matching tag, so release-plz treats it as unreleased and skips the broken baseline diff. This is the exact pattern already used for the `structured-zstd-wasm` and `structured-zstd-c` crates (both non-published members added after the shared tag).

No crate code changes; config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration to properly manage benchmark infrastructure across the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->