### PR TITLE
chore: release v0.0.42

### DIFF
--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "structured-zstd"
-version = "0.0.41"
+version = "0.0.42"
 rust-version = "1.92"
 authors = [
     "Moritz Borcherding <moritz.borcherding@web.de>",


### PR DESCRIPTION
## Why

release-plz is deadlocked. Its `Create release PR` job runs `cargo package` over the **workspace at the last-release baseline (v0.0.41)**, and the v0.0.41 tree has `ffi-bench` depending on `structured-zstd` by `path` only (no `version`). cargo rejects that when packaging:

```
error: failed to verify manifest at ffi-bench/Cargo.toml
  all dependencies must have a version requirement specified when packaging.
  dependency `structured-zstd` does not specify a version
```

PR #435 fixed this on `main`, but the v0.0.41 **tag tree is immutable** — release-plz keeps packaging the broken baseline, so every run since the v0.0.41 release (#432, #433, #435) is red. No `main` commit can change what release-plz packages for the v0.0.41 baseline.

## Fix

Bump `structured-zstd` 0.0.41 → 0.0.42 and cut **v0.0.42** manually, moving release-plz's baseline past the broken v0.0.41 tree. The v0.0.42 tree already carries the #435 ffi-bench version fix, so `cargo package --workspace` passes against it (verified locally: full `cargo package --workspace` is green on current `main`).

## Required follow-up (manual, after merge)

release-plz cannot create the release itself while deadlocked. After this merges, create the GitHub release so the tag lands and `release.yml` (trigger: `release: created`) runs:

```
gh release create v0.0.42 --target main --title "v0.0.42" --generate-notes
```

Once tag `v0.0.42` exists, release-plz's next run packages the v0.0.42 baseline (with the fix) and works again. CHANGELOG is left to release-plz (manual edits are guarded / overwritten by its next run).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.0.42.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->