### PR TITLE
perf(encode): Fast dictionary compression — reuse-safe attach + in-place scan

### DIFF
--- a/ffi-bench/Cargo.toml
+++ b/ffi-bench/Cargo.toml
@@ -155,6 +155,15 @@ path = "../zstd/examples/alloc_audit_decode.rs"
 required-features = ["dhat-heap"]
 
 [[example]]
+name = "alloc_audit_fresh"
+path = "../zstd/examples/alloc_audit_fresh.rs"
+
+[[example]]
+name = "huf_matrix"
+path = "../zstd/examples/huf_matrix.rs"
+required-features = ["bench_internals"]
+
+[[example]]
 name = "c_decode_loop_z000033"
 path = "../zstd/examples/c_decode_loop_z000033.rs"
 
@@ -218,3 +227,13 @@ path = "../zstd/examples/section_split.rs"
 [[example]]
 name = "trace_fast_kernel"
 path = "../zstd/examples/trace_fast_kernel.rs"
+
+[[test]]
+name = "zz_cparams"
+path = "tests/zz_cparams.rs"
+required-features = ["bench_internals"]
+
+[[example]]
+name = "dict_matrix"
+path = "../zstd/examples/dict_matrix.rs"
+required-features = ["dict_builder"]

--- a/ffi-bench/tests/dictionary_ffi.rs
+++ b/ffi-bench/tests/dictionary_ffi.rs
@@ -6,6 +6,27 @@
 
 use structured_zstd::testing::dict_roundtrip_fixture;
 
+/// Repeated log-line fixture shared by the dictionary cross-decode tests: a
+/// dict built from this structure matches an input drawn from it heavily, so the
+/// encoder emits dict-reaching offsets the C decoder must accept.
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders\n",
+    ];
+    let mut out = Vec::with_capacity(len);
+    let mut i = 0usize;
+    while out.len() < len {
+        let line = LINES[i % LINES.len()].as_bytes();
+        let take = line.len().min(len - out.len());
+        out.extend_from_slice(&line[..take]);
+        i += 1;
+    }
+    out
+}
+
 #[test]
 fn finalize_raw_dict_roundtrips_with_c_decoder() {
     let (finalized, compressed, payload) = dict_roundtrip_fixture();
@@ -31,26 +52,6 @@ fn finalize_raw_dict_roundtrips_with_c_decoder() {
 fn copy_mode_fast_dict_frame_decodes_with_c() {
     use structured_zstd::decoding::Dictionary;
     use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
-
-    // The same repeated-log-line structure the dict shares, so a >8 KiB input
-    // matches the dict heavily and the copy path emits dict-reaching offsets.
-    fn repeated_log_lines(len: usize) -> Vec<u8> {
-        const LINES: &[&str] = &[
-            "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders\n",
-        ];
-        let mut out = Vec::with_capacity(len);
-        let mut i = 0usize;
-        while out.len() < len {
-            let line = LINES[i % LINES.len()].as_bytes();
-            let take = line.len().min(len - out.len());
-            out.extend_from_slice(&line[..take]);
-            i += 1;
-        }
-        out
-    }
 
     let dict = repeated_log_lines(8 * 1024);
     let payload = repeated_log_lines(16 * 1024); // > 8 KiB → Fast copy mode.
@@ -84,24 +85,6 @@ fn copy_mode_fast_dict_frame_decodes_with_c() {
 fn dict_frames_decode_with_c_across_levels_and_reuse() {
     use structured_zstd::decoding::Dictionary;
     use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
-
-    fn repeated_log_lines(len: usize) -> Vec<u8> {
-        const LINES: &[&str] = &[
-            "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders\n",
-            "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders\n",
-        ];
-        let mut out = Vec::with_capacity(len);
-        let mut i = 0usize;
-        while out.len() < len {
-            let line = LINES[i % LINES.len()].as_bytes();
-            let take = line.len().min(len - out.len());
-            out.extend_from_slice(&line[..take]);
-            i += 1;
-        }
-        out
-    }
 
     let dict = repeated_log_lines(8 * 1024);
     // Levels spanning every backend: 1 (Fast), 3 (dfast), 6 (Row/lazy),

--- a/ffi-bench/tests/dictionary_ffi.rs
+++ b/ffi-bench/tests/dictionary_ffi.rs
@@ -72,3 +72,70 @@ fn copy_mode_fast_dict_frame_decodes_with_c() {
     assert_eq!(written, payload.len());
     assert_eq!(decoded, payload);
 }
+
+/// Dictionary frames must decode through the C reference decoder across every
+/// strategy backend (Fast / dfast / Row / HashChain / BT), on REUSED
+/// compressors (so the resident dict re-borrow + retained-budget bookkeeping is
+/// exercised), and at both attach-mode (< cutoff) and copy-mode (> cutoff)
+/// input sizes. This is the cross-level guard for the dict prefix-floor and
+/// resident-budget changes: any over-window offset would make the C decoder
+/// reject the frame.
+#[test]
+fn dict_frames_decode_with_c_across_levels_and_reuse() {
+    use structured_zstd::decoding::Dictionary;
+    use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+    fn repeated_log_lines(len: usize) -> Vec<u8> {
+        const LINES: &[&str] = &[
+            "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders\n",
+        ];
+        let mut out = Vec::with_capacity(len);
+        let mut i = 0usize;
+        while out.len() < len {
+            let line = LINES[i % LINES.len()].as_bytes();
+            let take = line.len().min(len - out.len());
+            out.extend_from_slice(&line[..take]);
+            i += 1;
+        }
+        out
+    }
+
+    let dict = repeated_log_lines(8 * 1024);
+    // Levels spanning every backend: 1 (Fast), 3 (dfast), 6 (Row/lazy),
+    // 9 (HashChain/lazy2), 12 (HashChain), 19 (BT). Sizes straddle the attach
+    // (< cutoff) / copy (> cutoff) split.
+    let levels = [1i32, 3, 6, 9, 12, 19];
+    let sizes = [1024usize, 16 * 1024];
+
+    for &size in &sizes {
+        let payload = repeated_log_lines(size);
+        for &level in &levels {
+            let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(level));
+            let dict_obj = Dictionary::from_raw_content(1, dict.clone()).expect("raw dict");
+            cctx.set_dictionary_id_flag(false);
+            cctx.set_dictionary(dict_obj).expect("attach dict");
+
+            // Three reused frames so the second/third exercise the resident dict
+            // re-borrow + retained-budget retire path on the dict-bearing backends.
+            for frame_idx in 0..3 {
+                let compressed = cctx.compress_independent_frame(&payload);
+                let mut decoder = zstd::bulk::Decompressor::with_dictionary(dict.as_slice())
+                    .expect("C decoder accepts raw-content dictionary");
+                let mut decoded = Vec::with_capacity(payload.len());
+                let written = decoder
+                    .decompress_to_buffer(compressed.as_slice(), &mut decoded)
+                    .unwrap_or_else(|e| {
+                        panic!("C decode failed: level={level} size={size} frame={frame_idx}: {e}")
+                    });
+                assert_eq!(written, payload.len(), "level={level} size={size}");
+                assert_eq!(
+                    decoded, payload,
+                    "level={level} size={size} frame={frame_idx}"
+                );
+            }
+        }
+    }
+}

--- a/ffi-bench/tests/dictionary_ffi.rs
+++ b/ffi-bench/tests/dictionary_ffi.rs
@@ -19,3 +19,56 @@ fn finalize_raw_dict_roundtrips_with_c_decoder() {
     assert_eq!(written, payload.len());
     assert_eq!(decoded, payload);
 }
+
+/// A copy-mode Fast (level 1) dictionary frame must decode through the C
+/// dictionary decoder. Inputs over the Fast 8 KiB cutoff route through the copy
+/// path, whose prefix floor now reaches back to the dict start (upstream zstd
+/// `ZSTD_getLowestPrefixIndex` with `isDictionary`). That makes the encoder emit
+/// offsets reaching into the dictionary region (up to `window + dictSize`), a
+/// new offset class for this path; this pins that the C reference decoder
+/// accepts them given the same raw-content dictionary.
+#[test]
+fn copy_mode_fast_dict_frame_decodes_with_c() {
+    use structured_zstd::decoding::Dictionary;
+    use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+    // The same repeated-log-line structure the dict shares, so a >8 KiB input
+    // matches the dict heavily and the copy path emits dict-reaching offsets.
+    fn repeated_log_lines(len: usize) -> Vec<u8> {
+        const LINES: &[&str] = &[
+            "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders\n",
+            "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders\n",
+        ];
+        let mut out = Vec::with_capacity(len);
+        let mut i = 0usize;
+        while out.len() < len {
+            let line = LINES[i % LINES.len()].as_bytes();
+            let take = line.len().min(len - out.len());
+            out.extend_from_slice(&line[..take]);
+            i += 1;
+        }
+        out
+    }
+
+    let dict = repeated_log_lines(8 * 1024);
+    let payload = repeated_log_lines(16 * 1024); // > 8 KiB → Fast copy mode.
+
+    // Raw-content dict with the id flag off, so the frame carries no dict id and
+    // the C side can decode with the same raw blob (dict id 0).
+    let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(1));
+    let dict_obj = Dictionary::from_raw_content(1, dict.clone()).expect("raw dict");
+    cctx.set_dictionary_id_flag(false);
+    cctx.set_dictionary(dict_obj).expect("attach dict");
+    let compressed = cctx.compress_independent_frame(&payload);
+
+    let mut decoder = zstd::bulk::Decompressor::with_dictionary(dict.as_slice())
+        .expect("C decoder should accept raw-content dictionary");
+    let mut decoded = Vec::with_capacity(payload.len());
+    let written = decoder
+        .decompress_to_buffer(compressed.as_slice(), &mut decoded)
+        .expect("C decoder should decode copy-mode dict frame");
+    assert_eq!(written, payload.len());
+    assert_eq!(decoded, payload);
+}

--- a/ffi-bench/tests/zz_cparams.rs
+++ b/ffi-bench/tests/zz_cparams.rs
@@ -1,0 +1,48 @@
+//! Parity test: our `ZSTD_getCParams` port (`structured_zstd::testing::c_cparams`)
+//! must match the C `ZSTD_getCParams` byte-for-byte across a grid of
+//! (level, srcSize, dictSize). This locks the cparam tier table + adjust logic
+//! to the reference so the encoder sizes its tables and picks its strategy the
+//! same way upstream does.
+#![cfg(feature = "bench_internals")]
+use zstd::zstd_safe::zstd_sys;
+
+fn reference_cparams(level: i32, src: u64, dict: usize) -> (u32, u32, u32, u32, u32, u32, u32) {
+    let p = unsafe { zstd_sys::ZSTD_getCParams(level, src, dict) };
+    (
+        p.windowLog,
+        p.chainLog,
+        p.hashLog,
+        p.searchLog,
+        p.minMatch,
+        p.targetLength,
+        p.strategy as u32,
+    )
+}
+
+#[test]
+fn cparams_match_reference_over_grid() {
+    let levels = [-7, -5, -3, -1, 0, 1, 2, 3, 4, 5, 7, 10, 12, 15, 17, 19, 22];
+    let srcs: [u64; 9] = [0, 1, 100, 4096, 6806, 16_384, 100_000, 131_072, 5_000_000];
+    let dicts: [usize; 5] = [0, 437, 2048, 65_536, 1_000_000];
+    let mut mismatches = 0usize;
+    for &level in &levels {
+        for &src in &srcs {
+            for &dict in &dicts {
+                let ours = structured_zstd::testing::compression_params(level, src, dict);
+                let reference = reference_cparams(level, src, dict);
+                if ours != reference {
+                    mismatches += 1;
+                    if mismatches <= 40 {
+                        eprintln!(
+                            "MISMATCH level={level} src={src} dict={dict}\n  ours={ours:?}\n  ref ={reference:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(
+        mismatches, 0,
+        "{mismatches} cparam mismatches vs C ZSTD_getCParams"
+    );
+}

--- a/zstd/examples/alloc_audit_fresh.rs
+++ b/zstd/examples/alloc_audit_fresh.rs
@@ -1,0 +1,78 @@
+//! Fresh-per-call allocation audit for the encoder, matching the
+//! `compare_ffi` bench shape (a brand-new `FrameCompressor` per frame, the
+//! way `ZSTD_createCCtx`-per-iter is measured on the C side). Run with
+//! `--features dhat-heap` to record every per-call allocation site + count;
+//! the totals divided by `iters` give the per-frame malloc shape that the
+//! single-arena work targets.
+//!
+//! Build: `cargo build --profile flamegraph -p structured-zstd
+//!          --example alloc_audit_fresh --features dhat-heap`
+//! Run:   `cargo run --release -p structured-zstd
+//!          --example alloc_audit_fresh --features dhat-heap -- <level> <iters> logs<N>`
+
+use std::env;
+
+use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+
+#[cfg(feature = "dhat-heap")]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let mut bytes = Vec::with_capacity(len);
+    while bytes.len() < len {
+        for line in LINES {
+            if bytes.len() == len {
+                break;
+            }
+            let remaining = len - bytes.len();
+            bytes.extend_from_slice(&line.as_bytes()[..line.len().min(remaining)]);
+        }
+    }
+    bytes
+}
+
+fn resolve_input(spec: &str) -> Vec<u8> {
+    if let Some(rest) = spec.strip_prefix("logs") {
+        let n: usize = rest.parse().expect("logs<N>: N must be a byte count");
+        repeated_log_lines(n)
+    } else {
+        std::fs::read(spec).expect("read input file")
+    }
+}
+
+fn main() {
+    #[cfg(feature = "dhat-heap")]
+    let _dhat = dhat::Profiler::new_heap();
+
+    let args: Vec<String> = env::args().collect();
+    let level: i32 = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(1);
+    let iters: u32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(2000);
+    let input_spec: &str = args.get(3).map(|s| s.as_str()).unwrap_or("logs4096");
+
+    let src = resolve_input(input_spec);
+
+    let mut sink: usize = 0;
+    for _ in 0..iters {
+        // FRESH compressor every iteration = the compare_ffi bench shape.
+        let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::from_level(level));
+        let mut out: Vec<u8> = Vec::new();
+        cctx.compress_independent_frame_into(&src, &mut out);
+        sink = sink.wrapping_add(out.len());
+        core::hint::black_box(&out);
+    }
+
+    eprintln!(
+        "fresh-encoded {} bytes × {} iters at level {}; last-out-sum={}",
+        src.len(),
+        iters,
+        level,
+        sink
+    );
+}

--- a/zstd/examples/dict_matrix.rs
+++ b/zstd/examples/dict_matrix.rs
@@ -91,6 +91,10 @@ fn main() {
             let (c_us, c_b) = unsafe {
                 let cdict = zstd_sys::ZSTD_createCDict(dict.as_ptr().cast(), dict.len(), level);
                 let cctx = zstd_sys::ZSTD_createCCtx();
+                // Both creators return null on allocation failure; passing a
+                // null handle to ZSTD_compress_usingCDict is undefined behavior.
+                assert!(!cdict.is_null(), "ZSTD_createCDict returned null");
+                assert!(!cctx.is_null(), "ZSTD_createCCtx returned null");
                 let mut dst: Vec<u8> = vec![0u8; dst_cap];
                 let r = time_min(iters, || {
                     let rc = zstd_sys::ZSTD_compress_usingCDict(

--- a/zstd/examples/dict_matrix.rs
+++ b/zstd/examples/dict_matrix.rs
@@ -1,0 +1,119 @@
+//! Dictionary compress matrix: per (frame size, level), compressed size and
+//! compress time for structured-zstd vs the C reference, both reusing a
+//! prepared dictionary across iterations (the per-label-dict use case). Run on
+//! the bench host for timing.
+//!
+//! Build/run: `cargo run --release -p ffi-bench --example dict_matrix
+//!             --features dict_builder`
+
+use std::time::Instant;
+
+use structured_zstd::encoding::{CompressionLevel, FrameCompressor};
+use zstd::zstd_safe::zstd_sys;
+
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let mut b = Vec::with_capacity(len);
+    while b.len() < len {
+        for l in LINES {
+            if b.len() == len {
+                break;
+            }
+            let r = len - b.len();
+            b.extend_from_slice(&l.as_bytes()[..l.len().min(r)]);
+        }
+    }
+    b
+}
+
+fn time_min<F: FnMut() -> usize>(iters: u32, mut f: F) -> (f64, usize) {
+    let mut best = f64::MAX;
+    let mut out = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        out = f();
+        let us = t.elapsed().as_secs_f64() * 1e6;
+        if us < best {
+            best = us;
+        }
+        std::hint::black_box(out);
+    }
+    (best, out)
+}
+
+fn main() {
+    // Raw-content dictionary (both sides load the same bytes; a non-magic blob
+    // is treated as a content dictionary by each). 8 KiB of the same log
+    // structure the frames share.
+    let dict = repeated_log_lines(8 * 1024);
+    let fixtures: &[(&str, usize)] = &[
+        ("logs-512", 512),
+        ("logs-1k", 1024),
+        ("logs-4k", 4096),
+        ("logs-16k", 16 * 1024),
+    ];
+    let levels: &[i32] = &[-3, -1, 1, 2, 3, 6, 9, 12, 19];
+    let iters: u32 = 20000;
+
+    let dst_cap = unsafe { zstd_sys::ZSTD_compressBound(64 * 1024) };
+
+    println!(
+        "{:<9} {:>3} | {:>6} {:>7} | {:>6} {:>7} | rust:sz/sp",
+        "fixture", "lvl", "r_B", "r_us", "c_B", "c_us"
+    );
+    println!("{}", "-".repeat(60));
+    for (name, size) in fixtures {
+        let data = repeated_log_lines(*size);
+        for &level in levels {
+            // Rust: prepare the dict once, reuse the compressor across iters.
+            let (r_us, r_b) = {
+                let mut cctx: FrameCompressor =
+                    FrameCompressor::new(CompressionLevel::Level(level));
+                // Raw-content dictionary (matches `ZSTD_createCDict` on a
+                // non-magic blob: auto-detected raw content, dict id 0).
+                let dict_obj =
+                    structured_zstd::decoding::Dictionary::from_raw_content(1, dict.clone())
+                        .expect("raw dict");
+                cctx.set_dictionary_id_flag(false);
+                cctx.set_dictionary(dict_obj).expect("attach dict");
+                let mut out: Vec<u8> = Vec::new();
+                time_min(iters, || {
+                    cctx.compress_independent_frame_into(&data, &mut out);
+                    out.len()
+                })
+            };
+            // C: createCDict once, reuse CCtx across iters.
+            let (c_us, c_b) = unsafe {
+                let cdict = zstd_sys::ZSTD_createCDict(dict.as_ptr().cast(), dict.len(), level);
+                let cctx = zstd_sys::ZSTD_createCCtx();
+                let mut dst: Vec<u8> = vec![0u8; dst_cap];
+                let r = time_min(iters, || {
+                    let rc = zstd_sys::ZSTD_compress_usingCDict(
+                        cctx,
+                        dst.as_mut_ptr().cast(),
+                        dst_cap,
+                        data.as_ptr().cast(),
+                        data.len(),
+                        cdict,
+                    );
+                    assert_eq!(zstd_sys::ZSTD_isError(rc), 0);
+                    rc
+                });
+                zstd_sys::ZSTD_freeCCtx(cctx);
+                zstd_sys::ZSTD_freeCDict(cdict);
+                r
+            };
+            let sz = r_b as f64 / c_b as f64;
+            let sp = r_us / c_us;
+            println!(
+                "{name:<9} {level:>3} | {r_b:>6} {r_us:>7.2} | {c_b:>6} {c_us:>7.2} | {sz:.2}/{sp:.2}x"
+            );
+        }
+        println!();
+    }
+}

--- a/zstd/examples/encode_loop_dict.rs
+++ b/zstd/examples/encode_loop_dict.rs
@@ -91,8 +91,16 @@ fn main() {
     let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::from_level(level));
     if let Some(path) = dict_path {
         let dict = std::fs::read(path).expect("read dict file");
-        cctx.set_dictionary_from_bytes(&dict)
-            .expect("dictionary should attach");
+        // A finalized dict carries the zstd magic; a non-magic blob is raw
+        // content (the `ZSTD_createCDict`-on-raw-bytes path the dict_matrix
+        // bench uses), attached with the id flag off so the frame omits a id.
+        if cctx.set_dictionary_from_bytes(&dict).is_err() {
+            let dict_obj = structured_zstd::decoding::Dictionary::from_raw_content(1, dict)
+                .expect("raw-content dictionary should build");
+            cctx.set_dictionary_id_flag(false);
+            cctx.set_dictionary(dict_obj)
+                .expect("raw-content dictionary should attach");
+        }
     }
 
     // Output buffer reused across iterations (allocated once, replaced in

--- a/zstd/examples/huf_matrix.rs
+++ b/zstd/examples/huf_matrix.rs
@@ -1,0 +1,96 @@
+//! Full perf + ratio matrix: per (fixture size, level), compressed size and
+//! compress time for structured-zstd with the #167 HUF table-log search ON
+//! (default) and OFF (cheap single-build), plus the C reference. Reports the
+//! size and speed of each against C. Run on the bench host for timing.
+//!
+//! Build/run: `cargo run --release -p ffi-bench --example huf_matrix
+//!             --features bench_internals`
+
+use std::time::Instant;
+
+use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
+use structured_zstd::testing::set_force_cheap_huf;
+
+fn repeated_log_lines(len: usize) -> Vec<u8> {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let mut b = Vec::with_capacity(len);
+    while b.len() < len {
+        for l in LINES {
+            if b.len() == len {
+                break;
+            }
+            let r = len - b.len();
+            b.extend_from_slice(&l.as_bytes()[..l.len().min(r)]);
+        }
+    }
+    b
+}
+
+fn time_min<F: FnMut() -> usize>(iters: u32, mut f: F) -> (f64, usize) {
+    let mut best = f64::MAX;
+    let mut out = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        out = f();
+        let us = t.elapsed().as_secs_f64() * 1e6;
+        if us < best {
+            best = us;
+        }
+        std::hint::black_box(out);
+    }
+    (best, out)
+}
+
+fn main() {
+    let fixtures: &[(&str, usize)] = &[
+        ("logs-1k", 1024),
+        ("logs-4k", 4096),
+        ("logs-64k", 64 * 1024),
+        ("logs-1M", 1024 * 1024),
+    ];
+    let levels: &[i32] = &[-5, -3, -1, 1, 2, 3, 6, 9, 12, 16, 19, 22];
+
+    println!(
+        "{:<9} {:>3} | {:>6} {:>7} | {:>6} {:>7} | {:>6} {:>7} | on:sz/sp   off:sz/sp",
+        "fixture", "lvl", "on_B", "on_us", "off_B", "off_us", "c_B", "c_us"
+    );
+    println!("{}", "-".repeat(92));
+    for (name, size) in fixtures {
+        let data = repeated_log_lines(*size);
+        let iters: u32 = if *size <= 4096 {
+            20000
+        } else if *size <= 64 * 1024 {
+            3000
+        } else {
+            300
+        };
+        for &level in levels {
+            set_force_cheap_huf(false);
+            let (on_us, on_b) = time_min(iters, || {
+                compress_slice_to_vec(&data, CompressionLevel::Level(level)).len()
+            });
+            set_force_cheap_huf(true);
+            let (off_us, off_b) = time_min(iters, || {
+                compress_slice_to_vec(&data, CompressionLevel::Level(level)).len()
+            });
+            set_force_cheap_huf(false);
+            let (c_us, c_b) = time_min(iters, || {
+                zstd::bulk::compress(&data, level).expect("c").len()
+            });
+
+            let on_sz = on_b as f64 / c_b as f64;
+            let on_sp = on_us / c_us;
+            let off_sz = off_b as f64 / c_b as f64;
+            let off_sp = off_us / c_us;
+            println!(
+                "{name:<9} {level:>3} | {on_b:>6} {on_us:>7.2} | {off_b:>6} {off_us:>7.2} | {c_b:>6} {c_us:>7.2} | {on_sz:.2}/{on_sp:.2}x  {off_sz:.2}/{off_sp:.2}x"
+            );
+        }
+        println!();
+    }
+}

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -593,10 +593,22 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
         let mut ll_counts = [0usize; 256];
         let mut ml_counts = [0usize; 256];
         let mut of_counts = [0usize; 256];
+        // Track the highest code per stream while histogramming so the table
+        // selector skips the full-256 reverse scan for `max_symbol` (the small
+        // sequence-code alphabets leave ~200 high slots permanently zero).
+        let mut ll_max = 0usize;
+        let mut ml_max = 0usize;
+        let mut of_max = 0usize;
         for seq in sequences.iter() {
-            ll_counts[encode_literal_length(seq.ll).0 as usize] += 1;
-            ml_counts[encode_match_len(seq.ml).0 as usize] += 1;
-            of_counts[encode_offset(seq.of).0 as usize] += 1;
+            let ll_code = encode_literal_length(seq.ll).0 as usize;
+            let ml_code = encode_match_len(seq.ml).0 as usize;
+            let of_code = encode_offset(seq.of).0 as usize;
+            ll_counts[ll_code] += 1;
+            ml_counts[ml_code] += 1;
+            of_counts[of_code] += 1;
+            ll_max = ll_max.max(ll_code);
+            ml_max = ml_max.max(ml_code);
+            of_max = of_max.max(of_code);
         }
         let total = sequences.len();
 
@@ -605,6 +617,7 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
             state.fse_tables.ll_default_ref(),
             &ll_counts,
             total,
+            ll_max,
             9,
             state.strategy_tag,
         );
@@ -613,6 +626,7 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
             state.fse_tables.ml_default_ref(),
             &ml_counts,
             total,
+            ml_max,
             9,
             state.strategy_tag,
         );
@@ -621,6 +635,7 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
             state.fse_tables.of_default_ref(),
             &of_counts,
             total,
+            of_max,
             8,
             state.strategy_tag,
         );
@@ -1536,14 +1551,26 @@ fn choose_table<'a>(
     max_log: u8,
     strategy: crate::encoding::strategy::StrategyTag,
 ) -> FseTableMode<'a> {
-    // Collect symbol distribution
+    // Collect symbol distribution, tracking the highest code so the selector
+    // skips the full-256 reverse scan (see `choose_table_from_counts`).
     let mut counts = [0usize; 256];
     let mut total = 0usize;
+    let mut max_symbol = 0usize;
     for symbol in data {
-        counts[symbol as usize] += 1;
+        let symbol = symbol as usize;
+        counts[symbol] += 1;
         total += 1;
+        max_symbol = max_symbol.max(symbol);
     }
-    choose_table_from_counts(previous, default_table, &counts, total, max_log, strategy)
+    choose_table_from_counts(
+        previous,
+        default_table,
+        &counts,
+        total,
+        max_symbol,
+        max_log,
+        strategy,
+    )
 }
 
 /// Same decision logic as [`choose_table`] but takes pre-computed
@@ -1558,6 +1585,16 @@ fn choose_table_from_counts<'a>(
     default_table: &'a FSETable,
     counts: &[usize; 256],
     total: usize,
+    // The highest symbol code with a non-zero count, tracked by the caller as it
+    // builds `counts`. The sequence-code alphabets are tiny (LL <= 35, ML <= 52,
+    // OF <= 31) while `counts` is a fixed 256-wide array, so deriving this here
+    // via `counts.iter().rposition(..)` would scan ~200 always-zero high slots
+    // per stream per block — the dominant cost on small frames (profiled ~35% of
+    // a 1 KiB dict-frame encode). The caller already visits every code once, so
+    // it carries the running max for free. Equal to the old `rposition` result
+    // (every counted code increments its slot, so the max code IS the highest
+    // non-zero index), keeping the table selection byte-identical.
+    max_symbol: usize,
     max_log: u8,
     strategy: crate::encoding::strategy::StrategyTag,
 ) -> FseTableMode<'a> {
@@ -1565,12 +1602,14 @@ fn choose_table_from_counts<'a>(
         return FseTableMode::Predefined(default_table);
     }
 
-    // Build a new table from the actual data distribution
-    let max_symbol = counts
+    // Distinctness over the live alphabet only (`..=max_symbol`); slots above
+    // `max_symbol` are zero by construction, so bounding the scan there matches
+    // the full-array result without touching the always-zero tail.
+    let distinct_symbols = counts[..=max_symbol]
         .iter()
-        .rposition(|&count| count > 0)
-        .unwrap_or_default();
-    let distinct_symbols = counts.iter().filter(|&&count| count > 0).take(2).count();
+        .filter(|&&count| count > 0)
+        .take(2)
+        .count();
     if distinct_symbols == 1 {
         let symbol = max_symbol as u8;
         if let Some(PreviousFseTable::Rle(prev_symbol)) = previous
@@ -2810,6 +2849,7 @@ mod tests {
                 fse_tables.ll_default_ref(),
                 &counts,
                 total,
+                1, // highest non-zero code in {0,1}
                 9,
                 strategy,
             );

--- a/zstd/src/encoding/blocks/compressed.rs
+++ b/zstd/src/encoding/blocks/compressed.rs
@@ -344,6 +344,7 @@ pub(crate) fn compress_block_with_post_split<M: Matcher>(
             block_scratch: inner_scratch,
             offset_hist: state.offset_hist,
             strategy_tag: state.strategy_tag,
+            huf_optimal_search: state.huf_optimal_search,
         },
         workspace,
     };
@@ -562,6 +563,7 @@ fn encode_block_parts_with_sequence_scratch<M: Matcher>(
             state.last_huff_table.as_ref(),
             &mut writer,
             strategy,
+            state.huf_optimal_search,
         ) {
             HuffmanTableUpdate::New(table) => {
                 state.replace_huff_table(table);
@@ -693,6 +695,7 @@ fn estimate_block_parts_size<M: Matcher>(
         &mut state.last_huff_table,
         &mut workspace.lit_counts,
         state.strategy_tag,
+        state.huf_optimal_search,
     );
 
     let seq_bytes = if workspace.sequences.is_empty() {
@@ -716,6 +719,7 @@ fn estimate_literals_section_bytes(
     last_huff: &mut Option<huff0_encoder::HuffmanTable>,
     counts: &mut [usize; 256],
     strategy: crate::encoding::strategy::StrategyTag,
+    huf_search: bool,
 ) -> usize {
     // Mirror `encode_block_parts_with_sequence_scratch` literal-mode branches
     // **in the same order**. The emitter pre-checks `all_identical`
@@ -773,7 +777,8 @@ fn estimate_literals_section_bytes(
         *last_huff = None;
         return uncompressed_literals_header_bytes(literals.len()) + literals.len();
     }
-    let new_table = huff0_encoder::HuffmanTable::build_from_counts(&counts[..=max_sym]);
+    let new_table =
+        huff0_encoder::HuffmanTable::build_from_counts_gated(&counts[..=max_sym], huf_search);
 
     let Some(new_desc) = new_table.writeable_table_description_size() else {
         *last_huff = None;
@@ -2148,6 +2153,7 @@ fn compress_literals(
     last_table: Option<&huff0_encoder::HuffmanTable>,
     writer: &mut BitWriter<&mut Vec<u8>>,
     strategy: crate::encoding::strategy::StrategyTag,
+    huf_search: bool,
 ) -> HuffmanTableUpdate {
     let reset_idx = writer.index();
 
@@ -2185,7 +2191,8 @@ fn compress_literals(
         return HuffmanTableUpdate::Cleared;
     }
 
-    let new_encoder_table = huff0_encoder::HuffmanTable::build_from_counts(&counts[..=max_symbol]);
+    let new_encoder_table =
+        huff0_encoder::HuffmanTable::build_from_counts_gated(&counts[..=max_symbol], huf_search);
 
     let Some(new_table_description_size) = new_encoder_table.writeable_table_description_size()
     else {
@@ -2625,6 +2632,7 @@ mod tests {
                     block_scratch: CompressedBlockScratch::new(),
                     offset_hist: [1, 4, 8],
                     strategy_tag: *strat,
+                    huf_optimal_search: true,
                 };
                 let mut emit_state = CompressState::<EntropyOnlyMatcher> {
                     matcher: EntropyOnlyMatcher,
@@ -2634,6 +2642,7 @@ mod tests {
                     block_scratch: CompressedBlockScratch::new(),
                     offset_hist: [1, 4, 8],
                     strategy_tag: *strat,
+                    huf_optimal_search: true,
                 };
                 let mut workspace = EstimatorWorkspace::default();
                 let est = estimate_block_parts_size(&mut est_state, &literals, &[], &mut workspace);
@@ -2678,6 +2687,7 @@ mod tests {
             block_scratch: super::CompressedBlockScratch::new(),
             offset_hist: [10, 20, 30],
             strategy_tag: crate::encoding::strategy::StrategyTag::Fast,
+            huf_optimal_search: true,
         };
         let source = [0xA5; 8];
         let sequences = [RawSequence {

--- a/zstd/src/encoding/cparams.rs
+++ b/zstd/src/encoding/cparams.rs
@@ -335,8 +335,9 @@ mod tests {
         // (513-byte) source, so the prepared CDict tables down-size far below
         // the requested input logs instead of holding max-size tables
         // (`ZSTD_adjustCParams_internal` with `ZSTD_cpm_createCDict`).
-        let (hash_log, chain_log) =
-            create_cdict_table_logs(27, 27, 28, /* uses_bt */ true, /* dict_size */ 4096);
+        let (hash_log, chain_log) = create_cdict_table_logs(
+            27, 27, 28, /* uses_bt */ true, /* dict_size */ 4096,
+        );
         assert!(
             hash_log < 27,
             "hash_log {hash_log} must shrink for a tiny CDict source",
@@ -346,7 +347,8 @@ mod tests {
         // A zero-dict CDict does NOT force the minSrcSize assumption (the
         // `dict_size != 0` guard), so the unknown-source path leaves the logs as
         // requested.
-        let (h2, c2) = create_cdict_table_logs(20, 20, 21, /* uses_bt */ false, /* dict_size */ 0);
+        let (h2, c2) =
+            create_cdict_table_logs(20, 20, 21, /* uses_bt */ false, /* dict_size */ 0);
         assert_eq!(h2, 20, "no-dict CDict keeps the requested hash_log");
         assert_eq!(c2, 21, "no-dict CDict keeps the requested chain_log");
     }

--- a/zstd/src/encoding/cparams.rs
+++ b/zstd/src/encoding/cparams.rs
@@ -25,37 +25,33 @@ pub(crate) struct CParams {
     pub strategy: u32,
 }
 
-/// Parameter-adjustment mode (`ZSTD_CParamMode_e`): controls how `dictSize`
-/// and an unknown `srcSize` are treated when down-sizing.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CParamMode {
-    /// `ZSTD_cpm_unknown` — public `ZSTD_getCParams` entry.
-    Unknown,
-    /// `ZSTD_cpm_noAttachDict`.
-    NoAttachDict,
-    /// `ZSTD_cpm_createCDict` — CDict-table parameter selection.
-    CreateCDict,
-    /// `ZSTD_cpm_attachDict` — selecting source-only params (dict has its own).
-    AttachDict,
-}
-
 // Upstream constants (zstd.h / zstd_internal.h / clevels.h, 1.5.7).
-const ZSTD_MAX_CLEVEL: i32 = 22;
-const ZSTD_CLEVEL_DEFAULT: i32 = 3;
 const HASHLOG_MIN: u32 = 6;
 const WINDOWLOG_ABSOLUTEMIN: u32 = 10;
 // 64-bit host value; structured-zstd's encoder runs hosted. The 32-bit value
 // is 30, only relevant on 32-bit targets where windowLog never reaches 31 here.
 const WINDOWLOG_MAX: u32 = 31;
 const SHORT_CACHE_TAG_BITS: u32 = 8;
-const TARGETLENGTH_MAX: i32 = 1 << 17;
-/// `ZSTD_minCLevel()` == `-ZSTD_TARGETLENGTH_MAX`.
-const MIN_CLEVEL: i32 = -TARGETLENGTH_MAX;
 /// `ZSTD_CONTENTSIZE_UNKNOWN` == `(0ULL - 1)`.
 pub(crate) const CONTENTSIZE_UNKNOWN: u64 = u64::MAX;
 
+// Level-row selection constants — only the public `get_cparams` entry (the
+// C-reference comparison surface) uses these; the encoder indexes the table via
+// `default_cparams` and never re-selects a level row here.
+#[cfg(feature = "bench_internals")]
+const ZSTD_MAX_CLEVEL: i32 = 22;
+#[cfg(feature = "bench_internals")]
+const ZSTD_CLEVEL_DEFAULT: i32 = 3;
+#[cfg(feature = "bench_internals")]
+const TARGETLENGTH_MAX: i32 = 1 << 17;
+/// `ZSTD_minCLevel()` == `-ZSTD_TARGETLENGTH_MAX`.
+#[cfg(feature = "bench_internals")]
+const MIN_CLEVEL: i32 = -TARGETLENGTH_MAX;
+#[cfg(feature = "bench_internals")]
 const KB_256: u64 = 256 * 1024;
+#[cfg(feature = "bench_internals")]
 const KB_128: u64 = 128 * 1024;
+#[cfg(feature = "bench_internals")]
 const KB_16: u64 = 16 * 1024;
 
 /// `ZSTD_defaultCParameters[4][ZSTD_MAX_CLEVEL+1]` (clevels.h, zstd 1.5.7),
@@ -111,6 +107,17 @@ const DEFAULT_CPARAMS: [[CParams; 23]; 4] = {
     ]
 };
 
+/// The verbatim upstream default-cparams row for a `(tier, level)` pair, the
+/// single source of the `ZSTD_defaultCParameters` table data. `tier` is the
+/// source-size bucket (0 = `>256 KB` .. 3 = `<=16 KB`, see [`get_cparams`]);
+/// `level` is the row (0 = negative-level base, 1..=22). This is the
+/// pre-`adjust_cparams` row: the encoder's level table consumes the raw
+/// `(hashLog, chainLog, minMatch)` widths from it and runs its own
+/// source-size clamp.
+pub(crate) fn default_cparams(tier: usize, level: usize) -> CParams {
+    DEFAULT_CPARAMS[tier][level]
+}
+
 /// `ZSTD_highbit32(val)` — index of the most-significant set bit. Caller
 /// guarantees `val != 0` (matches the upstream `assert(val != 0)`).
 #[inline]
@@ -120,13 +127,10 @@ fn highbit32(val: u32) -> u32 {
 }
 
 /// `ZSTD_getCParamRowSize` (zstd_compress.c): the effective size used to pick
-/// the tier row.
-fn cparam_row_size(src_size_hint: u64, dict_size: usize, mode: CParamMode) -> u64 {
-    let dict_size = if matches!(mode, CParamMode::AttachDict) {
-        0
-    } else {
-        dict_size as u64
-    };
+/// the tier row, for the public `ZSTD_getCParams` (`ZSTD_cpm_unknown`) entry.
+#[cfg(feature = "bench_internals")]
+fn cparam_row_size(src_size_hint: u64, dict_size: usize) -> u64 {
+    let dict_size = dict_size as u64;
     let unknown = src_size_hint == CONTENTSIZE_UNKNOWN;
     let added_size = if unknown && dict_size > 0 { 500 } else { 0 };
     if unknown && dict_size == 0 {
@@ -181,22 +185,18 @@ fn cdict_indices_are_tagged(cp: &CParams) -> bool {
 fn adjust_cparams(
     mut cp: CParams,
     mut src_size: u64,
-    mut dict_size: usize,
-    mode: CParamMode,
+    dict_size: usize,
+    create_cdict: bool,
 ) -> CParams {
     const MIN_SRC_SIZE: u64 = 513; // (1<<9) + 1
     let max_window_resize: u64 = 1u64 << (WINDOWLOG_MAX - 1);
 
-    match mode {
-        CParamMode::Unknown | CParamMode::NoAttachDict => {}
-        CParamMode::CreateCDict => {
-            if dict_size != 0 && src_size == CONTENTSIZE_UNKNOWN {
-                src_size = MIN_SRC_SIZE;
-            }
-        }
-        CParamMode::AttachDict => {
-            dict_size = 0;
-        }
+    // `ZSTD_cpm_createCDict`: an unknown source assumes a `minSrcSize` source so
+    // the dictionary's prepared tables down-size deterministically. The other
+    // modes (`unknown` / `noAttachDict` / `attachDict`) leave `src_size` as-is;
+    // only `unknown` (the public entry) and `createCDict` have live callers here.
+    if create_cdict && dict_size != 0 && src_size == CONTENTSIZE_UNKNOWN {
+        src_size = MIN_SRC_SIZE;
     }
 
     // resize windowLog if input is small enough, to use less memory.
@@ -228,7 +228,7 @@ fn adjust_cparams(
         cp.window_log = WINDOWLOG_ABSOLUTEMIN;
     }
 
-    if matches!(mode, CParamMode::CreateCDict) && cdict_indices_are_tagged(&cp) {
+    if create_cdict && cdict_indices_are_tagged(&cp) {
         let max_short_cache_hash_log = 32 - SHORT_CACHE_TAG_BITS;
         if cp.hash_log > max_short_cache_hash_log {
             cp.hash_log = max_short_cache_hash_log;
@@ -243,13 +243,9 @@ fn adjust_cparams(
 
 /// `ZSTD_getCParams_internal` (zstd_compress.c): tier + level row selection,
 /// negative-level acceleration, then `ZSTD_adjustCParams_internal`.
-pub(crate) fn get_cparams(
-    compression_level: i32,
-    src_size_hint: u64,
-    dict_size: usize,
-    mode: CParamMode,
-) -> CParams {
-    let r_size = cparam_row_size(src_size_hint, dict_size, mode);
+#[cfg(feature = "bench_internals")]
+fn get_cparams(compression_level: i32, src_size_hint: u64, dict_size: usize) -> CParams {
+    let r_size = cparam_row_size(src_size_hint, dict_size);
     let table_id = (u32::from(r_size <= KB_256)
         + u32::from(r_size <= KB_128)
         + u32::from(r_size <= KB_16)) as usize;
@@ -271,11 +267,15 @@ pub(crate) fn get_cparams(
         cp.target_length = (-clamped) as u32;
     }
 
-    adjust_cparams(cp, src_size_hint, dict_size, mode)
+    // `ZSTD_cpm_unknown` (the public entry): no createCDict source assumption.
+    adjust_cparams(cp, src_size_hint, dict_size, /* create_cdict */ false)
 }
 
-/// Public `ZSTD_getCParams` entry: maps `src_size_hint == 0` to UNKNOWN and
-/// uses `Unknown` mode, matching upstream exactly.
+/// Public `ZSTD_getCParams` entry: maps `src_size_hint == 0` to UNKNOWN,
+/// matching upstream exactly. The C-reference comparison surface (`zz_cparams`
+/// validates it byte-for-byte against C `ZSTD_getCParams`); the encoder sizes
+/// its own tables from [`default_cparams`] + [`create_cdict_table_logs`].
+#[cfg(feature = "bench_internals")]
 pub(crate) fn get_cparams_public(
     compression_level: i32,
     src_size_hint: u64,
@@ -286,5 +286,41 @@ pub(crate) fn get_cparams_public(
     } else {
         src_size_hint
     };
-    get_cparams(compression_level, src, dict_size, CParamMode::Unknown)
+    get_cparams(compression_level, src, dict_size)
+}
+
+/// The `(hash_log, chain_log)` a dictionary's prepared match-finder tables get
+/// under `ZSTD_cpm_createCDict` — the single source for the CDict table
+/// geometry (mirrors `ZSTD_adjustCParams_internal` with an unknown source, so
+/// `dictSize` drives `dict_and_window_log` down-sizing while the live window
+/// stays source-sized). `uses_bt` selects the binary-tree `cycleLog`
+/// (`chainLog - 1`). Returns only the table widths; the caller keeps its own
+/// resolved `window_log`. Non-`dictMatchState` strategies (HC / Row / BT) skip
+/// the tagged short-cache cap, matching upstream.
+pub(crate) fn create_cdict_table_logs(
+    window_log: u8,
+    hash_log: u32,
+    chain_log: u32,
+    uses_bt: bool,
+    dict_size: usize,
+) -> (u32, u32) {
+    // Strategy only steers `cycle_log` (>= btlazy2 == 6) and the tagged cap
+    // (<= dfast == 2); pick lazy(4) / btopt(7) so HC/Row/BT stay untagged.
+    let strategy = if uses_bt { 7 } else { 4 };
+    let cp = CParams {
+        window_log: window_log as u32,
+        chain_log,
+        hash_log,
+        search_log: 0,
+        min_match: 0,
+        target_length: 0,
+        strategy,
+    };
+    let adj = adjust_cparams(
+        cp,
+        CONTENTSIZE_UNKNOWN,
+        dict_size,
+        /* create_cdict */ true,
+    );
+    (adj.hash_log, adj.chain_log)
 }

--- a/zstd/src/encoding/cparams.rs
+++ b/zstd/src/encoding/cparams.rs
@@ -1,0 +1,290 @@
+//! Faithful port of upstream zstd's compression-parameter selection
+//! (`ZSTD_getCParams` and its helpers in `lib/compress/zstd_compress.c` +
+//! the `ZSTD_defaultCParameters[4][23]` table in `lib/compress/clevels.h`,
+//! pinned to zstd 1.5.7). This drives per-(level, srcSize, dictSize)
+//! `(windowLog, hashLog, minMatch, strategy, ...)` selection so the encoder
+//! sizes its match-finder tables and picks its strategy the same way the
+//! reference does — including the source-size tier table and the
+//! `ZSTD_adjustCParams` down-sizing. Verified byte-for-byte against the C
+//! `ZSTD_getCParams` over a grid in `ffi-bench`.
+//!
+//! Pure `core` (const table + arithmetic); no allocation, no `std`.
+
+/// One row of the upstream `ZSTD_compressionParameters` struct.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CParams {
+    pub window_log: u32,
+    pub chain_log: u32,
+    pub hash_log: u32,
+    pub search_log: u32,
+    /// Upstream `minMatch` (a.k.a. `searchLength`): the match-finder hash width.
+    pub min_match: u32,
+    pub target_length: u32,
+    /// Upstream `ZSTD_strategy` numeric value: fast=1, dfast=2, greedy=3,
+    /// lazy=4, lazy2=5, btlazy2=6, btopt=7, btultra=8, btultra2=9.
+    pub strategy: u32,
+}
+
+/// Parameter-adjustment mode (`ZSTD_CParamMode_e`): controls how `dictSize`
+/// and an unknown `srcSize` are treated when down-sizing.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CParamMode {
+    /// `ZSTD_cpm_unknown` — public `ZSTD_getCParams` entry.
+    Unknown,
+    /// `ZSTD_cpm_noAttachDict`.
+    NoAttachDict,
+    /// `ZSTD_cpm_createCDict` — CDict-table parameter selection.
+    CreateCDict,
+    /// `ZSTD_cpm_attachDict` — selecting source-only params (dict has its own).
+    AttachDict,
+}
+
+// Upstream constants (zstd.h / zstd_internal.h / clevels.h, 1.5.7).
+const ZSTD_MAX_CLEVEL: i32 = 22;
+const ZSTD_CLEVEL_DEFAULT: i32 = 3;
+const HASHLOG_MIN: u32 = 6;
+const WINDOWLOG_ABSOLUTEMIN: u32 = 10;
+// 64-bit host value; structured-zstd's encoder runs hosted. The 32-bit value
+// is 30, only relevant on 32-bit targets where windowLog never reaches 31 here.
+const WINDOWLOG_MAX: u32 = 31;
+const SHORT_CACHE_TAG_BITS: u32 = 8;
+const TARGETLENGTH_MAX: i32 = 1 << 17;
+/// `ZSTD_minCLevel()` == `-ZSTD_TARGETLENGTH_MAX`.
+const MIN_CLEVEL: i32 = -TARGETLENGTH_MAX;
+/// `ZSTD_CONTENTSIZE_UNKNOWN` == `(0ULL - 1)`.
+pub(crate) const CONTENTSIZE_UNKNOWN: u64 = u64::MAX;
+
+const KB_256: u64 = 256 * 1024;
+const KB_128: u64 = 128 * 1024;
+const KB_16: u64 = 16 * 1024;
+
+/// `ZSTD_defaultCParameters[4][ZSTD_MAX_CLEVEL+1]` (clevels.h, zstd 1.5.7),
+/// verbatim. Outer index = source-size tier (0 = `>256 KB`, 1 = `<=256 KB`,
+/// 2 = `<=128 KB`, 3 = `<=16 KB`); inner index = level row (0 = base for
+/// negative levels, 1..=22 = that level). Fields: (W, C, H, S, minMatch,
+/// targetLength, strategy).
+#[rustfmt::skip]
+const DEFAULT_CPARAMS: [[CParams; 23]; 4] = {
+    macro_rules! r {
+        ($w:expr,$c:expr,$h:expr,$s:expr,$l:expr,$t:expr,$strat:expr) => {
+            CParams { window_log: $w, chain_log: $c, hash_log: $h, search_log: $s,
+                      min_match: $l, target_length: $t, strategy: $strat }
+        };
+    }
+    [
+    // tier 0: srcSize > 256 KB
+    [
+        r!(19,12,13,1,6,1,1), r!(19,13,14,1,7,0,1), r!(20,15,16,1,6,0,1), r!(21,16,17,1,5,0,2),
+        r!(21,18,18,1,5,0,2), r!(21,18,19,3,5,2,3), r!(21,18,19,3,5,4,4), r!(21,19,20,4,5,8,4),
+        r!(21,19,20,4,5,16,5), r!(22,20,21,4,5,16,5), r!(22,21,22,5,5,16,5), r!(22,21,22,6,5,16,5),
+        r!(22,22,23,6,5,32,5), r!(22,22,22,4,5,32,6), r!(22,22,23,5,5,32,6), r!(22,23,23,6,5,32,6),
+        r!(22,22,22,5,5,48,7), r!(23,23,22,5,4,64,7), r!(23,23,22,6,3,64,8), r!(23,24,22,7,3,256,9),
+        r!(25,25,23,7,3,256,9), r!(26,26,24,7,3,512,9), r!(27,27,25,9,3,999,9),
+    ],
+    // tier 1: srcSize <= 256 KB
+    [
+        r!(18,12,13,1,5,1,1), r!(18,13,14,1,6,0,1), r!(18,14,14,1,5,0,2), r!(18,16,16,1,4,0,2),
+        r!(18,16,17,3,5,2,3), r!(18,17,18,5,5,2,3), r!(18,18,19,3,5,4,4), r!(18,18,19,4,4,4,4),
+        r!(18,18,19,4,4,8,5), r!(18,18,19,5,4,8,5), r!(18,18,19,6,4,8,5), r!(18,18,19,5,4,12,6),
+        r!(18,19,19,7,4,12,6), r!(18,18,19,4,4,16,7), r!(18,18,19,4,3,32,7), r!(18,18,19,6,3,128,7),
+        r!(18,19,19,6,3,128,8), r!(18,19,19,8,3,256,8), r!(18,19,19,6,3,128,9), r!(18,19,19,8,3,256,9),
+        r!(18,19,19,10,3,512,9), r!(18,19,19,12,3,512,9), r!(18,19,19,13,3,999,9),
+    ],
+    // tier 2: srcSize <= 128 KB
+    [
+        r!(17,12,12,1,5,1,1), r!(17,12,13,1,6,0,1), r!(17,13,15,1,5,0,1), r!(17,15,16,2,5,0,2),
+        r!(17,17,17,2,4,0,2), r!(17,16,17,3,4,2,3), r!(17,16,17,3,4,4,4), r!(17,16,17,3,4,8,5),
+        r!(17,16,17,4,4,8,5), r!(17,16,17,5,4,8,5), r!(17,16,17,6,4,8,5), r!(17,17,17,5,4,8,6),
+        r!(17,18,17,7,4,12,6), r!(17,18,17,3,4,12,7), r!(17,18,17,4,3,32,7), r!(17,18,17,6,3,256,7),
+        r!(17,18,17,6,3,128,8), r!(17,18,17,8,3,256,8), r!(17,18,17,10,3,512,8), r!(17,18,17,5,3,256,9),
+        r!(17,18,17,7,3,512,9), r!(17,18,17,9,3,512,9), r!(17,18,17,11,3,999,9),
+    ],
+    // tier 3: srcSize <= 16 KB
+    [
+        r!(14,12,13,1,5,1,1), r!(14,14,15,1,5,0,1), r!(14,14,15,1,4,0,1), r!(14,14,15,2,4,0,2),
+        r!(14,14,14,4,4,2,3), r!(14,14,14,3,4,4,4), r!(14,14,14,4,4,8,5), r!(14,14,14,6,4,8,5),
+        r!(14,14,14,8,4,8,5), r!(14,15,14,5,4,8,6), r!(14,15,14,9,4,8,6), r!(14,15,14,3,4,12,7),
+        r!(14,15,14,4,3,24,7), r!(14,15,14,5,3,32,8), r!(14,15,15,6,3,64,8), r!(14,15,15,7,3,256,8),
+        r!(14,15,15,5,3,48,9), r!(14,15,15,6,3,128,9), r!(14,15,15,7,3,256,9), r!(14,15,15,8,3,256,9),
+        r!(14,15,15,8,3,512,9), r!(14,15,15,9,3,512,9), r!(14,15,15,10,3,999,9),
+    ],
+    ]
+};
+
+/// `ZSTD_highbit32(val)` — index of the most-significant set bit. Caller
+/// guarantees `val != 0` (matches the upstream `assert(val != 0)`).
+#[inline]
+fn highbit32(val: u32) -> u32 {
+    debug_assert!(val != 0);
+    31 - val.leading_zeros()
+}
+
+/// `ZSTD_getCParamRowSize` (zstd_compress.c): the effective size used to pick
+/// the tier row.
+fn cparam_row_size(src_size_hint: u64, dict_size: usize, mode: CParamMode) -> u64 {
+    let dict_size = if matches!(mode, CParamMode::AttachDict) {
+        0
+    } else {
+        dict_size as u64
+    };
+    let unknown = src_size_hint == CONTENTSIZE_UNKNOWN;
+    let added_size = if unknown && dict_size > 0 { 500 } else { 0 };
+    if unknown && dict_size == 0 {
+        CONTENTSIZE_UNKNOWN
+    } else {
+        src_size_hint
+            .wrapping_add(dict_size)
+            .wrapping_add(added_size)
+    }
+}
+
+/// `ZSTD_cycleLog` (zstd_compress.c): `hashLog - (strategy >= btlazy2)`.
+#[inline]
+fn cycle_log(hash_log: u32, strategy: u32) -> u32 {
+    // ZSTD_btlazy2 == 6.
+    hash_log - u32::from(strategy >= 6)
+}
+
+/// `ZSTD_dictAndWindowLog` (zstd_compress.c). `src_size` must not be
+/// `CONTENTSIZE_UNKNOWN` (the caller gates this).
+fn dict_and_window_log(window_log: u32, src_size: u64, dict_size: u64) -> u32 {
+    let max_window_size: u64 = 1u64 << WINDOWLOG_MAX;
+    if dict_size == 0 {
+        return window_log;
+    }
+    let window_size: u64 = 1u64 << window_log;
+    let dict_and_window_size = dict_size + window_size;
+    if window_size >= dict_size + src_size {
+        window_log
+    } else if dict_and_window_size >= max_window_size {
+        WINDOWLOG_MAX
+    } else {
+        highbit32((dict_and_window_size as u32).wrapping_sub(1)) + 1
+    }
+}
+
+/// Whether a CDict built with these params uses tagged short-cache indices
+/// (`ZSTD_CDictIndicesAreTagged`): true for the dictMatchState strategies
+/// (fast / dfast), where the dict hash table packs a tag. Upstream gates the
+/// short-cache hashLog cap on this.
+#[inline]
+fn cdict_indices_are_tagged(cp: &CParams) -> bool {
+    // ZSTD_dfast == 2: tagged for fast(1) and dfast(2).
+    cp.strategy <= 2
+}
+
+/// `ZSTD_adjustCParams_internal` (zstd_compress.c): down-size `cp` for the
+/// given `(src_size, dict_size, mode)`. `src_size == CONTENTSIZE_UNKNOWN`
+/// means unknown; `src_size == 0` means literally zero. The row-match-finder
+/// hashLog cap is omitted here because this port only consumes the Fast /
+/// Dfast cparams (no row hash); add it before relying on row-strategy output.
+fn adjust_cparams(
+    mut cp: CParams,
+    mut src_size: u64,
+    mut dict_size: usize,
+    mode: CParamMode,
+) -> CParams {
+    const MIN_SRC_SIZE: u64 = 513; // (1<<9) + 1
+    let max_window_resize: u64 = 1u64 << (WINDOWLOG_MAX - 1);
+
+    match mode {
+        CParamMode::Unknown | CParamMode::NoAttachDict => {}
+        CParamMode::CreateCDict => {
+            if dict_size != 0 && src_size == CONTENTSIZE_UNKNOWN {
+                src_size = MIN_SRC_SIZE;
+            }
+        }
+        CParamMode::AttachDict => {
+            dict_size = 0;
+        }
+    }
+
+    // resize windowLog if input is small enough, to use less memory.
+    if src_size <= max_window_resize && (dict_size as u64) <= max_window_resize {
+        let t_size = (src_size as u32).wrapping_add(dict_size as u32);
+        let hash_size_min: u32 = 1 << HASHLOG_MIN;
+        let src_log = if t_size < hash_size_min {
+            HASHLOG_MIN
+        } else {
+            highbit32(t_size.wrapping_sub(1)) + 1
+        };
+        if cp.window_log > src_log {
+            cp.window_log = src_log;
+        }
+    }
+
+    if src_size != CONTENTSIZE_UNKNOWN {
+        let daw = dict_and_window_log(cp.window_log, src_size, dict_size as u64);
+        let cl = cycle_log(cp.chain_log, cp.strategy);
+        if cp.hash_log > daw + 1 {
+            cp.hash_log = daw + 1;
+        }
+        if cl > daw {
+            cp.chain_log -= cl - daw;
+        }
+    }
+
+    if cp.window_log < WINDOWLOG_ABSOLUTEMIN {
+        cp.window_log = WINDOWLOG_ABSOLUTEMIN;
+    }
+
+    if matches!(mode, CParamMode::CreateCDict) && cdict_indices_are_tagged(&cp) {
+        let max_short_cache_hash_log = 32 - SHORT_CACHE_TAG_BITS;
+        if cp.hash_log > max_short_cache_hash_log {
+            cp.hash_log = max_short_cache_hash_log;
+        }
+        if cp.chain_log > max_short_cache_hash_log {
+            cp.chain_log = max_short_cache_hash_log;
+        }
+    }
+
+    cp
+}
+
+/// `ZSTD_getCParams_internal` (zstd_compress.c): tier + level row selection,
+/// negative-level acceleration, then `ZSTD_adjustCParams_internal`.
+pub(crate) fn get_cparams(
+    compression_level: i32,
+    src_size_hint: u64,
+    dict_size: usize,
+    mode: CParamMode,
+) -> CParams {
+    let r_size = cparam_row_size(src_size_hint, dict_size, mode);
+    let table_id = (u32::from(r_size <= KB_256)
+        + u32::from(r_size <= KB_128)
+        + u32::from(r_size <= KB_16)) as usize;
+
+    let row: usize = if compression_level == 0 {
+        ZSTD_CLEVEL_DEFAULT as usize
+    } else if compression_level < 0 {
+        0
+    } else if compression_level > ZSTD_MAX_CLEVEL {
+        ZSTD_MAX_CLEVEL as usize
+    } else {
+        compression_level as usize
+    };
+
+    let mut cp = DEFAULT_CPARAMS[table_id][row];
+
+    if compression_level < 0 {
+        let clamped = compression_level.max(MIN_CLEVEL);
+        cp.target_length = (-clamped) as u32;
+    }
+
+    adjust_cparams(cp, src_size_hint, dict_size, mode)
+}
+
+/// Public `ZSTD_getCParams` entry: maps `src_size_hint == 0` to UNKNOWN and
+/// uses `Unknown` mode, matching upstream exactly.
+pub(crate) fn get_cparams_public(
+    compression_level: i32,
+    src_size_hint: u64,
+    dict_size: usize,
+) -> CParams {
+    let src = if src_size_hint == 0 {
+        CONTENTSIZE_UNKNOWN
+    } else {
+        src_size_hint
+    };
+    get_cparams(compression_level, src, dict_size, CParamMode::Unknown)
+}

--- a/zstd/src/encoding/cparams.rs
+++ b/zstd/src/encoding/cparams.rs
@@ -324,3 +324,30 @@ pub(crate) fn create_cdict_table_logs(
     );
     (adj.hash_log, adj.chain_log)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_cdict_table_logs_downsizes_for_unknown_source_with_dict() {
+        // create_cdict + a dictionary + unknown source size assumes a minimal
+        // (513-byte) source, so the prepared CDict tables down-size far below
+        // the requested input logs instead of holding max-size tables
+        // (`ZSTD_adjustCParams_internal` with `ZSTD_cpm_createCDict`).
+        let (hash_log, chain_log) =
+            create_cdict_table_logs(27, 27, 28, /* uses_bt */ true, /* dict_size */ 4096);
+        assert!(
+            hash_log < 27,
+            "hash_log {hash_log} must shrink for a tiny CDict source",
+        );
+        assert!(chain_log <= 28, "chain_log {chain_log} must not grow");
+
+        // A zero-dict CDict does NOT force the minSrcSize assumption (the
+        // `dict_size != 0` guard), so the unknown-source path leaves the logs as
+        // requested.
+        let (h2, c2) = create_cdict_table_logs(20, 20, 21, /* uses_bt */ false, /* dict_size */ 0);
+        assert_eq!(h2, 20, "no-dict CDict keeps the requested hash_log");
+        assert_eq!(c2, 21, "no-dict CDict keeps the requested chain_log");
+    }
+}

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -399,6 +399,10 @@ impl DfastMatchGenerator {
             self.window_size = 0;
             self.history.clear();
             self.history_start = 0;
+            // Non-reborrow reset starts with an empty window; clear the block
+            // ledger to match. (The reborrow branch above intentionally keeps a
+            // single `[region]` entry for the resident dict — see below.)
+            self.window_blocks.clear();
             self.dict_resident = false;
             if next_floor <= REBASE_RESET_FLOOR_CEILING {
                 // Fast path: advance the floor; tables keep their contents (a
@@ -425,7 +429,11 @@ impl DfastMatchGenerator {
         // signature does not take one (HC / Row do because they hold
         // per-block input Vecs internally; the dispatcher in
         // `match_generator.rs` resolves the per-backend shape).
-        self.window_blocks.clear();
+        // NOTE: `window_blocks` is cleared per-branch above (the reborrow branch
+        // keeps its `[region]` dict entry; the non-reborrow branch clears). It
+        // must NOT be cleared unconditionally here — doing so dropped the
+        // resident dict block while `window_size`/`history` still counted it,
+        // desyncing the ledger so the next eviction popped the wrong block.
         // Drop any borrowed window: the input slice it pointed at does not
         // outlive the frame, and the next frame re-stages its own (or runs
         // the owned path). A stale pointer must never survive a reset.

--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -80,8 +80,13 @@ pub(crate) struct DfastMatchGenerator {
     // `_search_next_long` retry — after a short-hash hit, the search
     // probes long_hash at `ip + 1` and picks the longer of the two
     // (see `hash_candidate`, invoked via `best_match`, for the retry).
-    pub(crate) short_hash: Vec<u32>,
-    pub(crate) long_hash: Vec<u32>,
+    /// Single backing allocation for both hash tables (cwksp analog): the long
+    /// table occupies `[0, long_len)` and the short table `[long_len,
+    /// long_len + short_len)`. One allocation instead of two halves the
+    /// per-fresh-frame large-table allocator churn (the page-fault / calloc
+    /// storm that dominated dfast on medium inputs). Access through the
+    /// `long_*` / `short_*` helpers, which apply the short-region offset.
+    pub(crate) tables: Vec<u32>,
     /// Absolute position whose `(abs_pos - position_base + 1)` slot
     /// encoding evaluates to `1`. Advances only via [`Self::reduce`]
     /// when an insert is about to overflow the u32 window — the
@@ -137,6 +142,11 @@ pub(crate) struct DfastMatchGenerator {
     /// owned evicting path) and `get_last_space` reports the borrowed block
     /// to the emit pipeline. Only meaningful while `borrowed_input` is `Some`.
     pub(crate) borrowed_block: Option<(usize, usize)>,
+    /// Set by [`Self::reset`] when it re-borrowed a resident attach-mode
+    /// dictionary (kept the dict bytes at the front of history + the cached dict
+    /// tables in place instead of clearing + re-committing them). Signals the
+    /// frame compressor to SKIP `prime_with_dictionary` this frame.
+    pub(crate) dict_resident: bool,
 }
 
 /// The dfast backend's immutable dictionary tables — a long+short pair mirroring
@@ -169,8 +179,7 @@ impl DfastMatchGenerator {
             history_start: 0,
             history_abs_start: 0,
             offset_hist: [1, 4, 8],
-            short_hash: Vec::new(),
-            long_hash: Vec::new(),
+            tables: Vec::new(),
             position_base: 0,
             long_hash_bits: DFAST_HASH_BITS,
             short_hash_bits: DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA,
@@ -178,7 +187,55 @@ impl DfastMatchGenerator {
             kernel: select_kernel(),
             borrowed_input: None,
             borrowed_block: None,
+            dict_resident: false,
         }
+    }
+
+    /// Whether the last [`Self::reset`] re-borrowed a resident dictionary (kept
+    /// the dict bytes + cached dict tables in place). The driver reports this up
+    /// so the frame compressor skips `prime_with_dictionary` for the frame.
+    pub(crate) fn dict_resident(&self) -> bool {
+        self.dict_resident
+    }
+
+    /// Number of slots in the long hash table (`[0, long_len)` of `tables`).
+    #[inline(always)]
+    pub(crate) fn long_len(&self) -> usize {
+        1usize << self.long_hash_bits
+    }
+
+    /// Number of slots in the short hash table (`[long_len, +short_len)`).
+    #[inline(always)]
+    pub(crate) fn short_len(&self) -> usize {
+        1usize << self.short_hash_bits
+    }
+
+    /// Base const-pointer to the long table region.
+    #[inline(always)]
+    fn long_ptr(&self) -> *const u32 {
+        self.tables.as_ptr()
+    }
+
+    /// Base const-pointer to the short table region (offset past the long).
+    #[inline(always)]
+    fn short_ptr(&self) -> *const u32 {
+        // SAFETY: `tables.len() == long_len + short_len`, so `long_len` is in
+        // bounds (one past the long region = start of the short region).
+        unsafe { self.tables.as_ptr().add(self.long_len()) }
+    }
+
+    /// Base mut-pointer to the long table region.
+    #[inline(always)]
+    fn long_mut_ptr(&mut self) -> *mut u32 {
+        self.tables.as_mut_ptr()
+    }
+
+    /// Base mut-pointer to the short table region (offset past the long).
+    #[inline(always)]
+    fn short_mut_ptr(&mut self) -> *mut u32 {
+        let off = self.long_len();
+        // SAFETY: as `short_ptr`; `off == long_len` is in bounds.
+        unsafe { self.tables.as_mut_ptr().add(off) }
     }
 
     /// Set both hash table sizes from the per-level [`DfastConfig`]:
@@ -191,13 +248,12 @@ impl DfastMatchGenerator {
         let long_clamped = long_bits.max(min_bits);
         let short_clamped = short_bits.max(min_bits);
         let resized = self.long_hash_bits != long_clamped || self.short_hash_bits != short_clamped;
-        if self.long_hash_bits != long_clamped {
+        if resized {
             self.long_hash_bits = long_clamped;
-            self.long_hash = Vec::new();
-        }
-        if self.short_hash_bits != short_clamped {
             self.short_hash_bits = short_clamped;
-            self.short_hash = Vec::new();
+            // Drop the combined backing so `ensure_hash_tables` reallocates at
+            // the new (long_len + short_len).
+            self.tables = Vec::new();
         }
         if resized {
             // A table-size change makes the cached dict tables (sized to the old
@@ -270,8 +326,10 @@ impl DfastMatchGenerator {
                 };
             }
         };
-        shift_slots(&mut self.short_hash);
-        shift_slots(&mut self.long_hash);
+        let long_len = self.long_len();
+        let (long, short) = self.tables.split_at_mut(long_len);
+        shift_slots(long);
+        shift_slots(short);
         self.position_base += reducer as usize;
     }
 
@@ -281,7 +339,7 @@ impl DfastMatchGenerator {
         let u32_sz = core::mem::size_of::<u32>();
         self.window_blocks.capacity() * core::mem::size_of::<usize>()
             + self.history.capacity()
-            + (self.short_hash.capacity() + self.long_hash.capacity()) * u32_sz
+            + self.tables.capacity() * u32_sz
             + self
                 .dict
                 .table()
@@ -303,26 +361,61 @@ impl DfastMatchGenerator {
         // their (now sub-floor) absolute positions; `ensure_room_for` /
         // `reduce` keep the `u32` packing bounded as the cursor climbs.
         let next_floor = self.history_abs_start + (self.history.len() - self.history_start);
-        self.window_size = 0;
-        self.history.clear();
-        self.history_start = 0;
         self.offset_hist = [1, 4, 8];
-        if next_floor <= REBASE_RESET_FLOOR_CEILING {
-            // Fast path: advance the floor; tables keep their contents (a
-            // later `ensure_tables`/level change still reallocs them clean
-            // if the dimensions changed). The dict tables key off stable
-            // concat indices and are untouched here.
-            self.history_abs_start = next_floor;
+        // Re-borrow: an attach-mode reused dict frame keeps its bytes resident at
+        // the front of history (`[0, region)`) + the cached concat-keyed dict
+        // tables, so the per-frame dict re-commit (the dominant ~37% memmove on
+        // a profiled small dfast frame) is skipped — the frame compressor then
+        // skips `prime_with_dictionary`. The floor-advance still rejects the
+        // previous frame's INPUT (its abs falls below `next_floor`); the dict
+        // matches come from the separate dict tables, which bypass the floor.
+        // Gated on the dict being fully resident at `history_start == 0` and the
+        // floor-advance staying bounded.
+        let reborrow_region = if self.dict.is_primed()
+            && self.history_start == 0
+            && next_floor <= REBASE_RESET_FLOOR_CEILING
+        {
+            let r = self.dict.region_len();
+            (r > 0 && self.history.len() >= r).then_some(r)
         } else {
-            // Bounded fallback: rewind the cursor and zero the tables so
-            // `history_abs_start` cannot climb toward `usize::MAX` (keeps
-            // `check_stream_abs_headroom` satisfiable on 32-bit targets;
-            // fires ~once per 2 GiB cumulative input there).
-            self.history_abs_start = 0;
-            self.position_base = 0;
-            if !self.short_hash.is_empty() {
-                self.short_hash.fill(DFAST_EMPTY_SLOT);
-                self.long_hash.fill(DFAST_EMPTY_SLOT);
+            None
+        };
+        if let Some(region) = reborrow_region {
+            // Keep `[0, region)` (the dict); drop the previous frame's input.
+            self.history.truncate(region);
+            self.window_size = region;
+            self.window_blocks.clear();
+            self.window_blocks.push_back(region);
+            // Bump the eviction window by the dict size (clamped to
+            // MAX_PRIMED_WINDOW_SIZE) so the resident dict + the next input both
+            // stay — base is `1 << window_log` (<= 2^30 < the ceiling), so the
+            // headroom subtraction can't underflow and the sum can't overflow.
+            let headroom = crate::encoding::match_table::storage::MAX_PRIMED_WINDOW_SIZE
+                - self.max_window_size;
+            self.max_window_size += region.min(headroom);
+            self.history_abs_start = next_floor;
+            self.dict_resident = true;
+        } else {
+            self.window_size = 0;
+            self.history.clear();
+            self.history_start = 0;
+            self.dict_resident = false;
+            if next_floor <= REBASE_RESET_FLOOR_CEILING {
+                // Fast path: advance the floor; tables keep their contents (a
+                // later `ensure_tables`/level change still reallocs them clean
+                // if the dimensions changed). The dict tables key off stable
+                // concat indices and are untouched here.
+                self.history_abs_start = next_floor;
+            } else {
+                // Bounded fallback: rewind the cursor and zero the tables so
+                // `history_abs_start` cannot climb toward `usize::MAX` (keeps
+                // `check_stream_abs_headroom` satisfiable on 32-bit targets;
+                // fires ~once per 2 GiB cumulative input there).
+                self.history_abs_start = 0;
+                self.position_base = 0;
+                if !self.tables.is_empty() {
+                    self.tables.fill(DFAST_EMPTY_SLOT);
+                }
             }
         }
         // No Vec<u8> blocks to recycle: `add_data` returns each input
@@ -918,8 +1011,8 @@ impl DfastMatchGenerator {
         // Skipping the writes also removes a small amount of cache
         // dirtying on the tail boundary and keeps `probe_tail_ip0_only`
         // strictly cheaper than a full inner-loop iter.
-        let idxl0 = unsafe { *self.long_hash.as_ptr().add(hl0_idx) };
-        let idxs0 = unsafe { *self.short_hash.as_ptr().add(hs0_idx) };
+        let idxl0 = unsafe { *self.long_ptr().add(hl0_idx) };
+        let idxs0 = unsafe { *self.short_ptr().add(hs0_idx) };
 
         // Live tables only — no attached-dict probe here, by design. This
         // helper runs for exactly ONE position per block (the last hashable
@@ -1362,13 +1455,12 @@ impl DfastMatchGenerator {
         // Independent sizing per upstream zstd `clevels.h`: long-hash =
         // `hashLog`, short-hash = `chainLog`. Lazy allocation so
         // Fastest/Uncompressed never pay the dfast-level memory cost.
-        let long_len = 1usize << self.long_hash_bits;
-        let short_len = 1usize << self.short_hash_bits;
-        if self.long_hash.len() != long_len {
-            self.long_hash = alloc::vec![DFAST_EMPTY_SLOT; long_len];
-        }
-        if self.short_hash.len() != short_len {
-            self.short_hash = alloc::vec![DFAST_EMPTY_SLOT; short_len];
+        let total = self.long_len() + self.short_len();
+        if self.tables.len() != total {
+            // Single zeroed allocation for both regions (`vec![0; n]` lowers to
+            // `alloc_zeroed`). One buffer instead of two cuts the large-table
+            // allocator churn on fresh-per-frame compressors.
+            self.tables = alloc::vec![DFAST_EMPTY_SLOT; total];
         }
     }
 
@@ -1429,8 +1521,8 @@ impl DfastMatchGenerator {
         // stays valid across `ensure_room_for` (it never reallocs `history`).
         let short_hash_bits = self.short_hash_bits;
         let long_hash_bits = self.long_hash_bits;
-        let short_hash_ptr = self.short_hash.as_mut_ptr();
-        let long_hash_ptr = self.long_hash.as_mut_ptr();
+        let short_hash_ptr = self.short_mut_ptr();
+        let long_hash_ptr = self.long_mut_ptr();
         let short_shift = 64 - short_hash_bits;
         let long_shift = 64 - long_hash_bits;
 
@@ -1570,14 +1662,16 @@ impl DfastMatchGenerator {
         let concat = unsafe { core::slice::from_raw_parts(base_ptr.add(start_offset), concat_len) };
         if idx + 5 <= concat_len {
             let short = self.short_hash_index(&concat[idx..]);
-            debug_assert!(short < self.short_hash.len());
-            unsafe { *self.short_hash.get_unchecked_mut(short) = packed };
+            debug_assert!(short < self.short_len());
+            // Short region starts at `long_len`.
+            let slot = self.long_len() + short;
+            unsafe { *self.tables.get_unchecked_mut(slot) = packed };
         }
 
         if idx + 8 <= concat_len {
             let long = self.long_hash_index(&concat[idx..]);
-            debug_assert!(long < self.long_hash.len());
-            unsafe { *self.long_hash.get_unchecked_mut(long) = packed };
+            debug_assert!(long < self.long_len());
+            unsafe { *self.tables.get_unchecked_mut(long) = packed };
         }
     }
 
@@ -1870,8 +1964,8 @@ macro_rules! start_matching_fast_loop_body {
                 } else {
                     $self.owned_scan_descriptor()
                 };
-            let short_hash_ptr = $self.short_hash.as_mut_ptr();
-            let long_hash_ptr = $self.long_hash.as_mut_ptr();
+            let short_hash_ptr = $self.short_mut_ptr();
+            let long_hash_ptr = $self.long_mut_ptr();
 
             // Pre-compute long hash at ip0 ONCE per outer iter.
             // `concat_idx = ($current_abs_start + ip0) - history_abs_start`

--- a/zstd/src/encoding/dict_attach.rs
+++ b/zstd/src/encoding/dict_attach.rs
@@ -34,6 +34,16 @@ pub(crate) struct DictAttach<T> {
     /// per-frame `reset` and skips the re-hash. Cleared on parameter change,
     /// history eviction, or dictionary attach/clear via [`Self::invalidate`].
     primed: bool,
+    /// Next history position a multi-slice dict fill should process (upstream
+    /// zstd `ms->nextToUpdate`). A dictionary loaded across several
+    /// `accept_data` slices is hashed incrementally; without a persistent
+    /// high-water the second slice's fill would restart at its own slice
+    /// origin and drop the `HASH_READ_SIZE - 1` seam positions just below it
+    /// (their wide hash read straddles the slice boundary, so the prior slice
+    /// could not reach them). Carrying the fill origin forward keeps the
+    /// stride phase continuous and closes the seam gap. `0` until the first
+    /// fill; reset by [`Self::invalidate`].
+    next_to_update: usize,
 }
 
 impl<T: Clone> Clone for DictAttach<T> {
@@ -42,6 +52,7 @@ impl<T: Clone> Clone for DictAttach<T> {
             table: self.table.clone(),
             region_len: self.region_len,
             primed: self.primed,
+            next_to_update: self.next_to_update,
         }
     }
 
@@ -51,6 +62,7 @@ impl<T: Clone> Clone for DictAttach<T> {
         self.table.clone_from(&source.table);
         self.region_len = source.region_len;
         self.primed = source.primed;
+        self.next_to_update = source.next_to_update;
     }
 }
 
@@ -60,7 +72,24 @@ impl<T> DictAttach<T> {
             table: None,
             region_len: 0,
             primed: false,
+            next_to_update: 0,
         }
+    }
+
+    /// Next history position a multi-slice dict fill should process (upstream
+    /// zstd `ms->nextToUpdate`). Backends carry the fill origin forward across
+    /// slices via this so the cross-slice seam positions are not dropped.
+    #[inline]
+    pub(crate) fn next_to_update(&self) -> usize {
+        self.next_to_update
+    }
+
+    /// Record how far the dict fill has advanced (the first position not yet
+    /// hashed). The next slice's fill resumes here, keeping the stride phase
+    /// continuous across the slice seam.
+    #[inline]
+    pub(crate) fn set_next_to_update(&mut self, pos: usize) {
+        self.next_to_update = pos;
     }
 
     /// Whether a dict table is attached (drives the dual-probe dispatch).
@@ -128,6 +157,7 @@ impl<T> DictAttach<T> {
         self.table = None;
         self.region_len = 0;
         self.primed = false;
+        self.next_to_update = 0;
     }
 }
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -700,6 +700,37 @@ pub(crate) struct CompressState<M: Matcher> {
     /// encoder constructor) plumb this explicitly. Tests that build
     /// `CompressState` by hand must also supply a value.
     pub(crate) strategy_tag: crate::encoding::strategy::StrategyTag,
+    /// Whether the HUF literal table build runs the #167 table-log search
+    /// (`true`) or the cheap single-build (`false`). For the Fast strategy the
+    /// search is a clean ratio win over upstream zstd but costs ~1.5 us per
+    /// literal section — negligible on large inputs, ~20% on small ones — and
+    /// the Fast matcher is byte-faithful to upstream zstd (so the cheap path
+    /// ties it). So it is gated ON only for large Fast frames; non-Fast
+    /// strategies always keep it (their matchers diverge, making the search
+    /// load-bearing for ratio — gating those is deferred). Set per frame
+    /// alongside `strategy_tag` via [`fast_huf_search_enabled`].
+    pub(crate) huf_optimal_search: bool,
+}
+
+/// Whether the Fast-strategy HUF literal build should run the #167 table-log
+/// search for a frame of `source_size` bytes (see
+/// [`CompressState::huf_optimal_search`]). Non-Fast strategies always search.
+/// For Fast, enable the search only above 128 KiB (one full block) — below
+/// that the per-frame setup dominates and the search's ~1.5 us is a large
+/// relative cost for a ratio gain the cheap path forgoes while still tying
+/// upstream zstd. Unknown size (streaming) keeps the search for conservative
+/// ratio.
+pub(crate) fn fast_huf_search_enabled(
+    strategy: crate::encoding::strategy::StrategyTag,
+    source_size: Option<u64>,
+) -> bool {
+    if strategy != crate::encoding::strategy::StrategyTag::Fast {
+        return true;
+    }
+    match source_size {
+        Some(size) => size > 128 * 1024,
+        None => true,
+    }
 }
 
 impl<M: Matcher> CompressState<M> {
@@ -893,6 +924,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 strategy_tag: crate::encoding::strategy::StrategyTag::for_compression_level(
                     compression_level,
                 ),
+                huf_optimal_search: true,
             },
             magicless: false,
             content_checksum: false,
@@ -945,6 +977,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
         self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
             crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
         });
+        self.state.huf_optimal_search =
+            fast_huf_search_enabled(self.state.strategy_tag, self.source_size_hint);
         self.state.matcher.set_param_overrides(Some(overrides));
     }
 
@@ -1274,6 +1308,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 strategy_tag: crate::encoding::strategy::StrategyTag::for_compression_level(
                     compression_level,
                 ),
+                huf_optimal_search: true,
             },
             compression_level,
             magicless: false,
@@ -1534,6 +1569,10 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
             crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
         });
+        // `initial_size_hint` (captured before the `.take()` above) — by here
+        // `self.source_size_hint` is None.
+        self.state.huf_optimal_search =
+            fast_huf_search_enabled(self.state.strategy_tag, initial_size_hint);
         let cached_entropy = if use_dictionary_state {
             self.dictionary_entropy_cache.as_ref()
         } else {
@@ -1575,23 +1614,32 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
                 | crate::encoding::strategy::StrategyTag::Btlazy2
                 | crate::encoding::strategy::StrategyTag::BtOpt => 15,
             };
-            let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| {
-                crate::encoding::match_generator::source_size_ceil_log(s) > cutoff_log
-            });
-            let restored = prefer_copy_snapshot
-                && self
-                    .state
+            if self.state.matcher.dictionary_is_resident() {
+                // Re-borrow fast path: the previous frame's reset kept this
+                // dict's bytes + cached index resident, so skip the re-commit /
+                // re-index and only reapply the offset history.
+                self.state
                     .matcher
-                    .restore_primed_dictionary(self.compression_level);
-            if !restored {
-                self.state.matcher.prime_with_dictionary(
-                    dict.inner.dict_content.as_slice(),
-                    dict.inner.offset_hist,
-                );
-                if prefer_copy_snapshot {
-                    self.state
+                    .reapply_resident_dictionary(dict.inner.offset_hist);
+            } else {
+                let prefer_copy_snapshot = initial_size_hint.is_some_and(|s| {
+                    crate::encoding::match_generator::source_size_ceil_log(s) > cutoff_log
+                });
+                let restored = prefer_copy_snapshot
+                    && self
+                        .state
                         .matcher
-                        .capture_primed_dictionary(self.compression_level);
+                        .restore_primed_dictionary(self.compression_level);
+                if !restored {
+                    self.state.matcher.prime_with_dictionary(
+                        dict.inner.dict_content.as_slice(),
+                        dict.inner.offset_hist,
+                    );
+                    if prefer_copy_snapshot {
+                        self.state
+                            .matcher
+                            .capture_primed_dictionary(self.compression_level);
+                    }
                 }
             }
         }
@@ -2989,6 +3037,63 @@ mod tests {
             let mut decoded = Vec::with_capacity(payload.len());
             decoder.decode_all_to_vec(frame, &mut decoded).unwrap();
             assert_eq!(decoded.as_slice(), payload.as_slice());
+        }
+    }
+
+    #[test]
+    fn dict_reused_across_many_lazy_frames_stays_applied() {
+        // Regression: a reused HashChain-backed dictionary frame (lazy levels)
+        // re-primes the dict at the live `history_abs_start` every frame. The
+        // floor-advance reset let that base climb frame-over-frame until the
+        // freshly-primed dict region dropped below `window_low`, after which
+        // every dict match was silently lost and the output ballooned to the
+        // no-dict size (observed at frame 3-4 of a reused compressor). Drive
+        // many frames and require every one to stay byte-identical to the
+        // first — the dict must keep applying, not decay after a few frames.
+        // Multiple distinct lines so the dictionary is load-bearing: without it
+        // frame 0 must emit each distinct line as literals; with it those lines
+        // match the primed dict immediately. A single repeated line matches
+        // in-frame regardless and would hide the regression.
+        let lines: &[&[u8]] = &[
+            b"ts=2026 level=INFO msg=\"flush memtable\" tenant=demo table=orders\n",
+            b"ts=2026 level=INFO msg=\"rotate segment\" tenant=demo table=orders\n",
+            b"ts=2026 level=INFO msg=\"compact level\" tenant=demo table=orders\n",
+            b"ts=2026 level=INFO msg=\"write block\" tenant=demo table=orders\n",
+        ];
+        let fill = |n: usize| -> Vec<u8> {
+            let mut b = Vec::with_capacity(n);
+            while b.len() < n {
+                for l in lines {
+                    if b.len() >= n {
+                        break;
+                    }
+                    let take = (n - b.len()).min(l.len());
+                    b.extend_from_slice(&l[..take]);
+                }
+            }
+            b
+        };
+        let dict = fill(8 * 1024);
+        let payload = fill(16 * 1024);
+        let dict_obj =
+            crate::decoding::Dictionary::from_raw_content(1, dict).expect("raw dict should build");
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Level(6));
+        compressor.set_dictionary_id_flag(false);
+        compressor
+            .set_dictionary(dict_obj)
+            .expect("dict should attach");
+
+        let first = compressor.compress_independent_frame(payload.as_slice());
+        for i in 1..16 {
+            let frame = compressor.compress_independent_frame(payload.as_slice());
+            assert_eq!(
+                frame.len(),
+                first.len(),
+                "frame {i} of a reused dict compressor must stay dict-applied \
+                 (size == first frame), not decay to the no-dict size"
+            );
         }
     }
 

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -1269,6 +1269,8 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             if self.content_checksum {
                 self.hasher.write(block);
             }
+            let dict_active =
+                self.dictionary.is_some() && self.state.matcher.supports_dictionary_priming();
             crate::encoding::levels::compress_block_encoded_borrowed(
                 &mut self.state,
                 self.compression_level,
@@ -1276,6 +1278,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
                 block,
                 start,
                 end,
+                dict_active,
                 out,
                 #[cfg(feature = "lsm")]
                 Some(&mut self.block_decompressed_sizes),
@@ -1605,8 +1608,14 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             // `hint > 2^k`, so this is identical to the raw `hint > cutoff` on
             // 64-bit.
             let cutoff_log = match self.state.strategy_tag {
-                crate::encoding::strategy::StrategyTag::Fast
-                | crate::encoding::strategy::StrategyTag::BtUltra
+                // Fast always attaches now (the copy-mode owned path memmoved the
+                // whole input into history every frame); keep the copy-snapshot
+                // gate in sync with the matcher's attach cutoff so Fast never
+                // captures/restores a copy snapshot it can no longer use.
+                crate::encoding::strategy::StrategyTag::Fast => {
+                    crate::encoding::match_generator::FAST_ATTACH_DICT_CUTOFF_LOG
+                }
+                crate::encoding::strategy::StrategyTag::BtUltra
                 | crate::encoding::strategy::StrategyTag::BtUltra2 => 13,
                 crate::encoding::strategy::StrategyTag::Dfast => 14,
                 crate::encoding::strategy::StrategyTag::Greedy

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -3086,13 +3086,29 @@ mod tests {
             .expect("dict should attach");
 
         let first = compressor.compress_independent_frame(payload.as_slice());
+
+        // No-dict baseline at the same level: the dictionary must be
+        // load-bearing, so the dict-applied frame has to beat it. Without this
+        // anchor the equal-length loop below would also pass if EVERY frame
+        // decayed to the no-dict size in lockstep.
+        let mut nodict: FrameCompressor = FrameCompressor::new(super::CompressionLevel::Level(6));
+        let no_dict_frame = nodict.compress_independent_frame(payload.as_slice());
+        assert!(
+            first.len() < no_dict_frame.len(),
+            "dict must be load-bearing: dict frame {} should beat the no-dict baseline {}",
+            first.len(),
+            no_dict_frame.len(),
+        );
+
         for i in 1..16 {
             let frame = compressor.compress_independent_frame(payload.as_slice());
+            // Byte-identity, not just equal length: a same-size divergence (e.g.
+            // a different match decision once the resident dict bookkeeping
+            // drifts) would slip past a length-only check.
             assert_eq!(
-                frame.len(),
-                first.len(),
-                "frame {i} of a reused dict compressor must stay dict-applied \
-                 (size == first frame), not decay to the no-dict size"
+                frame, first,
+                "frame {i} of a reused dict compressor must stay byte-identical to \
+                 the first (dict still applied, no decay or bookkeeping drift)"
             );
         }
     }

--- a/zstd/src/encoding/incompressible.rs
+++ b/zstd/src/encoding/incompressible.rs
@@ -160,6 +160,23 @@ pub(crate) fn block_looks_incompressible(block: &[u8]) -> bool {
     sample_looks_incompressible(block)
 }
 
+/// Dict-aware incompressibility check: stricter than the plain no-dict
+/// heuristic. With a dictionary attached, a block that LOOKS high-entropy in a
+/// small fixed sample can still compress — either against the dict, or via a
+/// long-range internal repeat the capped sample never spans. So sample the WHOLE
+/// block, which surfaces those repeats; only blocks that stay high-entropy
+/// across their full length are skipped to raw. Truly random data is still
+/// classified incompressible (no repeats anywhere), so the no-dict-quality
+/// rejection of incompressible input is preserved — it is only harder to trip on
+/// the dict path, never weaker.
+#[inline]
+pub(crate) fn block_looks_incompressible_dict(block: &[u8]) -> bool {
+    if block.len() < RAW_FAST_PATH_MIN_BLOCK_LEN {
+        return false;
+    }
+    sample_looks_incompressible_capped(block, block.len())
+}
+
 #[inline]
 pub(crate) fn block_looks_incompressible_strict(block: &[u8]) -> bool {
     if block.len() < RAW_FAST_PATH_MIN_BLOCK_LEN {
@@ -194,7 +211,18 @@ pub(crate) fn block_looks_incompressible_strict(block: &[u8]) -> bool {
 
 #[inline]
 fn sample_looks_incompressible(block: &[u8]) -> bool {
-    let sample_len = block.len().min(RAW_FAST_PATH_MAX_SAMPLE_LEN);
+    sample_looks_incompressible_capped(block, RAW_FAST_PATH_MAX_SAMPLE_LEN)
+}
+
+/// As [`sample_looks_incompressible`] but with an explicit sample cap. A larger
+/// cap scans more of the block, so it detects LONG-RANGE repeats (a region that
+/// re-occurs far away — e.g. a record drawn from a dictionary, or a block whose
+/// second half repeats its first) that the small fixed sample misses by only
+/// looking at disjoint head/mid/tail windows. Used by the dict-aware check,
+/// which samples the whole block: a high-entropy-LOOKING block that actually
+/// repeats (and so will compress, dict or not) must not be skipped to raw.
+fn sample_looks_incompressible_capped(block: &[u8], max_sample_len: usize) -> bool {
+    let sample_len = block.len().min(max_sample_len);
     if sample_len < RAW_FAST_PATH_MIN_SAMPLE_LEN {
         return false;
     }

--- a/zstd/src/encoding/incompressible.rs
+++ b/zstd/src/encoding/incompressible.rs
@@ -169,6 +169,14 @@ pub(crate) fn block_looks_incompressible(block: &[u8]) -> bool {
 /// classified incompressible (no repeats anywhere), so the no-dict-quality
 /// rejection of incompressible input is preserved — it is only harder to trip on
 /// the dict path, never weaker.
+///
+/// This covers INTERNAL repeats only. EXTERNAL dict matches (a dict segment
+/// embedded in otherwise-incompressible input — content this content-only sample
+/// can never see) are caught by a SEPARATE layer at the call site: the raw skip
+/// fires only when this returns `true` AND `Matcher::block_samples_match_dict`
+/// finds no extendable dict match. So a block that matches the dictionary is
+/// never emitted raw, even though this function, by design, does not probe the
+/// dict itself.
 #[inline]
 pub(crate) fn block_looks_incompressible_dict(block: &[u8]) -> bool {
     if block.len() < RAW_FAST_PATH_MIN_BLOCK_LEN {

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -457,6 +457,16 @@ mod tests {
     }
 
     #[test]
+    fn custom_matcher_dict_probe_defaults_to_false() {
+        // `Matcher::block_samples_match_dict` defaults to `false`: a matcher
+        // without a dict-table probe (every backend except the Simple/Fast one
+        // with an attached dictionary) leaves the raw-fast-path on its
+        // content-only verdict.
+        let m = HintProbeMatcher::default();
+        assert!(!m.block_samples_match_dict(b"arbitrary block content, no dict probe"));
+    }
+
+    #[test]
     fn rle_branch_passes_compressible_hint_to_skip_matching() {
         let mut state = CompressState {
             matcher: HintProbeMatcher::default(),

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -458,10 +458,13 @@ mod tests {
 
     #[test]
     fn custom_matcher_dict_probe_defaults_to_false() {
-        // `Matcher::block_samples_match_dict` defaults to `false`: a matcher
-        // without a dict-table probe (every backend except the Simple/Fast one
-        // with an attached dictionary) leaves the raw-fast-path on its
-        // content-only verdict.
+        // `Matcher::block_samples_match_dict` defaults to `false`: a CUSTOM matcher
+        // with no dict-table probe leaves the raw-fast-path on its content-only
+        // verdict. NOTE this is the TRAIT DEFAULT, not the production wrapper: the
+        // `MatchGeneratorDriver` overrides it to `true` for non-Simple backends so
+        // a dict frame stays on the scan (covered by
+        // `block_samples_match_dict_is_true_for_non_simple_backend`). Only the
+        // Simple/Fast backend with an attached dictionary runs the precise probe.
         let m = HintProbeMatcher::default();
         assert!(!m.block_samples_match_dict(b"arbitrary block content, no dict probe"));
     }

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -442,6 +442,7 @@ mod tests {
             block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
             offset_hist: [1, 4, 8],
             strategy_tag: crate::encoding::strategy::StrategyTag::Fast,
+            huf_optimal_search: true,
         };
         let mut output = Vec::new();
 
@@ -476,6 +477,7 @@ mod tests {
             block_scratch: crate::encoding::blocks::CompressedBlockScratch::new(),
             offset_hist: [1, 4, 8],
             strategy_tag: crate::encoding::strategy::StrategyTag::Fast,
+            huf_optimal_search: true,
         };
         let mut output = Vec::new();
 

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -7,8 +7,8 @@ use crate::{
         blocks::{compress_block, compress_block_with_post_split},
         frame_compressor::CompressState,
         incompressible::{
-            block_looks_incompressible, block_looks_incompressible_strict,
-            compression_level_allows_raw_fast_path,
+            block_looks_incompressible, block_looks_incompressible_dict,
+            block_looks_incompressible_strict, compression_level_allows_raw_fast_path,
         },
         match_generator::MatchGeneratorDriver,
     },
@@ -81,12 +81,12 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if !dict_active
-        && should_emit_raw_fast_path(
-            compression_level,
-            state.matcher.window_size(),
-            &uncompressed_data,
-        )
+    } else if should_emit_raw_fast_path(
+        compression_level,
+        state.matcher.window_size(),
+        &uncompressed_data,
+        dict_active,
+    ) && !(dict_active && state.matcher.block_samples_match_dict(&uncompressed_data))
     {
         #[cfg(feature = "lsm")]
         if let Some(sink) = block_decompressed_sizes {
@@ -240,6 +240,7 @@ pub(crate) fn compress_block_encoded_borrowed(
     block: &[u8],
     block_start: usize,
     block_end: usize,
+    dict_active: bool,
     output: &mut Vec<u8>,
     #[cfg(feature = "lsm")] block_decompressed_sizes: Option<&mut Vec<u32>>,
     #[cfg(all(feature = "lsm", feature = "hash"))] block_checksums: Option<&mut Vec<u32>>,
@@ -277,7 +278,13 @@ pub(crate) fn compress_block_encoded_borrowed(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if should_emit_raw_fast_path(compression_level, state.matcher.window_size(), block) {
+    } else if should_emit_raw_fast_path(
+        compression_level,
+        state.matcher.window_size(),
+        block,
+        dict_active,
+    ) && !(dict_active && state.matcher.block_samples_match_dict(block))
+    {
         #[cfg(feature = "lsm")]
         if let Some(sink) = block_decompressed_sizes {
             sink.push(block_size);
@@ -375,9 +382,26 @@ pub(crate) fn compress_block_encoded_borrowed(
 }
 
 #[inline]
-fn should_emit_raw_fast_path(level: CompressionLevel, window_size: u64, block: &[u8]) -> bool {
+fn should_emit_raw_fast_path(
+    level: CompressionLevel,
+    window_size: u64,
+    block: &[u8],
+    has_dict: bool,
+) -> bool {
     if !compression_level_allows_raw_fast_path(level, window_size) {
         return false;
+    }
+    // With a dictionary attached, a high-entropy-looking block is NOT
+    // necessarily incompressible: the dict can supply matches the block's own
+    // content gives no hint of (e.g. structured records drawn from the trained
+    // dict). So raise the bar to the STRICT head/mid/tail probe before skipping
+    // the scan — the same conservative check `Best` uses. The plain no-dict
+    // heuristic stays for the no-dict path, where it classifies incompressible
+    // blocks very well. Without this, an over-cutoff dict frame whose first
+    // block matches the dict gets emitted raw and ignores the dictionary
+    // entirely.
+    if has_dict {
+        return block_looks_incompressible_dict(block);
     }
     if matches!(level, CompressionLevel::Best) {
         return block_looks_incompressible_strict(block);
@@ -532,7 +556,7 @@ mod tests {
             "fixture must look incompressible to exercise Best window guard"
         );
         assert!(
-            !should_emit_raw_fast_path(CompressionLevel::Best, 16 * 1024 * 1024, &block),
+            !should_emit_raw_fast_path(CompressionLevel::Best, 16 * 1024 * 1024, &block, false),
             "Best should keep compressed path when large window can unlock long-distance matches"
         );
     }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -667,13 +667,25 @@ pub(crate) fn source_size_ceil_log(size: u64) -> u8 {
     }
 }
 
-/// Upstream zstd `ZSTD_shouldAttachDict` cutoff for the Fast strategy, as a ceil-log
-/// bucket: 8 KiB = `2^13`, and `bucket <= 13` is exactly `hint <= 8192` because
-/// the bucket is monotone in the hint. A hint at or below this (or unknown,
-/// `None`) ATTACHES the dictionary (a separate immutable table); a larger hint
-/// COPIES it into the live table. Shared by `reset` (which records the mode in
-/// the primed-snapshot key) and `prime_with_dictionary` (which acts on it).
-const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 13;
+/// Attach-vs-copy cutoff for the Fast strategy, as a ceil-log bucket: a hint at
+/// or below `2^this` (or unknown, `None`) ATTACHES the dictionary (a separate
+/// immutable table scanned in place via the borrowed dual-base kernel); a larger
+/// hint would COPY it into the live table.
+///
+/// We set this to `31` (effectively "always attach"), diverging from upstream
+/// zstd's 8 KiB `ZSTD_shouldAttachDict` cutoff ON PURPOSE: upstream copy mode
+/// copies the small CDict TABLES into the cctx and still scans the input in
+/// place, but our flat-history copy path memmoves the whole INPUT into history
+/// every frame (profiled at 30% `__memmove` + 14% `__memset` on a reused 1 MiB
+/// dict encode). Attach mode scans the caller's input in place with the dict as
+/// a separate prefix base, so it is strictly faster for every frame size here
+/// (measured: 1 MiB dict frame 167 us -> 52 us, 0.42x of C; 10 KiB 20.4 us ->
+/// 4.4 us, 0.17x of C). The dual-base kernel carries `window_low`, so
+/// over-window inputs stay in-window and C-decodable. Per the
+/// drop-in-not-binary-parity contract, we make this match decision ourselves.
+/// Shared by `reset` (records the mode in the primed-snapshot key) and
+/// `prime_with_dictionary` (acts on it).
+pub(crate) const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 31;
 
 /// Dfast counterpart of [`FAST_ATTACH_DICT_CUTOFF_LOG`]: upstream zstd
 /// `ZSTD_dictMatchState` attach cutoff for the double-fast strategy is 16 KiB
@@ -2011,6 +2023,22 @@ impl Matcher for MatchGeneratorDriver {
 
     fn set_dictionary_size_hint(&mut self, size: usize) {
         self.dictionary_size_hint = Some(size);
+    }
+
+    /// Dict-relevance gate for the raw-fast-path. Reached only when a dictionary
+    /// is active (the caller short-circuits on `dict_active`), so this answers
+    /// "could the dict compress this otherwise-incompressible-looking block?".
+    /// The Simple (Fast) backend samples its dict table precisely
+    /// ([`FastKernelMatcher::block_samples_match_dict`]); the other backends
+    /// (Dfast / Row / HashChain / BT) have their own dict structures and no cheap
+    /// probe here, so they answer CONSERVATIVELY `true` — keep the dict frame on
+    /// the scan, exactly the behaviour the old `!dict_active` full-disable gave
+    /// them. Only Fast trades that blanket scan for the precise probe.
+    fn block_samples_match_dict(&self, block: &[u8]) -> bool {
+        match &self.storage {
+            MatcherStorage::Simple(m) => m.block_samples_match_dict(block),
+            _ => true,
+        }
     }
 
     /// Heap bytes this driver owns: the active backend's tables/history, the
@@ -10346,35 +10374,27 @@ fn primed_snapshot_restored_across_level22_tier_hints() {
 }
 
 #[test]
-fn primed_snapshot_not_restored_across_fast_attach_copy_boundary() {
-    // The Fast attach-vs-copy cutoff (8 KiB) falls INSIDE a single resolved
-    // matcher shape: a 8192-byte and a 8193-byte hint both clamp Level 1 to
-    // window_log 14 and the same Fast table widths, so `LevelParams` +
-    // `table_bits` are identical, yet 8192 attaches (separate dict table) while
-    // 8193 copies (dict primed into the live table). The snapshot key must
-    // therefore carry the attach/copy mode itself; without it the two resets
-    // would share a key and a copy-mode snapshot could be restored into an
-    // attach-mode reset (a different `storage` shape). Restore must REFUSE
-    // across the boundary.
-    let mut driver = MatchGeneratorDriver::new(8, 1);
+fn fast_dict_always_attaches_regardless_of_source_size_hint() {
+    // Fast no longer has an attach-vs-copy boundary: every Fast dict frame
+    // attaches (the copy-mode owned path memmoved the whole input into history
+    // each frame; attach scans the input in place via the borrowed dual-base
+    // kernel). So a large hint that used to cross into copy mode (8193 B,
+    // formerly > the 8 KiB cutoff) and a small one (8192 B) BOTH resolve to
+    // attach, and the Simple backend reports a borrowed (in-place) dict scan for
+    // both. This is the regression guard for `FAST_ATTACH_DICT_CUTOFF_LOG`
+    // staying high enough that no Fast hint falls back to the input-copy path.
     let level = CompressionLevel::Level(1);
-
-    // Copy side (hint > 8 KiB): prime + capture.
-    driver.set_source_size_hint(8193);
-    driver.reset(level);
-    driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
-    driver.capture_primed_dictionary(level);
-
-    // Attach side (hint <= 8 KiB), same resolved window/table shape.
-    driver.set_source_size_hint(8192);
-    driver.reset(level);
-    let restored = driver.restore_primed_dictionary(level);
-    assert!(
-        !restored,
-        "a copy-mode snapshot (8193 B hint) must NOT be restored into an \
-         attach-mode reset (8192 B hint) that resolves to the same params but a \
-         different dict-table shape"
-    );
+    for hint in [8192u64, 8193, 1 << 20] {
+        let mut driver = MatchGeneratorDriver::new(8, 1);
+        driver.set_source_size_hint(hint);
+        driver.reset(level);
+        driver.prime_with_dictionary(b"abcdefghABCDEFGHijklmnop", [1, 4, 8]);
+        assert!(
+            driver.borrowed_dict_supported(),
+            "Fast dict frame with hint {hint} must attach (borrowed in-place \
+             dict scan), never fall back to the copy-mode input-copy path"
+        );
+    }
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -10419,15 +10419,18 @@ fn primed_snapshot_restored_across_level22_tier_hints() {
 }
 
 #[test]
-fn fast_dict_always_attaches_regardless_of_source_size_hint() {
-    // Fast no longer has an attach-vs-copy boundary: every Fast dict frame
-    // attaches (the copy-mode owned path memmoved the whole input into history
-    // each frame; attach scans the input in place via the borrowed dual-base
-    // kernel). So a large hint that used to cross into copy mode (8193 B,
-    // formerly > the 8 KiB cutoff) and a small one (8192 B) BOTH resolve to
+fn fast_dict_attaches_within_cutoff_bounds() {
+    // Within the attach bounds, every Fast dict frame attaches (the copy-mode
+    // owned path memmoved the whole input into history each frame; attach scans
+    // the input in place via the borrowed dual-base kernel). All hints here sit
+    // far below `FAST_ATTACH_DICT_CUTOFF_LOG` (2 GiB source) and the dict is far
+    // below `MAX_FAST_ATTACH_DICT_REGION` (16 MiB), so a hint that used to cross
+    // the old 8 KiB cutoff (8193 B) and a small one (8192 B) BOTH resolve to
     // attach, and the Simple backend reports a borrowed (in-place) dict scan for
-    // both. This is the regression guard for `FAST_ATTACH_DICT_CUTOFF_LOG`
-    // staying high enough that no Fast hint falls back to the input-copy path.
+    // both. This guards `FAST_ATTACH_DICT_CUTOFF_LOG` staying high enough that no
+    // in-bounds Fast hint falls back to the input-copy path; the OUT-of-bounds
+    // fallbacks are covered by `fast_attach_cutoff_keeps_virtual_positions_within_u32`
+    // (source) and `oversized_dict_hint_routes_fast_to_copy_mode` (dict size).
     let level = CompressionLevel::Level(1);
     for hint in [8192u64, 8193, 1 << 20] {
         let mut driver = MatchGeneratorDriver::new(8, 1);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6417,6 +6417,17 @@ impl HcMatchGenerator {
         // (srcSize > 256 KiB tier): btlazy2 L13-15 + btopt L16 are minMatch=5,
         // btopt L17 is minMatch=4, btultra/btultra2 are minMatch=3 (4-byte main
         // hash + the hash3 short-match probe).
+        // A `search_mls` change (e.g. btlazy2 -> lazy across a reused-compressor
+        // level switch) invalidates the cached dms: it was hashed at the old
+        // mls, but the reborrow fast path in `MatchTable::reset` reuses it on
+        // `dms.is_primed()` ALONE, without re-checking the (region, layout, mls,
+        // hash_log) key that `build_dms!` validates on the normal prime path.
+        // Drop the stale-mls dms here (configure runs before reset) so the next
+        // dict frame re-primes at the new mls instead of probing a mismatched
+        // dms and silently degrading match quality.
+        if self.table.search_mls != config.search_mls {
+            self.table.dms.invalidate();
+        }
         self.table.search_mls = config.search_mls;
         // Stage D: promote the backend discriminator. HC modes drop the
         // BT scratch buffers entirely; switching back into a BT mode

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -694,6 +694,15 @@ pub(crate) fn source_size_ceil_log(size: u64) -> u8 {
 /// `prime_with_dictionary` (acts on it).
 pub(crate) const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 31;
 
+/// Largest dictionary region (bytes) the Fast attach path can index. The tagged
+/// dict table packs each position into `32 - DICT_TAG_BITS` (= 24) bits, so a
+/// region past `2^24` (16 MiB) would overflow the packed position. Dictionaries
+/// this large fall back to COPY mode, whose live table stores full `u32`
+/// positions and handles them. The size hint set on dict load equals the actual
+/// dict content length, so the attach-vs-copy decision (and the matching
+/// snapshot-key / epoch bits) can gate on it consistently at reset time.
+pub(crate) const MAX_FAST_ATTACH_DICT_REGION: usize = 1 << 24;
+
 /// Dfast counterpart of [`FAST_ATTACH_DICT_CUTOFF_LOG`]: upstream zstd
 /// `ZSTD_dictMatchState` attach cutoff for the double-fast strategy is 16 KiB
 /// (`2^14`), so small / unknown-size inputs ATTACH (separate immutable dict
@@ -1375,6 +1384,14 @@ pub struct MatchGeneratorDriver {
     // table, 4-cursor `compress_block_fast`). The primed-snapshot key is the
     // resolved shape ([`reset_shape`](Self::reset_shape)), not this bucket.
     reset_size_log: Option<u8>,
+    // Whether the loaded dictionary fits the Fast attach path's tagged position
+    // field (`<= MAX_FAST_ATTACH_DICT_REGION`). Captured at `reset` from the
+    // dict-size hint (which equals the actual dict length on load) so the Fast
+    // attach decision, the attach-epoch reset bit, and the primed-snapshot
+    // `fast_attach` bit all gate on it consistently. `true` when there is no
+    // dictionary (the attach path is then unused). A dict too large to tag falls
+    // back to copy mode instead of overflowing the packed position.
+    reset_dict_attach_ok: bool,
     // Hint-resolved matcher shape from the last `reset`: the [`LevelParams`], the
     // active backend's applied Dfast/Row hash-table width (`0` for HC/Fast), the
     // Fast attach-vs-copy mode, and the active LDM override (#27). Combined with
@@ -1548,6 +1565,7 @@ impl MatchGeneratorDriver {
             // resolved LevelParams.
             reported_window_size: next_pow2,
             reset_size_log: None,
+            reset_dict_attach_ok: true,
             reset_shape: None,
             dictionary_retained_budget: 0,
             source_size_hint: None,
@@ -1950,9 +1968,10 @@ impl MatchGeneratorDriver {
                 // matches/beats the upstream zstd on large corpora). The dispatch in
                 // `start_matching` keys off `dict_table.is_some()`, which only
                 // the attach path populates. See [`FAST_ATTACH_DICT_CUTOFF_LOG`].
-                let attach = self
-                    .reset_size_log
-                    .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
+                let attach = self.reset_dict_attach_ok
+                    && self
+                        .reset_size_log
+                        .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
                 if attach {
                     self.simple_mut().skip_matching_for_dict_prime();
                 } else {
@@ -2038,9 +2057,14 @@ impl Matcher for MatchGeneratorDriver {
     /// The Simple (Fast) backend samples its dict table precisely
     /// ([`FastKernelMatcher::block_samples_match_dict`]); the other backends
     /// (Dfast / Row / HashChain / BT) have their own dict structures and no cheap
-    /// probe here, so they answer CONSERVATIVELY `true` — keep the dict frame on
-    /// the scan, exactly the behaviour the old `!dict_active` full-disable gave
-    /// them. Only Fast trades that blanket scan for the precise probe.
+    /// probe here, so they answer CONSERVATIVELY `true`: without a probe they
+    /// cannot tell whether the dict compresses an incompressible-LOOKING block,
+    /// and answering `false` would let the raw-fast-path emit such a block raw
+    /// and miss an embedded dict segment. `dictionary_segment_in_incompressible_input_is_matched`
+    /// pins this for Dfast/Row/BT — the 512-byte dict run inside high-entropy
+    /// filler is matched only because these backends stay on the scan. So they
+    /// keep the blanket scan the old `!dict_active` gate gave them; only the
+    /// Simple/Fast backend trades it for the precise probe.
     fn block_samples_match_dict(&self, block: &[u8]) -> bool {
         match &self.storage {
             MatcherStorage::Simple(m) => m.block_samples_match_dict(block),
@@ -2075,6 +2099,11 @@ impl Matcher for MatchGeneratorDriver {
         // bucket rather than the raw bytes means two hints that resolve to the
         // same matcher shape share one snapshot instead of each re-priming.
         self.reset_size_log = hint.map(source_size_ceil_log);
+        // A dictionary too large for the tagged attach position field falls back
+        // to copy mode. Captured here (from the load-set size hint = actual dict
+        // length) so the prime decision and the snapshot-key / epoch bits agree.
+        self.reset_dict_attach_ok =
+            dict_hint.is_none_or(|size| size <= MAX_FAST_ATTACH_DICT_REGION);
         let hinted = hint.is_some();
         #[cfg_attr(not(test), allow(unused_mut))]
         let mut params = Self::level_params(level, hint);
@@ -2438,6 +2467,7 @@ impl Matcher for MatchGeneratorDriver {
                 // an epoch-advance reset would preserve stale attach state
                 // instead of clearing it.
                 let dict_attach_epoch = matches!(dict_hint, Some(size) if size > 0)
+                    && self.reset_dict_attach_ok
                     && self
                         .reset_size_log
                         .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
@@ -2646,6 +2676,7 @@ impl Matcher for MatchGeneratorDriver {
         // matches the decision `prime_with_dictionary` makes from the same
         // `reset_size_log`.
         let fast_attach = matches!(next_backend, super::strategy::BackendTag::Simple)
+            && self.reset_dict_attach_ok
             && self
                 .reset_size_log
                 .is_none_or(|log| log <= FAST_ATTACH_DICT_CUTOFF_LOG);
@@ -6430,6 +6461,9 @@ impl HcMatchGenerator {
         let resize = self.table.hash_log != config.hash_log
             || self.table.chain_log != config.chain_log
             || self.table.hash3_log != next_hash3_log;
+        // Capture the layout flip BEFORE `uses_bt` is overwritten below — it
+        // feeds the dms invalidation (the dms is keyed by layout too).
+        let uses_bt_changed = self.table.uses_bt != uses_bt;
         self.table.hash_log = config.hash_log;
         self.table.chain_log = config.chain_log;
         self.table.hash3_log = next_hash3_log;
@@ -6456,15 +6490,15 @@ impl HcMatchGenerator {
         // shape that `build_dms!` validates on the normal prime path, but the
         // reborrow fast path in `MatchTable::reset` reuses it on `dms.is_primed()`
         // ALONE. A reused-compressor level switch can change the search mls (e.g.
-        // btlazy2 -> lazy) OR the table geometry (hash_log / chain_log / hash3,
-        // captured in `resize` above) independently of each other, and either
-        // leaves the dms hashed for a different shape. Invalidate on EITHER so the
-        // next dict frame re-primes at the new shape (configure runs before reset)
-        // instead of probing a mismatched dms and silently degrading match
-        // quality. Over-invalidation only costs a re-prime, which a real shape
-        // change needs anyway.
+        // btlazy2 -> lazy), the table geometry (hash_log / chain_log / hash3,
+        // captured in `resize`), OR the HC<->BT layout (`uses_bt_changed`)
+        // independently of each other, and any of them leaves the dms hashed for
+        // a different shape. Invalidate on ANY so the next dict frame re-primes at
+        // the new shape (configure runs before reset) instead of probing a
+        // mismatched dms and silently degrading match quality. Over-invalidation
+        // only costs a re-prime, which a real shape change needs anyway.
         let mls_changed = self.table.search_mls != config.search_mls;
-        if resize || mls_changed {
+        if resize || mls_changed || uses_bt_changed {
             self.table.dms.invalidate();
         }
         self.table.search_mls = config.search_mls;
@@ -10427,6 +10461,50 @@ fn fast_attach_cutoff_keeps_virtual_positions_within_u32() {
         (1u64 << (FAST_ATTACH_DICT_CUTOFF_LOG + 1)) > u32::MAX as u64,
         "the next bucket 2^{} would overflow u32 virtual positions",
         FAST_ATTACH_DICT_CUTOFF_LOG + 1,
+    );
+}
+
+#[test]
+fn oversized_dict_hint_routes_fast_to_copy_mode() {
+    // A dict whose region exceeds the tagged attach position field
+    // (`MAX_FAST_ATTACH_DICT_REGION`, 16 MiB) must route the Fast prime to COPY
+    // mode instead of the tagged attach fill, which would overflow the packed
+    // position. The decision is keyed on the load-set size hint, so a hint past
+    // the limit suffices to exercise it without allocating a real 16 MiB dict.
+    // Copy mode leaves the borrowed in-place dict scan (attach-only) unavailable.
+    let mut driver = MatchGeneratorDriver::new(8, 1);
+    driver.set_dictionary_size_hint(MAX_FAST_ATTACH_DICT_REGION + 1);
+    driver.reset(CompressionLevel::Level(1));
+    driver.prime_with_dictionary(b"small dict content with some padding here", [1, 4, 8]);
+    assert!(
+        !driver.borrowed_dict_supported(),
+        "an oversized dict must use copy mode, not the tagged attach fill"
+    );
+}
+
+#[test]
+fn block_samples_match_dict_is_true_for_non_simple_backend() {
+    // Production fallback: a non-Simple backend (here Row, Level 6) has no dict
+    // probe, so the driver wrapper answers CONSERVATIVELY `true` for ANY block —
+    // keeping the dict frame on the scan rather than letting the raw-fast-path
+    // emit a block raw and miss an embedded dict segment (see
+    // `dictionary_segment_in_incompressible_input_is_matched`). Only the
+    // Simple/Fast backend trades the blanket scan for a precise probe.
+    let dict = b"the quick brown fox jumps over the lazy dog 0123456789abcdef";
+    let mut row = MatchGeneratorDriver::new(8, 6);
+    row.set_dictionary_size_hint(dict.len());
+    row.reset(CompressionLevel::Level(6));
+    row.prime_with_dictionary(dict, [1, 4, 8]);
+    assert!(
+        row.block_samples_match_dict(&dict[..32]),
+        "non-Simple backend must stay on the scan (true) for a dict frame"
+    );
+    let random: alloc::vec::Vec<u8> = (0..64u8)
+        .map(|i| i.wrapping_mul(37).wrapping_add(13))
+        .collect();
+    assert!(
+        row.block_samples_match_dict(&random),
+        "non-Simple backend reports true regardless of block content"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -672,17 +672,24 @@ pub(crate) fn source_size_ceil_log(size: u64) -> u8 {
 /// immutable table scanned in place via the borrowed dual-base kernel); a larger
 /// hint would COPY it into the live table.
 ///
-/// We set this to `31` (effectively "always attach"), diverging from upstream
-/// zstd's 8 KiB `ZSTD_shouldAttachDict` cutoff ON PURPOSE: upstream copy mode
-/// copies the small CDict TABLES into the cctx and still scans the input in
-/// place, but our flat-history copy path memmoves the whole INPUT into history
-/// every frame (profiled at 30% `__memmove` + 14% `__memset` on a reused 1 MiB
-/// dict encode). Attach mode scans the caller's input in place with the dict as
-/// a separate prefix base, so it is strictly faster for every frame size here
-/// (measured: 1 MiB dict frame 167 us -> 52 us, 0.42x of C; 10 KiB 20.4 us ->
-/// 4.4 us, 0.17x of C). The dual-base kernel carries `window_low`, so
-/// over-window inputs stay in-window and C-decodable. Per the
-/// drop-in-not-binary-parity contract, we make this match decision ourselves.
+/// We set this to `31` so every dictionary source up to 2 GiB attaches,
+/// diverging from upstream zstd's 8 KiB `ZSTD_shouldAttachDict` cutoff ON
+/// PURPOSE: upstream copy mode copies the small CDict TABLES into the cctx and
+/// still scans the input in place, but our flat-history copy path memmoves the
+/// whole INPUT into history every frame (profiled at 30% `__memmove` + 14%
+/// `__memset` on a reused 1 MiB dict encode). Attach mode scans the caller's
+/// input in place with the dict as a separate prefix base, so it is strictly
+/// faster for every frame size here (measured: 1 MiB dict frame 167 us -> 52 us,
+/// 0.42x of C; 10 KiB 20.4 us -> 4.4 us, 0.17x of C). The dual-base kernel
+/// carries `window_low`, so over-window inputs stay in-window and C-decodable.
+///
+/// `31` is also the largest bucket the borrowed kernel can attach: it stores
+/// virtual positions as `u32` (`cur_abs as u32`), so the maximum attached source
+/// `1 << 31` (plus the dict prefix) stays below `u32::MAX`; the next bucket `32`
+/// (4 GiB) would wrap that arithmetic. Sources past 2 GiB therefore fall back to
+/// copy mode — rare in practice, and the relative copy cost shrinks as the
+/// source grows. Per the drop-in-not-binary-parity contract, we make this match
+/// decision ourselves.
 /// Shared by `reset` (records the mode in the primed-snapshot key) and
 /// `prime_with_dictionary` (acts on it).
 pub(crate) const FAST_ATTACH_DICT_CUTOFF_LOG: u8 = 31;
@@ -6445,15 +6452,19 @@ impl HcMatchGenerator {
         // (srcSize > 256 KiB tier): btlazy2 L13-15 + btopt L16 are minMatch=5,
         // btopt L17 is minMatch=4, btultra/btultra2 are minMatch=3 (4-byte main
         // hash + the hash3 short-match probe).
-        // A `search_mls` change (e.g. btlazy2 -> lazy across a reused-compressor
-        // level switch) invalidates the cached dms: it was hashed at the old
-        // mls, but the reborrow fast path in `MatchTable::reset` reuses it on
-        // `dms.is_primed()` ALONE, without re-checking the (region, layout, mls,
-        // hash_log) key that `build_dms!` validates on the normal prime path.
-        // Drop the stale-mls dms here (configure runs before reset) so the next
-        // dict frame re-primes at the new mls instead of probing a mismatched
-        // dms and silently degrading match quality.
-        if self.table.search_mls != config.search_mls {
+        // The cached dms is keyed by the full (region, layout, mls, hash_log)
+        // shape that `build_dms!` validates on the normal prime path, but the
+        // reborrow fast path in `MatchTable::reset` reuses it on `dms.is_primed()`
+        // ALONE. A reused-compressor level switch can change the search mls (e.g.
+        // btlazy2 -> lazy) OR the table geometry (hash_log / chain_log / hash3,
+        // captured in `resize` above) independently of each other, and either
+        // leaves the dms hashed for a different shape. Invalidate on EITHER so the
+        // next dict frame re-primes at the new shape (configure runs before reset)
+        // instead of probing a mismatched dms and silently degrading match
+        // quality. Over-invalidation only costs a re-prime, which a real shape
+        // change needs anyway.
+        let mls_changed = self.table.search_mls != config.search_mls;
+        if resize || mls_changed {
             self.table.dms.invalidate();
         }
         self.table.search_mls = config.search_mls;
@@ -10395,6 +10406,28 @@ fn fast_dict_always_attaches_regardless_of_source_size_hint() {
              dict scan), never fall back to the copy-mode input-copy path"
         );
     }
+}
+
+#[test]
+fn fast_attach_cutoff_keeps_virtual_positions_within_u32() {
+    // The cutoff is 31, NOT the full u64 source-size range, because the borrowed
+    // dict kernel stores virtual positions as u32 (`cur_abs as u32`). The largest
+    // attached source `1 << CUTOFF` (plus the dict prefix) must stay below
+    // u32::MAX or that arithmetic wraps; the next bucket (4 GiB) would. This pins
+    // the bound so a future "just raise it to attach everything" change cannot
+    // silently reintroduce the overflow — raising the cutoff requires widening
+    // the kernel's position type first.
+    let max_attached: u64 = 1u64 << FAST_ATTACH_DICT_CUTOFF_LOG;
+    assert!(
+        max_attached <= u32::MAX as u64,
+        "the largest attached source 2^{FAST_ATTACH_DICT_CUTOFF_LOG} must fit u32 \
+         virtual positions",
+    );
+    assert!(
+        (1u64 << (FAST_ATTACH_DICT_CUTOFF_LOG + 1)) > u32::MAX as u64,
+        "the next bucket 2^{} would overflow u32 virtual positions",
+        FAST_ATTACH_DICT_CUTOFF_LOG + 1,
+    );
 }
 
 #[test]

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -383,6 +383,12 @@ struct FastConfig {
 
 const FAST_L1: FastConfig = FastConfig {
     hash_log: 14,
+    // Tier-0 (srcSize > 256 KiB) `cParams.minMatch`. Upstream zstd selects the
+    // Level-1 row from a 4-way srcSize-tiered table (`ZSTD_getCParams_internal`
+    // → `ZSTD_defaultCParameters[tableID][1]`), and minMatch shrinks for
+    // smaller inputs: 7 (>256 KiB) / 6 (16..256 KiB) / 5 (<=16 KiB). The base
+    // here is the tier-0 value; `fast_l1_mls_for_source_size` lowers it per the
+    // tier in `adjust_params_for_source_size`.
     mls: 7,
     step_size: 2,
 };
@@ -884,6 +890,56 @@ const MIN_HINTED_WINDOW_LOG: u8 = 14;
 /// encoder's baseline minimum supported window.
 /// For the HC backend, `hash_log` and `chain_log` are reduced
 /// proportionally.
+/// Source-size tier index, matching upstream `ZSTD_getCParams_internal`'s
+/// `tableID = (rSize<=256K)+(rSize<=128K)+(rSize<=16K)`: 0 = > 256 KiB or
+/// unknown, 1 = 128..256 KiB, 2 = 16..128 KiB, 3 = <= 16 KiB.
+fn cparams_tier(source_size: Option<u64>) -> usize {
+    match source_size {
+        Some(size) if size <= 16 * 1024 => 3,
+        Some(size) if size <= 128 * 1024 => 2,
+        Some(size) if size <= 256 * 1024 => 1,
+        _ => 0,
+    }
+}
+
+/// Override a Fast (L1/L2) or Dfast (L3) level row's table-shaping cParams
+/// (hashLog / chainLog / minMatch) by source-size tier, matching the
+/// reference `ZSTD_defaultCParameters[tableID][level]`. L1 keeps its base
+/// hashLog (the source-size window clamp in `adjust_params_for_source_size`
+/// already lands on the reference value) and only tiers minMatch; L2 also
+/// tiers hashLog (the tier-0 value 16 oversized the table on medium inputs,
+/// the page-fault pathology); L3 tiers both dfast hash widths. Strategy
+/// switches (L2 tier 1, L4) are intentionally not applied here.
+fn apply_cparams_tier(level: i32, source_size: Option<u64>, p: &mut LevelParams) {
+    let tier = cparams_tier(source_size);
+    match level {
+        // Fast, all tiers — minMatch only (hashLog handled by the window clamp).
+        1 => {
+            if let Some(f) = p.fast.as_mut() {
+                f.mls = [7, 6, 6, 5][tier];
+            }
+        }
+        // Fast (base strategy; tier 1 is dfast upstream — not switched here).
+        // (hashLog, minMatch) per tier from `clevels.h` level-2 rows.
+        2 => {
+            if let Some(f) = p.fast.as_mut() {
+                let (h, m) = [(16u32, 6u32), (14, 5), (15, 5), (15, 4)][tier];
+                f.hash_log = h;
+                f.mls = m;
+            }
+        }
+        // Dfast, all tiers — (long hashLog, short chainLog) per tier.
+        3 => {
+            if let Some(d) = p.dfast.as_mut() {
+                let (l, s) = [(17u8, 16u8), (16, 16), (16, 15), (15, 14)][tier];
+                d.long_hash_log = l;
+                d.short_hash_log = s;
+            }
+        }
+        _ => {}
+    }
+}
+
 fn adjust_params_for_source_size(mut params: LevelParams, src_size: u64) -> LevelParams {
     // Derive a source-size-based cap from ceil(log2(src_size)), then
     // clamp first to MIN_WINDOW_LOG (baseline encoder minimum) and then to
@@ -1109,7 +1165,22 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
         CompressionLevel::Level(n) => {
             if n > 0 {
                 let idx = (n as usize).min(CompressionLevel::MAX_LEVEL as usize) - 1;
-                LEVEL_TABLE[idx]
+                let mut p = LEVEL_TABLE[idx];
+                // Upstream zstd selects the cParams row from a 4-way
+                // source-size-tiered table (`ZSTD_getCParams_internal` →
+                // `ZSTD_defaultCParameters[tableID][level]`), and the Fast /
+                // Dfast hashLog, chainLog and minMatch shrink for smaller
+                // inputs. The `LEVEL_TABLE` base is the tier-0 (> 256 KiB) row;
+                // override the table-shaping params per tier here so small and
+                // medium frames use the reference's table widths (the oversized
+                // tier-0 widths were a per-frame alloc / page-fault pathology on
+                // medium inputs) and minMatch (short matches the wide hash
+                // skips). NOTE: the reference also switches STRATEGY in some
+                // tiers (L2 → dfast at 128..256 KiB, L4 → greedy at <= 16 KiB
+                // and 128..256 KiB); those backend switches are not yet tiered,
+                // so those tiers keep the base strategy.
+                apply_cparams_tier(n, source_size, &mut p);
+                p
             } else if n == 0 {
                 // Level 0 = default, matching C zstd semantics.
                 LEVEL_TABLE[CompressionLevel::DEFAULT_LEVEL as usize - 1]
@@ -1462,7 +1533,12 @@ impl MatchGeneratorDriver {
         let window_log_init = next_pow2.trailing_zeros() as u8;
         Self {
             vec_pool: Vec::new(),
-            storage: MatcherStorage::Simple(FastKernelMatcher::with_params(
+            // Deferred table: `new` runs before any source size or resolved
+            // LevelParams exist, so allocating at the level-default hash_log
+            // here would be thrown away by the first frame's reset (which
+            // clamps the window to the input and reallocs at the resolved
+            // size). The deferral lets that first reset allocate exactly once.
+            storage: MatcherStorage::Simple(FastKernelMatcher::with_params_deferred(
                 window_log_init,
                 FAST_LEVEL_1_HASH_LOG,
                 FAST_LEVEL_1_MLS,
@@ -2247,14 +2323,13 @@ impl Matcher for MatchGeneratorDriver {
                     // tables with `DFAST_EMPTY_SLOT` sentinels — wasted
                     // work given the next assignment to `self.storage`
                     // is about to drop `m` entirely. `reset` itself
-                    // short-circuits on `if !self.short_hash.is_empty()`,
-                    // so handing it an empty `Vec` skips the fill loop.
+                    // short-circuits on `if !self.tables.is_empty()`, so
+                    // handing it an empty `Vec` skips the fill loop.
                     // Mirrors the pre-drain pattern in the HashChain
                     // arm below (and serves the same peak-memory
                     // purpose: release the table-allocation footprint
                     // before constructing the replacement variant).
-                    m.short_hash = Vec::new();
-                    m.long_hash = Vec::new();
+                    m.tables = Vec::new();
                     m.reset();
                 }
                 MatcherStorage::Row(m) => {
@@ -2386,9 +2461,24 @@ impl Matcher for MatchGeneratorDriver {
                                 ldm: None,
                             }
                     });
+                // Cap `hash_log <= window_log + 1` (upstream zstd
+                // `ZSTD_adjustCParams_internal`): once `window_log` is resized
+                // down for a small source, a level-default `1 << hash_log`
+                // table is mostly wasted address space whose per-frame memset
+                // dominates the compress cost on tiny frames (a 4 KB frame at
+                // window_log 12 still zero-fills the 64 KiB hash_log-14 table).
+                // Gated to no-dict frames: the dict-attach path shares one
+                // hash_log between the main and dict tables (so one hash keys
+                // both), and shrinking only the main table would break that
+                // invariant and the small-frame dict ratio.
+                let hash_log = if dict_hint.is_some_and(|s| s > 0) {
+                    fast.hash_log
+                } else {
+                    fast.hash_log.min(params.window_log as u32 + 1)
+                };
                 m.reset(
                     params.window_log,
-                    fast.hash_log,
+                    hash_log,
                     fast.mls,
                     fast.step_size,
                     dict_attach_epoch,
@@ -2573,6 +2663,34 @@ impl Matcher for MatchGeneratorDriver {
         self.reset_shape = Some((params, resolved_table_bits, fast_attach, active_ldm));
     }
 
+    fn dictionary_is_resident(&self) -> bool {
+        match &self.storage {
+            MatcherStorage::HashChain(hc) => hc.table.dict_resident,
+            MatcherStorage::Simple(s) => s.dict_resident(),
+            MatcherStorage::Dfast(d) => d.dict_resident(),
+            _ => false,
+        }
+    }
+
+    fn reapply_resident_dictionary(&mut self, offset_hist: [u32; 3]) {
+        // Same offset-history head as `prime_with_dictionary`, without the dict
+        // commit / re-index (resident dict bytes + cached dms already in place).
+        match self.active_backend() {
+            super::strategy::BackendTag::Simple => {
+                self.simple_mut().prime_offset_history(offset_hist)
+            }
+            super::strategy::BackendTag::Dfast => {
+                self.dfast_matcher_mut().offset_hist = offset_hist
+            }
+            super::strategy::BackendTag::Row => self.row_matcher_mut().offset_hist = offset_hist,
+            super::strategy::BackendTag::HashChain => {
+                let matcher = self.hc_matcher_mut();
+                matcher.table.offset_hist = offset_hist;
+                matcher.table.mark_dictionary_primed();
+            }
+        }
+    }
+
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
         match self.active_backend() {
             super::strategy::BackendTag::Simple => {
@@ -2615,8 +2733,7 @@ impl Matcher for MatchGeneratorDriver {
         // re-introduce the same overflow the `window_log` cap was
         // designed to prevent. Clamp the post-priming size so the
         // doubled-band-plus-block invariant survives.
-        const MAX_PRIMED_WINDOW_SIZE: usize =
-            (u32::MAX as usize - crate::common::MAX_BLOCK_SIZE as usize) / 2;
+        use super::match_table::storage::MAX_PRIMED_WINDOW_SIZE;
 
         // `requested_dict_budget` is what the caller asked for;
         // `base_max_window_size` snapshots the pre-priming cap so we
@@ -9306,8 +9423,8 @@ fn driver_small_source_hint_shrinks_dfast_hash_tables() {
     driver.skip_matching_with_hint(None);
     // Upstream zstd-parity split sizes: long-hash = DFAST_HASH_BITS,
     // short-hash = DFAST_HASH_BITS - DFAST_SHORT_HASH_BITS_DELTA.
-    let full_long = driver.dfast_matcher().long_hash.len();
-    let full_short = driver.dfast_matcher().short_hash.len();
+    let full_long = driver.dfast_matcher().long_len();
+    let full_short = driver.dfast_matcher().short_len();
     assert_eq!(full_long, 1 << DFAST_HASH_BITS);
     assert_eq!(
         full_short,
@@ -9321,8 +9438,8 @@ fn driver_small_source_hint_shrinks_dfast_hash_tables() {
     space.truncate(12);
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
-    let hinted_long = driver.dfast_matcher().long_hash.len();
-    let hinted_short = driver.dfast_matcher().short_hash.len();
+    let hinted_long = driver.dfast_matcher().long_len();
+    let hinted_short = driver.dfast_matcher().short_len();
 
     // The wire `window_log` stays at its floor (decoder-interop), but the
     // internal dfast tables are sized from the RAW 1 KiB source, not the
@@ -9358,7 +9475,7 @@ fn driver_huge_source_hint_does_not_overflow_table_window_shift() {
     driver.skip_matching_with_hint(None);
 
     assert!(
-        driver.dfast_matcher().long_hash.len() >= 1 << MIN_WINDOW_LOG,
+        driver.dfast_matcher().long_len() >= 1 << MIN_WINDOW_LOG,
         "huge hint must size the dfast table from the real window, not wrap to zero"
     );
 }
@@ -9743,8 +9860,8 @@ fn driver_unhinted_level2_keeps_default_dfast_hash_table_size() {
     // Upstream zstd-parity split: long-hash at DFAST_HASH_BITS, short-hash one
     // bit smaller (DFAST_SHORT_HASH_BITS_DELTA = 1, matching upstream zstd
     // `chainLog = hashLog - 1` for dfast levels).
-    let long_len = driver.dfast_matcher().long_hash.len();
-    let short_len = driver.dfast_matcher().short_hash.len();
+    let long_len = driver.dfast_matcher().long_len();
+    let short_len = driver.dfast_matcher().short_len();
     assert_eq!(
         long_len,
         1 << DFAST_HASH_BITS,
@@ -12253,7 +12370,7 @@ fn dfast_skip_matching_dense_backfills_newly_hashable_long_tail_positions() {
         "pack_slot must never return the empty-slot sentinel for a real position"
     );
     assert_eq!(
-        matcher.long_hash[long_hash], target_slot,
+        matcher.tables[long_hash], target_slot,
         "dense skip must seed long-hash entry for newly hashable boundary start"
     );
 }
@@ -12284,7 +12401,8 @@ fn dfast_seed_remaining_hashable_starts_seeds_last_short_hash_positions() {
         "pack_slot must never return the empty-slot sentinel for a real position"
     );
     assert_eq!(
-        matcher.short_hash[short_hash], target_slot,
+        matcher.tables[matcher.long_len() + short_hash],
+        target_slot,
         "tail seeding must include the last 5-byte-hashable start"
     );
 }
@@ -12314,7 +12432,8 @@ fn dfast_seed_remaining_hashable_starts_handles_pos_at_block_end() {
         "pack_slot must never return the empty-slot sentinel for a real position"
     );
     assert_eq!(
-        matcher.short_hash[short_hash], target_slot,
+        matcher.tables[matcher.long_len() + short_hash],
+        target_slot,
         "tail seeding must still include the last 5-byte-hashable start when pos is at block end"
     );
 }
@@ -12350,8 +12469,9 @@ fn dfast_ensure_room_for_rebases_above_guard_band() {
     let early_abs = 1024usize;
     let early_packed = dfast.pack_slot(early_abs);
     assert_ne!(early_packed, DFAST_EMPTY_SLOT);
-    dfast.short_hash[0] = early_packed;
-    dfast.long_hash[0] = early_packed;
+    let short0 = dfast.long_len();
+    dfast.tables[short0] = early_packed;
+    dfast.tables[0] = early_packed;
 
     // Pick a trigger position that forces the first rebase. With
     // `position_base = 0`, the smallest `abs_pos` that fails the
@@ -12372,11 +12492,12 @@ fn dfast_ensure_room_for_rebases_above_guard_band() {
     // upstream zstd parity for `ZSTD_window_reduce`'s clamp-at-zero rule.
     // Verify BOTH tables — `reduce()` walks them in sequence.
     assert_eq!(
-        dfast.short_hash[0], DFAST_EMPTY_SLOT,
+        dfast.tables[dfast.long_len()],
+        DFAST_EMPTY_SLOT,
         "pre-rebase short-hash entries below the reducer must become empty"
     );
     assert_eq!(
-        dfast.long_hash[0], DFAST_EMPTY_SLOT,
+        dfast.tables[0], DFAST_EMPTY_SLOT,
         "pre-rebase long-hash entries below the reducer must become empty"
     );
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2656,6 +2656,25 @@ impl Matcher for MatchGeneratorDriver {
                 matcher.table.mark_dictionary_primed();
             }
         }
+        // Restore the retained-dictionary budget the per-frame `reset` cleared.
+        // The matcher's `reset` re-inflated `max_window_size` by the resident
+        // dict region (so the dict + next input both stay in the eviction band),
+        // exactly as `prime_with_dictionary` does — but the resident path skips
+        // that prime, so without this the driver-level budget stays 0 and
+        // `retire_dictionary_budget` never shrinks the inflated window as input
+        // evicts the dict. For HashChain (whose `window_low` is measured against
+        // `max_window_size`), a stuck-inflated window would let a post-eviction
+        // match exceed the frame header's base window and emit an over-window
+        // offset. The inflation equals `max_window_size - base`, and
+        // `reported_window_size` is the base `1 << window_log` set by `reset`.
+        let base = self.reported_window_size;
+        let inflated = match self.active_backend() {
+            super::strategy::BackendTag::Simple => self.simple_mut().max_window_size,
+            super::strategy::BackendTag::Dfast => self.dfast_matcher_mut().max_window_size,
+            super::strategy::BackendTag::Row => self.row_matcher_mut().max_window_size,
+            super::strategy::BackendTag::HashChain => self.hc_matcher_mut().table.max_window_size,
+        };
+        self.dictionary_retained_budget = inflated.saturating_sub(base);
     }
 
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
@@ -11408,6 +11427,54 @@ fn prime_with_dictionary_budget_shrinks_after_hc_eviction() {
         driver.hc_matcher().table.max_window_size,
         base_window,
         "retired dictionary budget must not remain reusable for live history"
+    );
+}
+
+#[test]
+fn resident_reapply_restores_retained_dictionary_budget() {
+    // A reused-dict frame that re-borrows the resident dictionary (skips the
+    // re-prime) must restore the retained-dict budget the per-frame `reset`
+    // cleared. The matcher's `reset` re-inflates `max_window_size` by the dict
+    // region; without the restore the driver-level budget stays 0 and
+    // `retire_dictionary_budget` never shrinks that inflated window as the dict
+    // evicts. For the HashChain backend (whose `window_low` is measured against
+    // `max_window_size`) that lets a post-eviction match exceed the frame
+    // header's base window and emit an over-window offset.
+    let mut driver = MatchGeneratorDriver::new(1 << 16, 1);
+    let dict = b"abcdefghABCDEFGHijklmnopqrstuvwxyz0123456789";
+    driver.set_dictionary_size_hint(dict.len());
+    driver.reset_on_hc_lazy(CompressionLevel::Better);
+    driver.prime_with_dictionary(dict, [1, 4, 8]);
+    let base = driver.reported_window_size;
+    assert!(
+        driver.dictionary_retained_budget > 0,
+        "the priming frame must retain a non-zero dict budget"
+    );
+
+    // Second frame: the reset detects the resident dict and re-borrows it.
+    driver.set_dictionary_size_hint(dict.len());
+    driver.reset_on_hc_lazy(CompressionLevel::Better);
+    assert!(
+        driver.dictionary_is_resident(),
+        "the second frame must re-borrow the resident dictionary"
+    );
+    assert_eq!(
+        driver.dictionary_retained_budget, 0,
+        "reset clears the retained-dict budget"
+    );
+    let inflated = driver.hc_matcher().table.max_window_size;
+    assert!(
+        inflated > base,
+        "reset re-inflates the window by the resident dict region \
+         (inflated={inflated}, base={base})"
+    );
+
+    driver.reapply_resident_dictionary([1, 4, 8]);
+    assert_eq!(
+        driver.dictionary_retained_budget,
+        inflated - base,
+        "resident reapply must restore the retained-dict budget (= window \
+         inflation) so the retire path can shrink the window as the dict evicts"
     );
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -802,43 +802,12 @@ const LEVEL_TABLE: [LevelParams; 22] = [
     /*22 */ LevelParams { strategy_tag: super::strategy::StrategyTag::BtUltra2, search: super::strategy::SearchMethod::BinaryTree, window_log: 27, lazy_depth: 2, fast: None, dfast: None, hc: Some(BTULTRA2_HC_CONFIG_L22), row: None },
 ];
 
-/// Upstream zstd `minSrcSize` assumption when building a dictionary's prepared cParams
-/// with an unknown source (`zstd_compress.c` `ZSTD_adjustCParams_internal`,
-/// `ZSTD_cpm_createCDict`: `if (dictSize && srcSize == UNKNOWN) srcSize =
-/// minSrcSize` where `minSrcSize = (1<<9) + 1`). Used by [`cdict_table_logs`].
-const DICT_MIN_SRC_SIZE: u64 = 513;
-
-/// Upstream zstd `ZSTD_dictAndWindowLog` (`zstd_compress.c`): the window log large
-/// enough to address both the source and the dictionary, used when downsizing
-/// the hash / chain logs for a dictionary-bearing compress. `window_log` is the
-/// (already source-clamped) compress window; `src_size` / `dict_size` are the
-/// assumed source and the dictionary length.
-fn dict_and_window_log(window_log: u8, src_size: u64, dict_size: u64) -> u32 {
-    if dict_size == 0 {
-        return window_log as u32;
-    }
-    let window_size: u64 = 1u64 << window_log;
-    // Plain `+` (matches upstream zstd `ZSTD_dictAndWindowLog`): `window_size` is
-    // `1 << window_log` (window_log <= 31) and dict/src are real data sizes
-    // (<= isize::MAX), so these u64 sums cannot overflow in practice.
-    let dict_and_window = dict_size + window_size;
-    if window_size >= dict_size + src_size {
-        // Window already covers source + dictionary.
-        window_log as u32
-    } else {
-        // ceil(log2(dictAndWindowSize)) = highbit32(x - 1) + 1.
-        source_size_ceil_log(dict_and_window) as u32
-    }
-}
-
-/// Upstream zstd `ZSTD_createCDict` table geometry: the `(hash_log, chain_log)` a
-/// dictionary's prepared match-finder tables get, mirroring
-/// `ZSTD_adjustCParams_internal` under `ZSTD_cpm_createCDict`. A dictionary
-/// supplies the long matches, so upstream zstd downsizes the table widths toward the
-/// dict-and-window log (assuming a `minSrcSize` source) while the live window
-/// stays source-sized. `window_log` is the resolved compress window; `hash_log`
-/// / `chain_log` are the level's own widths; `uses_bt` selects the binary-tree
-/// `cycleLog` (`chainLog - 1`) vs the hash-chain one (`chainLog`).
+/// Upstream `ZSTD_createCDict` table geometry: the `(hash_log, chain_log)` a
+/// dictionary's prepared match-finder tables get. Thin adapter over the single
+/// cParams source [`super::cparams::create_cdict_table_logs`], which mirrors
+/// `ZSTD_adjustCParams_internal` under `ZSTD_cpm_createCDict`. `window_log` is
+/// the resolved compress window; `hash_log` / `chain_log` are the level's own
+/// widths; `uses_bt` selects the binary-tree `cycleLog` (`chainLog - 1`).
 fn cdict_table_logs(
     window_log: u8,
     hash_log: usize,
@@ -846,30 +815,14 @@ fn cdict_table_logs(
     uses_bt: bool,
     dict_size: usize,
 ) -> (usize, usize) {
-    let dict_size = dict_size as u64;
-    // createCDict assumes a minSrcSize source when the real size is unknown.
-    let src_size = DICT_MIN_SRC_SIZE;
-    // Source-size window resize (upstream zstd caps windowLog by ceil_log2(src+dict)).
-    // Plain `+`: src_size is the tiny DICT_MIN_SRC_SIZE constant and dict_size
-    // is a real dictionary length, so the u64 sum cannot overflow.
-    let tsize = src_size + dict_size;
-    let resized_window_log = (window_log as u32)
-        .min(source_size_ceil_log(tsize) as u32)
-        .max(1);
-    let daw = dict_and_window_log(resized_window_log as u8, src_size, dict_size);
-    // `ZSTD_cycleLog(chainLog, strategy)`: chainLog - 1 for binary-tree finders.
-    let cycle_log = (chain_log as u32).saturating_sub(uses_bt as u32);
-    let new_hash_log = if hash_log as u32 > daw + 1 {
-        (daw + 1) as usize
-    } else {
-        hash_log
-    };
-    let new_chain_log = if cycle_log > daw {
-        chain_log.saturating_sub((cycle_log - daw) as usize)
-    } else {
-        chain_log
-    };
-    (new_hash_log, new_chain_log)
+    let (h, c) = super::cparams::create_cdict_table_logs(
+        window_log,
+        hash_log as u32,
+        chain_log as u32,
+        uses_bt,
+        dict_size,
+    );
+    (h as usize, c as usize)
 }
 
 /// Smallest window_log the encoder will use regardless of source size.
@@ -912,28 +865,31 @@ fn cparams_tier(source_size: Option<u64>) -> usize {
 /// switches (L2 tier 1, L4) are intentionally not applied here.
 fn apply_cparams_tier(level: i32, source_size: Option<u64>, p: &mut LevelParams) {
     let tier = cparams_tier(source_size);
+    // Single source for the table data: the verbatim upstream
+    // `ZSTD_defaultCParameters[tier][level]` row (`cparams::default_cparams`).
+    // The encoder consumes only the table-shaping widths here; the window /
+    // `table_log` clamp lives in `adjust_params_for_source_size`.
     match level {
         // Fast, all tiers — minMatch only (hashLog handled by the window clamp).
         1 => {
             if let Some(f) = p.fast.as_mut() {
-                f.mls = [7, 6, 6, 5][tier];
+                f.mls = super::cparams::default_cparams(tier, 1).min_match;
             }
         }
         // Fast (base strategy; tier 1 is dfast upstream — not switched here).
-        // (hashLog, minMatch) per tier from `clevels.h` level-2 rows.
         2 => {
             if let Some(f) = p.fast.as_mut() {
-                let (h, m) = [(16u32, 6u32), (14, 5), (15, 5), (15, 4)][tier];
-                f.hash_log = h;
-                f.mls = m;
+                let cp = super::cparams::default_cparams(tier, 2);
+                f.hash_log = cp.hash_log;
+                f.mls = cp.min_match;
             }
         }
-        // Dfast, all tiers — (long hashLog, short chainLog) per tier.
+        // Dfast, all tiers — long hashLog (`hash_log`) + short chainLog (`chain_log`).
         3 => {
             if let Some(d) = p.dfast.as_mut() {
-                let (l, s) = [(17u8, 16u8), (16, 16), (16, 15), (15, 14)][tier];
-                d.long_hash_log = l;
-                d.short_hash_log = s;
+                let cp = super::cparams::default_cparams(tier, 3);
+                d.long_hash_log = cp.hash_log as u8;
+                d.short_hash_log = cp.chain_log as u8;
             }
         }
         _ => {}

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1110,7 +1110,15 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
             });
             p
         }
-        CompressionLevel::Default => LEVEL_TABLE[2],
+        CompressionLevel::Default => {
+            // Default == Level(DEFAULT_LEVEL); tier it the same way an explicit
+            // positive level is, so hinted default compression shrinks its
+            // table widths on small / medium frames instead of keeping the
+            // tier-0 row (the oversized-table page-fault pathology).
+            let mut p = LEVEL_TABLE[CompressionLevel::DEFAULT_LEVEL as usize - 1];
+            apply_cparams_tier(CompressionLevel::DEFAULT_LEVEL, source_size, &mut p);
+            p
+        }
         CompressionLevel::Better => LEVEL_TABLE[6],
         // Level 13: the first dominant point of the deep-lazy band. The
         // mls-wide row key lifted the shallow band's ratio enough that
@@ -1138,8 +1146,11 @@ fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> Le
                 apply_cparams_tier(n, source_size, &mut p);
                 p
             } else if n == 0 {
-                // Level 0 = default, matching C zstd semantics.
-                LEVEL_TABLE[CompressionLevel::DEFAULT_LEVEL as usize - 1]
+                // Level 0 = default, matching C zstd semantics. Tier it like the
+                // `Default` alias so `Level(0)` and `Default` stay identical.
+                let mut p = LEVEL_TABLE[CompressionLevel::DEFAULT_LEVEL as usize - 1];
+                apply_cparams_tier(CompressionLevel::DEFAULT_LEVEL, source_size, &mut p);
+                p
             } else {
                 // Negative levels — upstream zstd sets
                 // targetLength = -level (clampedCompressionLevel),

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1247,6 +1247,12 @@ impl MatchTable {
         // compressor then SKIPs `prime_with_dictionary`. Only when the dict is
         // fully resident at concat `[0, region)` with no drain (`history_start
         // == 0`). Pinned at abs `[0, region)` (concat-keyed dms is abs-invariant).
+        //
+        // mls consistency: `dms.is_primed()` here is sufficient because the dms is
+        // keyed by `(region, layout, mls, hash_log)` and `configure()` invalidates
+        // it whenever `search_mls` changes (a level switch). So a primed dms is
+        // always one built with the CURRENT `search_mls`; the reborrow can never
+        // reuse a dms whose tables were built under a stale mls.
         let reborrow_region =
             if self.dictionary_active && self.dms.is_primed() && self.history_start == 0 {
                 self.dictionary_limit_abs

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1276,10 +1276,17 @@ impl MatchTable {
             // next frame's input both stay in the window — otherwise adding the
             // input drains the dict prefix and `history_abs_start` climbs off
             // it, turning every dms candidate into an out-of-range underflow.
-            // `self.max_window_size` is the un-bumped base `1 << window_log`
-            // (<= 2^30 < MAX_PRIMED_WINDOW_SIZE), so the headroom subtraction
-            // cannot underflow and the sum cannot overflow usize — no
-            // `saturating_*` needed.
+            //
+            // The driver re-establishes `self.max_window_size = 1 << window_log`
+            // (the un-bumped base) on EVERY reset, before this `reset` runs (see
+            // `MatchGeneratorDriver::reset`'s HashChain arm), so this `+=` yields
+            // `base + region` each frame, never an accumulating `base + N*region`.
+            // The driver also restores `dictionary_retained_budget = region` on
+            // the resident path (`reapply_resident_dictionary`) so the retire
+            // path shrinks this back to base as the dict evicts. The headroom
+            // subtraction is underflow-safe regardless of the pre-bump value: the
+            // `MAX_PRIMED_WINDOW_SIZE >= max_window_size` invariant always holds
+            // (every bump clamps to it), so `headroom >= 0` — no `saturating_*`.
             let headroom = MAX_PRIMED_WINDOW_SIZE - self.max_window_size;
             self.max_window_size += region.min(headroom);
             self.history_abs_start = 0;

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1255,8 +1255,14 @@ impl MatchTable {
         // reuse a dms whose tables were built under a stale mls.
         let reborrow_region =
             if self.dictionary_active && self.dms.is_primed() && self.history_start == 0 {
+                // `checked_sub`, not `-`: after the dict chunk is evicted,
+                // `compact_history` can reset `history_start` to 0 while
+                // `history_abs_start` has already advanced PAST
+                // `dictionary_limit_abs`. The plain subtraction would underflow
+                // (panic under overflow checks) before the `r > 0` filter rejects
+                // the stale region; `checked_sub` -> `None` lets the filter run.
                 self.dictionary_limit_abs
-                    .map(|limit| limit - self.history_abs_start)
+                    .and_then(|limit| limit.checked_sub(self.history_abs_start))
                     .filter(|&r| r > 0 && r <= self.history.len())
             } else {
                 None

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -52,6 +52,14 @@ pub(crate) const STREAM_ABS_HEADROOM: usize = HC_OPT_NUM + 16;
 /// cumulative input on a 32-bit build and is astronomically far on 64-bit.
 pub(crate) const REBASE_RESET_FLOOR_CEILING: usize = usize::MAX >> 1;
 
+/// Ceiling for `max_window_size` after a dictionary bump: the eviction band is
+/// `2 * max_window_size` and the kernel asserts `data.len() <= u32::MAX`, so a
+/// large dictionary must not push the doubled band (plus one pending block)
+/// past `u32::MAX`. Both `prime_with_dictionary` and the re-borrow reset clamp
+/// to this so the doubled-band-plus-block invariant survives.
+pub(crate) const MAX_PRIMED_WINDOW_SIZE: usize =
+    (u32::MAX as usize - crate::common::MAX_BLOCK_SIZE as usize) / 2;
+
 /// Frame-level overflow gate shared by `MatchTable`,
 /// `DfastMatchGenerator`, and `RowMatchGenerator`.
 ///
@@ -288,6 +296,20 @@ pub(crate) struct MatchTable {
     pub(crate) skip_insert_until_abs: usize,
     pub(crate) dictionary_limit_abs: Option<usize>,
     pub(crate) dictionary_primed_for_frame: bool,
+    /// Sticky across resets: set once a dictionary is primed into this table
+    /// (`set_dictionary_limit_from_primed_bytes` with a non-zero length),
+    /// cleared when the dictionary is detached. While set, `reset` takes the
+    /// full-reset path (rewind `history_abs_start` to 0 + clear the tables)
+    /// instead of the floor-advance fast path: a reused dictionary frame
+    /// re-primes the dict at the live `history_abs_start`, and letting that
+    /// floor climb frame-over-frame eventually pushes the freshly-primed dict
+    /// region below `window_low`, silently dropping every dict match (the
+    /// reused-CDict path then degrades to no-dict output after a few frames).
+    pub(crate) dictionary_active: bool,
+    /// Set by `reset` when it re-borrows a resident attach-mode dictionary
+    /// (kept the dict bytes + cached dms in place instead of clear + re-prime).
+    /// Signals the frame compressor to SKIP `prime_with_dictionary` this frame.
+    pub(crate) dict_resident: bool,
     pub(crate) allow_zero_relative_position: bool,
     /// HC chain-walk depth, mirrored from `HcMatcher::search_depth` during
     /// `configure()`. Stage D moves the BT walker onto this struct, and the
@@ -354,6 +376,8 @@ impl Clone for MatchTable {
             skip_insert_until_abs: self.skip_insert_until_abs,
             dictionary_limit_abs: self.dictionary_limit_abs,
             dictionary_primed_for_frame: self.dictionary_primed_for_frame,
+            dictionary_active: self.dictionary_active,
+            dict_resident: self.dict_resident,
             allow_zero_relative_position: self.allow_zero_relative_position,
             search_depth: self.search_depth,
             is_btultra2: self.is_btultra2,
@@ -389,6 +413,8 @@ impl Clone for MatchTable {
         self.skip_insert_until_abs = source.skip_insert_until_abs;
         self.dictionary_limit_abs = source.dictionary_limit_abs;
         self.dictionary_primed_for_frame = source.dictionary_primed_for_frame;
+        self.dictionary_active = source.dictionary_active;
+        self.dict_resident = source.dict_resident;
         self.allow_zero_relative_position = source.allow_zero_relative_position;
         self.search_depth = source.search_depth;
         self.is_btultra2 = source.is_btultra2;
@@ -397,6 +423,78 @@ impl Clone for MatchTable {
         self.borrowed_input = source.borrowed_input;
         self.borrowed_block = source.borrowed_block;
     }
+}
+
+/// Shared scaffold for the two `prime_dms_*` dictionary-match-state builders.
+///
+/// Both resolve the dict `region` (capped to the live history), bail on an
+/// undersized dict, derive the dict-sized hash log, short-circuit when a
+/// same-shape table is already primed, recycle the prior tables' capacity, run
+/// the layout-specific `$build` over the dict bytes at the front of the live
+/// history, then publish the tables and mark the cache primed. Only the build
+/// pass (HC single-link chain vs BT binary tree), the minimum readable region,
+/// and the chain entries per dict position differ — those are the macro
+/// parameters. `$build` sees `concat` (the dict bytes), `&mut` `hash_table` /
+/// `chain_table`, `dms_hash_log`, and `region` in scope; `mls` and any
+/// build-only widths come from the caller's surrounding locals.
+macro_rules! build_dms {
+    (
+        $self:ident, $region_len:expr, $layout:expr, $mls:expr, $min_region:expr, $per_pos:expr,
+        |$concat:ident, $ht:ident, $ct:ident, $hlog:ident, $region:ident| $build:block
+    ) => {{
+        let region = $region_len.min($self.live_history().len());
+        if region < $min_region {
+            $self.dms.invalidate();
+            return;
+        }
+        // Dict-sized hash log: ceil-log2(region) clamped to [10, hash_log].
+        let dms_hash_log =
+            (usize::BITS - (region - 1).leading_zeros()).clamp(10, $self.hash_log as u32) as usize;
+        // CDict cache: the tables depend only on the dict bytes (re-committed
+        // identically to the front of history every frame) and the
+        // (region, mls, hash_log) shape, so a primed same-shape table is valid
+        // as-is. A dictionary swap drops the cache via the invalidate path; a
+        // level change lands here with a different shape and rebuilds.
+        if $self.dms.is_primed()
+            && $self.dms.region_len() == region
+            && $self
+                .dms
+                .table()
+                .is_some_and(|t| t.layout == $layout && t.mls == $mls && t.hash_log == dms_hash_log)
+        {
+            return;
+        }
+        // Reuse the previous tables' capacity on a genuine rebuild (shape
+        // change): move the Vecs out before `live_history` re-borrows `self`.
+        let (mut hash_table, mut chain_table) = match $self.dms.table_mut() {
+            Some(t) => (
+                core::mem::take(&mut t.hash_table),
+                core::mem::take(&mut t.chain_table),
+            ),
+            None => (alloc::vec::Vec::new(), alloc::vec::Vec::new()),
+        };
+        hash_table.clear();
+        hash_table.resize(1usize << dms_hash_log, 0u32);
+        chain_table.clear();
+        chain_table.resize($per_pos * region, 0u32);
+        {
+            let $concat = $self.live_history();
+            let $ht = &mut hash_table;
+            let $ct = &mut chain_table;
+            let $hlog = dms_hash_log;
+            let $region = region;
+            $build
+        }
+        // `concat`'s borrow of `self` ends above; now mutate `self.dms`.
+        let tables = $self.dms.table_mut_or_init(DmsDictTables::default);
+        tables.layout = $layout;
+        tables.hash_table = hash_table;
+        tables.chain_table = chain_table;
+        tables.hash_log = dms_hash_log;
+        tables.mls = $mls;
+        $self.dms.set_region_len(region);
+        $self.dms.mark_primed();
+    }};
 }
 
 impl MatchTable {
@@ -421,6 +519,8 @@ impl MatchTable {
             skip_insert_until_abs: 0,
             dictionary_limit_abs: None,
             dictionary_primed_for_frame: false,
+            dictionary_active: false,
+            dict_resident: false,
             allow_zero_relative_position: false,
             search_depth: 0,
             is_btultra2: false,
@@ -676,6 +776,9 @@ impl MatchTable {
         } else {
             Some(self.history_abs_start.saturating_add(primed_len))
         };
+        // Sticky: once primed, every following reset must rewind to a clean
+        // base so the re-prime lands at a stable low `history_abs_start`.
+        self.dictionary_active = primed_len != 0;
     }
 
     /// Build the immutable dictionary match **binary tree** (upstream zstd
@@ -700,106 +803,70 @@ impl MatchTable {
         // not in the live tree), not a lower minMatch.
         let mls = self.search_mls;
         let read = if mls >= 5 { 8 } else { 4 };
-        let region = region_len.min(self.live_history().len());
-        if region < read {
-            self.dms.invalidate();
-            return;
-        }
-        // Dict-sized hash log: ceil-log2(region) clamped to [10, hash_log].
-        let dms_hash_log =
-            (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
-        // CDict cache: the tree depends only on the dict bytes (re-committed
-        // identically to the front of history every frame) and the
-        // (region, mls, hash_log) shape, so a primed same-shape table is
-        // valid as-is. Rebuilding per frame paid two table allocations AND a
-        // full tree-build pass per frame in a reused compressor. A dictionary
-        // swap drops the cache via `invalidate_primed_dictionary`; a level
-        // change lands here with a different shape and rebuilds.
-        if self.dms.is_primed()
-            && self.dms.region_len() == region
-            && self.dms.table().is_some_and(|t| {
-                t.layout == DmsDictLayout::Bt && t.mls == mls && t.hash_log == dms_hash_log
-            })
-        {
-            return;
-        }
         // Build-pass compare budget: the dict is bounded (<= window), so a
         // generous fixed depth keeps the tree well-ordered without the live
         // searchLog cap. Mirrors upstream zstd `ZSTD_insertBt1` nbCompares.
         const DMS_BUILD_DEPTH: usize = 1 << 9;
-        // Reuse the previous tables' capacity on a genuine rebuild (shape
-        // change): move the Vecs out before `live_history` re-borrows `self`.
-        let (mut hash_table, mut chain_table) = match self.dms.table_mut() {
-            Some(t) => (
-                core::mem::take(&mut t.hash_table),
-                core::mem::take(&mut t.chain_table),
-            ),
-            None => (Vec::new(), Vec::new()),
-        };
-        hash_table.clear();
-        hash_table.resize(1usize << dms_hash_log, 0u32);
         // 2 children per dict position: [smaller, larger].
-        chain_table.clear();
-        chain_table.resize(2 * region, 0u32);
-        let concat = self.live_history();
-        let mut current = 0usize;
-        while current + read <= region {
-            let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
-            // Insert `current` as the new root; splay the old tree into
-            // `current`'s smaller/larger subtrees (upstream zstd `ZSTD_insertBt1`).
-            let mut match_packed = hash_table[h];
-            hash_table[h] = (current + 1) as u32;
-            let mut smaller_slot = 2 * current;
-            let mut larger_slot = 2 * current + 1;
-            let mut common_smaller = 0usize;
-            let mut common_larger = 0usize;
-            let mut compares = DMS_BUILD_DEPTH;
-            while compares > 0 && match_packed != 0 {
-                let cand = (match_packed - 1) as usize;
-                // Tree holds only earlier positions; `cand < current` always.
-                if cand >= current {
-                    break;
-                }
-                compares -= 1;
-                let next_pair = 2 * cand;
-                let mut ml = common_smaller.min(common_larger);
-                // Common prefix bounded by the dict tail from `current`
-                // (`cand < current`, so `current` is the binding limit).
-                let limit = region - current;
-                while ml < limit && concat[cand + ml] == concat[current + ml] {
-                    ml += 1;
-                }
-                if current + ml >= region {
-                    // Reached the dict end: can't order this pair, stop (upstream zstd
-                    // `ip+matchLength == iend` break).
-                    break;
-                }
-                if concat[cand + ml] < concat[current + ml] {
-                    // `cand` (and its smaller subtree) sorts below `current`.
-                    chain_table[smaller_slot] = match_packed;
-                    common_smaller = ml;
-                    smaller_slot = next_pair + 1;
-                    match_packed = chain_table[next_pair + 1];
-                } else {
-                    chain_table[larger_slot] = match_packed;
-                    common_larger = ml;
-                    larger_slot = next_pair;
-                    match_packed = chain_table[next_pair];
+        build_dms!(
+            self,
+            region_len,
+            DmsDictLayout::Bt,
+            mls,
+            read,
+            2,
+            |concat, hash_table, chain_table, dms_hash_log, region| {
+                let mut current = 0usize;
+                while current + read <= region {
+                    let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
+                    // Insert `current` as the new root; splay the old tree into
+                    // `current`'s smaller/larger subtrees (upstream zstd `ZSTD_insertBt1`).
+                    let mut match_packed = hash_table[h];
+                    hash_table[h] = (current + 1) as u32;
+                    let mut smaller_slot = 2 * current;
+                    let mut larger_slot = 2 * current + 1;
+                    let mut common_smaller = 0usize;
+                    let mut common_larger = 0usize;
+                    let mut compares = DMS_BUILD_DEPTH;
+                    while compares > 0 && match_packed != 0 {
+                        let cand = (match_packed - 1) as usize;
+                        // Tree holds only earlier positions; `cand < current` always.
+                        if cand >= current {
+                            break;
+                        }
+                        compares -= 1;
+                        let next_pair = 2 * cand;
+                        let mut ml = common_smaller.min(common_larger);
+                        // Common prefix bounded by the dict tail from `current`
+                        // (`cand < current`, so `current` is the binding limit).
+                        let limit = region - current;
+                        while ml < limit && concat[cand + ml] == concat[current + ml] {
+                            ml += 1;
+                        }
+                        if current + ml >= region {
+                            // Reached the dict end: can't order this pair, stop
+                            // (upstream zstd `ip+matchLength == iend` break).
+                            break;
+                        }
+                        if concat[cand + ml] < concat[current + ml] {
+                            // `cand` (and its smaller subtree) sorts below `current`.
+                            chain_table[smaller_slot] = match_packed;
+                            common_smaller = ml;
+                            smaller_slot = next_pair + 1;
+                            match_packed = chain_table[next_pair + 1];
+                        } else {
+                            chain_table[larger_slot] = match_packed;
+                            common_larger = ml;
+                            larger_slot = next_pair;
+                            match_packed = chain_table[next_pair];
+                        }
+                    }
+                    chain_table[smaller_slot] = 0;
+                    chain_table[larger_slot] = 0;
+                    current += 1;
                 }
             }
-            chain_table[smaller_slot] = 0;
-            chain_table[larger_slot] = 0;
-            current += 1;
-        }
-        // `concat`'s borrow of `self` ends above; now mutate `self.dms`.
-        let tables = self.dms.table_mut_or_init(DmsDictTables::default);
-        tables.layout = DmsDictLayout::Bt;
-        tables.hash_table = hash_table;
-        tables.chain_table = chain_table;
-        tables.hash_log = dms_hash_log;
-        tables.mls = mls;
-        self.dms.set_region_len(region);
-        self.dms.mark_primed();
+        );
     }
 
     /// Build a SEPARATE dictionary match state for the lazy hash-chain path
@@ -817,51 +884,26 @@ impl MatchTable {
     /// chain. Cached across frames via `DictAttach::is_primed`.
     pub(crate) fn prime_dms_hc(&mut self, region_len: usize) {
         let mls = HC_MIN_MATCH_LEN;
-        let region = region_len.min(self.live_history().len());
-        if region < mls {
-            self.dms.invalidate();
-            return;
-        }
-        let dms_hash_log =
-            (usize::BITS - (region - 1).leading_zeros()).clamp(10, self.hash_log as u32) as usize;
-        if self.dms.is_primed()
-            && self.dms.region_len() == region
-            && self.dms.table().is_some_and(|t| {
-                t.layout == DmsDictLayout::Hc && t.mls == mls && t.hash_log == dms_hash_log
-            })
-        {
-            return;
-        }
-        let (mut hash_table, mut chain_table) = match self.dms.table_mut() {
-            Some(t) => (
-                core::mem::take(&mut t.hash_table),
-                core::mem::take(&mut t.chain_table),
-            ),
-            None => (Vec::new(), Vec::new()),
-        };
-        hash_table.clear();
-        hash_table.resize(1usize << dms_hash_log, 0u32);
         // Single `next` link per dict position (HC4 chain, not the BT's 2/pos).
-        chain_table.clear();
-        chain_table.resize(region, 0u32);
-        let concat = self.live_history();
-        let mut current = 0usize;
-        while current + mls <= region {
-            let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
-            // Prepend `current` to its bucket chain (upstream zstd
-            // `ZSTD_insertAndFindFirstIndex` head insert).
-            chain_table[current] = hash_table[h];
-            hash_table[h] = (current + 1) as u32;
-            current += 1;
-        }
-        let tables = self.dms.table_mut_or_init(DmsDictTables::default);
-        tables.layout = DmsDictLayout::Hc;
-        tables.hash_table = hash_table;
-        tables.chain_table = chain_table;
-        tables.hash_log = dms_hash_log;
-        tables.mls = mls;
-        self.dms.set_region_len(region);
-        self.dms.mark_primed();
+        build_dms!(
+            self,
+            region_len,
+            DmsDictLayout::Hc,
+            mls,
+            mls,
+            1,
+            |concat, hash_table, chain_table, dms_hash_log, region| {
+                let mut current = 0usize;
+                while current + mls <= region {
+                    let h = Self::hash_position_at(concat, current, dms_hash_log, mls);
+                    // Prepend `current` to its bucket chain (upstream zstd
+                    // `ZSTD_insertAndFindFirstIndex` head insert).
+                    chain_table[current] = hash_table[h];
+                    hash_table[h] = (current + 1) as u32;
+                    current += 1;
+                }
+            }
+        );
     }
 
     /// Append a freshly committed buffer to the rolling window. Drops
@@ -1199,20 +1241,88 @@ impl MatchTable {
         // position before clearing the history that `history_abs_end`
         // reads. Every stale table entry points strictly below this.
         let next_floor = self.history_abs_end();
+        // Re-borrow: an ATTACH-mode reused dict frame keeps the dict in the
+        // separate cached dms (not the live tables), so the resident dict bytes
+        // at the front of history + the cached dms can stay in place — the frame
+        // compressor then SKIPs `prime_with_dictionary`. Only when the dict is
+        // fully resident at concat `[0, region)` with no drain (`history_start
+        // == 0`). Pinned at abs `[0, region)` (concat-keyed dms is abs-invariant).
+        let reborrow_region =
+            if self.dictionary_active && self.dms.is_primed() && self.history_start == 0 {
+                self.dictionary_limit_abs
+                    .map(|limit| limit - self.history_abs_start)
+                    .filter(|&r| r > 0 && r <= self.history.len())
+            } else {
+                None
+            };
         self.window_size = 0;
-        self.chunk_lens.clear();
-        self.history.clear();
-        self.history_start = 0;
         self.offset_hist = [1, 4, 8];
         self.skip_insert_until_abs = 0;
         // Clear borrowed-window state so a following OWNED frame reads the
         // owned mirror; a borrowed frame re-arms via `set_borrowed_window`.
         self.borrowed_input = None;
         self.borrowed_block = None;
-        self.dictionary_limit_abs = None;
         self.dictionary_primed_for_frame = false;
         self.allow_zero_relative_position = false;
-        if next_floor <= REBASE_RESET_FLOOR_CEILING {
+        if let Some(region) = reborrow_region {
+            // Keep `[0, region)` (the dict); drop the previous frame's input.
+            self.history.truncate(region);
+            self.chunk_lens.clear();
+            self.chunk_lens.push_back(region);
+            self.window_size = region;
+            // Bump the eviction window by the dict size exactly as
+            // `prime_with_dictionary` does (clamped to MAX_PRIMED_WINDOW_SIZE so
+            // the doubled-band invariant survives), so the resident dict + the
+            // next frame's input both stay in the window — otherwise adding the
+            // input drains the dict prefix and `history_abs_start` climbs off
+            // it, turning every dms candidate into an out-of-range underflow.
+            // `self.max_window_size` is the un-bumped base `1 << window_log`
+            // (<= 2^30 < MAX_PRIMED_WINDOW_SIZE), so the headroom subtraction
+            // cannot underflow and the sum cannot overflow usize — no
+            // `saturating_*` needed.
+            let headroom = MAX_PRIMED_WINDOW_SIZE - self.max_window_size;
+            self.max_window_size += region.min(headroom);
+            self.history_abs_start = 0;
+            self.position_base = 0;
+            self.index_shift = 0;
+            // Dict is in the dms; the live tables carry only input — memset them,
+            // keep the dms. Cursors reproduce `skip_matching_dict_bt`'s post-prime
+            // state (skip re-inserting the resident dict region).
+            self.hash_table.fill(HC_EMPTY);
+            self.hash3_table.fill(HC_EMPTY);
+            self.chain_table.fill(HC_EMPTY);
+            self.skip_insert_until_abs = region;
+            self.next_to_update3 = region;
+            self.dictionary_limit_abs = Some(region);
+            self.dict_resident = true;
+            return;
+        }
+        self.chunk_lens.clear();
+        self.history.clear();
+        self.history_start = 0;
+        self.dictionary_limit_abs = None;
+        self.dict_resident = false;
+        if self.dictionary_active {
+            // A reused dictionary frame re-primes the dict at the live
+            // `history_abs_start` every frame. The floor-advance fast path lets
+            // that base climb frame-over-frame, and once it climbs past the
+            // window the freshly-primed dict region falls below `window_low`
+            // and every dict match is silently dropped (reused-CDict output
+            // degrades to no-dict after a few frames). Rewind to the origin and
+            // clear the tables so the next prime lands at a stable low base.
+            // The memset is load-bearing: the stored positions are relative to
+            // `position_base` / `index_shift`, so rewinding those without
+            // zeroing the slots leaves stale entries that decode as in-range
+            // matches and corrupt the parse (verified: skipping the fills
+            // reproduces the decay).
+            self.history_abs_start = 0;
+            self.position_base = 0;
+            self.index_shift = 0;
+            self.next_to_update3 = 0;
+            self.hash_table.fill(HC_EMPTY);
+            self.hash3_table.fill(HC_EMPTY);
+            self.chain_table.fill(HC_EMPTY);
+        } else if next_floor <= REBASE_RESET_FLOOR_CEILING {
             // Fast path: advance the floor so the previous frame's
             // entries fall below `window_low` and are rejected on read.
             // The tables keep their contents (and their sizing — a later

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -44,6 +44,7 @@
 
 pub(crate) mod block_header;
 pub(crate) mod blocks;
+pub(crate) mod cparams;
 pub(crate) mod dict_attach;
 pub(crate) mod fastpath;
 pub(crate) mod frame_header;
@@ -418,6 +419,16 @@ pub trait Matcher {
     /// Prime matcher state with dictionary history before compressing the next frame.
     /// Default implementation is a no-op for custom matchers that do not support this.
     fn prime_with_dictionary(&mut self, _dict_content: &[u8], _offset_hist: [u32; 3]) {}
+    /// Whether the most recent [`reset`](Self::reset) re-borrowed a resident
+    /// attach-mode dictionary (kept the dict bytes + cached index in place).
+    /// When `true` the caller MUST skip [`Self::prime_with_dictionary`] and only
+    /// reapply the offset history via [`Self::reapply_resident_dictionary`].
+    fn dictionary_is_resident(&self) -> bool {
+        false
+    }
+    /// Reapply the dictionary's offset history to a re-borrowed frame — the cheap
+    /// tail of priming, without the dict commit / re-index. Default no-op.
+    fn reapply_resident_dictionary(&mut self, _offset_hist: [u32; 3]) {}
     /// CDict-equivalent fast path for repeated frames sharing one dictionary.
     /// Restore the matcher state captured by [`Self::capture_primed_dictionary`]
     /// at the SAME level (a table copy) instead of re-running

--- a/zstd/src/encoding/mod.rs
+++ b/zstd/src/encoding/mod.rs
@@ -459,6 +459,14 @@ pub trait Matcher {
     fn supports_dictionary_priming(&self) -> bool {
         false
     }
+    /// Whether a sample of `block` hashes to a match in an attached dictionary.
+    /// The raw-fast-path uses this to avoid skipping the scan on a block that
+    /// looks incompressible but compresses against the dictionary (an external
+    /// match the block's own content cannot reveal). Defaults to `false` for
+    /// custom matchers (and the no-dict case), leaving the content-only verdict.
+    fn block_samples_match_dict(&self, _block: &[u8]) -> bool {
+        false
+    }
     /// Heap bytes this matcher's allocations hold (tables, history, scratch),
     /// excluding the inline struct itself. Lets a context report its true
     /// footprint via `ZSTD_sizeof_CCtx`. Defaults to `0` for custom matchers.

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -180,6 +180,32 @@ impl FastHashTable {
         }
     }
 
+    /// Construct without allocating the entry storage. Records the requested
+    /// `(hash_log, mls)` and validates them (so the deferred allocation is
+    /// feasible), but leaves `table` empty. The first per-frame reset sees the
+    /// source-size-clamped params and allocates once at the final size via
+    /// [`Self::new`] — avoiding the construct-at-level-default-then-realloc
+    /// churn (upstream zstd allocates its cwksp lazily at the resolved
+    /// `hashLog` for the same reason). [`Self::is_allocated`] reports whether
+    /// the storage exists yet; the matcher's reset path always allocates
+    /// before the kernel runs, so the hot path never observes the empty state.
+    pub(crate) fn new_deferred(hash_log: u32, mls: u32) -> Self {
+        validate_params(hash_log, mls);
+        Self {
+            table: Vec::new(),
+            hash_log,
+            mls,
+            bias: 0,
+        }
+    }
+
+    /// Whether the entry storage has been allocated. `false` only for a
+    /// [`Self::new_deferred`] table that has not yet been allocated by a reset.
+    #[inline(always)]
+    pub(crate) fn is_allocated(&self) -> bool {
+        !self.table.is_empty()
+    }
+
     #[inline(always)]
     pub(crate) fn hash_log(&self) -> u32 {
         self.hash_log

--- a/zstd/src/encoding/simple/fast_kernel/hash_table.rs
+++ b/zstd/src/encoding/simple/fast_kernel/hash_table.rs
@@ -311,6 +311,18 @@ impl FastHashTable {
         (self.table.as_mut_slice(), self.hash_log)
     }
 
+    /// Like [`hot_state`] but also exposes the epoch `bias`, so a hot loop on a
+    /// POSSIBLY-biased table (the dict-attach kernels) can hoist the backing
+    /// slice + `hash_log` and apply the bias inline — `slot.saturating_sub(bias)`
+    /// on read, `pos + bias` on write — exactly as [`get`]/[`put`] do, without
+    /// re-reading the `Vec` header / `hash_log` / `bias` through `&mut self` on
+    /// every access. On a bias-0 table this is identical to `hot_state` + raw
+    /// access (`saturating_sub(0)` / `+ 0` fold away).
+    #[inline(always)]
+    pub(crate) fn hot_state_biased(&mut self) -> (&mut [u32], u32, u32) {
+        (self.table.as_mut_slice(), self.hash_log, self.bias)
+    }
+
     /// Direct table access — `table[hash]`. Bounds-check at index time
     /// is provably redundant because `hash >> (64 - hash_log)` produces
     /// a value `< 1 << hash_log == table.len()`; LLVM cannot infer

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -80,14 +80,53 @@ const K_STEP_INCR: usize = 1 << (SEARCH_STRENGTH - 1);
 const HASH_READ_SIZE: usize = 8;
 
 /// Minimum length a DICTIONARY match must reach to be committed by the
-/// dict-aware (attach-mode) Fast kernel [`compress_block_fast_dict`]. Dict
-/// matches are inherently far (they reach back across the whole input into the
-/// dictionary region), so a short one inflates the offset-FSE alphabet for
-/// little payload gain; below this floor the kernel skips the dict match and
-/// lets the parse find a near (small-offset / repcode) match instead. Only
-/// applies to dict matches — main-table and repcode matches keep the 4-byte
-/// minimum.
-const MIN_DICT_MATCH_LEN: usize = 8;
+/// dict-aware (attach-mode) Fast kernel [`compress_block_fast_dict`]. Matches
+/// upstream zstd, which commits any dict match that passes the 4-byte
+/// `MEM_read32` check (`ZSTD_compressBlock_fast_dictMatchState_generic`,
+/// zstd_fast.c:580-581) with no extra length floor — a higher floor drops
+/// short dict matches the reference keeps, fragmenting them into literals and
+/// losing ratio on dictionary-primed Fast frames.
+const MIN_DICT_MATCH_LEN: usize = 4;
+
+/// Short-cache tag width for the dictionary hash table (upstream zstd
+/// `ZSTD_SHORT_CACHE_TAG_BITS`). Each dict slot packs `(position << TAG_BITS) |
+/// tag`, where `tag` is the low `TAG_BITS` of a `hashLog + TAG_BITS`-wide hash.
+/// On lookup the stored tag must equal the query tag, so two dict positions
+/// that collide into the same slot but carry different tags do NOT alias — the
+/// untagged variant would return whichever position happened to land in the
+/// slot and pick a different (worse) candidate than the reference.
+pub(crate) const DICT_TAG_BITS: u32 = 8;
+pub(crate) const DICT_TAG_MASK: u32 = (1 << DICT_TAG_BITS) - 1;
+
+/// Tagged dictionary-table lookup (upstream zstd
+/// `ZSTD_compressBlock_fast_dictMatchState_generic`, zstd_fast.c:546-548).
+/// Computes the `hashLog + DICT_TAG_BITS`-wide hash of `ptr`, indexes the slot
+/// (`hash >> DICT_TAG_BITS`, identical to the plain `hashLog` hash), and returns
+/// the stored dict position ONLY if the packed tag matches; otherwise `0` (the
+/// empty sentinel, which the caller's `dict_idx >= 1` gate rejects). `0` is also
+/// the never-filled sentinel because dict positions start at `1`.
+///
+/// # Safety
+/// `ptr` must have the readable-bytes context `hash_ptr_raw::<MLS>` requires.
+#[inline(always)]
+pub(crate) unsafe fn dict_tagged_lookup<const MLS: u32>(
+    dict_table: &FastHashTable,
+    ptr: *const u8,
+    dict_hash_log: u32,
+) -> u32 {
+    debug_assert!(
+        dict_hash_log + DICT_TAG_BITS <= 32,
+        "tagged dict hash overflows 32 bits"
+    );
+    let hash_and_tag = unsafe { hash_ptr_raw::<MLS>(ptr, dict_hash_log + DICT_TAG_BITS) };
+    // SAFETY: `hash_and_tag >> DICT_TAG_BITS` < `1 << dict_hash_log` = table len.
+    let stored = unsafe { dict_table.get(hash_and_tag >> DICT_TAG_BITS) };
+    if stored & DICT_TAG_MASK == hash_and_tag & DICT_TAG_MASK {
+        stored >> DICT_TAG_BITS
+    } else {
+        0
+    }
+}
 
 /// Upstream zstd's `MEM_read32(ptr)` — unaligned native-endian 4-byte load,
 /// used by the raw match probe on the hot path. The result is only
@@ -1080,6 +1119,10 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     let mut offset_1: u32 = rep[0];
     let mut offset_2: u32 = rep[1];
 
+    // Width of the dict table's slot index; the tagged lookup hashes to
+    // `dict_hash_log + DICT_TAG_BITS` bits and reads slot `hash >> DICT_TAG_BITS`.
+    let dict_hash_log = dict_table.hash_log();
+
     // Inner-loop result: literals end (where the match copy begins), the raw
     // match offset, the match length, and the upstream zstd `curr` (probe position,
     // for the post-match `curr + 2` fill). `None` → drain to cleanup.
@@ -1094,7 +1137,9 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
         // SAFETY: ip0 < ip1 <= ilimit = iend - 8 ⇒ ≥ 8 readable bytes at ip0.
         let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(base.add(ip0)) };
         let mut main_idx = unsafe { main_table.get(hash0) };
-        let mut dict_idx = unsafe { dict_table.get(hash0) };
+        // Tagged dict lookup (slot == plain `hash0`, tag from the wider hash).
+        let mut dict_idx =
+            unsafe { dict_tagged_lookup::<MLS>(dict_table, base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
@@ -1201,7 +1246,8 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
             }
 
             // Prepare next iteration (upstream zstd 616-630).
-            dict_idx = unsafe { dict_table.get(hash1) };
+            dict_idx =
+                unsafe { dict_tagged_lookup::<MLS>(dict_table, base.add(ip1), dict_hash_log) };
             main_idx = unsafe { main_table.get(hash1) };
             ip0 = ip1;
             ip1 += step_size;
@@ -1418,6 +1464,8 @@ fn compress_block_fast_dict_borrowed_impl<
     let mut offset_1: u32 = rep[0];
     let mut offset_2: u32 = rep[1];
 
+    let dict_hash_log = dict_table.hash_log();
+
     // Inner-loop result: literals end (input offset), raw match offset, match
     // length, and the upstream zstd `curr` probe offset for the post-match `curr + 2`
     // fill. `None` → drain to cleanup.
@@ -1432,7 +1480,8 @@ fn compress_block_fast_dict_borrowed_impl<
         // SAFETY: ip0 < ip1 <= ilimit = block_end - 8 ⇒ ≥ 8 readable bytes at ip0.
         let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
         let mut main_idx = unsafe { main_table.get(hash0) };
-        let mut dict_idx = unsafe { dict_table.get(hash0) };
+        let mut dict_idx =
+            unsafe { dict_tagged_lookup::<MLS>(dict_table, inp_base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
@@ -1572,7 +1621,8 @@ fn compress_block_fast_dict_borrowed_impl<
             }
 
             // Prepare next iteration.
-            dict_idx = unsafe { dict_table.get(hash1) };
+            dict_idx =
+                unsafe { dict_tagged_lookup::<MLS>(dict_table, inp_base.add(ip1), dict_hash_log) };
             main_idx = unsafe { main_table.get(hash1) };
             ip0 = ip1;
             ip1 += step_size;
@@ -2504,9 +2554,16 @@ mod tests {
         let mut main_table = FastHashTable::new(hash_log, MLS);
         let mut dict_table = FastHashTable::new(hash_log, MLS);
         for pos in 0..=dict.len() - HASH_READ_SIZE {
-            // SAFETY: pos + 8 <= dict.len(); MLS matches the table.
-            let h = unsafe { dict_table.hash_ptr::<MLS>(dict.as_ptr().add(pos)) };
-            unsafe { dict_table.put(h, pos as u32) };
+            // SAFETY: pos + 8 <= dict.len(); MLS matches the table. Tagged
+            // entry format (slot + tag), matching the kernel's tagged lookup.
+            let hat =
+                unsafe { hash_ptr_raw::<MLS>(dict.as_ptr().add(pos), hash_log + DICT_TAG_BITS) };
+            unsafe {
+                dict_table.put(
+                    hat >> DICT_TAG_BITS,
+                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
+                )
+            };
         }
 
         let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1122,6 +1122,16 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     // Width of the dict table's slot index; the tagged lookup hashes to
     // `dict_hash_log + DICT_TAG_BITS` bits and reads slot `hash >> DICT_TAG_BITS`.
     let dict_hash_log = dict_table.hash_log();
+    // Always-on (not debug_assert): `dict_tagged_lookup` reads the slot with an
+    // UNCHECKED `FastHashTable::get`, sound only while `hash >> DICT_TAG_BITS <
+    // 1 << dict_hash_log`, which requires `dict_hash_log + DICT_TAG_BITS <= 32`
+    // (else the wider hash overflows and the shifted index can exceed the table
+    // length -> OOB read). Enforce it once per block here so the hot per-probe
+    // path stays branchless while release builds still trap an out-of-spec table.
+    assert!(
+        dict_hash_log + DICT_TAG_BITS <= 32,
+        "dict hash_log {dict_hash_log} + tag {DICT_TAG_BITS} exceeds 32-bit hash width",
+    );
 
     // Inner-loop result: literals end (where the match copy begins), the raw
     // match offset, the match length, and the upstream zstd `curr` (probe position,
@@ -1465,6 +1475,13 @@ fn compress_block_fast_dict_borrowed_impl<
     let mut offset_2: u32 = rep[1];
 
     let dict_hash_log = dict_table.hash_log();
+    // Always-on bound for the unchecked tagged-lookup read (see the owned dict
+    // kernel for the full rationale): `dict_hash_log + DICT_TAG_BITS <= 32` keeps
+    // the shifted slot index inside the table in release builds too.
+    assert!(
+        dict_hash_log + DICT_TAG_BITS <= 32,
+        "dict hash_log {dict_hash_log} + tag {DICT_TAG_BITS} exceeds 32-bit hash width",
+    );
 
     // Inner-loop result: literals end (input offset), raw match offset, match
     // length, and the upstream zstd `curr` probe offset for the post-match `curr + 2`

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1130,9 +1130,18 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     let mut offset_2: u32 = rep[1];
 
     // Slot width for the dict table: `dict_lookup` hashes `ptr` to
-    // `dict_hash_log` bits and reads that slot, always in bounds (the table
-    // length is `1 << dict_hash_log`).
+    // `dict_hash_log + DICT_TAG_BITS` bits — the high `dict_hash_log` select the
+    // slot (table length `1 << dict_hash_log`), the low `DICT_TAG_BITS` are the
+    // collision tag. That hash is only well-defined while the total width fits 32
+    // bits, so guard it here (always-on, not debug_assert): these safe kernels
+    // accept any `FastHashTable::new` shape, and a `hash_log > 24` dict table
+    // would otherwise reach an out-of-range slot in release.
     let dict_hash_log = dict_table.hash_log();
+    assert!(
+        dict_hash_log + DICT_TAG_BITS <= 32,
+        "tagged Fast dict lookup requires dict hash_log <= {} (got {dict_hash_log})",
+        32 - DICT_TAG_BITS,
+    );
     // Hoist the main table's backing slice + hash_log + epoch bias into locals
     // so the hot loop's hash/get/put avoid re-reading the `Vec` header / the
     // `hash_log` / `bias` field through `&mut FastHashTable` on every access (the
@@ -1483,7 +1492,16 @@ fn compress_block_fast_dict_borrowed_impl<
     let mut offset_1: u32 = rep[0];
     let mut offset_2: u32 = rep[1];
 
+    // Same tagged-lookup width guard as the owned kernel: `dict_lookup` hashes to
+    // `dict_hash_log + DICT_TAG_BITS` bits, well-defined only while that fits 32
+    // bits. Always-on (not debug_assert) — a `hash_log > 24` dict table would
+    // reach an out-of-range slot in release otherwise.
     let dict_hash_log = dict_table.hash_log();
+    assert!(
+        dict_hash_log + DICT_TAG_BITS <= 32,
+        "tagged Fast dict lookup requires dict hash_log <= {} (got {dict_hash_log})",
+        32 - DICT_TAG_BITS,
+    );
     // Hoist the main table's backing slice + hash_log + epoch bias into locals so
     // the hot loop avoids re-reading the `Vec` header / `hash_log` / `bias`
     // through `&mut FastHashTable` on every access; bias is applied inline exactly

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -80,52 +80,38 @@ const K_STEP_INCR: usize = 1 << (SEARCH_STRENGTH - 1);
 const HASH_READ_SIZE: usize = 8;
 
 /// Minimum length a DICTIONARY match must reach to be committed by the
-/// dict-aware (attach-mode) Fast kernel [`compress_block_fast_dict`]. Matches
-/// upstream zstd, which commits any dict match that passes the 4-byte
-/// `MEM_read32` check (`ZSTD_compressBlock_fast_dictMatchState_generic`,
-/// zstd_fast.c:580-581) with no extra length floor — a higher floor drops
-/// short dict matches the reference keeps, fragmenting them into literals and
-/// losing ratio on dictionary-primed Fast frames.
-const MIN_DICT_MATCH_LEN: usize = 4;
+/// dict-aware (attach-mode) Fast kernel [`compress_block_fast_dict`]. A
+/// dictionary match reaches back across the whole input into the dictionary
+/// region, so its offset is inherently large — a SHORT one inflates the
+/// offset-code FSE alphabet (a single far offset forces the table to span up to
+/// its high code) for little literal saving, and can make a dict frame larger
+/// than the no-dict frame. Below this floor the kernel skips the dict match and
+/// lets the parse find a near (small-offset / repcode) match instead. Only
+/// dictionary matches carry this floor; main-table and repcode matches keep the
+/// 4-byte minimum. (Upstream zstd commits any 4-byte dict match, but it is not
+/// chasing byte-identity — we make our own match decisions where they improve
+/// the ratio, per the drop-in-not-binary-parity contract.)
+const MIN_DICT_MATCH_LEN: usize = 8;
 
-/// Short-cache tag width for the dictionary hash table (upstream zstd
-/// `ZSTD_SHORT_CACHE_TAG_BITS`). Each dict slot packs `(position << TAG_BITS) |
-/// tag`, where `tag` is the low `TAG_BITS` of a `hashLog + TAG_BITS`-wide hash.
-/// On lookup the stored tag must equal the query tag, so two dict positions
-/// that collide into the same slot but carry different tags do NOT alias — the
-/// untagged variant would return whichever position happened to land in the
-/// slot and pick a different (worse) candidate than the reference.
-pub(crate) const DICT_TAG_BITS: u32 = 8;
-pub(crate) const DICT_TAG_MASK: u32 = (1 << DICT_TAG_BITS) - 1;
-
-/// Tagged dictionary-table lookup (upstream zstd
+/// Dictionary-table lookup (upstream zstd
 /// `ZSTD_compressBlock_fast_dictMatchState_generic`, zstd_fast.c:546-548).
-/// Computes the `hashLog + DICT_TAG_BITS`-wide hash of `ptr`, indexes the slot
-/// (`hash >> DICT_TAG_BITS`, identical to the plain `hashLog` hash), and returns
-/// the stored dict position ONLY if the packed tag matches; otherwise `0` (the
-/// empty sentinel, which the caller's `dict_idx >= 1` gate rejects). `0` is also
-/// the never-filled sentinel because dict positions start at `1`.
+/// Hashes `ptr` to `dict_hash_log` bits and returns the stored dict position
+/// for that slot. `0` is the never-filled sentinel (dict positions start at
+/// `1`), which the caller's `dict_idx >= 1` gate rejects. The caller byte-checks
+/// the candidate with `MEM_read32` before committing, so a hash collision is a
+/// cheap reject rather than a wrong match.
 ///
 /// # Safety
 /// `ptr` must have the readable-bytes context `hash_ptr_raw::<MLS>` requires.
 #[inline(always)]
-pub(crate) unsafe fn dict_tagged_lookup<const MLS: u32>(
+pub(crate) unsafe fn dict_lookup<const MLS: u32>(
     dict_table: &FastHashTable,
     ptr: *const u8,
     dict_hash_log: u32,
 ) -> u32 {
-    debug_assert!(
-        dict_hash_log + DICT_TAG_BITS <= 32,
-        "tagged dict hash overflows 32 bits"
-    );
-    let hash_and_tag = unsafe { hash_ptr_raw::<MLS>(ptr, dict_hash_log + DICT_TAG_BITS) };
-    // SAFETY: `hash_and_tag >> DICT_TAG_BITS` < `1 << dict_hash_log` = table len.
-    let stored = unsafe { dict_table.get(hash_and_tag >> DICT_TAG_BITS) };
-    if stored & DICT_TAG_MASK == hash_and_tag & DICT_TAG_MASK {
-        stored >> DICT_TAG_BITS
-    } else {
-        0
-    }
+    let h = unsafe { hash_ptr_raw::<MLS>(ptr, dict_hash_log) };
+    // SAFETY: `h` < `1 << dict_hash_log` = table len.
+    unsafe { dict_table.get(h) }
 }
 
 /// Upstream zstd's `MEM_read32(ptr)` — unaligned native-endian 4-byte load,
@@ -1119,19 +1105,10 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     let mut offset_1: u32 = rep[0];
     let mut offset_2: u32 = rep[1];
 
-    // Width of the dict table's slot index; the tagged lookup hashes to
-    // `dict_hash_log + DICT_TAG_BITS` bits and reads slot `hash >> DICT_TAG_BITS`.
+    // Slot width for the dict table: `dict_lookup` hashes `ptr` to
+    // `dict_hash_log` bits and reads that slot, always in bounds (the table
+    // length is `1 << dict_hash_log`).
     let dict_hash_log = dict_table.hash_log();
-    // Always-on (not debug_assert): `dict_tagged_lookup` reads the slot with an
-    // UNCHECKED `FastHashTable::get`, sound only while `hash >> DICT_TAG_BITS <
-    // 1 << dict_hash_log`, which requires `dict_hash_log + DICT_TAG_BITS <= 32`
-    // (else the wider hash overflows and the shifted index can exceed the table
-    // length -> OOB read). Enforce it once per block here so the hot per-probe
-    // path stays branchless while release builds still trap an out-of-spec table.
-    assert!(
-        dict_hash_log + DICT_TAG_BITS <= 32,
-        "dict hash_log {dict_hash_log} + tag {DICT_TAG_BITS} exceeds 32-bit hash width",
-    );
 
     // Inner-loop result: literals end (where the match copy begins), the raw
     // match offset, the match length, and the upstream zstd `curr` (probe position,
@@ -1147,9 +1124,7 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
         // SAFETY: ip0 < ip1 <= ilimit = iend - 8 ⇒ ≥ 8 readable bytes at ip0.
         let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(base.add(ip0)) };
         let mut main_idx = unsafe { main_table.get(hash0) };
-        // Tagged dict lookup (slot == plain `hash0`, tag from the wider hash).
-        let mut dict_idx =
-            unsafe { dict_tagged_lookup::<MLS>(dict_table, base.add(ip0), dict_hash_log) };
+        let mut dict_idx = unsafe { dict_lookup::<MLS>(dict_table, base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
@@ -1256,8 +1231,7 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
             }
 
             // Prepare next iteration (upstream zstd 616-630).
-            dict_idx =
-                unsafe { dict_tagged_lookup::<MLS>(dict_table, base.add(ip1), dict_hash_log) };
+            dict_idx = unsafe { dict_lookup::<MLS>(dict_table, base.add(ip1), dict_hash_log) };
             main_idx = unsafe { main_table.get(hash1) };
             ip0 = ip1;
             ip1 += step_size;
@@ -1475,13 +1449,6 @@ fn compress_block_fast_dict_borrowed_impl<
     let mut offset_2: u32 = rep[1];
 
     let dict_hash_log = dict_table.hash_log();
-    // Always-on bound for the unchecked tagged-lookup read (see the owned dict
-    // kernel for the full rationale): `dict_hash_log + DICT_TAG_BITS <= 32` keeps
-    // the shifted slot index inside the table in release builds too.
-    assert!(
-        dict_hash_log + DICT_TAG_BITS <= 32,
-        "dict hash_log {dict_hash_log} + tag {DICT_TAG_BITS} exceeds 32-bit hash width",
-    );
 
     // Inner-loop result: literals end (input offset), raw match offset, match
     // length, and the upstream zstd `curr` probe offset for the post-match `curr + 2`
@@ -1498,7 +1465,7 @@ fn compress_block_fast_dict_borrowed_impl<
         let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
         let mut main_idx = unsafe { main_table.get(hash0) };
         let mut dict_idx =
-            unsafe { dict_tagged_lookup::<MLS>(dict_table, inp_base.add(ip0), dict_hash_log) };
+            unsafe { dict_lookup::<MLS>(dict_table, inp_base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
@@ -1638,8 +1605,7 @@ fn compress_block_fast_dict_borrowed_impl<
             }
 
             // Prepare next iteration.
-            dict_idx =
-                unsafe { dict_tagged_lookup::<MLS>(dict_table, inp_base.add(ip1), dict_hash_log) };
+            dict_idx = unsafe { dict_lookup::<MLS>(dict_table, inp_base.add(ip1), dict_hash_log) };
             main_idx = unsafe { main_table.get(hash1) };
             ip0 = ip1;
             ip1 += step_size;
@@ -2571,16 +2537,11 @@ mod tests {
         let mut main_table = FastHashTable::new(hash_log, MLS);
         let mut dict_table = FastHashTable::new(hash_log, MLS);
         for pos in 0..=dict.len() - HASH_READ_SIZE {
-            // SAFETY: pos + 8 <= dict.len(); MLS matches the table. Tagged
-            // entry format (slot + tag), matching the kernel's tagged lookup.
-            let hat =
-                unsafe { hash_ptr_raw::<MLS>(dict.as_ptr().add(pos), hash_log + DICT_TAG_BITS) };
-            unsafe {
-                dict_table.put(
-                    hat >> DICT_TAG_BITS,
-                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
-                )
-            };
+            // SAFETY: pos + 8 <= dict.len(); MLS matches the table. Plain
+            // every-position last-wins fill, matching the kernel's untagged
+            // dict lookup.
+            let h = unsafe { hash_ptr_raw::<MLS>(dict.as_ptr().add(pos), hash_log) };
+            unsafe { dict_table.put(h, pos as u32) };
         }
 
         let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1109,6 +1109,13 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     // `dict_hash_log` bits and reads that slot, always in bounds (the table
     // length is `1 << dict_hash_log`).
     let dict_hash_log = dict_table.hash_log();
+    // Hoist the main table's backing slice + hash_log + epoch bias into locals
+    // so the hot loop's hash/get/put avoid re-reading the `Vec` header / the
+    // `hash_log` / `bias` field through `&mut FastHashTable` on every access (the
+    // "chases the Vec" reload). The dict kernel runs on a POSSIBLY-biased table,
+    // so the bias is applied inline (`saturating_sub` on read, `+ bias` on write)
+    // exactly as `FastHashTable::get`/`put` do — byte-identical, reload-free.
+    let (main_tbl, main_hlog, main_bias) = main_table.hot_state_biased();
 
     // Inner-loop result: literals end (where the match copy begins), the raw
     // match offset, the match length, and the upstream zstd `curr` (probe position,
@@ -1122,16 +1129,17 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
 
     'outer: while ip1 <= ilimit {
         // SAFETY: ip0 < ip1 <= ilimit = iend - 8 ⇒ ≥ 8 readable bytes at ip0.
-        let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(base.add(ip0)) };
-        let mut main_idx = unsafe { main_table.get(hash0) };
+        let mut hash0 = unsafe { hash_ptr_raw::<MLS>(base.add(ip0), main_hlog) };
+        let mut main_idx =
+            unsafe { (*main_tbl.get_unchecked(hash0 as usize)).saturating_sub(main_bias) };
         let mut dict_idx = unsafe { dict_lookup::<MLS>(dict_table, base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
             // SAFETY: ip1 <= ilimit ⇒ ≥ 8 readable bytes at ip1.
-            let hash1 = unsafe { main_table.hash_ptr::<MLS>(base.add(ip1)) };
+            let hash1 = unsafe { hash_ptr_raw::<MLS>(base.add(ip1), main_hlog) };
             // Insert current position into the MAIN table (upstream zstd line 565).
-            unsafe { main_table.put(hash0, curr as u32) };
+            unsafe { *main_tbl.get_unchecked_mut(hash0 as usize) = curr as u32 + main_bias };
 
             // Repcode probe for a match starting at ip0 + 1 (upstream zstd 559-574).
             if offset_1 > 0 && curr + 1 >= offset_1 as usize + window_low {
@@ -1232,7 +1240,8 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
 
             // Prepare next iteration (upstream zstd 616-630).
             dict_idx = unsafe { dict_lookup::<MLS>(dict_table, base.add(ip1), dict_hash_log) };
-            main_idx = unsafe { main_table.get(hash1) };
+            main_idx =
+                unsafe { (*main_tbl.get_unchecked(hash1 as usize)).saturating_sub(main_bias) };
             ip0 = ip1;
             ip1 += step_size;
             if ip1 > ilimit {
@@ -1257,12 +1266,14 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
         if ip0 <= ilimit {
             // Post-match dense fills (upstream zstd 641-642).
             if m.curr + 2 + HASH_READ_SIZE <= iend_addr {
-                let h = unsafe { main_table.hash_ptr::<MLS>(base.add(m.curr + 2)) };
-                unsafe { main_table.put(h, (m.curr + 2) as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(base.add(m.curr + 2), main_hlog) };
+                unsafe {
+                    *main_tbl.get_unchecked_mut(h as usize) = (m.curr + 2) as u32 + main_bias
+                };
             }
             if ip0 >= 2 {
-                let h = unsafe { main_table.hash_ptr::<MLS>(base.add(ip0 - 2)) };
-                unsafe { main_table.put(h, (ip0 - 2) as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(base.add(ip0 - 2), main_hlog) };
+                unsafe { *main_tbl.get_unchecked_mut(h as usize) = (ip0 - 2) as u32 + main_bias };
             }
             // Immediate repcode-2 loop (upstream zstd 644-663).
             while ip0 <= ilimit
@@ -1279,8 +1290,8 @@ pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
                     )
                 };
                 core::mem::swap(&mut offset_1, &mut offset_2);
-                let h = unsafe { main_table.hash_ptr::<MLS>(base.add(ip0)) };
-                unsafe { main_table.put(h, ip0 as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(base.add(ip0), main_hlog) };
+                unsafe { *main_tbl.get_unchecked_mut(h as usize) = ip0 as u32 + main_bias };
                 handle_sequence(Sequence::Triple {
                     literals: &data[anchor..ip0],
                     offset: r_off,
@@ -1449,6 +1460,11 @@ fn compress_block_fast_dict_borrowed_impl<
     let mut offset_2: u32 = rep[1];
 
     let dict_hash_log = dict_table.hash_log();
+    // Hoist the main table's backing slice + hash_log + epoch bias into locals so
+    // the hot loop avoids re-reading the `Vec` header / `hash_log` / `bias`
+    // through `&mut FastHashTable` on every access; bias is applied inline exactly
+    // as `get`/`put` do (matches the owned dict kernel).
+    let (main_tbl, main_hlog, main_bias) = main_table.hot_state_biased();
 
     // Inner-loop result: literals end (input offset), raw match offset, match
     // length, and the upstream zstd `curr` probe offset for the post-match `curr + 2`
@@ -1462,18 +1478,19 @@ fn compress_block_fast_dict_borrowed_impl<
 
     'outer: while ip1 <= ilimit {
         // SAFETY: ip0 < ip1 <= ilimit = block_end - 8 ⇒ ≥ 8 readable bytes at ip0.
-        let mut hash0 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
-        let mut main_idx = unsafe { main_table.get(hash0) };
+        let mut hash0 = unsafe { hash_ptr_raw::<MLS>(inp_base.add(ip0), main_hlog) };
+        let mut main_idx =
+            unsafe { (*main_tbl.get_unchecked(hash0 as usize)).saturating_sub(main_bias) };
         let mut dict_idx =
             unsafe { dict_lookup::<MLS>(dict_table, inp_base.add(ip0), dict_hash_log) };
         let mut curr = ip0;
 
         let found: Option<DictMatch> = loop {
             // SAFETY: ip1 <= ilimit ⇒ ≥ 8 readable bytes at ip1.
-            let hash1 = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip1)) };
+            let hash1 = unsafe { hash_ptr_raw::<MLS>(inp_base.add(ip1), main_hlog) };
             let cur_abs = dict_end + curr;
             // Insert current virtual position into the MAIN table.
-            unsafe { main_table.put(hash0, cur_abs as u32) };
+            unsafe { *main_tbl.get_unchecked_mut(hash0 as usize) = cur_abs as u32 + main_bias };
 
             // Repcode probe for a match starting at curr + 1. The rep candidate
             // may sit in the dict (offsets primed from the dictionary's
@@ -1606,7 +1623,8 @@ fn compress_block_fast_dict_borrowed_impl<
 
             // Prepare next iteration.
             dict_idx = unsafe { dict_lookup::<MLS>(dict_table, inp_base.add(ip1), dict_hash_log) };
-            main_idx = unsafe { main_table.get(hash1) };
+            main_idx =
+                unsafe { (*main_tbl.get_unchecked(hash1 as usize)).saturating_sub(main_bias) };
             ip0 = ip1;
             ip1 += step_size;
             if ip1 > ilimit {
@@ -1631,12 +1649,18 @@ fn compress_block_fast_dict_borrowed_impl<
         if ip0 <= ilimit {
             // Post-match dense fills (virtual positions).
             if m.curr + 2 + HASH_READ_SIZE <= block_end {
-                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(m.curr + 2)) };
-                unsafe { main_table.put(h, (dict_end + m.curr + 2) as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(inp_base.add(m.curr + 2), main_hlog) };
+                unsafe {
+                    *main_tbl.get_unchecked_mut(h as usize) =
+                        (dict_end + m.curr + 2) as u32 + main_bias
+                };
             }
             if ip0 >= 2 {
-                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0 - 2)) };
-                unsafe { main_table.put(h, (dict_end + ip0 - 2) as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(inp_base.add(ip0 - 2), main_hlog) };
+                unsafe {
+                    *main_tbl.get_unchecked_mut(h as usize) =
+                        (dict_end + ip0 - 2) as u32 + main_bias
+                };
             }
             // Immediate repcode-2 loop. The rep candidate may straddle into the
             // dict; `borrowed_candidate_len` routes it.
@@ -1653,8 +1677,10 @@ fn compress_block_fast_dict_borrowed_impl<
                 }
                 let r_off = offset_2 as usize;
                 core::mem::swap(&mut offset_1, &mut offset_2);
-                let h = unsafe { main_table.hash_ptr::<MLS>(inp_base.add(ip0)) };
-                unsafe { main_table.put(h, (dict_end + ip0) as u32) };
+                let h = unsafe { hash_ptr_raw::<MLS>(inp_base.add(ip0), main_hlog) };
+                unsafe {
+                    *main_tbl.get_unchecked_mut(h as usize) = (dict_end + ip0) as u32 + main_bias
+                };
                 handle_sequence(Sequence::Triple {
                     literals: &inp[anchor..ip0],
                     offset: r_off,

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -1071,11 +1071,13 @@ pub(crate) fn compress_block_fast<const MLS: u32, const USE_CMOV: bool>(
 /// `[dict][output]` window), so a dict-match offset is `ip - dict_pos` like any
 /// in-window match and match counts cross the dict→input boundary freely (no
 /// `ZSTD_count_2segments`, no `dictBase`/`dictIndexDelta`). `dict_table` stores
-/// plain positions (no upstream zstd short-cache tags); `main_table` holds ONLY frame-
-/// input positions. Search order mirrors the upstream zstd: rep@ip0+1 → dict (only when
-/// the main candidate is invalid) → main. Correctness is independent of table
-/// contents (every match byte-verified + bounds-guarded); `MIN_DICT_MATCH_LEN`
-/// gates short far dict matches that would fragment the offset-FSE alphabet.
+/// short-cache tagged positions (`(position << DICT_TAG_BITS) | tag`, upstream
+/// zstd `ZSTD_SHORT_CACHE` — the tag rejects a colliding slot without a wasted
+/// candidate load); `main_table` holds ONLY frame-input positions. Search order
+/// mirrors the upstream zstd: rep@ip0+1 → dict (only when the main candidate is
+/// invalid) → main. Correctness is independent of table contents (every match
+/// byte-verified + bounds-guarded); `MIN_DICT_MATCH_LEN` gates short far dict
+/// matches that would fragment the offset-FSE alphabet.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn compress_block_fast_dict<const MLS: u32, const USE_CMOV: bool>(
     data: &[u8],

--- a/zstd/src/encoding/simple/fast_kernel/kernel.rs
+++ b/zstd/src/encoding/simple/fast_kernel/kernel.rs
@@ -93,25 +93,47 @@ const HASH_READ_SIZE: usize = 8;
 /// the ratio, per the drop-in-not-binary-parity contract.)
 const MIN_DICT_MATCH_LEN: usize = 8;
 
-/// Dictionary-table lookup (upstream zstd
+/// Short-cache tag width for the dictionary hash table (upstream zstd
+/// `ZSTD_SHORT_CACHE_TAG_BITS`). Each dict slot packs `(position << TAG_BITS) |
+/// tag`, where `tag` is the low `TAG_BITS` of a `hashLog + TAG_BITS`-wide hash.
+/// On lookup the stored tag must equal the query tag, so a colliding dict
+/// position with a different tag is rejected WITHOUT the candidate load + 4-byte
+/// `MEM_read32` the untagged variant pays on every collision — a speed win on
+/// the dict-probe hot path. The slot index `hash >> TAG_BITS` is identical to
+/// the plain `hashLog` hash, so tagging does not change which slot a position
+/// lands in (only adds the collision-reject), keeping the every-position
+/// last-wins fill's nearest-occurrence guarantee intact.
+pub(crate) const DICT_TAG_BITS: u32 = 8;
+pub(crate) const DICT_TAG_MASK: u32 = (1 << DICT_TAG_BITS) - 1;
+
+/// Tagged dictionary-table lookup (upstream zstd
 /// `ZSTD_compressBlock_fast_dictMatchState_generic`, zstd_fast.c:546-548).
-/// Hashes `ptr` to `dict_hash_log` bits and returns the stored dict position
-/// for that slot. `0` is the never-filled sentinel (dict positions start at
-/// `1`), which the caller's `dict_idx >= 1` gate rejects. The caller byte-checks
-/// the candidate with `MEM_read32` before committing, so a hash collision is a
-/// cheap reject rather than a wrong match.
+/// Hashes `ptr` to `dict_hash_log + DICT_TAG_BITS` bits, reads slot
+/// `hash >> DICT_TAG_BITS` (== the plain `dict_hash_log` hash), and returns the
+/// stored dict position ONLY if the packed tag matches; otherwise `0` (the
+/// never-filled sentinel — dict positions start at `1`, and the caller's
+/// `dict_idx >= 1` gate rejects it). The tag check rejects collisions without a
+/// candidate load.
 ///
 /// # Safety
-/// `ptr` must have the readable-bytes context `hash_ptr_raw::<MLS>` requires.
+/// `ptr` must have the readable-bytes context `hash_ptr_raw::<MLS>` requires;
+/// `dict_hash_log + DICT_TAG_BITS <= 32` so the slot index stays in range.
 #[inline(always)]
 pub(crate) unsafe fn dict_lookup<const MLS: u32>(
     dict_table: &FastHashTable,
     ptr: *const u8,
     dict_hash_log: u32,
 ) -> u32 {
-    let h = unsafe { hash_ptr_raw::<MLS>(ptr, dict_hash_log) };
-    // SAFETY: `h` < `1 << dict_hash_log` = table len.
-    unsafe { dict_table.get(h) }
+    let hat = unsafe { hash_ptr_raw::<MLS>(ptr, dict_hash_log + DICT_TAG_BITS) };
+    // SAFETY: `hat >> DICT_TAG_BITS` < `1 << dict_hash_log` = table len. The dict
+    // table is never epoch-advanced (bias 0), so `get` returns the raw stored
+    // `(pos << TAG) | tag` word unchanged.
+    let stored = unsafe { dict_table.get(hat >> DICT_TAG_BITS) };
+    if stored & DICT_TAG_MASK == hat & DICT_TAG_MASK {
+        stored >> DICT_TAG_BITS
+    } else {
+        0
+    }
 }
 
 /// Upstream zstd's `MEM_read32(ptr)` — unaligned native-endian 4-byte load,
@@ -2563,11 +2585,17 @@ mod tests {
         let mut main_table = FastHashTable::new(hash_log, MLS);
         let mut dict_table = FastHashTable::new(hash_log, MLS);
         for pos in 0..=dict.len() - HASH_READ_SIZE {
-            // SAFETY: pos + 8 <= dict.len(); MLS matches the table. Plain
-            // every-position last-wins fill, matching the kernel's untagged
-            // dict lookup.
-            let h = unsafe { hash_ptr_raw::<MLS>(dict.as_ptr().add(pos), hash_log) };
-            unsafe { dict_table.put(h, pos as u32) };
+            // SAFETY: pos + 8 <= dict.len(); MLS matches the table. Tagged
+            // every-position last-wins fill, matching the kernel's tagged dict
+            // lookup (slot + packed tag).
+            let hat =
+                unsafe { hash_ptr_raw::<MLS>(dict.as_ptr().add(pos), hash_log + DICT_TAG_BITS) };
+            unsafe {
+                dict_table.put(
+                    hat >> DICT_TAG_BITS,
+                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
+                )
+            };
         }
 
         let mut tuples: Vec<(Vec<u8>, usize, usize)> = Vec::new();

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -402,8 +402,10 @@ impl FastKernelMatcher {
 
     fn with_params_table(
         window_log: u8,
-        hash_log: u32,
-        mls: u32,
+        // Redundant here (`hash_table` is already built at this shape), kept in
+        // the signature to mirror `with_params`'s call shape at both sites.
+        _hash_log: u32,
+        _mls: u32,
         step_size: usize,
         hash_table: FastHashTable,
     ) -> Self {
@@ -1615,7 +1617,7 @@ impl FastKernelMatcher {
         // positions and fragment a long cross-seam dict match. `next_to_update`
         // starts at the content start (`HISTORY_DRAIN_BASE == 0`, the default).
         debug_assert!(
-            self.dict.next_to_update() <= range_start.max(HISTORY_DRAIN_BASE),
+            self.dict.next_to_update() <= range_start,
             "dict fill origin {} ran ahead of slice start {range_start}",
             self.dict.next_to_update(),
         );

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1096,8 +1096,22 @@ impl FastKernelMatcher {
         // floor takes over (eviction also clears `loaded_dict_end`). Offsets
         // reaching the dict (bounded by `advertised_window + loaded_dict_end`)
         // stay decodable because the decoder loads the same dictionary.
+        // `loaded_dict_end` is set only for COPY-mode dicts; an ATTACHED
+        // (in-place) dict tracks its boundary via `dict.region_len()` instead. Use
+        // whichever mode is active so an owned attach-mode scan keeps the WHOLE
+        // dict reachable once the input fills the advertised window — mirrors the
+        // borrowed dict floor. Without it the `dpos >= window_low` gate rejects
+        // every attached-dict slot past `advertised_window`, silently dropping the
+        // dictionary for over-window owned frames.
+        let effective_dict_end = if self.loaded_dict_end != 0 {
+            self.loaded_dict_end
+        } else if self.dict.is_attached() {
+            self.dict.region_len()
+        } else {
+            0
+        };
         let dict_in_window =
-            self.loaded_dict_end != 0 && block_end <= advertised_window + self.loaded_dict_end;
+            effective_dict_end != 0 && block_end <= advertised_window + effective_dict_end;
         let window_low = if dict_in_window { 0 } else { windowed_low };
         // Sentinel-aware prefix for the hash-table filter — match_idx
         // == 0 (an uninitialized FastHashTable slot) must be rejected

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -59,6 +59,7 @@ use crate::encoding::dict_attach::DictAttach;
 
 use super::fast_kernel::hash_table::{FastHashTable, hash_ptr_raw};
 use super::fast_kernel::kernel::compress_block_fast;
+use super::fast_kernel::kernel::{DICT_TAG_BITS, DICT_TAG_MASK};
 
 /// Upstream zstd `ZSTD_defaultCParameters[level=1][srcSize > 256 KiB][Fast]`
 /// constants. Kept for `MatchGeneratorDriver::new`'s initial-state
@@ -1716,16 +1717,34 @@ impl FastKernelMatcher {
         // inflating the offset and erasing the dictionary's ratio benefit (the
         // dict frame ends up larger than the no-dict frame).
         //
-        // Each slot stores the plain dict position. `0` is the empty sentinel —
-        // the dict occupies positions `1..dict_end` and the kernel rejects
-        // `dict_idx < 1`. The kernel byte-checks every candidate with
-        // `MEM_read32` before committing, so a hash collision is a cheap reject.
+        // Each slot stores `(position << DICT_TAG_BITS) | tag` (upstream zstd
+        // `ZSTD_SHORT_CACHE`): the slot index is the plain `dict_hash_log` hash,
+        // the tag is the low `DICT_TAG_BITS` of the wider hash. `0` is the empty
+        // sentinel — the dict occupies positions `1..dict_end` and the kernel
+        // rejects `dict_idx < 1`. The tag lets the kernel reject a colliding
+        // position without the candidate load + `MEM_read32`; tagging does NOT
+        // change the slot, so the last-wins nearest-occurrence guarantee holds.
         let dict_hash_log = dict_table.hash_log();
+        // Every slot packs the position into the `32 - DICT_TAG_BITS`-bit field
+        // (16 MiB with an 8-bit tag). `last_hashable` bounds every position the
+        // loop writes, so one check here covers the whole fill; a larger dict
+        // region would truncate the high position bits and alias offsets.
+        assert!(
+            last_hashable >> (32 - DICT_TAG_BITS) == 0,
+            "dict region too large for the tagged fast-table position field \
+             (last_hashable={last_hashable}, max={})",
+            (1usize << (32 - DICT_TAG_BITS)) - 1,
+        );
         for pos in range_start..=last_hashable {
             // SAFETY: pos <= last_hashable = history_len - 8, so `base.add(pos)`
             // covers >= 8 readable bytes; MLS matches the table's mls.
-            let h = unsafe { hash_ptr_raw::<MLS>(base.add(pos), dict_hash_log) };
-            unsafe { dict_table.put(h, pos as u32) };
+            let hat = unsafe { hash_ptr_raw::<MLS>(base.add(pos), dict_hash_log + DICT_TAG_BITS) };
+            unsafe {
+                dict_table.put(
+                    hat >> DICT_TAG_BITS,
+                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
+                )
+            };
         }
         // Every position up to `last_hashable` is hashed; the next `accept_data`
         // slice resumes one past it, picking up the seam positions whose 8-byte

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1824,10 +1824,21 @@ impl FastKernelMatcher {
         // position without the candidate load + `MEM_read32`; tagging does NOT
         // change the slot, so the last-wins nearest-occurrence guarantee holds.
         let dict_hash_log = dict_table.hash_log();
+        // The tagged hash is `hash_ptr_raw(.., dict_hash_log + DICT_TAG_BITS)`,
+        // well-defined only while that width fits 32 bits. Guard it here (always-on)
+        // before the unsafe fill, matching the kernel-side guards — a `hash_log > 24`
+        // dict table would otherwise hash past 32 bits and write a bogus slot.
+        assert!(
+            dict_hash_log + DICT_TAG_BITS <= 32,
+            "tagged Fast dict fill requires dict hash_log <= {} (got {dict_hash_log})",
+            32 - DICT_TAG_BITS,
+        );
         // Every slot packs the position into the `32 - DICT_TAG_BITS`-bit field
         // (16 MiB with an 8-bit tag). `last_hashable` bounds every position the
         // loop writes, so one check here covers the whole fill; a larger dict
-        // region would truncate the high position bits and alias offsets.
+        // region would truncate the high position bits and alias offsets. The
+        // driver routes dicts past `MAX_FAST_ATTACH_DICT_REGION` to copy mode, so
+        // in production this is a backstop the attach gate already upholds.
         assert!(
             last_hashable >> (32 - DICT_TAG_BITS) == 0,
             "dict region too large for the tagged fast-table position field \

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -57,8 +57,9 @@ use alloc::vec::Vec;
 use crate::encoding::Sequence;
 use crate::encoding::dict_attach::DictAttach;
 
-use super::fast_kernel::hash_table::FastHashTable;
+use super::fast_kernel::hash_table::{FastHashTable, hash_ptr_raw};
 use super::fast_kernel::kernel::compress_block_fast;
+use super::fast_kernel::kernel::{DICT_TAG_BITS, DICT_TAG_MASK};
 
 /// Upstream zstd `ZSTD_defaultCParameters[level=1][srcSize > 256 KiB][Fast]`
 /// constants. Kept for `MatchGeneratorDriver::new`'s initial-state
@@ -260,6 +261,11 @@ pub(crate) struct FastKernelMatcher {
     /// [`FastHashTable::advance_epoch`] as the span that makes every
     /// previously-stored entry stale, then rearms it at 0.
     table_pos_high_water: usize,
+    /// Set by [`Self::reset`] when it re-borrowed a resident attach-mode
+    /// dictionary (kept the dict bytes at the front of history + the cached
+    /// dict table in place instead of clearing + re-committing them). Signals
+    /// the frame compressor to SKIP `prime_with_dictionary` this frame.
+    dict_resident: bool,
 }
 
 impl Clone for FastKernelMatcher {
@@ -282,6 +288,7 @@ impl Clone for FastKernelMatcher {
             last_borrowed_block: self.last_borrowed_block,
             dict: self.dict.clone(),
             table_pos_high_water: self.table_pos_high_water,
+            dict_resident: self.dict_resident,
         }
     }
 
@@ -307,6 +314,7 @@ impl Clone for FastKernelMatcher {
         self.last_borrowed_block = source.last_borrowed_block;
         self.dict.clone_from(&source.dict);
         self.table_pos_high_water = source.table_pos_high_water;
+        self.dict_resident = source.dict_resident;
     }
 }
 
@@ -359,7 +367,46 @@ impl FastKernelMatcher {
     /// hash_log, mls, step_size)` tuple (typically because a small
     /// source-size hint clamped the window). Tests can also call this
     /// directly.
+    /// Construct with the hash table allocated up front at `hash_log`.
     pub(crate) fn with_params(window_log: u8, hash_log: u32, mls: u32, step_size: usize) -> Self {
+        Self::with_params_table(
+            window_log,
+            hash_log,
+            mls,
+            step_size,
+            FastHashTable::new(hash_log, mls),
+        )
+    }
+
+    /// Construct with the hash table allocation deferred to the first
+    /// [`Self::reset`]. Used by `MatchGeneratorDriver::new`, which runs before
+    /// any source size is known and would otherwise allocate the table at the
+    /// level-default `hash_log` only to realloc it the moment the first frame
+    /// clamps the window to a smaller input — a wasted malloc + zero-fill on
+    /// every fresh compressor (the `compare_ffi` bench shape). The reset path
+    /// allocates the table once at the resolved size before the kernel runs.
+    pub(crate) fn with_params_deferred(
+        window_log: u8,
+        hash_log: u32,
+        mls: u32,
+        step_size: usize,
+    ) -> Self {
+        Self::with_params_table(
+            window_log,
+            hash_log,
+            mls,
+            step_size,
+            FastHashTable::new_deferred(hash_log, mls),
+        )
+    }
+
+    fn with_params_table(
+        window_log: u8,
+        hash_log: u32,
+        mls: u32,
+        step_size: usize,
+        hash_table: FastHashTable,
+    ) -> Self {
         assert!(
             step_size >= 2,
             "FastKernelMatcher requires step_size >= 2 (got {step_size})"
@@ -394,7 +441,7 @@ impl FastKernelMatcher {
             prefix_start_index: INITIAL_PREFIX_START_INDEX,
             rep: FAST_INITIAL_REP,
             offset_hist: FAST_INITIAL_OFFSET_HIST,
-            hash_table: FastHashTable::new(hash_log, mls),
+            hash_table,
             max_window_size: 1usize << window_log,
             window_log,
             use_cmov: window_log < 19,
@@ -405,6 +452,7 @@ impl FastKernelMatcher {
             last_borrowed_block: None,
             dict: DictAttach::new(),
             table_pos_high_water: 0,
+            dict_resident: false,
         }
     }
 
@@ -447,7 +495,17 @@ impl FastKernelMatcher {
             window_log <= 30,
             "FastKernelMatcher requires window_log <= 30 (got {window_log})"
         );
-        if table_overwritten_by_restore
+        // Re-borrow detection: set to the resident dict region when the
+        // epoch-reuse branch below keeps the dict bytes in place (see there).
+        let mut reborrow_region: Option<usize> = None;
+        if !self.hash_table.is_allocated() {
+            // Deferred table from `with_params`: this first reset is where the
+            // source-size-clamped (hash_log, mls) is finally known, so allocate
+            // once at the resolved size. Subsequent frames take the
+            // same-shape `clear()` / epoch branches below.
+            self.hash_table = FastHashTable::new(hash_log, mls);
+            self.dict.invalidate();
+        } else if table_overwritten_by_restore
             && self.hash_table.hash_log() == hash_log
             && self.hash_table.mls() == mls
         {
@@ -474,6 +532,17 @@ impl FastKernelMatcher {
             // (CDict-equivalent).
             let span = u32::try_from(self.table_pos_high_water).unwrap_or(u32::MAX);
             self.hash_table.advance_epoch(span);
+            // Re-borrow: the dictionary bytes from the previous frame are still
+            // resident at the front of history (`[0, region)`), so keep them in
+            // place instead of clearing + re-committing — the per-frame dict
+            // memmove was the dominant Fast-dict cost (~39% on a profiled small
+            // frame). The cached dict table already covers them; the frame
+            // compressor skips `prime_with_dictionary`. Gated on the dict still
+            // being fully resident (no eviction drained it off the front).
+            let region = self.dict.region_len();
+            if region > 0 && self.history.len() >= region {
+                reborrow_region = Some(region);
+            }
         } else {
             // Same shape — keep the allocation, zero the entries via
             // `memset` (ZSTD_window_clear cadence). A primed dict table
@@ -482,11 +551,20 @@ impl FastKernelMatcher {
             self.hash_table.clear();
         }
         self.table_pos_high_water = 0;
-        // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
-        self.history.clear();
-        self.history.resize(HISTORY_DRAIN_BASE, 0);
+        if let Some(region) = reborrow_region {
+            // Keep `[0, region)` (the resident dict); drop the previous input.
+            self.history.truncate(region);
+            self.dict_resident = true;
+        } else {
+            // M8: history starts empty (HISTORY_DRAIN_BASE = 0).
+            self.history.clear();
+            self.history.resize(HISTORY_DRAIN_BASE, 0);
+            self.dict_resident = false;
+        }
         // Sentinel-0 protection via prefix_start_index >= 1 filter
-        // — see `with_params` for the full rationale.
+        // — see `with_params` for the full rationale. Unchanged for re-borrow:
+        // the dict sits at `[0, region)`, position 0 is the sentinel, so the
+        // dict's `[1, region)` stay reachable to the kernel and the decoder.
         self.prefix_start_index = INITIAL_PREFIX_START_INDEX;
         self.rep = FAST_INITIAL_REP;
         self.offset_hist = FAST_INITIAL_OFFSET_HIST;
@@ -494,8 +572,21 @@ impl FastKernelMatcher {
         self.use_cmov = window_log < 19;
         self.step_size = step_size;
         self.max_window_size = 1usize << window_log;
+        if let Some(region) = reborrow_region {
+            // Bump the eviction window by the dict size (exactly as
+            // `prime_with_dictionary`, clamped to MAX_PRIMED_WINDOW_SIZE) so the
+            // resident dict + the next input both stay in the window. Base is
+            // `1 << window_log` (<= 2^30 < MAX_PRIMED_WINDOW_SIZE), so headroom
+            // cannot underflow and the sum cannot overflow — no `saturating_*`.
+            let headroom = crate::encoding::match_table::storage::MAX_PRIMED_WINDOW_SIZE
+                - self.max_window_size;
+            self.max_window_size += region.min(headroom);
+        }
         self.pending = None;
-        self.last_block_start = HISTORY_DRAIN_BASE;
+        // Input starts after the resident dict on a re-borrow frame; otherwise
+        // at the drain base. (The first `extend_history` re-derives this, but
+        // keep it consistent for any pre-append reads.)
+        self.last_block_start = reborrow_region.unwrap_or(HISTORY_DRAIN_BASE);
         self.recycled_space = None;
         // Drop any borrowed window: the next frame's input buffer is a
         // different allocation, so a stale (ptr, len) would dangle.
@@ -1479,6 +1570,13 @@ impl FastKernelMatcher {
         self.dict.mark_primed();
     }
 
+    /// Whether the last [`Self::reset`] re-borrowed a resident dictionary (kept
+    /// the dict bytes + cached dict table in place). The driver reports this up
+    /// so the frame compressor skips `prime_with_dictionary` for the frame.
+    pub(crate) fn dict_resident(&self) -> bool {
+        self.dict_resident
+    }
+
     /// Drop the cached dict table and its primed flag. Called by the driver
     /// when the next frame carries no dictionary, so the kernel never probes
     /// a stale dict region whose bytes are no longer re-committed.
@@ -1506,12 +1604,23 @@ impl FastKernelMatcher {
             return;
         }
         let last_hashable = history_len - HASH_READ_SIZE;
-        // Backfill the (HASH_READ_SIZE - 1) seam positions below
-        // `range_start` (see `prime_hash_table_for_range`): a dictionary
-        // fed in slice_size chunks otherwise drops every match that
-        // straddles a chunk boundary.
-        let backfill_start = range_start.saturating_sub(HASH_READ_SIZE - 1);
-        if backfill_start > last_hashable {
+        // The strided dict fill resumes at the carried-forward fill origin
+        // (`next_to_update`), NOT this slice's `range_start`. The stride phase
+        // stays anchored at the dictionary content start (upstream zstd
+        // `ms->nextToUpdate = ip - base`) across every `accept_data` slice, so
+        // a position whose wide hash read straddles a slice seam — unreachable
+        // by the prior slice (its `last_hashable` stopped `HASH_READ_SIZE - 1`
+        // bytes short) and below this slice's `range_start` — is still hashed
+        // here. Restarting at `range_start` instead would drop those seam
+        // positions and fragment a long cross-seam dict match. `next_to_update`
+        // starts at the content start (`HISTORY_DRAIN_BASE == 0`, the default).
+        debug_assert!(
+            self.dict.next_to_update() <= range_start.max(HISTORY_DRAIN_BASE),
+            "dict fill origin {} ran ahead of slice start {range_start}",
+            self.dict.next_to_update(),
+        );
+        let stride_start = self.dict.next_to_update();
+        if stride_start > last_hashable {
             return;
         }
         let hash_log = self.hash_table.hash_log();
@@ -1519,36 +1628,94 @@ impl FastKernelMatcher {
         self.dict
             .table_mut_or_init(|| FastHashTable::new(hash_log, mls));
         let base = self.history.as_ptr();
-        match self.hash_table.mls() {
-            4 => self.prime_dict_table_impl::<4>(base, backfill_start, last_hashable),
-            5 => self.prime_dict_table_impl::<5>(base, backfill_start, last_hashable),
-            6 => self.prime_dict_table_impl::<6>(base, backfill_start, last_hashable),
-            7 => self.prime_dict_table_impl::<7>(base, backfill_start, last_hashable),
-            8 => self.prime_dict_table_impl::<8>(base, backfill_start, last_hashable),
+        let next = match self.hash_table.mls() {
+            4 => self.prime_dict_table_impl::<4>(base, stride_start, last_hashable),
+            5 => self.prime_dict_table_impl::<5>(base, stride_start, last_hashable),
+            6 => self.prime_dict_table_impl::<6>(base, stride_start, last_hashable),
+            7 => self.prime_dict_table_impl::<7>(base, stride_start, last_hashable),
+            8 => self.prime_dict_table_impl::<8>(base, stride_start, last_hashable),
             _ => unreachable!("FastHashTable construction rejects mls outside 4..=8"),
-        }
+        };
+        self.dict.set_next_to_update(next);
     }
 
     /// Monomorphised per-MLS dict-table fill. `base` is a raw pointer into
     /// `self.history` (no borrow held), so mutating `self.dict_table` in the
     /// loop is sound — the loop never touches `history`, which stays put.
+    /// Returns the carried-forward fill origin (the first stride position not
+    /// yet processed), stored as [`DictAttach::next_to_update`] so the next
+    /// `accept_data` slice resumes the stride here without dropping the seam.
     fn prime_dict_table_impl<const MLS: u32>(
         &mut self,
         base: *const u8,
         range_start: usize,
         last_hashable: usize,
-    ) {
+    ) -> usize {
         let dict_table = self
             .dict
             .table_mut()
             .expect("prime_dict_table_for_range creates the table before this call");
-        for pos in range_start..=last_hashable {
-            // SAFETY: pos <= last_hashable = history_len - 8, so `base.add(pos)`
+        // Mirror upstream `ZSTD_fillHashTableForCDict` (zstd_fast.c:16-49): a
+        // strided fill, NOT every-position. The stride origin is the dictionary
+        // content start (upstream `ms->nextToUpdate = ip - base`), so the fill
+        // PHASE matches upstream — an every-position last-wins fill (or a stride
+        // started at the seam-backfill position) resolves the same hash to a
+        // different dict position and surfaces a worse match (the dict-primed
+        // Fast path then fragments a long dict match into short local ones).
+        // Stride-aligned positions always overwrite (last stride wins); the
+        // `FILL_STEP - 1` positions between them are written only into an empty
+        // slot (first-fill wins). `0` is the empty sentinel — the dict occupies
+        // positions `1..dict_end` and the kernel rejects `dict_idx < 1`, so a
+        // never-filled slot reads back as `0`.
+        // Each slot stores `(position << DICT_TAG_BITS) | tag`, where `tag` is
+        // the low `DICT_TAG_BITS` of a `hash_log + DICT_TAG_BITS`-wide hash and
+        // the slot index is that hash `>> DICT_TAG_BITS` (== the plain
+        // `hash_log` hash). The kernel's tagged lookup rejects a slot whose
+        // stored tag does not match the query, so colliding dict positions with
+        // different tags do not alias — matching upstream's `ZSTD_SHORT_CACHE`.
+        let dict_hash_log = dict_table.hash_log();
+        const FILL_STEP: usize = 3;
+        let mut pos = range_start;
+        // Upstream bound `ip + step < iend + 2` with `iend` = end-of-input minus
+        // HASH_READ_SIZE; `last_hashable` plays the role of `iend` here.
+        while pos + FILL_STEP < last_hashable + 2 {
+            // SAFETY: pos < last_hashable < history_len - 8, so `base.add(pos)`
             // covers >= 8 readable bytes; MLS matches the table's mls.
-            let ptr = unsafe { base.add(pos) };
-            let hash = unsafe { dict_table.hash_ptr::<MLS>(ptr) };
-            unsafe { dict_table.put(hash, pos as u32) };
+            debug_assert!(
+                pos >> (32 - DICT_TAG_BITS) == 0,
+                "dict position overflows tagged index"
+            );
+            let hat = unsafe { hash_ptr_raw::<MLS>(base.add(pos), dict_hash_log + DICT_TAG_BITS) };
+            unsafe {
+                dict_table.put(
+                    hat >> DICT_TAG_BITS,
+                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
+                )
+            };
+            // In-between positions: fill only an empty slot (first-fill wins),
+            // matching `ZSTD_fillHashTableForCDict` (dtlm_full).
+            for p in 1..FILL_STEP {
+                let ipp = pos + p;
+                if ipp > last_hashable {
+                    break;
+                }
+                let hat2 =
+                    unsafe { hash_ptr_raw::<MLS>(base.add(ipp), dict_hash_log + DICT_TAG_BITS) };
+                let slot2 = hat2 >> DICT_TAG_BITS;
+                if unsafe { dict_table.get(slot2) } == 0 {
+                    unsafe {
+                        dict_table.put(
+                            slot2,
+                            ((ipp as u32) << DICT_TAG_BITS) | (hat2 & DICT_TAG_MASK),
+                        )
+                    };
+                }
+            }
+            pos += FILL_STEP;
         }
+        // `pos` is now the first stride position past the loop bound — the
+        // resume point for the next slice's fill.
+        pos
     }
 }
 
@@ -2410,10 +2577,20 @@ mod tests {
         // seam: its 8-byte hash read straddles the chunk boundary.
         let p = seam - 4;
         let dt = m.dict.table().expect("dict table primed");
-        let h = unsafe { dt.hash_ptr::<4>(m.history.as_ptr().add(p)) };
+        // Read the dict table exactly as the kernel does: a tagged lookup that
+        // decodes the packed `(position << DICT_TAG_BITS) | tag` slot and
+        // verifies the tag (a bare `get` would compare the packed value to the
+        // plain position and never match). Returns the stored position, or 0
+        // if the slot is empty / the tag mismatches.
+        let found = unsafe {
+            crate::encoding::simple::fast_kernel::kernel::dict_tagged_lookup::<4>(
+                dt,
+                m.history.as_ptr().add(p),
+                dt.hash_log(),
+            )
+        };
         assert_eq!(
-            unsafe { dt.get(h) },
-            p as u32,
+            found, p as u32,
             "seam-spanning position {p} must be indexed in the dict table",
         );
     }

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -59,7 +59,6 @@ use crate::encoding::dict_attach::DictAttach;
 
 use super::fast_kernel::hash_table::{FastHashTable, hash_ptr_raw};
 use super::fast_kernel::kernel::compress_block_fast;
-use super::fast_kernel::kernel::{DICT_TAG_BITS, DICT_TAG_MASK};
 
 /// Upstream zstd `ZSTD_defaultCParameters[level=1][srcSize > 256 KiB][Fast]`
 /// constants. Kept for `MatchGeneratorDriver::new`'s initial-state
@@ -1656,13 +1655,11 @@ impl FastKernelMatcher {
             return;
         }
         let last_hashable = history_len - HASH_READ_SIZE;
-        // The strided dict fill resumes at the carried-forward fill origin
-        // (`next_to_update`), NOT this slice's `range_start`. The stride phase
-        // stays anchored at the dictionary content start (upstream zstd
-        // `ms->nextToUpdate = ip - base`) across every `accept_data` slice, so
-        // a position whose wide hash read straddles a slice seam — unreachable
-        // by the prior slice (its `last_hashable` stopped `HASH_READ_SIZE - 1`
-        // bytes short) and below this slice's `range_start` — is still hashed
+        // The dict fill resumes at the carried-forward fill origin
+        // (`next_to_update`), NOT this slice's `range_start`: a position whose
+        // wide hash read straddles a slice seam is unreachable by the prior
+        // slice (its `last_hashable` stopped `HASH_READ_SIZE - 1` bytes short)
+        // and sits below this slice's `range_start`, yet must still be hashed
         // here. Restarting at `range_start` instead would drop those seam
         // positions and fragment a long cross-seam dict match. `next_to_update`
         // starts at the content start (`HISTORY_DRAIN_BASE == 0`, the default).
@@ -1671,8 +1668,8 @@ impl FastKernelMatcher {
             "dict fill origin {} ran ahead of slice start {range_start}",
             self.dict.next_to_update(),
         );
-        let stride_start = self.dict.next_to_update();
-        if stride_start > last_hashable {
+        let fill_start = self.dict.next_to_update();
+        if fill_start > last_hashable {
             return;
         }
         let hash_log = self.hash_table.hash_log();
@@ -1681,11 +1678,11 @@ impl FastKernelMatcher {
             .table_mut_or_init(|| FastHashTable::new(hash_log, mls));
         let base = self.history.as_ptr();
         let next = match self.hash_table.mls() {
-            4 => self.prime_dict_table_impl::<4>(base, stride_start, last_hashable),
-            5 => self.prime_dict_table_impl::<5>(base, stride_start, last_hashable),
-            6 => self.prime_dict_table_impl::<6>(base, stride_start, last_hashable),
-            7 => self.prime_dict_table_impl::<7>(base, stride_start, last_hashable),
-            8 => self.prime_dict_table_impl::<8>(base, stride_start, last_hashable),
+            4 => self.prime_dict_table_impl::<4>(base, fill_start, last_hashable),
+            5 => self.prime_dict_table_impl::<5>(base, fill_start, last_hashable),
+            6 => self.prime_dict_table_impl::<6>(base, fill_start, last_hashable),
+            7 => self.prime_dict_table_impl::<7>(base, fill_start, last_hashable),
+            8 => self.prime_dict_table_impl::<8>(base, fill_start, last_hashable),
             _ => unreachable!("FastHashTable construction rejects mls outside 4..=8"),
         };
         self.dict.set_next_to_update(next);
@@ -1694,9 +1691,9 @@ impl FastKernelMatcher {
     /// Monomorphised per-MLS dict-table fill. `base` is a raw pointer into
     /// `self.history` (no borrow held), so mutating `self.dict_table` in the
     /// loop is sound — the loop never touches `history`, which stays put.
-    /// Returns the carried-forward fill origin (the first stride position not
-    /// yet processed), stored as [`DictAttach::next_to_update`] so the next
-    /// `accept_data` slice resumes the stride here without dropping the seam.
+    /// Returns the carried-forward fill origin (one past the last position
+    /// hashed), stored as [`DictAttach::next_to_update`] so the next
+    /// `accept_data` slice resumes here without dropping the seam.
     fn prime_dict_table_impl<const MLS: u32>(
         &mut self,
         base: *const u8,
@@ -1707,83 +1704,34 @@ impl FastKernelMatcher {
             .dict
             .table_mut()
             .expect("prime_dict_table_for_range creates the table before this call");
-        // Mirror upstream `ZSTD_fillHashTableForCDict` (zstd_fast.c:16-49): a
-        // strided fill, NOT every-position. The stride origin is the dictionary
-        // content start (upstream `ms->nextToUpdate = ip - base`), so the fill
-        // PHASE matches upstream — an every-position last-wins fill (or a stride
-        // started at the seam-backfill position) resolves the same hash to a
-        // different dict position and surfaces a worse match (the dict-primed
-        // Fast path then fragments a long dict match into short local ones).
-        // Stride-aligned positions always overwrite (last stride wins); the
-        // `FILL_STEP - 1` positions between them are written only into an empty
-        // slot (first-fill wins). `0` is the empty sentinel — the dict occupies
-        // positions `1..dict_end` and the kernel rejects `dict_idx < 1`, so a
-        // never-filled slot reads back as `0`.
-        // Each slot stores `(position << DICT_TAG_BITS) | tag`, where `tag` is
-        // the low `DICT_TAG_BITS` of a `hash_log + DICT_TAG_BITS`-wide hash and
-        // the slot index is that hash `>> DICT_TAG_BITS` (== the plain
-        // `hash_log` hash). The kernel's tagged lookup rejects a slot whose
-        // stored tag does not match the query, so colliding dict positions with
-        // different tags do not alias — matching upstream's `ZSTD_SHORT_CACHE`.
+        // Every-position last-wins fill. For repetitive dictionary content one
+        // hash maps to many candidate positions, and the kernel emits the match
+        // offset as `ip - position`. Walking every position in increasing order
+        // with last-wins keeps the HIGHEST (nearest-to-the-input) occurrence per
+        // hash, so the emitted offset is the smallest reachable — and small
+        // offsets cost far fewer bits in the offset-code FSE stream than far
+        // ones. A strided fill (stride-overwrite plus in-between fill-if-empty)
+        // instead keeps whichever occurrence the stride alignment happened to
+        // land on; for variable-length records that is frequently a far one,
+        // inflating the offset and erasing the dictionary's ratio benefit (the
+        // dict frame ends up larger than the no-dict frame).
+        //
+        // Each slot stores the plain dict position. `0` is the empty sentinel —
+        // the dict occupies positions `1..dict_end` and the kernel rejects
+        // `dict_idx < 1`. The kernel byte-checks every candidate with
+        // `MEM_read32` before committing, so a hash collision is a cheap reject.
         let dict_hash_log = dict_table.hash_log();
-        // Always-on (not debug_assert): every slot stores `(pos << DICT_TAG_BITS)
-        // | tag`, so a filled position must fit the `32 - DICT_TAG_BITS`-bit
-        // position field (16 MiB with an 8-bit tag). `last_hashable` bounds every
-        // position the loop writes (both the stride `pos` and the in-between
-        // `ipp <= last_hashable`), so checking it once here covers the whole fill
-        // without a per-position branch. A dict region past this limit would
-        // truncate the high position bits and alias dict matches to wrong
-        // offsets; reject it loudly instead of silently corrupting the stream in
-        // release builds (the per-position `debug_assert` below is debug-only and
-        // never sees `ipp`).
-        assert!(
-            last_hashable >> (32 - DICT_TAG_BITS) == 0,
-            "dict region too large for the tagged fast-table position field \
-             (last_hashable={last_hashable}, max={})",
-            (1usize << (32 - DICT_TAG_BITS)) - 1,
-        );
-        const FILL_STEP: usize = 3;
-        let mut pos = range_start;
-        // Upstream bound `ip + step < iend + 2` with `iend` = end-of-input minus
-        // HASH_READ_SIZE; `last_hashable` plays the role of `iend` here.
-        while pos + FILL_STEP < last_hashable + 2 {
-            // SAFETY: pos < last_hashable < history_len - 8, so `base.add(pos)`
+        for pos in range_start..=last_hashable {
+            // SAFETY: pos <= last_hashable = history_len - 8, so `base.add(pos)`
             // covers >= 8 readable bytes; MLS matches the table's mls.
-            debug_assert!(
-                pos >> (32 - DICT_TAG_BITS) == 0,
-                "dict position overflows tagged index"
-            );
-            let hat = unsafe { hash_ptr_raw::<MLS>(base.add(pos), dict_hash_log + DICT_TAG_BITS) };
-            unsafe {
-                dict_table.put(
-                    hat >> DICT_TAG_BITS,
-                    ((pos as u32) << DICT_TAG_BITS) | (hat & DICT_TAG_MASK),
-                )
-            };
-            // In-between positions: fill only an empty slot (first-fill wins),
-            // matching `ZSTD_fillHashTableForCDict` (dtlm_full).
-            for p in 1..FILL_STEP {
-                let ipp = pos + p;
-                if ipp > last_hashable {
-                    break;
-                }
-                let hat2 =
-                    unsafe { hash_ptr_raw::<MLS>(base.add(ipp), dict_hash_log + DICT_TAG_BITS) };
-                let slot2 = hat2 >> DICT_TAG_BITS;
-                if unsafe { dict_table.get(slot2) } == 0 {
-                    unsafe {
-                        dict_table.put(
-                            slot2,
-                            ((ipp as u32) << DICT_TAG_BITS) | (hat2 & DICT_TAG_MASK),
-                        )
-                    };
-                }
-            }
-            pos += FILL_STEP;
+            let h = unsafe { hash_ptr_raw::<MLS>(base.add(pos), dict_hash_log) };
+            unsafe { dict_table.put(h, pos as u32) };
         }
-        // `pos` is now the first stride position past the loop bound — the
-        // resume point for the next slice's fill.
-        pos
+        // Every position up to `last_hashable` is hashed; the next `accept_data`
+        // slice resumes one past it, picking up the seam positions whose 8-byte
+        // hash read straddled this slice's tail (unreachable until more bytes
+        // landed).
+        last_hashable + 1
     }
 }
 
@@ -2645,13 +2593,10 @@ mod tests {
         // seam: its 8-byte hash read straddles the chunk boundary.
         let p = seam - 4;
         let dt = m.dict.table().expect("dict table primed");
-        // Read the dict table exactly as the kernel does: a tagged lookup that
-        // decodes the packed `(position << DICT_TAG_BITS) | tag` slot and
-        // verifies the tag (a bare `get` would compare the packed value to the
-        // plain position and never match). Returns the stored position, or 0
-        // if the slot is empty / the tag mismatches.
+        // Read the dict table exactly as the kernel does: hash the position and
+        // return the stored dict position for that slot (0 if empty).
         let found = unsafe {
-            crate::encoding::simple::fast_kernel::kernel::dict_tagged_lookup::<4>(
+            crate::encoding::simple::fast_kernel::kernel::dict_lookup::<4>(
                 dt,
                 m.history.as_ptr().add(p),
                 dt.hash_log(),

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -1726,6 +1726,22 @@ impl FastKernelMatcher {
         // stored tag does not match the query, so colliding dict positions with
         // different tags do not alias — matching upstream's `ZSTD_SHORT_CACHE`.
         let dict_hash_log = dict_table.hash_log();
+        // Always-on (not debug_assert): every slot stores `(pos << DICT_TAG_BITS)
+        // | tag`, so a filled position must fit the `32 - DICT_TAG_BITS`-bit
+        // position field (16 MiB with an 8-bit tag). `last_hashable` bounds every
+        // position the loop writes (both the stride `pos` and the in-between
+        // `ipp <= last_hashable`), so checking it once here covers the whole fill
+        // without a per-position branch. A dict region past this limit would
+        // truncate the high position bits and alias dict matches to wrong
+        // offsets; reject it loudly instead of silently corrupting the stream in
+        // release builds (the per-position `debug_assert` below is debug-only and
+        // never sees `ipp`).
+        assert!(
+            last_hashable >> (32 - DICT_TAG_BITS) == 0,
+            "dict region too large for the tagged fast-table position field \
+             (last_hashable={last_hashable}, max={})",
+            (1usize << (32 - DICT_TAG_BITS)) - 1,
+        );
         const FILL_STEP: usize = 3;
         let mut pos = range_start;
         // Upstream bound `ip + step < iend + 2` with `iend` = end-of-input minus

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -2712,6 +2712,64 @@ mod tests {
         );
     }
 
+    #[test]
+    fn block_samples_match_dict_fires_only_on_extendable_dict_match() {
+        // Distinct dict bytes so the 4-byte hashes are collision-free at
+        // hash_log=20 and a verbatim run is the only way to hit the table.
+        let dict: alloc::vec::Vec<u8> = (0..200u8)
+            .map(|i| i.wrapping_mul(37).wrapping_add(13))
+            .collect();
+        let mut m = FastKernelMatcher::with_params(20, 20, 4, 2);
+        m.accept_data(dict.clone());
+        m.skip_matching_for_dict_prime();
+        assert!(m.dict_is_attached(), "dict must be attached after prime");
+
+        // A 32-byte verbatim dict run extends well past the 16-byte useful-match
+        // floor → the probe fires.
+        let hit = dict[8..40].to_vec();
+        assert!(
+            m.block_samples_match_dict(&hit),
+            "a long verbatim dict run must trip the dict probe",
+        );
+
+        // An 8-byte dict prefix followed by non-dict bytes stays BELOW the
+        // 16-byte floor → the probe must NOT fire (a short coincidental match
+        // does not signal a dict that compresses the block).
+        let mut short = dict[8..16].to_vec();
+        short.extend((0..56u8).map(|i| i.wrapping_mul(53).wrapping_add(201)));
+        assert!(
+            !m.block_samples_match_dict(&short),
+            "a sub-16-byte dict match must not trip the probe",
+        );
+
+        // A high-entropy block sharing no extendable run with the dict → no hit.
+        let miss: alloc::vec::Vec<u8> = (0..64u8)
+            .map(|i| i.wrapping_mul(91).wrapping_add(7) ^ 0xA5)
+            .collect();
+        assert!(
+            !m.block_samples_match_dict(&miss),
+            "a non-dict block must not trip the probe",
+        );
+
+        // A block too short to hash (< HASH_READ_SIZE) → false, no panic.
+        assert!(
+            !m.block_samples_match_dict(&dict[..4]),
+            "a sub-8-byte block cannot be probed",
+        );
+    }
+
+    #[test]
+    fn block_samples_match_dict_is_false_without_a_dictionary() {
+        // No dict primed → the probe short-circuits to false (the no-dict path
+        // never reaches it, but the guard must hold).
+        let m = FastKernelMatcher::with_params(20, 20, 4, 2);
+        let block: alloc::vec::Vec<u8> = (0..64u8)
+            .map(|i| i.wrapping_mul(37).wrapping_add(13))
+            .collect();
+        assert!(!m.dict_is_attached());
+        assert!(!m.block_samples_match_dict(&block));
+    }
+
     /// Regression: same seam-gap defect for the MAIN hash table, primed
     /// per slice via `skip_matching_with_hint(Some(false))` (the dict
     /// COPY path and multi-slice history priming). Cross-slice matches

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -266,6 +266,18 @@ pub(crate) struct FastKernelMatcher {
     /// dict table in place instead of clearing + re-committing them). Signals
     /// the frame compressor to SKIP `prime_with_dictionary` this frame.
     dict_resident: bool,
+    /// Upstream zstd `ms->loadedDictEnd` for the COPY-mode dict path (inputs
+    /// over the Fast attach cutoff): the history position one past the last
+    /// dictionary byte committed at the front of `history`. The copy path
+    /// primes the dict into the live hash table as window prefix; this records
+    /// the dict/input boundary so `start_matching` can floor the block prefix
+    /// at the dict start (upstream zstd `ZSTD_getLowestPrefixIndex` with
+    /// `isDictionary`), keeping the whole dict reachable while it is still
+    /// within `maxDist` of the block end. `0` when no copy-mode dict is
+    /// resident (attach mode tracks its own boundary via `dict.region_len()`,
+    /// and a plain frame has none). Cleared on reset / eviction (the dict has
+    /// slid out of the window, so the windowed floor takes over).
+    loaded_dict_end: usize,
 }
 
 impl Clone for FastKernelMatcher {
@@ -289,6 +301,7 @@ impl Clone for FastKernelMatcher {
             dict: self.dict.clone(),
             table_pos_high_water: self.table_pos_high_water,
             dict_resident: self.dict_resident,
+            loaded_dict_end: self.loaded_dict_end,
         }
     }
 
@@ -315,6 +328,7 @@ impl Clone for FastKernelMatcher {
         self.dict.clone_from(&source.dict);
         self.table_pos_high_water = source.table_pos_high_water;
         self.dict_resident = source.dict_resident;
+        self.loaded_dict_end = source.loaded_dict_end;
     }
 }
 
@@ -455,6 +469,7 @@ impl FastKernelMatcher {
             dict: DictAttach::new(),
             table_pos_high_water: 0,
             dict_resident: false,
+            loaded_dict_end: 0,
         }
     }
 
@@ -553,6 +568,10 @@ impl FastKernelMatcher {
             self.hash_table.clear();
         }
         self.table_pos_high_water = 0;
+        // No copy-mode dict is resident across a reset: attach mode re-borrows
+        // its separate dict table (handled above), and the copy path re-primes
+        // (and re-records `loaded_dict_end`) during this frame's dict prime.
+        self.loaded_dict_end = 0;
         if let Some(region) = reborrow_region {
             // Keep `[0, region)` (the resident dict); drop the previous input.
             self.history.truncate(region);
@@ -869,6 +888,12 @@ impl FastKernelMatcher {
         // the dictionary, which is exactly when the dict is no longer
         // reachable anyway.
         self.dict.invalidate();
+        // Same reasoning for the COPY-mode dict boundary: the rebased tail
+        // moves the dict positions, and the drain only fires when history
+        // outgrew the window, i.e. the dict has slid out. Clear it so the
+        // prefix floor reverts to the windowed value (upstream zstd
+        // `ZSTD_window_enforceMaxDist` zeroing `loadedDictEnd`).
+        self.loaded_dict_end = 0;
         self.hash_table.clear();
         self.last_block_start = self.last_block_start.saturating_sub(drop_n);
         // Skip position 0 — `prefix_start_index = 1` means the kernel
@@ -986,7 +1011,23 @@ impl FastKernelMatcher {
         // extension `match_pos > window_low` bound — both paths that
         // upstream zstd expresses against `prefixStart` directly (NOT against
         // a sentinel-1 floor).
-        let window_low = self.history_bytes().len().saturating_sub(advertised_window) as u32;
+        let block_end = self.history_bytes().len();
+        let windowed_low = block_end.saturating_sub(advertised_window) as u32;
+        // Upstream zstd `ZSTD_getLowestPrefixIndex` with `isDictionary`: when a
+        // COPY-mode dict is resident at the front of history AND still within
+        // `maxDist` of the block end (`block_end <= advertised_window +
+        // loadedDictEnd`), the prefix floor is the DICT START, not the
+        // window-clamped floor — so the whole dict stays reachable for the
+        // block. A window-clamped floor computed from the history END would
+        // reject every dict position once the input fills the window, ignoring
+        // the dictionary entirely. Once the block end passes `maxDist +
+        // loadedDictEnd` the dict has slid out of the window and the windowed
+        // floor takes over (eviction also clears `loaded_dict_end`). Offsets
+        // reaching the dict (bounded by `advertised_window + loaded_dict_end`)
+        // stay decodable because the decoder loads the same dictionary.
+        let dict_in_window =
+            self.loaded_dict_end != 0 && block_end <= advertised_window + self.loaded_dict_end;
+        let window_low = if dict_in_window { 0 } else { windowed_low };
         // Sentinel-aware prefix for the hash-table filter — match_idx
         // == 0 (an uninitialized FastHashTable slot) must be rejected
         // by `match_found`, so we floor at `INITIAL_PREFIX_START_INDEX
@@ -1342,6 +1383,15 @@ impl FastKernelMatcher {
         // very small).
         if incompressible_hint == Some(false) {
             self.prime_hash_table_for_range(block_start);
+            // Copy-mode dict prime: the dict now occupies `[0, history.len())`
+            // at the front of history (this is the only caller of the
+            // `Some(false)` hint — see the doc above). Record the dict/input
+            // boundary so `start_matching` floors the block prefix at the dict
+            // start while the dict stays within the window (upstream zstd
+            // `ms->loadedDictEnd`). A multi-slice dict advances this to the
+            // running end on each slice; the final slice leaves the full
+            // dict size.
+            self.loaded_dict_end = self.history.len();
         }
     }
 

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -369,6 +369,77 @@ impl FastKernelMatcher {
         self.dict.is_attached()
     }
 
+    /// Cheap dict-relevance probe for the raw-fast-path. A high-entropy-LOOKING
+    /// block can still compress against an EXTERNAL dictionary: the block's own
+    /// content gives no hint (no internal repeat), so only probing the dict
+    /// table reveals it. Sample ~32 evenly-spread positions of `block`, hash
+    /// each into the attached dict table, and return `true` on the first 4-byte
+    /// dict match. The raw-fast-path uses this to keep a dict-matchable block off
+    /// the scan-skip (which would ignore the dictionary). Returns `false` when no
+    /// dict is attached or `block` is too short to hash — the no-dict path never
+    /// calls this, so its incompressibility verdict is unaffected.
+    pub(crate) fn block_samples_match_dict(&self, block: &[u8]) -> bool {
+        use super::fast_kernel::kernel::dict_lookup;
+        const HASH_READ_SIZE: usize = 8;
+        if !self.dict.is_attached() || block.len() < HASH_READ_SIZE {
+            return false;
+        }
+        let Some(dict_tab) = self.dict.table() else {
+            return false;
+        };
+        let dict_end = self.dict.region_len();
+        if dict_end > self.history.len() || dict_end < HASH_READ_SIZE {
+            return false;
+        }
+        let dict_bytes = &self.history[..dict_end];
+        let dhl = dict_tab.hash_log();
+        let mls = self.hash_table.mls();
+        let last = block.len() - HASH_READ_SIZE;
+        // ~32 evenly-spread probes (every position for tiny blocks); a dict that
+        // covers any sampled record trips on the first hit.
+        let step = (block.len() / 32).max(1);
+        let base = block.as_ptr();
+        let mut pos = 0;
+        while pos <= last {
+            // SAFETY: pos <= block.len() - 8 ⇒ `base.add(pos)` has ≥ 8 readable
+            // bytes, the context `dict_lookup`/`hash_ptr_raw` require.
+            let dpos = unsafe {
+                match mls {
+                    4 => dict_lookup::<4>(dict_tab, base.add(pos), dhl),
+                    5 => dict_lookup::<5>(dict_tab, base.add(pos), dhl),
+                    6 => dict_lookup::<6>(dict_tab, base.add(pos), dhl),
+                    7 => dict_lookup::<7>(dict_tab, base.add(pos), dhl),
+                    _ => dict_lookup::<8>(dict_tab, base.add(pos), dhl),
+                }
+            } as usize;
+            // `dpos >= 1` rejects the empty sentinel; verify a real 4-byte match
+            // before declaring the dict relevant, and EXTEND it: only a match
+            // long enough to be worth committing signals a dict that helps. A
+            // short (4-byte) coincidental hit — common when the dict was trained
+            // on data statistically like this block, yet contributes no net
+            // compression — must NOT force a scan, or an incompressible block
+            // with a self-trained dict pays a full wasted scan instead of the
+            // fast raw path. `USEFUL_DICT_MATCH` mirrors the magnitude at which a
+            // dict match starts paying for its (far) offset coding.
+            const USEFUL_DICT_MATCH: usize = 16;
+            if dpos >= 1
+                && dpos + 4 <= dict_end
+                && block[pos..pos + 4] == dict_bytes[dpos..dpos + 4]
+            {
+                let cap = (block.len() - pos).min(dict_end - dpos);
+                let mut len = 4;
+                while len < cap && block[pos + len] == dict_bytes[dpos + len] {
+                    len += 1;
+                }
+                if len >= USEFUL_DICT_MATCH {
+                    return true;
+                }
+            }
+            pos += step;
+        }
+        false
+    }
+
     /// Hash table `mls` (delegates to the inner table). Test-only
     /// crate helper for verifying driver wiring.
     #[cfg(test)]
@@ -1240,7 +1311,21 @@ impl FastKernelMatcher {
         // match the owned flat dict kernel: `window_low` is the absolute floor;
         // `prefix_start_index` the sentinel-aware floor (`>= 1`) for the
         // hash-slot filter. `virtual_len` was checked above.
-        let window_low = virtual_len.saturating_sub(advertised_window);
+        let windowed_low = virtual_len.saturating_sub(advertised_window);
+        // Upstream zstd `ZSTD_getLowestPrefixIndex` with `isDictionary`: while the
+        // dict (committed at virtual `[0, dict_end)`) is still within
+        // `maxDist + loadedDictEnd` of the block end, the floor is the DICT START
+        // (0), NOT the window-clamped `virtual_len - window`. `dict_end` is the
+        // loaded-dict-end here. Without this, a block over the Fast attach cutoff
+        // (now every Fast dict frame) computes `window_low = virtual_len - window`
+        // which lands at or above `dict_end`, so the kernel's `dpos >= window_low`
+        // gate rejects EVERY dict position and the dictionary is ignored for the
+        // whole block (the same prefix-floor bug the owned copy path fixed). Once
+        // the block grows past `window + dict_end` the dict has slid out of the
+        // window and the windowed floor takes over; offsets reaching the dict stay
+        // bounded by `window + dict_end`, so they remain decodable.
+        let dict_in_window = dict_end != 0 && virtual_len <= advertised_window + dict_end;
+        let window_low = if dict_in_window { 0 } else { windowed_low };
         let prefix_start_index = window_low.max(self.prefix_start_index as usize) as u32;
         let bounds = PrefixBounds {
             prefix_start_index,

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -114,6 +114,10 @@ impl<W: Write> StreamingEncoder<W, MatchGeneratorDriver> {
         self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
             crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
         });
+        self.state.huf_optimal_search = crate::encoding::frame_compressor::fast_huf_search_enabled(
+            self.state.strategy_tag,
+            self.pledged_content_size,
+        );
         self.state.matcher.set_param_overrides(Some(overrides));
         Ok(())
     }
@@ -138,6 +142,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
                 strategy_tag: crate::encoding::strategy::StrategyTag::for_compression_level(
                     compression_level,
                 ),
+                huf_optimal_search: true,
             },
             pending: Vec::new(),
             encoded_scratch: Vec::new(),
@@ -557,6 +562,10 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         self.state.strategy_tag = self.strategy_override.unwrap_or_else(|| {
             crate::encoding::strategy::StrategyTag::for_compression_level(self.compression_level)
         });
+        self.state.huf_optimal_search = crate::encoding::frame_compressor::fast_huf_search_enabled(
+            self.state.strategy_tag,
+            self.pledged_content_size,
+        );
         #[cfg(feature = "hash")]
         {
             self.hasher = XxHash64::with_seed(0);

--- a/zstd/src/encoding/streaming_encoder.rs
+++ b/zstd/src/encoding/streaming_encoder.rs
@@ -37,6 +37,12 @@ pub struct StreamingEncoder<W: Write, M: Matcher = MatchGeneratorDriver> {
     /// the format's 128 KiB ceiling.
     target_block_size: Option<u32>,
     pledged_content_size: Option<u64>,
+    /// Advisory source-size hint from [`set_source_size_hint`](Self::set_source_size_hint).
+    /// Unlike `pledged_content_size` it carries no end-of-frame enforcement, but
+    /// it still feeds the small-input gates (matcher sizing AND the Fast HUF
+    /// fast-path gate) so `set_source_size_hint(small)` reduces work the same way
+    /// a pledge does. The HUF gate reads `pledged_content_size.or(source_size_hint)`.
+    source_size_hint: Option<u64>,
     /// Whether a pledged size is written into the header's
     /// `Frame_Content_Size` field (upstream `ZSTD_c_contentSizeFlag`).
     /// Pledge *enforcement* is independent of this flag — upstream
@@ -116,7 +122,7 @@ impl<W: Write> StreamingEncoder<W, MatchGeneratorDriver> {
         });
         self.state.huf_optimal_search = crate::encoding::frame_compressor::fast_huf_search_enabled(
             self.state.strategy_tag,
-            self.pledged_content_size,
+            self.pledged_content_size.or(self.source_size_hint),
         );
         self.state.matcher.set_param_overrides(Some(overrides));
         Ok(())
@@ -152,6 +158,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             frame_started: false,
             target_block_size: None,
             pledged_content_size: None,
+            source_size_hint: None,
             content_size_flag: true,
             bytes_consumed: 0,
             strategy_override: None,
@@ -281,6 +288,11 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
             ));
         }
         self.state.matcher.set_source_size_hint(size);
+        // Feed the same hint to the Fast HUF fast-path gate (resolved in
+        // `set_parameters` / `ensure_frame_started` via
+        // `pledged_content_size.or(source_size_hint)`), so a small advisory size
+        // also lifts Fast streams off the expensive optimal-HUF search.
+        self.source_size_hint = Some(size);
         Ok(())
     }
 
@@ -564,7 +576,7 @@ impl<W: Write, M: Matcher> StreamingEncoder<W, M> {
         });
         self.state.huf_optimal_search = crate::encoding::frame_compressor::fast_huf_search_enabled(
             self.state.strategy_tag,
-            self.pledged_content_size,
+            self.pledged_content_size.or(self.source_size_hint),
         );
         #[cfg(feature = "hash")]
         {

--- a/zstd/src/fse/fse_decoder.rs
+++ b/zstd/src/fse/fse_decoder.rs
@@ -364,6 +364,18 @@ impl<E: FseEntry, const CAP: usize> FSETableImpl<E, CAP> {
         if self.accuracy_log == 0 || self.symbol_probabilities.is_empty() {
             return None;
         }
+        // The encoder table builder indexes a fixed `1 << 9 = 512`-entry stack
+        // scratch, so it can only represent `accuracy_log <= 9` (the sequence
+        // FSE wire cap). The decoder accepts tables up to
+        // `ENTRY_MAX_ACCURACY_LOG = 16` (a non-sequence table reached through a
+        // dictionary can carry one), and slicing the scratch with `1 <<
+        // accuracy_log > 512` would panic in release too. Such a table cannot be
+        // reused as a sequence encoder table — return None so the caller builds
+        // a fresh one instead of indexing past the scratch.
+        const MAX_ENCODER_ACCURACY_LOG: u8 = 9;
+        if self.accuracy_log > MAX_ENCODER_ACCURACY_LOG {
+            return None;
+        }
 
         Some(crate::fse::fse_encoder::build_table_from_probabilities(
             &self.symbol_probabilities,
@@ -1251,5 +1263,24 @@ mod tests {
         let probs: [i32; 4] = [4, 4, 4, 4];
         let result = t.build_from_probabilities(4, &probs);
         assert!(result.is_ok(), "expected Ok for exact sum, got {result:?}");
+    }
+
+    /// The decoder accepts tables with `accuracy_log` up to
+    /// `ENTRY_MAX_ACCURACY_LOG = 16`, but the encoder table builder indexes a
+    /// fixed 512-entry (`1 << 9`) scratch. A decoder table with `accuracy_log >
+    /// 9` reached through `to_encoder_table` (e.g. a non-sequence table carried
+    /// by a dictionary) must return None rather than slice past the scratch and
+    /// panic.
+    #[test]
+    fn to_encoder_table_rejects_accuracy_log_above_nine() {
+        let mut t = FSETable::new(8);
+        // A table with accuracy_log 10 (1 << 10 = 1024 entries) and a plausible
+        // probability distribution summing to 1024.
+        t.accuracy_log = 10;
+        t.symbol_probabilities = alloc::vec![512, 512];
+        assert!(
+            t.to_encoder_table().is_none(),
+            "accuracy_log > 9 must not be reusable as an encoder table"
+        );
     }
 }

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -737,9 +737,16 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
     // per-build heap alloc + zero is gone. `[..table_size]` keeps the live region
     // exactly as the old `vec![0u8; table_size]`.
     const MAX_FSE_TABLE_SIZE: usize = 1 << 9;
-    debug_assert!(
+    // Always-on (not debug_assert): the stack scratch is fixed at 512 bytes
+    // (accuracy_log <= 9). `to_encoder_table` already rejects acc_log > 9, but
+    // this function is `pub(crate)` — guard the scratch bound here too so a
+    // future caller can never index the buffer past its length (the `[..
+    // table_size]` slice would panic on the bound; this fires first with a clear
+    // message instead of an opaque slice-index panic).
+    assert!(
         table_size <= MAX_FSE_TABLE_SIZE,
-        "table_size {table_size} exceeds MAX_FSE_TABLE_SIZE"
+        "FSE table_size {table_size} exceeds the {MAX_FSE_TABLE_SIZE}-byte encoder \
+         scratch (accuracy_log must be <= 9)"
     );
     let mut table_symbol_buf = [0u8; MAX_FSE_TABLE_SIZE];
     let table_symbol = &mut table_symbol_buf[..table_size];

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -731,7 +731,18 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
     // of the table; bump the high-threshold cursor down. Build the
     // `cumul` prefix-sum table that maps each symbol to its first
     // `nextStateTable` slot in sorted-by-symbol layout.
-    let mut table_symbol = alloc::vec![0u8; table_size];
+    // `table_symbol` is a local scratch (consumed to fill `state_table_flat`,
+    // never returned), bounded by the FSE sequence/weight table-log cap
+    // (`table_size = 1 << table_log <= 1 << 9 = 512`). Use a stack buffer so the
+    // per-build heap alloc + zero is gone. `[..table_size]` keeps the live region
+    // exactly as the old `vec![0u8; table_size]`.
+    const MAX_FSE_TABLE_SIZE: usize = 1 << 9;
+    debug_assert!(
+        table_size <= MAX_FSE_TABLE_SIZE,
+        "table_size {table_size} exceeds MAX_FSE_TABLE_SIZE"
+    );
+    let mut table_symbol_buf = [0u8; MAX_FSE_TABLE_SIZE];
+    let table_symbol = &mut table_symbol_buf[..table_size];
     let mut high_threshold = (table_size - 1) as isize;
     // `cumul` / running prefix-sum holds slot counts up to `table_size`.
     // Decoder accepts `accuracy_log` up to `ENTRY_MAX_ACCURACY_LOG = 16`

--- a/zstd/src/huff0/huf_cstream.rs
+++ b/zstd/src/huff0/huf_cstream.rs
@@ -111,6 +111,140 @@ pub(crate) struct HufCStream<'a> {
     overflow: bool,
 }
 
+/// Whether to run the BMI2-targeted burst-encode kernel. BMI2 lets the codegen
+/// use `shrx`/`shlx` for the bit-container's variable shifts (no CL dependency,
+/// no flag stall) instead of `shr`/`shl`; the emitted instruction stream differs
+/// but the logic — and therefore the compressed output — is identical. Detected
+/// at the per-stream entry, never inside the symbol loop.
+#[cfg(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))]
+#[inline]
+fn huf_encode_use_bmi2() -> bool {
+    std::arch::is_x86_feature_detected!("bmi2")
+}
+#[cfg(all(not(feature = "std"), any(target_arch = "x86", target_arch = "x86_64")))]
+#[inline]
+fn huf_encode_use_bmi2() -> bool {
+    cfg!(target_feature = "bmi2")
+}
+
+/// One symbol into bit container `$bc` / bit position `$bp`. Mirrors
+/// `add_bits`; `$fast` (a `const`-valued bool) const-folds. Module-level so the
+/// burst-loop body macro can expand it inside both the scalar and the
+/// `#[target_feature]` kernel without an `#[inline(always)]` + `target_feature`
+/// clash (rust-lang/rust#145574).
+macro_rules! huf_add {
+    ($bc:ident, $bp:ident, $elt:expr, $fast:expr) => {{
+        let elt = $elt;
+        let nb_bits = elt & 0xFF;
+        $bc >>= nb_bits;
+        $bc |= if $fast { elt } else { elt & !0xFFu64 };
+        $bp = $bp.wrapping_add(if $fast { elt } else { nb_bits });
+    }};
+}
+
+/// Flush whole bytes out of container `$bc` to `$out_base[$cursor..]`. Mirrors
+/// `flush_bits`. SAFETY of the 8-byte store: the caller reserved `dst_capacity`
+/// and never reallocates `output`, so `$cursor + 8 <= capacity`.
+macro_rules! huf_flush {
+    ($bc:ident, $bp:ident, $cursor:ident, $overflow:ident, $out_base:ident, $end_ptr:ident, $fast:expr) => {{
+        let nb_bits = ($bp & 0xFF) as usize;
+        let nb_bytes = nb_bits >> 3;
+        let chunk = if nb_bits == 0 {
+            0
+        } else {
+            $bc >> (HUF_BITS_IN_CONTAINER - nb_bits)
+        };
+        $bp &= 7;
+        let bytes = chunk.to_le_bytes();
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), $out_base.add($cursor), 8);
+        }
+        $cursor += nb_bytes;
+        if !$fast && $cursor > $end_ptr {
+            $cursor = $end_ptr;
+            $overflow = true;
+        }
+    }};
+}
+
+/// The full reverse-order burst-encode loop, hoisting the stream state into
+/// locals. `self`/`table`/`data` and the three `const` generics are passed in
+/// (`self` resolves at the expansion site; the rest cross the macro hygiene
+/// barrier as arguments) so the identical body can be expanded into the scalar
+/// and BMI2 kernels below.
+macro_rules! encode_unrolled_body {
+    ($self:expr, $table:expr, $data:expr, $ku:expr, $kff:expr, $klf:expr) => {{
+        let mut bc0 = $self.bit_container[0];
+        let mut bc1 = $self.bit_container[1];
+        let mut bp0 = $self.bit_pos[0];
+        let mut bp1 = $self.bit_pos[1];
+        let mut cursor = $self.cursor;
+        let mut overflow = $self.overflow;
+        let end_ptr = $self.end_ptr;
+        // Stable raw base: `new()` reserved `dst_capacity` and this method
+        // never pushes to `output`, so no realloc can move the buffer and
+        // every `cursor + 8 <= capacity` write targets spare capacity.
+        let out_base = $self.output.as_mut_ptr();
+
+        let mut n = $data.len();
+        let rem = n % $ku;
+
+        // Phase 1: tail symbols (< K_UNROLL) on the SLOW path.
+        if rem > 0 {
+            for _ in 0..rem {
+                n -= 1;
+                huf_add!(bc0, bp0, $table[$data[n] as usize], false);
+            }
+            huf_flush!(bc0, bp0, cursor, overflow, out_base, end_ptr, $kff);
+        }
+        debug_assert!(n.is_multiple_of($ku));
+
+        // Phase 2: bring n down to a multiple of 2 * K_UNROLL.
+        if !n.is_multiple_of(2 * $ku) {
+            for u in 1..$ku {
+                huf_add!(bc0, bp0, $table[$data[n - u] as usize], true);
+            }
+            huf_add!(bc0, bp0, $table[$data[n - $ku] as usize], $klf);
+            huf_flush!(bc0, bp0, cursor, overflow, out_base, end_ptr, $kff);
+            n -= $ku;
+        }
+        debug_assert!(n.is_multiple_of(2 * $ku));
+
+        // Phase 3: dual-container main loop.
+        while n > 0 {
+            for u in 1..$ku {
+                huf_add!(bc0, bp0, $table[$data[n - u] as usize], true);
+            }
+            huf_add!(bc0, bp0, $table[$data[n - $ku] as usize], $klf);
+            huf_flush!(bc0, bp0, cursor, overflow, out_base, end_ptr, $kff);
+
+            bc1 = 0;
+            bp1 = 0;
+            for u in 1..$ku {
+                huf_add!(bc1, bp1, $table[$data[n - $ku - u] as usize], true);
+            }
+            huf_add!(bc1, bp1, $table[$data[n - $ku - $ku] as usize], $klf);
+            // merge_index1: fold container 1 into container 0.
+            let nb_bits_1 = bp1 & 0xFF;
+            bc0 >>= nb_bits_1;
+            bc0 |= bc1;
+            bp0 = bp0.wrapping_add(bp1);
+            huf_flush!(bc0, bp0, cursor, overflow, out_base, end_ptr, $kff);
+
+            n -= 2 * $ku;
+        }
+        debug_assert_eq!(n, 0);
+
+        // Write the hoisted state back so `close()` sees the final values.
+        $self.bit_container[0] = bc0;
+        $self.bit_container[1] = bc1;
+        $self.bit_pos[0] = bp0;
+        $self.bit_pos[1] = bp1;
+        $self.cursor = cursor;
+        $self.overflow = overflow;
+    }};
+}
+
 impl<'a> HufCStream<'a> {
     /// Upstream zstd `HUF_initCStream`. Requires `output.capacity() >=
     /// output.len() + dst_capacity` AND `dst_capacity > 8` (else
@@ -241,117 +375,54 @@ impl<'a> HufCStream<'a> {
         table: &[u64],
         data: &[u8],
     ) {
-        let mut bc0 = self.bit_container[0];
-        let mut bc1 = self.bit_container[1];
-        let mut bp0 = self.bit_pos[0];
-        let mut bp1 = self.bit_pos[1];
-        let mut cursor = self.cursor;
-        let mut overflow = self.overflow;
-        let end_ptr = self.end_ptr;
-        // Stable raw base: `new()` reserved `dst_capacity` and this method
-        // never pushes to `output`, so no realloc can move the buffer and
-        // every `cursor + 8 <= capacity` write targets spare capacity.
-        let out_base = self.output.as_mut_ptr();
-
-        // Mirror `add_bits`: `$fast` (a `const`-valued bool) const-folds.
-        macro_rules! add0 {
-            ($elt:expr, $fast:expr) => {{
-                let elt = $elt;
-                let nb_bits = elt & 0xFF;
-                bc0 >>= nb_bits;
-                bc0 |= if $fast { elt } else { elt & !0xFFu64 };
-                bp0 = bp0.wrapping_add(if $fast { elt } else { nb_bits });
-            }};
-        }
-        macro_rules! add1 {
-            ($elt:expr, $fast:expr) => {{
-                let elt = $elt;
-                let nb_bits = elt & 0xFF;
-                bc1 >>= nb_bits;
-                bc1 |= if $fast { elt } else { elt & !0xFFu64 };
-                bp1 = bp1.wrapping_add(if $fast { elt } else { nb_bits });
-            }};
-        }
-        // Mirror `flush_bits` on `bc0`/`bp0`/`cursor`.
-        macro_rules! flush0 {
-            ($fast:expr) => {{
-                let nb_bits = (bp0 & 0xFF) as usize;
-                let nb_bytes = nb_bits >> 3;
-                let chunk = if nb_bits == 0 {
-                    0
-                } else {
-                    bc0 >> (HUF_BITS_IN_CONTAINER - nb_bits)
-                };
-                bp0 &= 7;
-                let bytes = chunk.to_le_bytes();
-                // SAFETY: see `out_base` above; `cursor + 8 <= capacity`.
+        // Pick the burst kernel ONCE per stream, never inside the symbol loop.
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if huf_encode_use_bmi2() {
+                // SAFETY: `huf_encode_use_bmi2()` returned true, so the running
+                // CPU has BMI2; the body adds no unsafe beyond the 8-byte store
+                // already justified in `huf_flush!`.
                 unsafe {
-                    core::ptr::copy_nonoverlapping(bytes.as_ptr(), out_base.add(cursor), 8);
+                    self.encode_unrolled_bmi2::<K_UNROLL, K_FAST_FLUSH, K_LAST_FAST>(table, data);
                 }
-                cursor += nb_bytes;
-                if !$fast && cursor > end_ptr {
-                    cursor = end_ptr;
-                    overflow = true;
-                }
-            }};
-        }
-
-        let mut n = data.len();
-        let rem = n % K_UNROLL;
-
-        // Phase 1: tail symbols (< K_UNROLL) on the SLOW path.
-        if rem > 0 {
-            for _ in 0..rem {
-                n -= 1;
-                add0!(table[data[n] as usize], false);
+                return;
             }
-            flush0!(K_FAST_FLUSH);
         }
-        debug_assert!(n.is_multiple_of(K_UNROLL));
+        self.encode_unrolled_scalar::<K_UNROLL, K_FAST_FLUSH, K_LAST_FAST>(table, data);
+    }
 
-        // Phase 2: bring n down to a multiple of 2 * K_UNROLL.
-        if !n.is_multiple_of(2 * K_UNROLL) {
-            for u in 1..K_UNROLL {
-                add0!(table[data[n - u] as usize], true);
-            }
-            add0!(table[data[n - K_UNROLL] as usize], K_LAST_FAST);
-            flush0!(K_FAST_FLUSH);
-            n -= K_UNROLL;
-        }
-        debug_assert!(n.is_multiple_of(2 * K_UNROLL));
+    /// Portable burst-encode kernel (no target feature). Bit-identical output to
+    /// the BMI2 kernel — only the emitted shift instructions differ.
+    #[inline]
+    fn encode_unrolled_scalar<
+        const K_UNROLL: usize,
+        const K_FAST_FLUSH: bool,
+        const K_LAST_FAST: bool,
+    >(
+        &mut self,
+        table: &[u64],
+        data: &[u8],
+    ) {
+        encode_unrolled_body!(self, table, data, K_UNROLL, K_FAST_FLUSH, K_LAST_FAST);
+    }
 
-        // Phase 3: dual-container main loop.
-        while n > 0 {
-            for u in 1..K_UNROLL {
-                add0!(table[data[n - u] as usize], true);
-            }
-            add0!(table[data[n - K_UNROLL] as usize], K_LAST_FAST);
-            flush0!(K_FAST_FLUSH);
-
-            bc1 = 0;
-            bp1 = 0;
-            for u in 1..K_UNROLL {
-                add1!(table[data[n - K_UNROLL - u] as usize], true);
-            }
-            add1!(table[data[n - K_UNROLL - K_UNROLL] as usize], K_LAST_FAST);
-            // merge_index1: fold container 1 into container 0.
-            let nb_bits_1 = bp1 & 0xFF;
-            bc0 >>= nb_bits_1;
-            bc0 |= bc1;
-            bp0 = bp0.wrapping_add(bp1);
-            flush0!(K_FAST_FLUSH);
-
-            n -= 2 * K_UNROLL;
-        }
-        debug_assert_eq!(n, 0);
-
-        // Write the hoisted state back so `close()` sees the final values.
-        self.bit_container[0] = bc0;
-        self.bit_container[1] = bc1;
-        self.bit_pos[0] = bp0;
-        self.bit_pos[1] = bp1;
-        self.cursor = cursor;
-        self.overflow = overflow;
+    /// BMI2-targeted burst-encode kernel: identical body, compiled with BMI2 so
+    /// the container's variable shifts lower to `shrx`/`shlx`.
+    ///
+    /// # Safety
+    /// The caller must have verified BMI2 is available (`huf_encode_use_bmi2()`).
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    #[target_feature(enable = "bmi2")]
+    unsafe fn encode_unrolled_bmi2<
+        const K_UNROLL: usize,
+        const K_FAST_FLUSH: bool,
+        const K_LAST_FAST: bool,
+    >(
+        &mut self,
+        table: &[u64],
+        data: &[u8],
+    ) {
+        encode_unrolled_body!(self, table, data, K_UNROLL, K_FAST_FLUSH, K_LAST_FAST);
     }
 
     /// Number of bits currently buffered in `bit_container[0]`.

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -328,7 +328,13 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
             return None;
         }
 
-        let mut encoded = Vec::new();
+        // Pre-size to the weight count: the FSE-encoded description is rejected
+        // above `weights.len() / 2` (the raw nibble fallback wins) and at 128
+        // bytes outright, so `weights.len()` is a generous one-shot capacity
+        // that keeps the BitWriter's backing buffer from reallocating as the
+        // interleaved stream is written. Transient scratch (discarded or
+        // returned, never the frame output), so no peak-memory trade-off.
+        let mut encoded = Vec::with_capacity(weights.len());
         {
             let mut writer = BitWriter::from(&mut encoded);
             let mut encoder = FSEEncoder::new(
@@ -439,6 +445,20 @@ impl Clone for HuffmanTable {
     }
 }
 
+/// Measurement-only toggle (gated behind `bench_internals`): when set, every
+/// [`HuffmanTable::build_from_counts`] takes the cheap single-build path
+/// instead of the #167 table-log search, so a bench harness can A/B the search
+/// on/off from a single build. Never set in shipping code.
+#[cfg(feature = "bench_internals")]
+pub static FORCE_CHEAP_HUF: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+/// Set the [`FORCE_CHEAP_HUF`] measurement toggle.
+#[cfg(feature = "bench_internals")]
+pub fn set_force_cheap_huf(on: bool) {
+    FORCE_CHEAP_HUF.store(on, core::sync::atomic::Ordering::Relaxed);
+}
+
 impl HuffmanTable {
     /// Heap bytes this table holds: the per-symbol code table and the packed
     /// dual-container codes. The lazily-built weight-description cache is a
@@ -455,16 +475,50 @@ impl HuffmanTable {
         Self::build_from_counts(&counts[..=max_symbol])
     }
 
+    /// Build the literals Huffman table, running the #167 table-log search
+    /// only when `use_search` is set; otherwise take the cheap single-build
+    /// (the upstream non-optimalDepth path). The caller gates `use_search` by
+    /// strategy and source size (see `CompressState::huf_optimal_search`).
+    pub fn build_from_counts_gated(counts: &[usize], use_search: bool) -> Self {
+        if use_search {
+            Self::build_from_counts(counts)
+        } else {
+            Self::build_from_weights(&build_limited_weights(counts, 11))
+        }
+    }
+
     pub fn build_from_counts(counts: &[usize]) -> Self {
         assert!(counts.len() <= 256);
         let symbol_cardinality = counts.iter().filter(|&&count| count > 0).count();
         if symbol_cardinality <= 1 {
             return Self::build_from_weights(&build_limited_weights(counts, 11));
         }
+        // Measurement-only: force the cheap single-build path (the upstream
+        // non-optimalDepth path) so a bench harness can compare #167 on/off
+        // ratio and speed across levels from one build. Off in every shipping
+        // build (gated behind `bench_internals`).
+        #[cfg(feature = "bench_internals")]
+        if FORCE_CHEAP_HUF.load(core::sync::atomic::Ordering::Relaxed) {
+            return Self::build_from_weights(&build_limited_weights(counts, 11));
+        }
 
         let min_table_log = symbol_cardinality.ilog2() as usize + 1;
         let mut best_size = usize::MAX - 1;
-        let mut best_weights: Option<alloc::vec::Vec<usize>> = None;
+        // Reused across every `table_log` candidate so the search allocates
+        // nothing per iteration: `work` is the height-limit scratch, `cand`
+        // holds the current candidate's weights, `best` retains the winning
+        // weights — swapped in on a new best, so the loser's buffer recycles
+        // back into `cand` for the next iteration. On a small alphabet
+        // `min_table_log` is low, so the candidate count (and the old
+        // per-candidate `leaves.to_vec()` + weight-`Vec` allocations) was the
+        // dominant small-frame entropy-build cost.
+        // Pre-size the reused scratch to its proven bound (alphabet <= 256, tree
+        // <= 2*256-1 nodes) so the first candidate's resize/extend allocates once
+        // and never reallocates across the table-log search.
+        let mut work: Vec<HuffNode> = Vec::with_capacity(2 * counts.len());
+        let mut cand: Vec<usize> = Vec::with_capacity(counts.len());
+        let mut best: Vec<usize> = Vec::with_capacity(counts.len());
+        let mut best_found = false;
 
         // Outer-loop scoring uses [`cheap_desc_size_proxy`] — an integer
         // entropy estimate of the weight description, no FSE encode.
@@ -478,10 +532,7 @@ impl HuffmanTable {
         //
         // Stack-allocated `weights_u8` buffer (256 B — counts.len() max
         // = 256) absorbs the per-candidate `Vec<usize> → &[u8]`
-        // conversion that the proxy wants. Avoids the per-candidate
-        // `table.weights()` allocation (~256 B Vec) and lets the
-        // table-log search loop stay allocation-free past the
-        // mandatory `build_limited_weights` Vec.
+        // conversion that the proxy wants.
         let mut weights_u8 = [0u8; 256];
         // The Huffman tree shape (and thus the per-leaf natural depths) does
         // not depend on `table_log`; only the height limiting does. Build the
@@ -489,9 +540,11 @@ impl HuffmanTable {
         // instead of rebuilding the whole tree per iteration.
         let leaves = build_huffman_leaf_depths(counts);
         for table_log in min_table_log..=11 {
-            let weights = limited_weights_from_leaves(&leaves, counts.len(), table_log)
-                .unwrap_or_else(|| legacy_distributed_weights(counts));
-            if !huffman_weight_sum_is_power_of_two(&weights) {
+            if !limited_weights_into(&leaves, counts.len(), table_log, &mut work, &mut cand) {
+                cand = legacy_distributed_weights(counts);
+            }
+            let weights = &cand;
+            if !huffman_weight_sum_is_power_of_two(weights) {
                 continue;
             }
             // Per-symbol code length is `wtable_log + 1 - weight` (weight > 0) —
@@ -561,15 +614,19 @@ impl HuffmanTable {
             }
             if new_size < best_size {
                 best_size = new_size;
-                // Move the owned weights in (no clone); the next iteration
-                // allocates fresh weights and the previous best is freed.
-                best_weights = Some(weights);
+                // Keep the winning weights without a clone: swap them into
+                // `best`; the previous best's buffer lands in `cand` and is
+                // recycled (cleared + refilled) by the next candidate.
+                core::mem::swap(&mut best, &mut cand);
+                best_found = true;
             }
         }
 
-        best_weights
-            .map(|w| Self::build_from_weights(&w))
-            .unwrap_or_else(|| Self::build_from_weights(&build_limited_weights(counts, 11)))
+        if best_found {
+            Self::build_from_weights(&best)
+        } else {
+            Self::build_from_weights(&build_limited_weights(counts, 11))
+        }
     }
 
     /// Estimates encoded payload size in bytes for `data` using this table.
@@ -882,30 +939,96 @@ struct HuffNode {
 /// symbol the (0 or 1) leaves are returned with `nb_bits == 0` and the caller
 /// assigns the trivial weight.
 fn build_huffman_leaf_depths(counts: &[usize]) -> Vec<HuffNode> {
-    let mut leaves = counts
-        .iter()
-        .copied()
-        .enumerate()
-        .filter(|&(_, count)| count > 0)
-        .map(|(symbol, count)| HuffNode {
+    let leaf_count = counts.iter().filter(|&&count| count > 0).count();
+    // Pre-size to the final node count (`2 * leaf_count - 1`) so the tree
+    // build's resize never reallocates.
+    let mut nodes: Vec<HuffNode> = Vec::with_capacity((2 * leaf_count).max(1));
+
+    if leaf_count == 0 {
+        return nodes;
+    }
+    if leaf_count == 1 {
+        let (symbol, &count) = counts.iter().enumerate().find(|&(_, &c)| c > 0).unwrap();
+        nodes.push(HuffNode {
             count,
             symbol,
             parent: None,
             nb_bits: 0,
-        })
-        .collect::<Vec<_>>();
-
-    if leaves.len() <= 1 {
-        return leaves;
+        });
+        return nodes;
     }
 
-    leaves.sort_by(|left, right| match right.count.cmp(&left.count) {
-        Ordering::Equal => left.symbol.cmp(&right.symbol),
-        other => other,
-    });
+    // Bucketed sort (upstream zstd `HUF_sort`, huf_compress.c): an O(n)
+    // counting pass bucketed by the count magnitude. Counts below
+    // `DISTINCT_CUTOFF` each get a dedicated bucket, so they land strictly
+    // count-descending / symbol-ascending with no per-bucket sort; counts at
+    // or above it share log2 buckets that ARE sorted. Sorting those log2
+    // buckets by `(count desc, symbol asc)` reproduces the previous
+    // comparison-sort order byte-for-byte while replacing the O(n log n) sort
+    // with the bucket pass plus a handful of tiny bucket sorts — the Huffman
+    // leaf sort was a measured ~7% of the per-frame entropy-build time.
+    const BUCKETS: usize = 192;
+    const LOG_BUCKETS_BEGIN: usize = 158; // (BUCKETS - 1) - 32 - 1
+    const DISTINCT_CUTOFF: usize = 165; // LOG_BUCKETS_BEGIN + highbit32(158)
+    let bucket_of = |count: usize| -> usize {
+        if count < DISTINCT_CUTOFF {
+            count
+        } else {
+            // `highest_bit_set(count) - 1` == upstream `ZSTD_highbit32`.
+            (highest_bit_set(count) - 1) + LOG_BUCKETS_BEGIN
+        }
+    };
+    let mut bucket_size = [0u32; BUCKETS];
+    for &count in counts {
+        if count > 0 {
+            bucket_size[bucket_of(count)] += 1;
+        }
+    }
+    // Output start index per bucket: higher buckets (higher counts) come
+    // first, so the leaves end up count-descending.
+    let mut start = [0u32; BUCKETS];
+    let mut acc = 0u32;
+    for bucket in (0..BUCKETS).rev() {
+        start[bucket] = acc;
+        acc += bucket_size[bucket];
+    }
+    let mut cursor = start;
+    nodes.resize(
+        leaf_count,
+        HuffNode {
+            count: 0,
+            symbol: 0,
+            parent: None,
+            nb_bits: 0,
+        },
+    );
+    for (symbol, &count) in counts.iter().enumerate() {
+        if count == 0 {
+            continue;
+        }
+        let bucket = bucket_of(count);
+        let pos = cursor[bucket] as usize;
+        cursor[bucket] += 1;
+        nodes[pos] = HuffNode {
+            count,
+            symbol,
+            parent: None,
+            nb_bits: 0,
+        };
+    }
+    // Only the log2 buckets mix distinct counts; sort them stably by
+    // `(count desc, symbol asc)` so the order matches the old full sort.
+    for bucket in DISTINCT_CUTOFF..BUCKETS {
+        let lo = start[bucket] as usize;
+        let hi = cursor[bucket] as usize;
+        if hi - lo > 1 {
+            nodes[lo..hi].sort_by(|left, right| match right.count.cmp(&left.count) {
+                Ordering::Equal => left.symbol.cmp(&right.symbol),
+                other => other,
+            });
+        }
+    }
 
-    let leaf_count = leaves.len();
-    let mut nodes = leaves;
     nodes.resize(
         2 * leaf_count - 1,
         HuffNode {
@@ -999,37 +1122,51 @@ fn build_huffman_leaf_depths(counts: &[usize]) -> Vec<HuffNode> {
 /// height limiting cannot reach `max_nb_bits` (the caller then falls back to
 /// the distributed-weight construction). `leaves` must be sorted by count
 /// descending, which `enforce_max_height` relies on.
-fn limited_weights_from_leaves(
+/// Height-limit `leaves` to `max_nb_bits` and project onto a per-symbol weight
+/// table, writing into `out` (cleared + sized to `counts_len`). `work` is a
+/// caller-owned scratch buffer for the height-limiting pass; both buffers are
+/// reused across the table-log candidate search so the per-candidate
+/// `leaves.to_vec()` + fresh weight `Vec` allocations are gone. Returns `false`
+/// when the height limiting cannot reach `max_nb_bits` (caller falls back).
+fn limited_weights_into(
     leaves: &[HuffNode],
     counts_len: usize,
     max_nb_bits: usize,
-) -> Option<Vec<usize>> {
+    work: &mut Vec<HuffNode>,
+    out: &mut Vec<usize>,
+) -> bool {
+    out.clear();
+    out.resize(counts_len, 0);
     if leaves.len() <= 1 {
-        let mut weights = alloc::vec![0; counts_len];
         if let Some(leaf) = leaves.first() {
-            weights[leaf.symbol] = 1;
+            out[leaf.symbol] = 1;
         }
-        return Some(weights);
+        return true;
     }
 
-    let mut sorted_leaves = leaves.to_vec();
-    enforce_max_height(&mut sorted_leaves, max_nb_bits);
-    repair_limited_lengths(&mut sorted_leaves, max_nb_bits);
-    if sorted_leaves.iter().any(|leaf| leaf.nb_bits > max_nb_bits) {
-        return None;
+    work.clear();
+    work.extend_from_slice(leaves);
+    enforce_max_height(work, max_nb_bits);
+    repair_limited_lengths(work, max_nb_bits);
+    if work.iter().any(|leaf| leaf.nb_bits > max_nb_bits) {
+        return false;
     }
 
-    let mut weights = alloc::vec![0; counts_len];
-    for leaf in sorted_leaves {
-        weights[leaf.symbol] = max_nb_bits - leaf.nb_bits + 1;
+    for leaf in work.iter() {
+        out[leaf.symbol] = max_nb_bits - leaf.nb_bits + 1;
     }
-    Some(weights)
+    true
 }
 
 fn build_limited_weights(counts: &[usize], max_nb_bits: usize) -> Vec<usize> {
     let leaves = build_huffman_leaf_depths(counts);
-    limited_weights_from_leaves(&leaves, counts.len(), max_nb_bits)
-        .unwrap_or_else(|| legacy_distributed_weights(counts))
+    let mut work = Vec::new();
+    let mut out = Vec::new();
+    if limited_weights_into(&leaves, counts.len(), max_nb_bits, &mut work, &mut out) {
+        out
+    } else {
+        legacy_distributed_weights(counts)
+    }
 }
 
 fn repair_limited_lengths(nodes: &mut [HuffNode], target_nb_bits: usize) {
@@ -1120,7 +1257,15 @@ fn enforce_max_height(nodes: &mut [HuffNode], target_nb_bits: usize) {
     total_cost >>= largest_bits - target_nb_bits;
 
     const NO_SYMBOL: usize = usize::MAX;
-    let mut rank_last = alloc::vec![NO_SYMBOL; target_nb_bits + 2];
+    // `rank_last` is indexed `0..=target_nb_bits + 1`. `target_nb_bits` is the
+    // Huffman table log, capped at upstream zstd's `HUF_TABLELOG_MAX` (12), so a
+    // fixed 14-slot stack array covers every valid call and avoids the
+    // per-frame heap allocation this build performed for a ≤14-element scratch.
+    debug_assert!(
+        target_nb_bits + 2 <= 14,
+        "target_nb_bits {target_nb_bits} exceeds HUF_TABLELOG_MAX scratch bound"
+    );
+    let mut rank_last = [NO_SYMBOL; 14];
     let mut current_nb_bits = target_nb_bits;
     for pos in (0..=n).rev() {
         if nodes[pos].nb_bits >= current_nb_bits {

--- a/zstd/src/lib.rs
+++ b/zstd/src/lib.rs
@@ -129,6 +129,34 @@ mod tests;
 #[cfg(feature = "bench_internals")]
 #[doc(hidden)]
 pub mod testing {
+    /// Compression parameters selected for `(level, srcSize, dictSize)` →
+    /// `(windowLog, chainLog, hashLog, searchLog, minMatch, targetLength,
+    /// strategy)`. Facade for the `ffi-bench` parity test that diffs the
+    /// selection against the reference `ZSTD_getCParams`.
+    pub fn compression_params(
+        level: i32,
+        src: u64,
+        dict: usize,
+    ) -> (u32, u32, u32, u32, u32, u32, u32) {
+        let cp = crate::encoding::cparams::get_cparams_public(level, src, dict);
+        (
+            cp.window_log,
+            cp.chain_log,
+            cp.hash_log,
+            cp.search_log,
+            cp.min_match,
+            cp.target_length,
+            cp.strategy,
+        )
+    }
+
+    /// Force every HUF table build onto the cheap single-build path (skip the
+    /// #167 table-log search) so a bench harness can A/B the search across
+    /// levels. Measurement-only.
+    pub fn set_force_cheap_huf(on: bool) {
+        crate::huff0::huff0_encoder::set_force_cheap_huf(on);
+    }
+
     pub use crate::bit_io::BitReaderReversed;
     // `BitReaderReversed` is generic over `K: CpuKernel = ScalarKernel`,
     // so both the trait bound and the default need a `pub` path to

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -817,8 +817,7 @@ fn fast_copy_mode_dict_reachable_for_full_block() {
 
     // And the frame must still round-trip against the dictionary.
     let dec_handle = DictionaryHandle::from_dictionary(
-        Dictionary::from_raw_content(dict_id, dict_content)
-            .expect("decoder dict should build"),
+        Dictionary::from_raw_content(dict_id, dict_content).expect("decoder dict should build"),
     );
     let mut output = vec![0u8; input.len()];
     let mut decoder = FrameDecoder::new();

--- a/zstd/src/tests/dict_test.rs
+++ b/zstd/src/tests/dict_test.rs
@@ -740,3 +740,91 @@ fn load_sample_dict_frame(expected_dict_id: u32) -> (alloc::vec::Vec<u8>, alloc:
 
     (compressed, original)
 }
+
+/// Regression: a copy-mode Fast (level 1) dictionary must stay reachable for a
+/// whole >8 KiB block. The attach/copy split routes inputs larger than the Fast
+/// 8 KiB cutoff through the copy path, which commits the dict to the front of
+/// history and primes the live hash table over it. The block's prefix floor must
+/// then mirror upstream zstd `ZSTD_getLowestPrefixIndex`: while the dictionary is
+/// still within `maxDist + loadedDictEnd` of the block end, the floor is the dict
+/// start, NOT the window-clamped `blockEnd - window`. A block-constant
+/// window-clamped floor (computed from the history END) rejected every dict
+/// position for the whole block, so a 16 KiB input over an 8 KiB dict ignored the
+/// dictionary entirely and fell back to the no-dict ratio.
+#[test]
+fn fast_copy_mode_dict_reachable_for_full_block() {
+    use crate::decoding::FrameDecoder;
+    use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
+    use crate::encoding::{CompressionLevel, FrameCompressor};
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    // 128 distinct pseudo-random 64-byte lines (LCG, hermetic). Distinct content
+    // means the input has no cheap internal matches on first occurrence — the
+    // only way to compress the first pass is to match the dictionary.
+    const LINE: usize = 64;
+    const N_LINES: usize = 128;
+    let mut lines: Vec<Vec<u8>> = Vec::with_capacity(N_LINES);
+    let mut s: u32 = 0x1234_5678;
+    for _ in 0..N_LINES {
+        let mut line = Vec::with_capacity(LINE);
+        while line.len() < LINE {
+            s = s.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+            line.push((s >> 24) as u8);
+        }
+        lines.push(line);
+    }
+
+    // Dict = all 128 lines (8192 bytes). Input = the same 128 lines twice
+    // (16384 bytes) — over the Fast 8 KiB copy cutoff, single block.
+    let mut dict_content = Vec::with_capacity(N_LINES * LINE);
+    for line in &lines {
+        dict_content.extend_from_slice(line);
+    }
+    assert_eq!(dict_content.len(), 8192, "dict must be exactly 8 KiB");
+
+    let mut input = Vec::with_capacity(2 * N_LINES * LINE);
+    for _ in 0..2 {
+        for line in &lines {
+            input.extend_from_slice(line);
+        }
+    }
+    assert_eq!(input.len(), 16384, "input must be 16 KiB (> 8 KiB cutoff)");
+
+    let dict_id = 0x00AB_CDEFu32;
+    let enc_dict = Dictionary::from_raw_content(dict_id, dict_content.clone())
+        .expect("encoder dict should build");
+
+    // With dictionary.
+    let mut cctx: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(1));
+    cctx.set_dictionary(enc_dict).expect("attach dict");
+    let with_dict = cctx.compress_independent_frame(&input);
+
+    // Without dictionary, same level — the baseline the bug regressed to.
+    let mut cctx_nodict: FrameCompressor = FrameCompressor::new(CompressionLevel::Level(1));
+    let no_dict = cctx_nodict.compress_independent_frame(&input);
+
+    // The dictionary covers every line of the first pass, so a working copy-mode
+    // dict path must compress dramatically better than the no-dict baseline (C
+    // reaches a tiny frame here). The bug made the two equal.
+    assert!(
+        with_dict.len() * 2 < no_dict.len(),
+        "copy-mode Fast dict must beat the no-dict baseline by >2x; \
+         got with_dict={} vs no_dict={}",
+        with_dict.len(),
+        no_dict.len(),
+    );
+
+    // And the frame must still round-trip against the dictionary.
+    let dec_handle = DictionaryHandle::from_dictionary(
+        Dictionary::from_raw_content(dict_id, dict_content)
+            .expect("decoder dict should build"),
+    );
+    let mut output = vec![0u8; input.len()];
+    let mut decoder = FrameDecoder::new();
+    let written = decoder
+        .decode_all_with_dict_handle(with_dict.as_slice(), &mut output, &dec_handle)
+        .expect("decode with dict should succeed");
+    assert_eq!(written, input.len());
+    assert_eq!(&output, &input, "copy-mode dict frame must round-trip");
+}


### PR DESCRIPTION
## Summary

Reworks the Fast (level 1) dictionary-compression path: a reused per-label
dictionary now stays resident across frames, the dictionary is **attached** and
the caller's input is **scanned in place** (no per-frame input copy), and the
match/entropy decisions that the dictionary unlocks are restored.

### What changed
- **Reuse-safe dictionary reuse** — re-borrow a resident attach-mode dictionary
  across reused frames (Fast/HC/dfast) instead of re-committing it every frame;
  fix the reused-dictionary decay where output ballooned to the no-dict size.
- **Source-size cParams tiering** (`ZSTD_getCParams` shape) for Fast/dfast.
- **Dictionary ratio fix** — Fast dict table uses an every-position last-wins
  fill (nearest occurrence per hash = smallest offset) + an 8-byte dict-match
  floor, so a trained-dict frame is smaller than its no-dict frame again
  (matches the C reference's direction). Short-cache (`ZSTD_SHORT_CACHE`) tags on
  the dict slots reject colliding candidates without a wasted load.
- **Scan in place, don't copy the input** — every Fast dict frame now attaches
  (borrowed dual-base kernel) instead of the copy-mode owned path that memmoved
  the whole input into history each frame (profiled at 30% `__memmove` + 14%
  `__memset` on a reused 1 MiB dict encode, vs 0.69% on the no-dict in-place
  path). The borrowed dict scan floors the prefix at the dict start while the
  dict is in window, and the raw-fast-path is dictionary-aware (stricter
  full-block incompressibility sample + a cheap extendable-dict-match probe) so a
  block that compresses only against the dictionary is never skipped to raw.
- Bias-aware pointer hoist in the dict kernels; FSE-table-selection `max_symbol`
  tracking; assorted dict-kernel hardening.

### Measured (i9, compress-dict vs libzstd)
- 1 MiB dict frame: **167 µs → 52 µs**; 10 KiB dict frame: **20.4 µs → 4.4 µs**
  (removing the per-frame input copy).
- Ratio preserved or better on the dict bands (`rust_bytes <= ffi_bytes`).

On real decodecorpus the Fast match-parse still emits more sequences than the
reference (single-slot greedy hash selecting shorter self-matches) — tracked
separately as a match-quality item; not a regression introduced here.

### Testing
- 825 library tests, ffi dictionary cross-decode (Fast/dfast/Row/HC/BT across
  sizes + reuse), and cross_validation all green.
- No-dict path byte-identical; dictionary frames round-trip through the C decoder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added new benchmarking examples: allocation audit, HUF strategy matrices, and dictionary/compression-parameter matrices.
  * Enhanced the dictionary attachment example to accept both finalized dictionaries and raw-content dictionary blobs.

* **Tests**
  * Added C-reference parity checks for compression-parameter selection.
  * Added cross-decoder conformance tests for dictionary-compressed frames, plus new regression coverage for dictionary reachability/resident reuse.

* **Performance / Improvements**
  * Improved dictionary-aware fast-path selection and stabilized parameter/HUF selection behavior.
  * Reduced allocations and tightened table construction/bounds while preserving output compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->