### PR TITLE
perf(encode): reuse the LDM producer table across dict frames

### DIFF
--- a/zstd-wasm/bench/bench.mjs
+++ b/zstd-wasm/bench/bench.mjs
@@ -166,7 +166,7 @@ for (const s of ["sample-1.service", "sample-2.service"]) {
 console.log("\n=== dictionary compress/decompress vs @bokuweb/zstd-wasm ===");
 const dictRows = [];
 for (const [scenario, data] of dictSamples) {
-  for (const level of [3, 19]) {
+  for (const level of LEVELS) {
     for (const [name, eng] of Object.entries(engines)) {
       const framed = eng.compressUsingDict(data, dict, level);
       const ok = eq(eng.decompressUsingDict(framed, dict), data);
@@ -184,7 +184,7 @@ for (const [scenario, data] of dictSamples) {
 }
 for (const [scenario, data] of dictSamples) {
   console.log(`\n${scenario} + dict (${data.length} bytes, dict ${dict.length})`);
-  for (const level of [3, 19]) {
+  for (const level of LEVELS) {
     const at = (n) => dictRows.find((r) => r.scenario === scenario && r.level === level && r.name === n);
     const b = at("bokuweb"), s = at("ours-simd128"), sc = at("ours-scalar");
     const x = (o) => (o.cNs / b.cNs).toFixed(2), xd = (o) => (o.dNs / b.dNs).toFixed(2);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2640,8 +2640,10 @@ impl Matcher for MatchGeneratorDriver {
         // clears an existing producer's table but does not null the
         // slot — installing here gives the new frame a fresh producer.
         #[cfg(feature = "hash")]
-        if let MatcherStorage::HashChain(hc) = &mut self.storage {
-            let producer = self
+        {
+            // Resolve the derived LDM params first (immutable borrow of the
+            // overrides), then reuse the existing producer's allocation below.
+            let derived_ldm = self
                 .param_overrides
                 .as_ref()
                 .and_then(|ov| ov.ldm)
@@ -2660,9 +2662,27 @@ impl Matcher for MatchGeneratorDriver {
                         min_match_length: ldm_ov.min_match.unwrap_or(0),
                         bucket_size_log: ldm_ov.bucket_size_log.unwrap_or(0),
                     };
-                    super::ldm::LdmProducer::new(seed.derive(strategy_ord))
+                    seed.derive(strategy_ord)
                 });
-            hc.set_ldm_producer(producer);
+            if let MatcherStorage::HashChain(hc) = &mut self.storage {
+                // Reuse the existing producer's hash-table allocation when the
+                // derived params are unchanged: only `clear()` (re-zero the
+                // table + re-seed the rolling hash, no allocation) is needed for
+                // the new frame. A params change (or the first frame) forces a
+                // fresh `LdmProducer::new`. On the reused-encoder compress-dict
+                // path this avoids re-allocating the LDM hash table (large at
+                // btultra2) every frame — upstream zstd reuses its `ldmState_t`
+                // the same way. `clear()` is mandatory here for correctness
+                // regardless of what `BtMatcher::reset` did to the old table.
+                let producer = derived_ldm.map(|p| match hc.take_ldm_producer() {
+                    Some(mut existing) if existing.params() == p => {
+                        existing.clear();
+                        existing
+                    }
+                    _ => super::ldm::LdmProducer::new(p),
+                });
+                hc.set_ldm_producer(producer);
+            }
         }
         // Record the resolved matcher shape for the primed-snapshot key. Captured
         // here (post-resolution, after the test-only param override) so the key


### PR DESCRIPTION
## Summary

Two compress-dict / LDM follow-ups on the reused-encoder path (the CoordiNode
per-label-dictionary shape):

1. **Reuse the LDM producer table across frames.** On the reused-encoder
   compress-dict path, `reset` built a fresh `LdmProducer` every frame,
   re-allocating its hash table (large at btultra2), while upstream zstd reuses
   its `ldmState_t`. Reuse the existing allocation when the derived LDM params
   are unchanged (`clear()` re-zeros without allocating; only a params change or
   the first frame builds a new one).

2. **Run the wasm dict bench over all benched levels.** The wasm dictionary
   bench looped `[3, 19]` while the non-dict bench covers `[1, 3, 19, 22]`, so
   levels 1 and 22 had no dict coverage. Aligned to `LEVELS`.

## Impact

- `compress-dict/level_22_btultra2_ldm` timing: **−3.84%** (criterion, i9;
  "Performance has improved", 31.66 → 30.45 µs vs base). Byte-identical output.
- wasm: levels 1 and 22 now exercised for dict compress/decompress; verified
  L1/L22 dict round-trip on the wasm build (L22 gives the best ratio).

## Testing

- `cargo nextest run -p structured-zstd --features "hash dict_builder"` — **823/823
  pass**, including the dict-primed byte-identity and reused-encoder tests.
- wasm dict round-trip verified for all four levels against the simd128 payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded dictionary compression benchmarks to cover all compression levels for more comprehensive testing.

* **Refactor**
  * Optimized compression engine efficiency by improving memory allocation reuse across operations, reducing overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->