### PR TITLE
build(ffi-bench): add version to structured-zstd path dependency

### DIFF
--- a/ffi-bench/Cargo.toml
+++ b/ffi-bench/Cargo.toml
@@ -27,7 +27,7 @@ path = "src/lib.rs"
 # bias every Rust-vs-libzstd comparison. Targets that genuinely need them opt
 # in per-target via `required-features` below, so a bench built in isolation
 # (`cargo bench --bench compare_ffi`) never links them.
-structured-zstd = { path = "../zstd", features = ["dict_builder"] }
+structured-zstd = { version = "0.0", path = "../zstd", features = ["dict_builder"] }
 zstd = { version = "0.13.3", features = ["zdict_builder", "experimental"] }
 criterion = "0.8"
 rand = "0.10"


### PR DESCRIPTION
## Summary

release-plz's `Create release PR` job fails on `cargo package`:

```
error: failed to verify manifest at ffi-bench/Cargo.toml
  all dependencies must have a version requirement specified when packaging.
  dependency `structured-zstd` does not specify a version
```

`cargo package` (which release-plz runs to determine next versions) verifies every workspace manifest, and a path-only dependency without a version requirement is rejected. `ffi-bench` depended on `structured-zstd` by `path` only; the `cli` and `zstd-wasm` crates already pin a loose version on the same path dep.

## Fix

Add `version = "0.0"` to ffi-bench's `structured-zstd` dependency (matching the `cli` convention — tracks every `0.0.x` without per-release churn). `ffi-bench` stays `publish = false` / `release = false`; this only makes its manifest valid for the workspace packaging check.

## Testing

`cargo package -p structured-zstd --allow-dirty` now passes (Packaging → Verifying → Finished) with no manifest error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->