### PR TITLE
perf(decode): branchy fused decodeSequence on the AVX2 short arm

### DIFF
--- a/zstd/src/decoding/seq_decoder_avx2.rs
+++ b/zstd/src/decoding/seq_decoder_avx2.rs
@@ -79,6 +79,97 @@ macro_rules! decode_one_body {
     }};
 }
 
+/// Donor-shape fused decode + offset-resolution for one sequence.
+///
+/// Mirrors upstream zstd `ZSTD_decodeSequence` (zstd_decompress_block.c:1228-1346)
+/// branch-for-branch on the 64-bit path: the offset extra-bit read is folded
+/// INTO the `ofBits>1 / ==0 / ==1` branches (no read in the rep-0 arm, one bit
+/// in the rep/1 arm, full read in the real-offset arm), and the repcode history
+/// rotation is resolved inline right there. ml/ll extra bits are read separately
+/// afterwards. This is the branchy counterpart to the branchless
+/// `do_offset_history` RULES table; we read of/ml/ll with individual
+/// demand-refilled `get_bits` instead of one PEXT triple, giving the branch
+/// predictor the offset-width context upstream relies on.
+///
+/// Our offset table stores `base_value = 1 << ofCode`, so `of_base + raw` is the
+/// offBase domain (1/2/3 = repcodes, >=4 = real offset + 3). The arithmetic here
+/// converts to the real-offset domain that the executor consumes and that
+/// `offset_hist` records (verified equal to `do_offset_history` across its full
+/// test matrix). Expands to `(ll, ml, actual_offset)`; rotates `$hist` in place.
+macro_rules! decode_seq_fused_cshape {
+    ($ll_dec:expr, $ml_dec:expr, $of_dec:expr, $br:expr, $hist:expr) => {{
+        let ll_state = $ll_dec.state;
+        let ml_state = $ml_dec.state;
+        let of_state = $of_dec.state;
+
+        let ll_base = ll_state.base_value;
+        let ml_base = ml_state.base_value;
+        let of_base = of_state.base_value;
+        let ll_bits = ll_state.num_additional_bits;
+        let ml_bits = ml_state.num_additional_bits;
+        let of_bits = of_state.num_additional_bits;
+
+        debug_assert!(of_bits <= MAX_OFFSET_CODE);
+
+        // === Offset + repcode (upstream branchy ofBits flow) ===
+        let actual_offset: u32 = if of_bits > 1 {
+            // Real offset: read ofBits, no repcode. offBase = of_base + raw >= 4.
+            let raw = $br.get_bits(of_bits) as u32;
+            let resolved = (of_base + raw).wrapping_sub(3);
+            $hist[2] = $hist[1];
+            $hist[1] = $hist[0];
+            $hist[0] = resolved;
+            resolved
+        } else {
+            let ll0 = ll_base == 0;
+            if of_bits == 0 {
+                // Repcode 0 (most common): no offset bits consumed.
+                let idx = usize::from(ll0);
+                let resolved = $hist[idx];
+                $hist[1] = $hist[idx ^ 1];
+                $hist[0] = resolved;
+                resolved
+            } else {
+                // ofBits == 1: one bit selects among rep1..rep3. The upstream
+                // repcode base for this arm is 1 (our of_base is 2 here).
+                let bit = $br.get_bits(1) as u32;
+                let off_code = 1 + u32::from(ll0) + bit; // in {1,2,3}
+                let mut temp = if off_code == 3 {
+                    $hist[0].wrapping_sub(1)
+                } else {
+                    $hist[off_code as usize]
+                };
+                // 0 is not a valid offset: force corruption to surface downstream
+                // (upstream `temp -= !temp`; our executor rejects offset 0).
+                temp = temp.wrapping_sub(u32::from(temp == 0));
+                if off_code != 1 {
+                    $hist[2] = $hist[1];
+                }
+                $hist[1] = $hist[0];
+                $hist[0] = temp;
+                temp
+            }
+        };
+        debug_assert_ne!(actual_offset, 0);
+
+        // === Match length + literal length extra bits ===
+        let ml = ml_base
+            + if ml_bits > 0 {
+                $br.get_bits(ml_bits) as u32
+            } else {
+                0
+            };
+        let ll = ll_base
+            + if ll_bits > 0 {
+                $br.get_bits(ll_bits) as u32
+            } else {
+                0
+            };
+
+        (ll, ml, actual_offset)
+    }};
+}
+
 /// Textual expansion of per-sequence execute. Fast path: the inlined AVX2
 /// match-copy macro [`exec_sequence_avx2_inline`]. Cold path: legacy
 /// try_push + repeat_lookahead_prefetched. Expands as a statement-block
@@ -336,22 +427,27 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
         let mut shadow_hist = *offset_hist;
         let mut fallback_err: Option<DecompressBlockError> = None;
         for i in 0..num_sequences {
-            let seq = decode_one_body!(&mut ll_dec, &mut ml_dec, &mut of_dec, &mut br);
-            let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
+            let (seq_ll, seq_ml, resolved_offset) = decode_seq_fused_cshape!(
+                &mut ll_dec,
+                &mut ml_dec,
+                &mut of_dec,
+                &mut br,
+                &mut shadow_hist
+            );
             let r = execute_one_body!(
                 buffer,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
-                seq.ll,
-                seq.ml,
+                seq_ll,
+                seq_ml,
                 resolved_offset
             );
             if let Err(e) = r {
                 fallback_err = Some(e);
                 break;
             }
-            seq_sum = seq_sum.wrapping_add(seq.ll).wrapping_add(seq.ml);
+            seq_sum = seq_sum.wrapping_add(seq_ll).wrapping_add(seq_ml);
 
             if i + 1 < num_sequences {
                 br.ensure_bits(max_update_bits);

--- a/zstd/src/decoding/seq_decoder_avx2.rs
+++ b/zstd/src/decoding/seq_decoder_avx2.rs
@@ -79,17 +79,92 @@ macro_rules! decode_one_body {
     }};
 }
 
-/// Donor-shape fused decode + offset-resolution for one sequence.
+/// Branchy offset/repcode resolution + ml/ll reads, parameterised by the
+/// bit-reader method `$rd` (`get_bits` = demand-refilled, or
+/// `get_bits_unchecked` = no per-read refill check after a prior
+/// `ensure_bits`). The control flow mirrors upstream `ZSTD_decodeSequence`:
+/// the offset extra-bit read is folded INTO the `ofBits>1 / ==0 / ==1`
+/// branches and the repcode history rotation is resolved inline. Expands to
+/// `(ll, ml, actual_offset)`; rotates `$hist` in place.
+macro_rules! cshape_resolve {
+    (
+        $rd:ident, $ll_base:expr, $ml_base:expr, $of_base:expr,
+        $ll_bits:expr, $ml_bits:expr, $of_bits:expr, $br:expr, $hist:expr
+    ) => {{
+        let ll_base = $ll_base;
+        let of_base = $of_base;
+        let ml_bits = $ml_bits;
+        let ll_bits = $ll_bits;
+        let of_bits = $of_bits;
+
+        let actual_offset: u32 = if of_bits > 1 {
+            // Real offset: read ofBits, no repcode. offBase = of_base + raw >= 4.
+            let raw = $br.$rd(of_bits) as u32;
+            let resolved = (of_base + raw).wrapping_sub(3);
+            $hist[2] = $hist[1];
+            $hist[1] = $hist[0];
+            $hist[0] = resolved;
+            resolved
+        } else {
+            let ll0 = ll_base == 0;
+            if of_bits == 0 {
+                // Repcode 0 (most common): no offset bits consumed.
+                let idx = usize::from(ll0);
+                let resolved = $hist[idx];
+                $hist[1] = $hist[idx ^ 1];
+                $hist[0] = resolved;
+                resolved
+            } else {
+                // ofBits == 1: one bit selects among rep1..rep3. The upstream
+                // repcode base for this arm is 1 (our of_base is 2 here).
+                let bit = $br.$rd(1) as u32;
+                let off_code = 1 + u32::from(ll0) + bit; // in {1,2,3}
+                let mut temp = if off_code == 3 {
+                    $hist[0].wrapping_sub(1)
+                } else {
+                    $hist[off_code as usize]
+                };
+                // 0 is not a valid offset: force corruption to surface downstream
+                // (upstream `temp -= !temp`; our executor rejects offset 0).
+                temp = temp.wrapping_sub(u32::from(temp == 0));
+                if off_code != 1 {
+                    $hist[2] = $hist[1];
+                }
+                $hist[1] = $hist[0];
+                $hist[0] = temp;
+                temp
+            }
+        };
+        debug_assert_ne!(actual_offset, 0);
+
+        // === Match length + literal length extra bits ===
+        let ml = $ml_base
+            + if ml_bits > 0 {
+                $br.$rd(ml_bits) as u32
+            } else {
+                0
+            };
+        let ll = ll_base
+            + if ll_bits > 0 {
+                $br.$rd(ll_bits) as u32
+            } else {
+                0
+            };
+
+        (ll, ml, actual_offset)
+    }};
+}
+
+/// Fused decode + offset-resolution for one sequence (upstream zstd shape).
 ///
 /// Mirrors upstream zstd `ZSTD_decodeSequence` (zstd_decompress_block.c:1228-1346)
-/// branch-for-branch on the 64-bit path: the offset extra-bit read is folded
-/// INTO the `ofBits>1 / ==0 / ==1` branches (no read in the rep-0 arm, one bit
-/// in the rep/1 arm, full read in the real-offset arm), and the repcode history
-/// rotation is resolved inline right there. ml/ll extra bits are read separately
-/// afterwards. This is the branchy counterpart to the branchless
-/// `do_offset_history` RULES table; we read of/ml/ll with individual
-/// demand-refilled `get_bits` instead of one PEXT triple, giving the branch
-/// predictor the offset-width context upstream relies on.
+/// branch-for-branch on the 64-bit path (see [`cshape_resolve`]), with our
+/// optimisation woven back in: the common `total <= 56` case does ONE
+/// `ensure_bits` up front, then all of/ml/ll reads go through
+/// `get_bits_unchecked` (no per-field refill branch). Only the rare
+/// wide-offset case (`total > 56`) falls back to demand-refilled `get_bits`.
+/// This keeps the winning branchy offset/repcode shape while reclaiming the
+/// single-refill efficiency the old PEXT-triple path had.
 ///
 /// Our offset table stores `base_value = 1 << ofCode`, so `of_base + raw` is the
 /// offBase domain (1/2/3 = repcodes, >=4 = real offset + 3). The arithmetic here
@@ -111,62 +186,27 @@ macro_rules! decode_seq_fused_cshape {
 
         debug_assert!(of_bits <= MAX_OFFSET_CODE);
 
-        // === Offset + repcode (upstream branchy ofBits flow) ===
-        let actual_offset: u32 = if of_bits > 1 {
-            // Real offset: read ofBits, no repcode. offBase = of_base + raw >= 4.
-            let raw = $br.get_bits(of_bits) as u32;
-            let resolved = (of_base + raw).wrapping_sub(3);
-            $hist[2] = $hist[1];
-            $hist[1] = $hist[0];
-            $hist[0] = resolved;
-            resolved
+        // total = exact bits consumed by this sequence in every arm (rep-0
+        // reads 0 offset bits so total = ml+ll; rep-1 reads 1; real reads ofBits).
+        let total = u16::from(of_bits) + u16::from(ml_bits) + u16::from(ll_bits);
+        if total <= 56 {
+            $br.ensure_bits(total as u8);
+            cshape_resolve!(
+                get_bits_unchecked,
+                ll_base,
+                ml_base,
+                of_base,
+                ll_bits,
+                ml_bits,
+                of_bits,
+                $br,
+                $hist
+            )
         } else {
-            let ll0 = ll_base == 0;
-            if of_bits == 0 {
-                // Repcode 0 (most common): no offset bits consumed.
-                let idx = usize::from(ll0);
-                let resolved = $hist[idx];
-                $hist[1] = $hist[idx ^ 1];
-                $hist[0] = resolved;
-                resolved
-            } else {
-                // ofBits == 1: one bit selects among rep1..rep3. The upstream
-                // repcode base for this arm is 1 (our of_base is 2 here).
-                let bit = $br.get_bits(1) as u32;
-                let off_code = 1 + u32::from(ll0) + bit; // in {1,2,3}
-                let mut temp = if off_code == 3 {
-                    $hist[0].wrapping_sub(1)
-                } else {
-                    $hist[off_code as usize]
-                };
-                // 0 is not a valid offset: force corruption to surface downstream
-                // (upstream `temp -= !temp`; our executor rejects offset 0).
-                temp = temp.wrapping_sub(u32::from(temp == 0));
-                if off_code != 1 {
-                    $hist[2] = $hist[1];
-                }
-                $hist[1] = $hist[0];
-                $hist[0] = temp;
-                temp
-            }
-        };
-        debug_assert_ne!(actual_offset, 0);
-
-        // === Match length + literal length extra bits ===
-        let ml = ml_base
-            + if ml_bits > 0 {
-                $br.get_bits(ml_bits) as u32
-            } else {
-                0
-            };
-        let ll = ll_base
-            + if ll_bits > 0 {
-                $br.get_bits(ll_bits) as u32
-            } else {
-                0
-            };
-
-        (ll, ml, actual_offset)
+            cshape_resolve!(
+                get_bits, ll_base, ml_base, of_base, ll_bits, ml_bits, of_bits, $br, $hist
+            )
+        }
     }};
 }
 


### PR DESCRIPTION
## Summary

Ports upstream zstd's branchy fused `ZSTD_decodeSequence`
(`zstd_decompress_block.c:1228-1346`) onto the AVX2 short-block
sequence-decode arm, then weaves our single-refill optimization back on top:

- **Branchy fused decode** — the offset extra-bit read is folded INTO the
  `ofBits > 1 / == 0 / == 1` branches (rep-0 reads zero offset bits, rep-1 one
  bit, real offsets the full width), and the repcode history rotation is
  resolved inline in the same branch. This replaces the unconditional
  triple-bit PEXT extract + separate branchless repcode table for the
  short-arm path. Verified equal to the previous branchless resolution across
  its full offset/litlen test matrix.
- **Single-ensure + unchecked reads** — the common `total <= 56` case does one
  `ensure_bits` up front and reads OF/ML/LL through `get_bits_unchecked`,
  removing the per-field refill branch. The per-sequence vendor-dispatch branch
  is gone as well (reads route straight through `bzhi`).

## Impact

Decode throughput on the decodecorpus `z000033` fixture (i9, BMI2+AVX2,
`perf stat` cycles + wall, flat `libzstd` control in the same session):

| | cycles | ns/iter | vs libzstd |
|---|---|---|---|
| base (after #437) | 214.2B | 1697µs | 1.43× |
| this PR | 194.7B | 1545µs | **1.30×** |

**-8.9% decode cycles / wall.** Output is byte-identical (the decoder produces
the same bytes; only the internal bit-read shape changed). The win is largest
where the sequence-execute path dominates (real decodecorpus data).

Only the AVX2 short-block arm changes; the long-pipeline arm, the VBMI2/BMI2
tiers, and the non-x86 paths are untouched.

## Testing

- `cargo nextest run -p structured-zstd --features kernel_bmi2` — **815/815
  pass** on x86_64 (i9), including the `cross_validation` and
  `roundtrip_integrity` suites.
- `cargo fmt --check` + `cargo clippy --lib` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced ZSTD decompression efficiency through improved sequence decoding and offset resolution processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->