### PR TITLE
perf(encode): close the L6-L9 lazy dictionary compress-speed gap

### DIFF
--- a/.github/bench-dashboard/index.html
+++ b/.github/bench-dashboard/index.html
@@ -1635,10 +1635,11 @@
           const lm = profileLogicalMetric(row);
           if (!lm) continue;
           const snap = row.generated_at || row.commit_sha || "local-run";
-          const inner = `${snap}|${lm}|${cohortKey(row)}`;
+          const cohort = cohortKey(row);
+          const inner = `${snap}|${lm}|${cohort}`;
           let agg = innerAgg.get(inner);
           if (!agg) {
-            agg = { snap, lm, rust_sum: 0, ffi_sum: 0, count: 0 };
+            agg = { snap, lm, cohort, rust_sum: 0, ffi_sum: 0, count: 0 };
             innerAgg.set(inner, agg);
           }
           agg.rust_sum += row.rust_value;
@@ -1646,9 +1647,56 @@
           agg.count += 1;
         }
 
+        // Comparability gate: the parser only emits a (level, scenario, target)
+        // row when BOTH rust and ffi have the value, so a snapshot missing a
+        // level for one side (e.g. an ffi bench that failed/was absent) simply
+        // has no cohort there. Averaging each snapshot over whatever cohorts it
+        // happens to have makes the denominator VARY across the timeline: the
+        // mean then jumps when a cohort drops, for a reason unrelated to perf.
+        // Throughput (MB/s spanning orders of magnitude across levels) is far
+        // more sensitive to that than the ratio (values ≈1, where dropping one
+        // barely moves the mean) — which is why a missing point skews the speed
+        // line but not the ratio. Restrict every snapshot's mean for a metric
+        // to the cohorts present in EVERY snapshot for that metric (the
+        // cross-snapshot intersection) so the denominator is identical at every
+        // point and the line tracks real perf, not data completeness.
+        const lmSnapCohorts = new Map(); // lm -> Map(snap -> Set(cohort))
+        for (const inner of innerAgg.values()) {
+          if (inner.count === 0) continue;
+          let bySnap = lmSnapCohorts.get(inner.lm);
+          if (!bySnap) {
+            bySnap = new Map();
+            lmSnapCohorts.set(inner.lm, bySnap);
+          }
+          let set = bySnap.get(inner.snap);
+          if (!set) {
+            set = new Set();
+            bySnap.set(inner.snap, set);
+          }
+          set.add(inner.cohort);
+        }
+        const lmCommonCohorts = new Map(); // lm -> Set(cohort) present in all snaps
+        for (const [lm, bySnap] of lmSnapCohorts) {
+          let common = null;
+          for (const set of bySnap.values()) {
+            if (common === null) {
+              common = new Set(set);
+            } else {
+              for (const c of [...common]) {
+                if (!set.has(c)) common.delete(c);
+              }
+            }
+          }
+          lmCommonCohorts.set(lm, common || new Set());
+        }
+
         const outerAgg = new Map();
         for (const inner of innerAgg.values()) {
           if (inner.count === 0) continue;
+          // Skip cohorts not present in every snapshot for this metric, so the
+          // outer mean's denominator is the same fixed cohort set at each point.
+          const common = lmCommonCohorts.get(inner.lm);
+          if (!common || !common.has(inner.cohort)) continue;
           const key = `${inner.snap}|${inner.lm}`;
           let agg = outerAgg.get(key);
           if (!agg) {

--- a/ffi-bench/tests/match_generator_ffi.rs
+++ b/ffi-bench/tests/match_generator_ffi.rs
@@ -122,15 +122,20 @@ fn assert_level22_sequences_match_reference(data: &[u8]) {
     }
 }
 
-#[test]
-fn level22_sequences_match_reference_on_corpus_proxy() {
-    let data = include_bytes!(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../zstd/decodecorpus_files/z000033"
-    ));
-    assert_level22_sequences_match_reference(data);
-}
-
+// NOTE: the large-corpus (`z000033`, ~1 MiB) exact-sequence-parity test was
+// removed. Inputs at/above the 128 KiB block size go through the block
+// pre-splitter, which matches upstream's SAMPLING tier but whose match parser
+// makes its own block-boundary choices, so the sequence partition legitimately
+// diverges from `ZSTD_generateSequences`. Binary sequence parity is NOT a
+// drop-in requirement (the crate is a drop-in replacement for libzstd, not a
+// byte-for-byte encoder port); the properties that DO matter for `z000033` at
+// level 22 — our output is no larger than upstream's and round-trips through
+// the reference decoder —
+// are pinned by `cross_validation::level22_stays_within_ffi_level22_on_corpus_proxy`
+// (`level22.len() <= ffi_level22.len()`) and the cross-validation round-trip
+// suite. The small-corpus case below (`z000030`, ~15 KiB, below the pre-split
+// threshold) keeps the exact-parity assertion, where the partition is
+// deterministic.
 #[test]
 fn level22_sequences_match_reference_on_small_corpus_proxy() {
     let data = include_bytes!(concat!(

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -61,6 +61,7 @@ use std::path::Path;
 use structured_zstd::encoding::CompressionLevel;
 use structured_zstd::encoding::sequence_capture::{
     CapturedRawSequence, compress_and_collect_sequences, compress_and_collect_sequences_with_dict,
+    compress_and_collect_sequences_with_raw_content,
 };
 
 /// Default level set when `STRUCTURED_ZSTD_BENCH_LEVEL` is unset.
@@ -304,6 +305,14 @@ fn collect_fixtures() -> Vec<(String, Vec<u8>)> {
         logs4k,
     ));
 
+    // 1 KiB variant — the `dict_matrix` `logs-1k` case that carries the L6
+    // Row/lazy dict ratio gap (26 vs 18 bytes; #434).
+    let logs1k = repeated_log_lines(1024);
+    out.push((
+        format!("small-1k-log-lines ({} bytes)", logs1k.len()),
+        logs1k,
+    ));
+
     out
 }
 
@@ -357,9 +366,18 @@ fn build_low_entropy_log(byte_budget: usize) -> Vec<u8> {
 
 fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize, dict: Option<&[u8]>) {
     let rust_capture = match dict {
-        Some(d) => {
+        // Auto-detect the dict kind the same way the C side's
+        // `ZSTD_CCtx_loadDictionary` does: a serialized dict (zstd dict magic
+        // `0xEC30A437`, LE bytes `37 A4 30 EC`) attaches via the magic path;
+        // anything else is a raw-content dict (the per-label-dict use case).
+        Some(d) if d.starts_with(&[0x37, 0xA4, 0x30, 0xEC]) => {
             compress_and_collect_sequences_with_dict(input, CompressionLevel::Level(level), d)
         }
+        Some(d) => compress_and_collect_sequences_with_raw_content(
+            input,
+            CompressionLevel::Level(level),
+            d,
+        ),
         None => compress_and_collect_sequences(input, CompressionLevel::Level(level)),
     };
     let (ffi_seqs, ffi_tail_lengths) = ffi_generate_sequences(input, level, dict);

--- a/zstd/examples/dict_matrix.rs
+++ b/zstd/examples/dict_matrix.rs
@@ -51,6 +51,12 @@ fn main() {
     // is treated as a content dictionary by each). 8 KiB of the same log
     // structure the frames share.
     let dict = repeated_log_lines(8 * 1024);
+    // Optional dump of the structural dict so the sequence comparator
+    // (`compare_ffi_sequences` + `STRUCTURED_ZSTD_BENCH_DICT`) can attach the
+    // exact same bytes when investigating the dict-primed match decisions.
+    if let Ok(path) = std::env::var("DICT_MATRIX_DUMP_DICT") {
+        std::fs::write(path.trim(), &dict).expect("write DICT_MATRIX_DUMP_DICT path");
+    }
     let fixtures: &[(&str, usize)] = &[
         ("logs-512", 512),
         ("logs-1k", 1024),

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -4388,11 +4388,12 @@ mod tests {
     }
 
     /// `level_pre_split` resolves the per-level split knob through the
-    /// `LevelParams` table, mirroring the upstream zstd `splitLevels[]` by strategy
-    /// (`ZSTD_optimalBlockSize`): fast → 0 (from-borders), dfast → 1,
-    /// greedy/lazy → 2, lazy2/btlazy2 (Lazy tag at depth 2) → 3,
-    /// btopt/btultra/btultra2 → 4. `Uncompressed` has no numeric level so it
-    /// stays `None`.
+    /// `LevelParams` table, returning the EFFECTIVE upstream `ZSTD_splitBlock`
+    /// level (`splitLevels[strategy] - 2`, clamped at 0) that
+    /// `ZSTD_optimalBlockSize` dispatches: fast/dfast/greedy/lazy(d1) → 0
+    /// (from-borders), lazy2/btlazy2 → 1 (byChunks rate 43),
+    /// btopt/btultra/btultra2 → 2 (byChunks rate 11). `Uncompressed` has no
+    /// numeric level so it stays `None`.
     #[test]
     fn pre_split_level_dispatches_by_compression_level() {
         use crate::encoding::CompressionLevel;
@@ -4400,8 +4401,8 @@ mod tests {
         assert_eq!(level_pre_split(CompressionLevel::Uncompressed), None);
         // Fastest = level 1 (fast) → 0 (from-borders).
         assert_eq!(level_pre_split(CompressionLevel::Fastest), Some(0));
-        // Default = level 3 (dfast) → 1.
-        assert_eq!(level_pre_split(CompressionLevel::Default), Some(1));
+        // Default = level 3 (dfast) → 0 (splitLevels 1 - 2, clamped).
+        assert_eq!(level_pre_split(CompressionLevel::Default), Some(0));
         // Better is a pure alias for level 7 (lazy): same as Level(7).
         assert_eq!(
             level_pre_split(CompressionLevel::Better),
@@ -4415,19 +4416,20 @@ mod tests {
             level_pre_split(CompressionLevel::Level(13)),
         );
         assert_eq!(level_pre_split(CompressionLevel::Level(2)), Some(0)); // fast
-        assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(1)); // dfast
-        assert_eq!(level_pre_split(CompressionLevel::Level(5)), Some(2)); // greedy
-        assert_eq!(level_pre_split(CompressionLevel::Level(7)), Some(2)); // lazy (depth 1)
-        // lazy2 / btlazy2 use the rate-1 full-scan splitter (4), not the
-        // rate-5 sampler (3): the sampler phantom-splits homogeneous periodic
-        // input (see `pre_split` comment + `periodic_stream_not_oversplit`).
-        assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(4)); // lazy2 lower bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(4)); // lazy2 (depth 2)
-        assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(4)); // lazy2 upper bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(4)); // btlazy2 lower bound
-        assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(4)); // btlazy2 (depth 2)
-        assert_eq!(level_pre_split(CompressionLevel::Level(16)), Some(4)); // btopt
-        assert_eq!(level_pre_split(CompressionLevel::Level(22)), Some(4)); // btultra2
+        assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(0)); // dfast
+        assert_eq!(level_pre_split(CompressionLevel::Level(5)), Some(0)); // greedy
+        assert_eq!(level_pre_split(CompressionLevel::Level(7)), Some(0)); // lazy (depth 1)
+        // lazy2 / btlazy2: splitLevels 3 - 2 = 1 (byChunks rate 43, hashLog 8).
+        // The coarse byte-histogram tier is robust to the periodic-input
+        // phantom-split the rate-5/hashLog-10 tier suffered, so it matches
+        // upstream AND stays whole on periodic input (`periodic_stream_not_oversplit`).
+        assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(1)); // lazy2 lower bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(1)); // lazy2 (depth 2)
+        assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(1)); // lazy2 upper bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(1)); // btlazy2 lower bound
+        assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(1)); // btlazy2 (depth 2)
+        assert_eq!(level_pre_split(CompressionLevel::Level(16)), Some(2)); // btopt
+        assert_eq!(level_pre_split(CompressionLevel::Level(22)), Some(2)); // btultra2
     }
 
     /// Regression: a homogeneous but periodic multi-block stream must not be

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -486,8 +486,7 @@ impl HcMatcher {
                         == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + gate_off))
                 };
                 if gate_ok {
-                    let current_ml =
-                        common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
+                    let current_ml = common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
                     if current_ml > ml {
                         ml = current_ml;
                         best_idx = dict_idx;
@@ -508,6 +507,53 @@ impl HcMatcher {
         (ml, best_idx, found)
     }
 
+    /// Single-rep (offset_1) probe — the lazy parser's inline rep check
+    /// (upstream `ZSTD_compressBlock_lazy_generic`: only `rep[0]` is tested per
+    /// position, the 3-rep rotation is the optimal parser's). Caller guarantees
+    /// `lit_len > 0`, so `rep[0]` is repcode index 0 with no ll0 rotation, and
+    /// extending it backwards over the literal run is sound. Strips
+    /// [`Self::repcode_candidate`] to its first rep: one window check, one
+    /// 4-byte gate, one count — a third of the per-position rep cost the 3-rep
+    /// probe paid (and which the lazy lookahead paid again at pos+1 / pos+2).
+    pub(crate) fn repcode_candidate_offset1(
+        table: &MatchTable,
+        abs_pos: usize,
+        lit_len: usize,
+    ) -> Option<MatchCandidate> {
+        let rep = table.offset_hist[0] as usize;
+        if rep == 0 || rep > abs_pos {
+            return None;
+        }
+        let concat = table.live_history();
+        let current_idx = abs_pos - table.history_abs_start;
+        if current_idx + HC_MIN_MATCH_LEN > concat.len() {
+            return None;
+        }
+        let candidate_pos = abs_pos - rep;
+        if candidate_pos
+            < table
+                .history_abs_start
+                .max(abs_pos.saturating_sub(table.max_window_size))
+        {
+            return None;
+        }
+        let candidate_idx = candidate_pos - table.history_abs_start;
+        // Cheap 4-byte equality gate before the SIMD count (upstream `MEM_read32`
+        // repcode gate); identical to the per-rep gate in `repcode_candidate`.
+        let base_ptr = concat.as_ptr();
+        if candidate_idx + 4 <= concat.len()
+            && unsafe {
+                MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx))
+                    != MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
+            }
+        {
+            return None;
+        }
+        let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
+        (match_len >= HC_MIN_MATCH_LEN)
+            .then(|| Self::extend_backwards(table, candidate_pos, abs_pos, match_len, lit_len))
+    }
+
     /// Combine the rep-code and chain-walk candidates and pick the
     /// better of the two. Monomorphised over `DICT` (upstream's compile-time
     /// `dictMode` template param): the `DICT = false` instance compiles WITHOUT
@@ -521,7 +567,17 @@ impl HcMatcher {
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
-        let rep = Self::repcode_candidate(table, abs_pos, lit_len);
+        // Upstream `ZSTD_compressBlock_lazy_generic` checks only offset_1
+        // (`rep[0]`) inline per position; the 3-rep rotation lives in the
+        // optimal parser, not the lazy loop. For `lit_len > 0` that is exactly
+        // `rep[0]` (repcode index 0, no ll0 rotation), so probe the single rep.
+        // The `lit_len == 0` case keeps the full rotated probe for encode
+        // correctness (the ll0 `rep[0]-1` rule).
+        let rep = if lit_len == 0 {
+            Self::repcode_candidate(table, abs_pos, lit_len)
+        } else {
+            Self::repcode_candidate_offset1(table, abs_pos, lit_len)
+        };
         let hash = self.hash_chain_candidate::<DICT>(table, abs_pos, lit_len);
         Self::better_candidate(rep, hash)
     }

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -281,6 +281,12 @@ impl HcMatcher {
     /// run ONCE at the end. No per-candidate `Option` / gain merge / backward
     /// extension — that per-attempt overhead is what the old gain-based walk
     /// paid over C.
+    ///
+    /// `#[inline(always)]`: folded INTO the out-of-line `find_best_match` so the
+    /// whole find (rep + chain + dms + selection) is ONE function — upstream's
+    /// `ZSTD_HcFindBestMatch` shape — reached by a single call per position, not
+    /// the find->chain->dms call chain that an out-of-line chain walk adds.
+    #[inline(always)]
     pub(crate) fn hash_chain_candidate<const DICT: bool>(
         &self,
         concat: &[u8],
@@ -597,11 +603,10 @@ impl HcMatcher {
     /// 4-byte gate, one count — a third of the per-position rep cost the 3-rep
     /// probe paid (and which the lazy lookahead paid again at pos+1 / pos+2).
     ///
-    /// `#[inline]`: upstream checks the rep INLINE in the lazy loop; keeping
-    /// this tiny single-rep probe out-of-line cost a call frame (prologue /
-    /// epilogue + arg setup) per find (~12% of the lazy scan as a separate
-    /// symbol). Inlining folds it into `find_best_match` like upstream.
-    #[inline]
+    /// `#[inline(always)]`: upstream checks the rep INLINE in the lazy loop;
+    /// folded into the (out-of-line) `find_best_match` monolith so the rep is
+    /// part of the single per-position find call, not a nested out-of-line probe.
+    #[inline(always)]
     pub(crate) fn repcode_candidate_offset1(
         concat: &[u8],
         table: &MatchTable,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -24,6 +24,39 @@ use super::opt::types::MatchCandidate;
 /// Upstream zstd parity: `MIN_MATCH` in `lib/compress/zstd_lazy.c`.
 pub(crate) const HC_MIN_MATCH_LEN: usize = 4;
 
+/// Forward-only match found by the lazy chain walk: the `(offset, length)` pair
+/// upstream's `ZSTD_HcFindBestMatch` returns (`size_t matchLength` in `rax` +
+/// the offset through `offsetPtr`). 16 bytes, so the find result + the lazy
+/// lookahead arg travel in registers (`rax:rdx`) instead of the 24-byte
+/// `MatchCandidate` (`start` included) the old find returned by value, which
+/// the System V ABI spills to the stack and the lazy loop then copies. The
+/// backward extension that produces `start` is deferred to the commit site
+/// (upstream does it once in the lazy loop after rep-vs-chain selection), so it
+/// never touches the per-position find/compare path.
+#[derive(Clone, Copy)]
+pub(crate) struct HcMatch {
+    /// Match offset (`abs_pos - candidate_pos`). Meaningful only when
+    /// [`HcMatch::is_match`] is true.
+    pub(crate) offset: usize,
+    /// Forward match length, or `< HC_MIN_MATCH_LEN` for "no match".
+    pub(crate) match_len: usize,
+}
+
+impl HcMatch {
+    /// The "no match found" sentinel (`match_len = 0`).
+    pub(crate) const NONE: Self = Self {
+        offset: 0,
+        match_len: 0,
+    };
+
+    /// A real match reaches at least `HC_MIN_MATCH_LEN`; shorter is the seed /
+    /// sentinel, not an emittable match.
+    #[inline]
+    pub(crate) fn is_match(self) -> bool {
+        self.match_len >= HC_MIN_MATCH_LEN
+    }
+}
+
 /// Hard cap on chain-walk depth. Used to size the fixed-length
 /// candidate buffer returned by [`HcMatcher::chain_candidates`].
 pub(crate) const MAX_HC_SEARCH_DEPTH: usize = 512;
@@ -79,21 +112,18 @@ impl HcMatcher {
 
     /// Pick the better of two candidate matches by [`match_gain`].
     /// `None` arms pass the surviving `Some` through.
-    pub(crate) fn better_candidate(
-        lhs: Option<MatchCandidate>,
-        rhs: Option<MatchCandidate>,
-    ) -> Option<MatchCandidate> {
-        match (lhs, rhs) {
-            (None, other) | (other, None) => other,
-            (Some(lhs), Some(rhs)) => {
-                let lhs_gain = Self::match_gain(lhs.match_len, lhs.offset);
-                let rhs_gain = Self::match_gain(rhs.match_len, rhs.offset);
-                if rhs_gain > lhs_gain {
-                    Some(rhs)
-                } else {
-                    Some(lhs)
-                }
-            }
+    pub(crate) fn better_candidate(lhs: HcMatch, rhs: HcMatch) -> HcMatch {
+        if !lhs.is_match() {
+            return rhs;
+        }
+        if !rhs.is_match() {
+            return lhs;
+        }
+        if Self::match_gain(rhs.match_len, rhs.offset) > Self::match_gain(lhs.match_len, lhs.offset)
+        {
+            rhs
+        } else {
+            lhs
         }
     }
 
@@ -175,11 +205,7 @@ impl HcMatcher {
     /// Probe the 3 rep-code offsets (with the upstream zstd `ll0 ↦ rep[0] − 1`
     /// fallback) and return the best in-range match. Pure helper —
     /// only reads from `MatchTable`, no HcMatcher state needed.
-    pub(crate) fn repcode_candidate(
-        table: &MatchTable,
-        abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
+    pub(crate) fn repcode_candidate(table: &MatchTable, abs_pos: usize, lit_len: usize) -> HcMatch {
         let reps = if lit_len == 0 {
             [
                 Some(table.offset_hist[1] as usize),
@@ -197,13 +223,13 @@ impl HcMatcher {
         let concat = table.live_history();
         let current_idx = abs_pos - table.history_abs_start;
         if current_idx + HC_MIN_MATCH_LEN > concat.len() {
-            return None;
+            return HcMatch::NONE;
         }
         // Raw base pointer for the upstream zstd-style `MEM_read32` 4-byte rep
         // gate below (single unaligned load each, no per-rep slice bounds check).
         let base_ptr = concat.as_ptr();
 
-        let mut best = None;
+        let mut best = HcMatch::NONE;
         for rep in reps.into_iter().flatten() {
             if rep == 0 || rep > abs_pos {
                 continue;
@@ -235,9 +261,13 @@ impl HcMatcher {
             }
             let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
             if match_len >= HC_MIN_MATCH_LEN {
-                let candidate =
-                    Self::extend_backwards(table, candidate_pos, abs_pos, match_len, lit_len);
-                best = Self::better_candidate(best, Some(candidate));
+                best = Self::better_candidate(
+                    best,
+                    HcMatch {
+                        offset: rep,
+                        match_len,
+                    },
+                );
             }
         }
         best
@@ -257,12 +287,11 @@ impl HcMatcher {
         dms_primed: bool,
         table: &MatchTable,
         abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
+    ) -> HcMatch {
         let current_idx = abs_pos - table.history_abs_start;
         let history_tail = concat.len();
         if current_idx + HC_MIN_MATCH_LEN > history_tail {
-            return None;
+            return HcMatch::NONE;
         }
 
         // Chain walk is inlined below — avoids the per-call 4 KiB
@@ -449,19 +478,16 @@ impl HcMatcher {
         // No-dict monomorph: keep the original `found` flag (see seed comment).
         let matched = if DICT { ml >= HC_MIN_MATCH_LEN } else { found };
         if !matched {
-            return None;
+            return HcMatch::NONE;
         }
-        // Single backward extension on the winner (upstream does this once in
-        // the lazy loop after rep-vs-chain selection; folded into the find here
-        // so `find_best_match` / the lazy loop keep the `MatchCandidate`
-        // contract). The extension preserves the forward offset.
-        Some(Self::extend_backwards(
-            table,
-            best_idx + history_abs_start,
-            abs_pos,
-            ml,
-            lit_len,
-        ))
+        // Forward `(offset, length)` only — the backward extension that produces
+        // `start` runs once at the commit site (upstream's lazy loop), off the
+        // per-position find/compare path. `offset = abs_pos - (best_idx +
+        // history_abs_start) = current_idx - best_idx`.
+        HcMatch {
+            offset: current_idx - best_idx,
+            match_len: ml,
+        }
     }
 
     /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
@@ -580,15 +606,14 @@ impl HcMatcher {
         concat: &[u8],
         table: &MatchTable,
         abs_pos: usize,
-        lit_len: usize,
-    ) -> Option<MatchCandidate> {
+    ) -> HcMatch {
         let rep = table.offset_hist[0] as usize;
         if rep == 0 || rep > abs_pos {
-            return None;
+            return HcMatch::NONE;
         }
         let current_idx = abs_pos - table.history_abs_start;
         if current_idx + HC_MIN_MATCH_LEN > concat.len() {
-            return None;
+            return HcMatch::NONE;
         }
         let candidate_pos = abs_pos - rep;
         if candidate_pos
@@ -596,7 +621,7 @@ impl HcMatcher {
                 .history_abs_start
                 .max(abs_pos.saturating_sub(table.max_window_size))
         {
-            return None;
+            return HcMatch::NONE;
         }
         let candidate_idx = candidate_pos - table.history_abs_start;
         // Cheap 4-byte equality gate before the SIMD count (upstream `MEM_read32`
@@ -608,11 +633,17 @@ impl HcMatcher {
                     != MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
             }
         {
-            return None;
+            return HcMatch::NONE;
         }
         let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
-        (match_len >= HC_MIN_MATCH_LEN)
-            .then(|| Self::extend_backwards(table, candidate_pos, abs_pos, match_len, lit_len))
+        if match_len >= HC_MIN_MATCH_LEN {
+            HcMatch {
+                offset: rep,
+                match_len,
+            }
+        } else {
+            HcMatch::NONE
+        }
     }
 
     /// Combine the rep-code and chain-walk candidates and pick the
@@ -629,7 +660,7 @@ impl HcMatcher {
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
-    ) -> Option<MatchCandidate> {
+    ) -> HcMatch {
         // `concat` is the full live history (dict + committed blocks + current
         // block), hoisted ONCE per block by the caller — `live_history()` is
         // loop-invariant for the position scan, so fetching it per find (in
@@ -645,9 +676,9 @@ impl HcMatcher {
         let rep = if lit_len == 0 {
             Self::repcode_candidate(table, abs_pos, lit_len)
         } else {
-            Self::repcode_candidate_offset1(concat, table, abs_pos, lit_len)
+            Self::repcode_candidate_offset1(concat, table, abs_pos)
         };
-        let hash = self.hash_chain_candidate::<DICT>(concat, dms_primed, table, abs_pos, lit_len);
+        let hash = self.hash_chain_candidate::<DICT>(concat, dms_primed, table, abs_pos);
         Self::better_candidate(rep, hash)
     }
 
@@ -674,7 +705,7 @@ impl HcMatcher {
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
-        best: MatchCandidate,
+        best: HcMatch,
     ) -> bool {
         if best.match_len >= self.target_len
             || abs_pos + 1 + HC_MIN_MATCH_LEN > table.history_abs_start + concat.len()
@@ -686,11 +717,8 @@ impl HcMatcher {
 
         let next =
             self.find_best_match::<DICT>(concat, dms_primed, table, abs_pos + 1, lit_len + 1);
-        if let Some(next) = next {
-            let next_gain = Self::match_gain(next.match_len, next.offset);
-            if next_gain > current_gain {
-                return false;
-            }
+        if next.is_match() && Self::match_gain(next.match_len, next.offset) > current_gain {
+            return false;
         }
 
         if self.lazy_depth >= 2
@@ -698,11 +726,10 @@ impl HcMatcher {
         {
             let next2 =
                 self.find_best_match::<DICT>(concat, dms_primed, table, abs_pos + 2, lit_len + 2);
-            if let Some(next2) = next2 {
-                let next2_gain = Self::match_gain(next2.match_len, next2.offset);
-                if next2_gain > current_gain + 4 {
-                    return false;
-                }
+            if next2.is_match()
+                && Self::match_gain(next2.match_len, next2.offset) > current_gain + 4
+            {
+                return false;
             }
         }
 
@@ -1027,8 +1054,8 @@ mod hc_tests {
     fn repcode_candidate_returns_none_when_suffix_too_short() {
         let mut t = table_with_history(b"abc");
         t.offset_hist = [1, 2, 3];
-        // current_idx + HC_MIN_MATCH_LEN > concat.len() → early None.
-        assert!(HcMatcher::repcode_candidate(&t, 0, 1).is_none());
+        // current_idx + HC_MIN_MATCH_LEN > concat.len() → early no-match.
+        assert!(!HcMatcher::repcode_candidate(&t, 0, 1).is_match());
     }
 
     #[test]
@@ -1040,7 +1067,7 @@ mod hc_tests {
         // No match possible at abs_pos=4 because every rep aims past
         // history start.
         let result = HcMatcher::repcode_candidate(&t, 4, 1);
-        assert!(result.is_none(), "no rep can land in-range");
+        assert!(!result.is_match(), "no rep can land in-range");
     }
 
     #[test]
@@ -1048,8 +1075,8 @@ mod hc_tests {
         let hc = HcMatcher::new(2, 4, 32);
         let t = table_with_history(b"abc");
         assert!(
-            hc.find_best_match::<false>(t.live_history(), false, &t, 0, 1)
-                .is_none()
+            !hc.find_best_match::<false>(t.live_history(), false, &t, 0, 1)
+                .is_match()
         );
     }
 
@@ -1087,29 +1114,13 @@ mod hc_tests {
         let hc = HcMatcher::new(2, 16, 64);
 
         // The forward winner (idx 12, forward 8) has no backward room.
-        let c0 = hc
-            .hash_chain_candidate::<false>(t.live_history(), false, &t, 24, 0)
-            .expect("forward match must be found");
+        let c0 = hc.hash_chain_candidate::<false>(t.live_history(), false, &t, 24);
+        assert!(c0.is_match(), "forward match must be found");
         assert_eq!(c0.match_len, 8, "longest forward match is 8 (idx 12)");
         assert_eq!(
             c0.offset, 12,
             "winner is the forward-8 candidate at offset 12"
         );
-
-        // With lit_len=3 the SHORTER-forward candidate (idx 3) could reach a
-        // total of 9 via backward extension, but forward-length selection keeps
-        // candidate 12 (forward 8) — backward room never promotes a shorter
-        // forward match. Result stays 8, not 9.
-        let c3 = hc
-            .hash_chain_candidate::<false>(t.live_history(), false, &t, 24, 3)
-            .expect("forward match must be found");
-        assert_eq!(
-            c3.match_len, 8,
-            "forward-length selection must keep the forward-8 winner (idx 12); \
-             a value of 9 would mean a shorter-forward candidate was promoted \
-             by its backward room (non-upstream gain-based selection)"
-        );
-        assert_eq!(c3.offset, 12, "winner unchanged by lit_len");
     }
 
     /// Forward-length ties keep the FIRST-visited candidate (upstream
@@ -1153,9 +1164,8 @@ mod hc_tests {
         t.chain_table[18 & chain_mask] = HC_EMPTY;
 
         let hc = HcMatcher::new(2, 16, 64);
-        let cand = hc
-            .hash_chain_candidate::<false>(t.live_history(), false, &t, abs_pos, 0)
-            .expect("walk must still produce a match");
+        let cand = hc.hash_chain_candidate::<false>(t.live_history(), false, &t, abs_pos);
+        assert!(cand.is_match(), "walk must still produce a match");
         assert_eq!(
             cand.match_len, 8,
             "both candidates have an 8-byte forward prefix"

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -500,10 +500,10 @@ impl HcMatcher {
 
     /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
     /// `zstd_lazy.c:748-770`). Split from [`Self::hash_chain_candidate`] so the
-    /// no-dict hot path keeps its small body / register budget. Runs its own
-    /// step budget (the caller's live-walk `_steps` is intentionally not
-    /// continued, so the dict search is never starved when a no-memset
-    /// floor-advance reset lets the live chain accumulate). The dict sits at the front of `concat`
+    /// no-dict hot path keeps its small body / register budget. Continues the
+    /// caller's `steps` against the shared `max_chain_steps` (upstream zstd:
+    /// the live + dms loops share one `nbAttempts`); the live walk's stale-tail
+    /// early-exit keeps `steps` small so the dms is not starved. The dict sits at the front of `concat`
     /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
     /// the offset / extension logic matches the live walk.
     ///
@@ -523,7 +523,7 @@ impl HcMatcher {
         history_abs_start: usize,
         history_tail: usize,
         max_chain_steps: usize,
-        _steps: usize,
+        mut steps: usize,
         mut best: Option<MatchCandidate>,
     ) -> Option<MatchCandidate> {
         let dms = match table.dms.table() {
@@ -536,18 +536,13 @@ impl HcMatcher {
         // surface the long dict match on the per-label-dict fixtures, vs the 8
         // from L6's searchLog=3). Floor the dict-walk budget at 16.
         let dms_budget = max_chain_steps.max(16);
-        // Dedicated dms step budget, independent of the live-chain walk's
-        // consumption. Upstream's per-frame index reset keeps the live chain
-        // short so the shared budget still reached the dms; a no-memset
-        // floor-advance lets the live chain accumulate across frames, and the
-        // shared counter would then be exhausted on stale live entries before
-        // the dms loop runs (0 dict attempts -> dict matches silently dropped,
-        // the gradual cross-frame decay). Resetting the counter gives the dict
-        // search its full >= 16 attempts in both the memset and floor-advance
-        // resets; the live chain is short enough in the memset case that the
-        // effective dms attempt count is unchanged. The caller's live-walk
-        // count (`_steps`) is intentionally not continued here.
-        let mut steps = 0usize;
+        // SHARED step budget with the live-chain walk (upstream zstd parity:
+        // `ZSTD_HcFindBestMatch` runs the live loop then the dms loop off ONE
+        // `nbAttempts`). The caller's `steps` carries the live walk's count; the
+        // dms continues from there against `dms_budget`. The live walk's
+        // early-exit on the stale-tail wrap keeps `steps` small (it doesn't burn
+        // the budget on accumulated cross-frame entries), so the dms still gets
+        // its attempts without a dedicated counter.
         let base_ptr = concat.as_ptr();
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -334,12 +334,20 @@ impl HcMatcher {
             .wrapping_sub(1)
             .wrapping_sub(table.index_shift)
             .wrapping_sub(history_abs_start);
+        // Hoist the chain-table base pointer ONCE: through `&MatchTable` the
+        // optimizer reloads the `Vec` (ptr, len) header — and re-checks bounds —
+        // on every `table.chain_table[..]`, a measured ~1.7x of upstream's
+        // per-find load count. `candidate_rel & chain_mask` is always
+        // `< chain_table.len()` (the table is `1 << chain_log` and
+        // `chain_mask == len - 1`), so the raw read is in-bounds.
+        let chain_ptr: *const u32 = table.chain_table.as_ptr();
         while steps < max_chain_steps {
             if cur == HC_EMPTY {
                 break;
             }
             let candidate_rel = cur.wrapping_sub(1) as usize;
-            let next = table.chain_table[candidate_rel & chain_mask];
+            // SAFETY: `candidate_rel & chain_mask < chain_table.len()`.
+            let next = unsafe { *chain_ptr.add(candidate_rel & chain_mask) };
             steps += 1;
             // Self-loop: two positions share `candidate_rel & chain_mask`.
             let self_loop = next == cur;
@@ -489,14 +497,19 @@ impl HcMatcher {
         let dms_budget = max_chain_steps.max(16);
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
+        // Hoist the dms chain-table base pointer (same Vec-header-reload removal
+        // as the live walk above).
+        let dms_chain_ptr: *const u32 = dms.chain_table.as_ptr();
         while steps < dms_budget {
             if dcur == 0 {
                 break;
             }
             // Dict position is a concat index in `[0, region)`; the dict is at
-            // the front so `dict_idx < current_idx` always.
+            // the front so `dict_idx < current_idx` always (and
+            // `< dms.chain_table.len()`).
             let dict_idx = (dcur - 1) as usize;
-            let dnext = dms.chain_table[dict_idx];
+            // SAFETY: `dict_idx` is a stored dict position `< chain_table.len()`.
+            let dnext = unsafe { *dms_chain_ptr.add(dict_idx) };
             steps += 1;
             let new_offset = current_idx - dict_idx;
             // Out-of-window dict positions are unreachable to the decoder.

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -494,6 +494,12 @@ impl HcMatcher {
             Some(d) => d,
             None => return best,
         };
+        // Match upstream zstd's effective dict search depth: ZSTD's CDict path
+        // adjusts cParams for the dedicated dict search so it runs deeper than
+        // the bare level searchLog (measured: upstream needs nbAttempts >= 16 to
+        // surface the long dict match on the per-label-dict fixtures, vs the 8
+        // from L6's searchLog=3). Floor the dict-walk budget at 16.
+        let max_chain_steps = max_chain_steps.max(16);
         let base_ptr = concat.as_ptr();
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
@@ -545,7 +551,11 @@ impl HcMatcher {
                             lit_len,
                         );
                         best = Self::better_candidate(best, Some(candidate));
-                        if best.is_some_and(|b| b.match_len >= self.target_len) {
+                        // Match upstream zstd `ZSTD_HcFindBestMatch`: the find
+                        // breaks only when the match reaches the input end
+                        // (`ip+ml == iLimit`), NOT on a `target_len` threshold —
+                        // `target_len` gates the lazy lookahead, not the find.
+                        if best.is_some_and(|b| current_idx + b.match_len >= history_tail) {
                             return best;
                         }
                     }

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -653,6 +653,14 @@ impl HcMatcher {
     /// `DICT = true` instance dual-probes the separate dictMatchState. The
     /// dispatcher in `start_matching_lazy` picks the instance from whether a dms
     /// is primed.
+    ///
+    /// `#[inline(never)]`: kept out-of-line (upstream's `ZSTD_HcFindBestMatch`
+    /// is its own function, with the lazy loop thin) so the find's register
+    /// pressure is contained in its own frame instead of competing with the
+    /// per-position loop state; the 16-byte `HcMatch` return travels in
+    /// `rax:rdx`, so the find->loop boundary stays a register pair, not a stack
+    /// spill.
+    #[inline(never)]
     pub(crate) fn find_best_match<const DICT: bool>(
         &self,
         concat: &[u8],

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -199,6 +199,9 @@ impl HcMatcher {
         if current_idx + HC_MIN_MATCH_LEN > concat.len() {
             return None;
         }
+        // Raw base pointer for the upstream zstd-style `MEM_read32` 4-byte rep
+        // gate below (single unaligned load each, no per-rep slice bounds check).
+        let base_ptr = concat.as_ptr();
 
         let mut best = None;
         for rep in reps.into_iter().flatten() {
@@ -214,6 +217,22 @@ impl HcMatcher {
                 continue;
             }
             let candidate_idx = candidate_pos - table.history_abs_start;
+            // Cheap 4-byte equality gate before the wider SIMD count (upstream
+            // zstd `MEM_read32` repcode gate in `ZSTD_compressBlock_lazy`).
+            // `HC_MIN_MATCH_LEN == 4` and `current_idx + 4 <= len` (the early
+            // return above), so a first-4-byte mismatch can never reach the
+            // match floor — reject without the vector load+count. Falls through
+            // to the full count only when the candidate lacks a 4-byte lookahead
+            // (short tail), so the accepted set is byte-identical to the
+            // unconditional count. Mirrors the chain-walk gate.
+            if candidate_idx + 4 <= concat.len()
+                && unsafe {
+                    MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx))
+                        != MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
+                }
+            {
+                continue;
+            }
             let match_len = common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
             if match_len >= HC_MIN_MATCH_LEN {
                 let candidate =

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -518,11 +518,22 @@ impl HcMatcher {
         // the bare level searchLog (measured: upstream needs nbAttempts >= 16 to
         // surface the long dict match on the per-label-dict fixtures, vs the 8
         // from L6's searchLog=3). Floor the dict-walk budget at 16.
-        let max_chain_steps = max_chain_steps.max(16);
+        let dms_budget = max_chain_steps.max(16);
+        // Dedicated dms step budget, independent of the live-chain walk's
+        // consumption. Upstream's per-frame index reset keeps the live chain
+        // short so the shared budget still reached the dms; a no-memset
+        // floor-advance lets the live chain accumulate across frames, and the
+        // shared counter would then be exhausted on stale live entries before
+        // the dms loop runs (0 dict attempts -> dict matches silently dropped,
+        // the gradual cross-frame decay). Resetting the counter gives the dict
+        // search its full >= 16 attempts in both the memset and floor-advance
+        // resets; the live chain is short enough in the memset case that the
+        // effective dms attempt count is unchanged.
+        steps = 0;
         let base_ptr = concat.as_ptr();
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
-        while steps < max_chain_steps {
+        while steps < dms_budget {
             if dcur == 0 {
                 break;
             }

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -617,8 +617,15 @@ impl HcMatcher {
 
     /// Upstream zstd `lazy` / `lazy2` lookahead: evaluate the match a byte
     /// (and optionally two) ahead before committing the current one.
-    /// Returns `Some(best)` if the current match wins, `None` if the
-    /// caller should defer.
+    /// Returns `true` if the current match `best` wins (commit it), `false`
+    /// if the caller should defer to a later position.
+    ///
+    /// Takes the already-unwrapped `best` BY VALUE and returns a `bool` rather
+    /// than threading `Option<MatchCandidate>` in and back out: the caller owns
+    /// `best` (from `find_best_match`) and reuses it on commit, so a 24-byte
+    /// candidate (32-byte `Option`) no longer gets marshalled across this call
+    /// boundary every position (it was a measured ~7% of the lazy scan on the
+    /// stack-arg copy).
     ///
     /// Lazy lookahead queries `pos + 1` / `pos + 2` before they are
     /// inserted into the hash tables — matching the C zstd ordering.
@@ -631,13 +638,12 @@ impl HcMatcher {
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
-        best: Option<MatchCandidate>,
-    ) -> Option<MatchCandidate> {
-        let best = best?;
+        best: MatchCandidate,
+    ) -> bool {
         if best.match_len >= self.target_len
             || abs_pos + 1 + HC_MIN_MATCH_LEN > table.history_abs_start + concat.len()
         {
-            return Some(best);
+            return true;
         }
 
         let current_gain = Self::match_gain(best.match_len, best.offset) + 4;
@@ -647,7 +653,7 @@ impl HcMatcher {
         if let Some(next) = next {
             let next_gain = Self::match_gain(next.match_len, next.offset);
             if next_gain > current_gain {
-                return None;
+                return false;
             }
         }
 
@@ -659,12 +665,12 @@ impl HcMatcher {
             if let Some(next2) = next2 {
                 let next2_gain = Self::match_gain(next2.match_len, next2.offset);
                 if next2_gain > current_gain + 4 {
-                    return None;
+                    return false;
                 }
             }
         }
 
-        Some(best)
+        true
     }
 
     /// Cross-platform dispatcher for the rep-code probe used by the

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -254,6 +254,7 @@ impl HcMatcher {
     pub(crate) fn hash_chain_candidate<const DICT: bool>(
         &self,
         concat: &[u8],
+        dms_primed: bool,
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
@@ -389,7 +390,10 @@ impl HcMatcher {
         // single `nbAttempts` across the live + dms loops). Skip it when the
         // live walk already reached iLimit (`ml` maximal, and the dms
         // self-tightening gate would read past `history_tail`).
-        if DICT && table.dms.is_primed() && current_idx + ml < history_tail {
+        // `dms_primed` is hoisted by the caller (block-invariant — the dict is
+        // primed before the block scan), replacing a per-find `dms.is_primed()`
+        // load from the cold `dms` cacheline.
+        if DICT && dms_primed && current_idx + ml < history_tail {
             let walk = self.dms_chain_walk(
                 table,
                 concat,
@@ -564,6 +568,7 @@ impl HcMatcher {
     pub(crate) fn find_best_match<const DICT: bool>(
         &self,
         concat: &[u8],
+        dms_primed: bool,
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
@@ -585,7 +590,7 @@ impl HcMatcher {
         } else {
             Self::repcode_candidate_offset1(concat, table, abs_pos, lit_len)
         };
-        let hash = self.hash_chain_candidate::<DICT>(concat, table, abs_pos, lit_len);
+        let hash = self.hash_chain_candidate::<DICT>(concat, dms_primed, table, abs_pos, lit_len);
         Self::better_candidate(rep, hash)
     }
 
@@ -601,6 +606,7 @@ impl HcMatcher {
     pub(crate) fn pick_lazy_match<const DICT: bool>(
         &self,
         concat: &[u8],
+        dms_primed: bool,
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
@@ -615,7 +621,8 @@ impl HcMatcher {
 
         let current_gain = Self::match_gain(best.match_len, best.offset) + 4;
 
-        let next = self.find_best_match::<DICT>(concat, table, abs_pos + 1, lit_len + 1);
+        let next =
+            self.find_best_match::<DICT>(concat, dms_primed, table, abs_pos + 1, lit_len + 1);
         if let Some(next) = next {
             let next_gain = Self::match_gain(next.match_len, next.offset);
             if next_gain > current_gain {
@@ -624,7 +631,8 @@ impl HcMatcher {
         }
 
         if self.lazy_depth >= 2 && abs_pos + 2 + HC_MIN_MATCH_LEN <= table.history_abs_end() {
-            let next2 = self.find_best_match::<DICT>(concat, table, abs_pos + 2, lit_len + 2);
+            let next2 =
+                self.find_best_match::<DICT>(concat, dms_primed, table, abs_pos + 2, lit_len + 2);
             if let Some(next2) = next2 {
                 let next2_gain = Self::match_gain(next2.match_len, next2.offset);
                 if next2_gain > current_gain + 4 {
@@ -975,7 +983,7 @@ mod hc_tests {
         let hc = HcMatcher::new(2, 4, 32);
         let t = table_with_history(b"abc");
         assert!(
-            hc.find_best_match::<false>(t.live_history(), &t, 0, 1)
+            hc.find_best_match::<false>(t.live_history(), false, &t, 0, 1)
                 .is_none()
         );
     }
@@ -1015,7 +1023,7 @@ mod hc_tests {
 
         // The forward winner (idx 12, forward 8) has no backward room.
         let c0 = hc
-            .hash_chain_candidate::<false>(t.live_history(), &t, 24, 0)
+            .hash_chain_candidate::<false>(t.live_history(), false, &t, 24, 0)
             .expect("forward match must be found");
         assert_eq!(c0.match_len, 8, "longest forward match is 8 (idx 12)");
         assert_eq!(
@@ -1028,7 +1036,7 @@ mod hc_tests {
         // candidate 12 (forward 8) — backward room never promotes a shorter
         // forward match. Result stays 8, not 9.
         let c3 = hc
-            .hash_chain_candidate::<false>(t.live_history(), &t, 24, 3)
+            .hash_chain_candidate::<false>(t.live_history(), false, &t, 24, 3)
             .expect("forward match must be found");
         assert_eq!(
             c3.match_len, 8,
@@ -1081,7 +1089,7 @@ mod hc_tests {
 
         let hc = HcMatcher::new(2, 16, 64);
         let cand = hc
-            .hash_chain_candidate::<false>(t.live_history(), &t, abs_pos, 0)
+            .hash_chain_candidate::<false>(t.live_history(), false, &t, abs_pos, 0)
             .expect("walk must still produce a match");
         assert_eq!(
             cand.match_len, 8,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -614,7 +614,7 @@ impl HcMatcher {
     ) -> Option<MatchCandidate> {
         let best = best?;
         if best.match_len >= self.target_len
-            || abs_pos + 1 + HC_MIN_MATCH_LEN > table.history_abs_end()
+            || abs_pos + 1 + HC_MIN_MATCH_LEN > table.history_abs_start + concat.len()
         {
             return Some(best);
         }
@@ -630,7 +630,9 @@ impl HcMatcher {
             }
         }
 
-        if self.lazy_depth >= 2 && abs_pos + 2 + HC_MIN_MATCH_LEN <= table.history_abs_end() {
+        if self.lazy_depth >= 2
+            && abs_pos + 2 + HC_MIN_MATCH_LEN <= table.history_abs_start + concat.len()
+        {
             let next2 =
                 self.find_best_match::<DICT>(concat, dms_primed, table, abs_pos + 2, lit_len + 2);
             if let Some(next2) = next2 {

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -543,7 +543,7 @@ impl HcMatcher {
         // more -- total per-find steps are bounded by `max_chain_steps + 16`,
         // not `max_chain_steps`. Intentional: the floor (not `max_chain_steps`)
         // is the binding dict-search constraint at those levels.
-        let dms_budget = max_chain_steps.max(16);
+        let dms_budget = max_chain_steps.max(steps + 16);
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
         // Hoist the dms chain-table base pointer (same Vec-header-reload removal

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -540,6 +540,12 @@ impl HcMatcher {
     /// [`Self::repcode_candidate`] to its first rep: one window check, one
     /// 4-byte gate, one count — a third of the per-position rep cost the 3-rep
     /// probe paid (and which the lazy lookahead paid again at pos+1 / pos+2).
+    ///
+    /// `#[inline]`: upstream checks the rep INLINE in the lazy loop; keeping
+    /// this tiny single-rep probe out-of-line cost a call frame (prologue /
+    /// epilogue + arg setup) per find (~12% of the lazy scan as a separate
+    /// symbol). Inlining folds it into `find_best_match` like upstream.
+    #[inline]
     pub(crate) fn repcode_candidate_offset1(
         concat: &[u8],
         table: &MatchTable,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -349,8 +349,6 @@ impl HcMatcher {
             // SAFETY: `candidate_rel & chain_mask < chain_table.len()`.
             let next = unsafe { *chain_ptr.add(candidate_rel & chain_mask) };
             steps += 1;
-            // Self-loop: two positions share `candidate_rel & chain_mask`.
-            let self_loop = next == cur;
 
             let candidate_idx = (cur as usize).wrapping_add(idx_bias);
             // A wrapped index (`>= current_idx`) means `abs < history_abs_start`:
@@ -410,7 +408,10 @@ impl HcMatcher {
                 }
             }
 
-            if self_loop {
+            // Self-loop (two positions share `candidate_rel & chain_mask`):
+            // checked here where `next` / `cur` are already live, not carried as
+            // a bool across the body (a register in this saturated walk).
+            if next == cur {
                 break;
             }
             cur = next;

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -358,8 +358,15 @@ impl HcMatcher {
             // monotonic, so the rest of the tail is older and also stale -- stop.
             // This is the early-exit the no-memset floor-advance reset needs; in
             // the memset reset the chain has no wrapped entries, so it never
-            // fires. Below-floor (`< floor_idx`) entries are NOT a break: a
-            // chain-slot collision can put an in-window entry after one.
+            // fires. INVARIANT: the memset reset zeroes every slot to `HC_EMPTY`
+            // (caught by the `cur == HC_EMPTY` break above) and uses `idx_bias`
+            // that maps stored positions back to indices `< current_idx`, so no
+            // surviving entry can wrap -- only the floor-advance path retains
+            // cross-frame entries that decode past `current_idx`. If a future
+            // change let a memset-reset chain produce a wrap, this break would
+            // silently cut the walk short (a miss-rate regression, not a
+            // correctness bug). Below-floor (`< floor_idx`) entries are NOT a
+            // break: a chain-slot collision can put an in-window entry after one.
             if candidate_idx >= current_idx {
                 break;
             }
@@ -494,6 +501,15 @@ impl HcMatcher {
         // dedicated dict search deeper than the bare level searchLog (measured:
         // upstream needs nbAttempts >= 16 to surface the long dict match on the
         // per-label-dict fixtures). Floor the shared budget at 16.
+        //
+        // NOTE on the per-find step budget: `steps` is SHARED with the live
+        // walk, but `dms_budget` floors at 16 regardless of how many steps the
+        // live walk already spent. So when `max_chain_steps < 16` (every
+        // standard HC level: L6 `searchLog = 3` -> 8), the live walk can spend
+        // its full `max_chain_steps` and the dms walk can still run up to 16
+        // more -- total per-find steps are bounded by `max_chain_steps + 16`,
+        // not `max_chain_steps`. Intentional: the floor (not `max_chain_steps`)
+        // is the binding dict-search constraint at those levels.
         let dms_budget = max_chain_steps.max(16);
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -295,7 +295,20 @@ impl HcMatcher {
         // the FORWARD match length, seeded at `MIN_MATCH - 1` so the first
         // candidate's self-tightening gate (`match + ml - 3`) degenerates to a
         // first-4-byte compare. `best_idx` is the winning candidate's concat
-        // index; `found` flips once `ml` reaches `MIN_MATCH`.
+        // index.
+        //
+        // `found` is tracked ONLY in the `DICT = false` monomorph. `ml >=
+        // MIN_MATCH` is always exactly equivalent to "a match was found" (ml
+        // only updates via `current_ml > ml`, whose first hit is >= MIN_MATCH),
+        // so the `DICT = true` path uses that equivalence and drops the bool —
+        // the dict monomorph is register-tight (it also runs the dms walk), and
+        // eliding `found` there frees a stack slot (measured: -5% cycles on the
+        // dict path). The `DICT = false` monomorph is NOT register-tight, and
+        // there the equivalent `ml < MIN_MATCH` final check changed codegen
+        // layout enough to cost ~+4% (same instruction count, worse IPC), so it
+        // keeps the original bool. `DICT` is const, so each monomorph compiles
+        // exactly one arm with no runtime branch; in the dict monomorph `found`
+        // is written/read only in dead `!DICT` arms and is fully eliminated.
         let mut ml = HC_MIN_MATCH_LEN - 1;
         let mut best_idx = 0usize;
         let mut found = false;
@@ -367,7 +380,11 @@ impl HcMatcher {
                     if current_ml > ml {
                         ml = current_ml;
                         best_idx = candidate_idx;
-                        found = true;
+                        // Dict path reads `ml >= MIN_MATCH`; only the no-dict
+                        // monomorph keeps the `found` flag (see seed comment).
+                        if !DICT {
+                            found = true;
+                        }
                         // Upstream `if (ip + currentMl == iLimit) break`: reached
                         // the input end (best possible); also keeps the next gate
                         // read in bounds.
@@ -394,6 +411,9 @@ impl HcMatcher {
         // primed before the block scan), replacing a per-find `dms.is_primed()`
         // load from the cold `dms` cacheline.
         if DICT && dms_primed && current_idx + ml < history_tail {
+            // dms runs only in the `DICT = true` monomorph, which uses the
+            // `ml >= MIN_MATCH` match test, so the walk tracks `(ml, best_idx)`
+            // and never the `found` flag.
             let walk = self.dms_chain_walk(
                 table,
                 concat,
@@ -404,14 +424,15 @@ impl HcMatcher {
                 steps,
                 ml,
                 best_idx,
-                found,
             );
             ml = walk.0;
             best_idx = walk.1;
-            found = walk.2;
         }
 
-        if !found {
+        // Dict monomorph: `ml >= MIN_MATCH` is the match test (drops `found`).
+        // No-dict monomorph: keep the original `found` flag (see seed comment).
+        let matched = if DICT { ml >= HC_MIN_MATCH_LEN } else { found };
+        if !matched {
             return None;
         }
         // Single backward extension on the winner (upstream does this once in
@@ -430,12 +451,14 @@ impl HcMatcher {
     /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
     /// `zstd_lazy.c:751-769`). Split from [`Self::hash_chain_candidate`] so the
     /// no-dict hot path keeps its small body / register budget. Shares the
-    /// caller's forward-length state (`ml` / `best_idx` / `found`) and `steps`
+    /// caller's forward-length state (`ml` / `best_idx`) and `steps`
     /// budget -- the live + dms loops are one bounded operation (upstream's
     /// single `nbAttempts`). The dict sits at the front of `concat`
     /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
-    /// the offset / gate / count logic matches the live walk. Returns the
-    /// updated `(ml, best_idx, found)`.
+    /// the offset / gate / count logic matches the live walk. Only the
+    /// `DICT = true` monomorph calls this, and it uses the `ml >= MIN_MATCH`
+    /// match test, so the walk returns `(ml, best_idx)` and tracks no `found`
+    /// flag.
     ///
     /// `#[inline]`: the `DICT = false` monomorph never references this (the
     /// `if DICT &&` gate is a compile-time false), so it is dropped from the
@@ -454,11 +477,10 @@ impl HcMatcher {
         mut steps: usize,
         mut ml: usize,
         mut best_idx: usize,
-        mut found: bool,
-    ) -> (usize, usize, bool) {
+    ) -> (usize, usize) {
         let dms = match table.dms.table() {
             Some(d) => d,
-            None => return (ml, best_idx, found),
+            None => return (ml, best_idx),
         };
         // Match upstream's effective dict search depth: the CDict path runs the
         // dedicated dict search deeper than the bare level searchLog (measured:
@@ -494,7 +516,6 @@ impl HcMatcher {
                     if current_ml > ml {
                         ml = current_ml;
                         best_idx = dict_idx;
-                        found = true;
                         if current_idx + ml >= history_tail {
                             break;
                         }
@@ -508,7 +529,7 @@ impl HcMatcher {
             }
             dcur = dnext;
         }
-        (ml, best_idx, found)
+        (ml, best_idx)
     }
 
     /// Single-rep (offset_1) probe — the lazy parser's inline rep check

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -536,14 +536,16 @@ impl HcMatcher {
         // per-label-dict fixtures). Floor the shared budget at 16.
         //
         // NOTE on the per-find step budget: `steps` is SHARED with the live
-        // walk, but `dms_budget` floors at 16 regardless of how many steps the
-        // live walk already spent. So when `max_chain_steps < 16` (every
-        // standard HC level: L6 `searchLog = 3` -> 8), the live walk can spend
-        // its full `max_chain_steps` and the dms walk can still run up to 16
-        // more -- total per-find steps are bounded by `max_chain_steps + 16`,
-        // not `max_chain_steps`. Intentional: the floor (not `max_chain_steps`)
-        // is the binding dict-search constraint at those levels.
-        let dms_budget = max_chain_steps.max(steps + 16);
+        // walk. The floor below is `max(max_chain_steps, 16)`, so the live and
+        // dms walks TOGETHER are bounded by it (= 16 at every standard HC level,
+        // where `max_chain_steps < 16`: L6 `searchLog = 3` -> 8); the dms
+        // consumes whatever the live walk left. Giving the dms a fresh 16
+        // attempts on top of the live walk instead (a per-walk, non-shared
+        // budget) was measured +3% cycles on the small-10k-random dict path
+        // with zero ratio change -- the shared floor already surfaces every
+        // dict match that reaches the output, so sharing it is intentional: the
+        // floor (not `max_chain_steps`) is the binding dict-search constraint.
+        let dms_budget = max_chain_steps.max(16);
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
         // Hoist the dms chain-table base pointer (same Vec-header-reload removal

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -371,7 +371,23 @@ impl HcMatcher {
             // Only process candidates in the live window, in relative space:
             // `floor_idx <= candidate_idx < current_idx`.
             let candidate_idx = (cur as usize).wrapping_add(idx_bias);
-            if candidate_idx >= floor_idx && candidate_idx < current_idx {
+            // A wrapped index (`>= current_idx`) means `abs < history_abs_start`:
+            // a stale entry from a previous frame. The chain is head-insert
+            // monotonic, so once the walk reaches the wrapped (stale) tail every
+            // deeper link is older and also stale — stop. This is the early-exit
+            // the no-memset floor-advance reset needs: without it the chain
+            // accumulates across frames and the walk runs the full
+            // `max_chain_steps` over the stale tail instead of exiting at the
+            // frame boundary (the memset reset used to keep the chain short, so
+            // the walk hit `HC_EMPTY` early). In the memset reset the chain has
+            // no wrapped entries, so this never fires — byte-identical. Stale
+            // BELOW-floor (`< floor_idx`) entries are NOT a break: a chain-slot
+            // collision can put an in-window entry after one, so keep skipping
+            // those (the `>= floor_idx` gate below).
+            if candidate_idx >= current_idx {
+                break;
+            }
+            if candidate_idx >= floor_idx {
                 // `candidate_idx < current_idx` (checked above), so the
                 // subtraction never underflows. `new_offset == abs_pos -
                 // candidate_abs`.
@@ -484,9 +500,10 @@ impl HcMatcher {
 
     /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
     /// `zstd_lazy.c:748-770`). Split from [`Self::hash_chain_candidate`] so the
-    /// no-dict hot path keeps its small body / register budget. Continues the
-    /// caller's `steps` against the shared `max_chain_steps` so the live + dms
-    /// search is one bounded operation. The dict sits at the front of `concat`
+    /// no-dict hot path keeps its small body / register budget. Runs its own
+    /// step budget (the caller's live-walk `_steps` is intentionally not
+    /// continued, so the dict search is never starved when a no-memset
+    /// floor-advance reset lets the live chain accumulate). The dict sits at the front of `concat`
     /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
     /// the offset / extension logic matches the live walk.
     ///
@@ -506,7 +523,7 @@ impl HcMatcher {
         history_abs_start: usize,
         history_tail: usize,
         max_chain_steps: usize,
-        mut steps: usize,
+        _steps: usize,
         mut best: Option<MatchCandidate>,
     ) -> Option<MatchCandidate> {
         let dms = match table.dms.table() {
@@ -528,8 +545,9 @@ impl HcMatcher {
         // the gradual cross-frame decay). Resetting the counter gives the dict
         // search its full >= 16 attempts in both the memset and floor-advance
         // resets; the live chain is short enough in the memset case that the
-        // effective dms attempt count is unchanged.
-        steps = 0;
+        // effective dms attempt count is unchanged. The caller's live-walk
+        // count (`_steps`) is intentionally not continued here.
+        let mut steps = 0usize;
         let base_ptr = concat.as_ptr();
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -253,11 +253,11 @@ impl HcMatcher {
     /// paid over C.
     pub(crate) fn hash_chain_candidate<const DICT: bool>(
         &self,
+        concat: &[u8],
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
-        let concat = table.live_history();
         let current_idx = abs_pos - table.history_abs_start;
         let history_tail = concat.len();
         if current_idx + HC_MIN_MATCH_LEN > history_tail {
@@ -516,6 +516,7 @@ impl HcMatcher {
     /// 4-byte gate, one count — a third of the per-position rep cost the 3-rep
     /// probe paid (and which the lazy lookahead paid again at pos+1 / pos+2).
     pub(crate) fn repcode_candidate_offset1(
+        concat: &[u8],
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
@@ -524,7 +525,6 @@ impl HcMatcher {
         if rep == 0 || rep > abs_pos {
             return None;
         }
-        let concat = table.live_history();
         let current_idx = abs_pos - table.history_abs_start;
         if current_idx + HC_MIN_MATCH_LEN > concat.len() {
             return None;
@@ -563,10 +563,17 @@ impl HcMatcher {
     /// is primed.
     pub(crate) fn find_best_match<const DICT: bool>(
         &self,
+        concat: &[u8],
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
     ) -> Option<MatchCandidate> {
+        // `concat` is the full live history (dict + committed blocks + current
+        // block), hoisted ONCE per block by the caller — `live_history()` is
+        // loop-invariant for the position scan, so fetching it per find (in
+        // `hash_chain_candidate` + the rep probe) was pure per-position
+        // overhead. See `start_matching_lazy`'s block-level hoist.
+        //
         // Upstream `ZSTD_compressBlock_lazy_generic` checks only offset_1
         // (`rep[0]`) inline per position; the 3-rep rotation lives in the
         // optimal parser, not the lazy loop. For `lit_len > 0` that is exactly
@@ -576,9 +583,9 @@ impl HcMatcher {
         let rep = if lit_len == 0 {
             Self::repcode_candidate(table, abs_pos, lit_len)
         } else {
-            Self::repcode_candidate_offset1(table, abs_pos, lit_len)
+            Self::repcode_candidate_offset1(concat, table, abs_pos, lit_len)
         };
-        let hash = self.hash_chain_candidate::<DICT>(table, abs_pos, lit_len);
+        let hash = self.hash_chain_candidate::<DICT>(concat, table, abs_pos, lit_len);
         Self::better_candidate(rep, hash)
     }
 
@@ -593,6 +600,7 @@ impl HcMatcher {
     /// itself, changing semantics.
     pub(crate) fn pick_lazy_match<const DICT: bool>(
         &self,
+        concat: &[u8],
         table: &MatchTable,
         abs_pos: usize,
         lit_len: usize,
@@ -607,7 +615,7 @@ impl HcMatcher {
 
         let current_gain = Self::match_gain(best.match_len, best.offset) + 4;
 
-        let next = self.find_best_match::<DICT>(table, abs_pos + 1, lit_len + 1);
+        let next = self.find_best_match::<DICT>(concat, table, abs_pos + 1, lit_len + 1);
         if let Some(next) = next {
             let next_gain = Self::match_gain(next.match_len, next.offset);
             if next_gain > current_gain {
@@ -616,7 +624,7 @@ impl HcMatcher {
         }
 
         if self.lazy_depth >= 2 && abs_pos + 2 + HC_MIN_MATCH_LEN <= table.history_abs_end() {
-            let next2 = self.find_best_match::<DICT>(table, abs_pos + 2, lit_len + 2);
+            let next2 = self.find_best_match::<DICT>(concat, table, abs_pos + 2, lit_len + 2);
             if let Some(next2) = next2 {
                 let next2_gain = Self::match_gain(next2.match_len, next2.offset);
                 if next2_gain > current_gain + 4 {
@@ -966,7 +974,10 @@ mod hc_tests {
     fn find_best_match_returns_none_for_short_suffix() {
         let hc = HcMatcher::new(2, 4, 32);
         let t = table_with_history(b"abc");
-        assert!(hc.find_best_match::<false>(&t, 0, 1).is_none());
+        assert!(
+            hc.find_best_match::<false>(t.live_history(), &t, 0, 1)
+                .is_none()
+        );
     }
 
     /// Forward-length selection (upstream `ZSTD_HcFindBestMatch`): the chain
@@ -1004,7 +1015,7 @@ mod hc_tests {
 
         // The forward winner (idx 12, forward 8) has no backward room.
         let c0 = hc
-            .hash_chain_candidate::<false>(&t, 24, 0)
+            .hash_chain_candidate::<false>(t.live_history(), &t, 24, 0)
             .expect("forward match must be found");
         assert_eq!(c0.match_len, 8, "longest forward match is 8 (idx 12)");
         assert_eq!(
@@ -1017,7 +1028,7 @@ mod hc_tests {
         // candidate 12 (forward 8) — backward room never promotes a shorter
         // forward match. Result stays 8, not 9.
         let c3 = hc
-            .hash_chain_candidate::<false>(&t, 24, 3)
+            .hash_chain_candidate::<false>(t.live_history(), &t, 24, 3)
             .expect("forward match must be found");
         assert_eq!(
             c3.match_len, 8,
@@ -1070,7 +1081,7 @@ mod hc_tests {
 
         let hc = HcMatcher::new(2, 16, 64);
         let cand = hc
-            .hash_chain_candidate::<false>(&t, abs_pos, 0)
+            .hash_chain_candidate::<false>(t.live_history(), &t, abs_pos, 0)
             .expect("walk must still produce a match");
         assert_eq!(
             cand.match_len, 8,

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -243,10 +243,14 @@ impl HcMatcher {
         best
     }
 
-    /// Best hash-chain match at `abs_pos`. Walks the chain via
-    /// [`Self::chain_candidates`], extends each survivor backwards
-    /// over the literal run, and short-circuits as soon as a
-    /// candidate crosses `target_len`.
+    /// Best hash-chain match at `abs_pos`, in upstream zstd's
+    /// `ZSTD_HcFindBestMatch` forward-length model: walk the live chain (and
+    /// the dms) tracking the longest FORWARD match (`currentMl > ml`, ties
+    /// keep the closest), gate each candidate on the self-tightening 4-byte
+    /// tail probe, and extend the single winner backwards over the literal
+    /// run ONCE at the end. No per-candidate `Option` / gain merge / backward
+    /// extension — that per-attempt overhead is what the old gain-based walk
+    /// paid over C.
     pub(crate) fn hash_chain_candidate<const DICT: bool>(
         &self,
         table: &MatchTable,
@@ -255,7 +259,8 @@ impl HcMatcher {
     ) -> Option<MatchCandidate> {
         let concat = table.live_history();
         let current_idx = abs_pos - table.history_abs_start;
-        if current_idx + HC_MIN_MATCH_LEN > concat.len() {
+        let history_tail = concat.len();
+        if current_idx + HC_MIN_MATCH_LEN > history_tail {
             return None;
         }
 
@@ -285,57 +290,15 @@ impl HcMatcher {
         let mut steps = 0usize;
         let history_abs_start = table.history_abs_start;
 
-        let mut best: Option<MatchCandidate> = None;
-        // Upstream zstd speculative tail check (`zstd_lazy.c:714`,
-        // `ZSTD_HcFindBestMatch`): once `best` is set, gate the
-        // expensive `common_prefix_len` walk on a 4-byte tail compare
-        // proving the new candidate can possibly reach the *forward*
-        // length required to outscore `best` under
-        // [`Self::better_candidate`] (gain = `len*4 - offset_bits`).
-        //
-        // Correctness — backward-extension–aware bound:
-        //   `best.match_len` is the *total* length stored by
-        //   [`Self::extend_backwards`]: forward bytes from
-        //   `current_idx` plus up to `lit_len` backward bytes
-        //   (`B_best = abs_pos − best.start`, capped by `lit_len`).
-        //   A new candidate can in principle replace `B_best` of its
-        //   own length with up to `lit_len` backward bytes, so the
-        //   worst-case forward length it needs to outscore `best`
-        //   is `best.match_len − lit_len + 1`. The 4-byte tail probe
-        //   at offset `best.match_len − lit_len − 3` covers exactly
-        //   that boundary (the read includes the byte at the
-        //   required-forward-length position itself). A mismatch
-        //   there is a proof the candidate cannot win regardless of
-        //   how much it later extends backwards.
-        //   When `best.match_len ≤ lit_len + 3` the worst-case
-        //   forward target is so close to `current_idx` that the
-        //   `common_prefix_len` cost is already trivial — the gate
-        //   is skipped via the `checked_sub`.
-        //
-        // Walk-order argument (offset monotonicity — REQUIRED gate
-        // precondition, enforced per-iteration):
-        //   Chain walks are LIFO in their dense form (newest first →
-        //   strictly increasing offset). But the chain table is
-        //   `chain_log`-bits wide; when a position is re-inserted at
-        //   the same masked chain index after the cycle wraps, an
-        //   older chain link can point into a slot that has since
-        //   been OVERWRITTEN with a newer (closer) position. The
-        //   walker then surfaces a candidate with a SMALLER offset
-        //   than ones it has already returned, breaking monotonicity.
-        //
-        //   The gate's bound (`tail_off = best.match_len − lit_len −
-        //   3` covers exactly the "new forward must reach
-        //   best.match_len − lit_len + 1" requirement) is only sound
-        //   when `new.offset_bits ≥ best.offset_bits`. Otherwise a
-        //   smaller-offset candidate can outscore `best` by gain at
-        //   *equal* total length — and the gate would skip it because
-        //   it only proves `match_len > best.match_len`. The
-        //   `new_offset >= best.offset` per-iteration check below
-        //   enforces the monotonicity precondition; on non-monotonic
-        //   walks we fall through to the full `common_prefix_len` so
-        //   the offset-bits advantage is given a chance to win.
-        let history_tail = concat.len();
-        // Raw base pointer for the upstream zstd-style `MEM_read32` 4-byte gates below
+        // Forward-length match state (upstream `ZSTD_HcFindBestMatch`): `ml` is
+        // the FORWARD match length, seeded at `MIN_MATCH - 1` so the first
+        // candidate's self-tightening gate (`match + ml - 3`) degenerates to a
+        // first-4-byte compare. `best_idx` is the winning candidate's concat
+        // index; `found` flips once `ml` reaches `MIN_MATCH`.
+        let mut ml = HC_MIN_MATCH_LEN - 1;
+        let mut best_idx = 0usize;
+        let mut found = false;
+        // Raw base pointer for the upstream zstd-style `MEM_read32` gate
         // (single unaligned load each, no per-candidate slice bounds check).
         let base_ptr = concat.as_ptr();
         // Loop-invariant precompute, hoisted out of the chain walk (upstream zstd:
@@ -364,106 +327,51 @@ impl HcMatcher {
             let candidate_rel = cur.wrapping_sub(1) as usize;
             let next = table.chain_table[candidate_rel & chain_mask];
             steps += 1;
-            // Self-loop: two positions share `candidate_rel & chain_mask`;
-            // stop after processing this slot.
+            // Self-loop: two positions share `candidate_rel & chain_mask`.
             let self_loop = next == cur;
 
-            // Only process candidates in the live window, in relative space:
-            // `floor_idx <= candidate_idx < current_idx`.
             let candidate_idx = (cur as usize).wrapping_add(idx_bias);
             // A wrapped index (`>= current_idx`) means `abs < history_abs_start`:
             // a stale entry from a previous frame. The chain is head-insert
-            // monotonic, so once the walk reaches the wrapped (stale) tail every
-            // deeper link is older and also stale — stop. This is the early-exit
-            // the no-memset floor-advance reset needs: without it the chain
-            // accumulates across frames and the walk runs the full
-            // `max_chain_steps` over the stale tail instead of exiting at the
-            // frame boundary (the memset reset used to keep the chain short, so
-            // the walk hit `HC_EMPTY` early). In the memset reset the chain has
-            // no wrapped entries, so this never fires — byte-identical. Stale
-            // BELOW-floor (`< floor_idx`) entries are NOT a break: a chain-slot
-            // collision can put an in-window entry after one, so keep skipping
-            // those (the `>= floor_idx` gate below).
+            // monotonic, so the rest of the tail is older and also stale -- stop.
+            // This is the early-exit the no-memset floor-advance reset needs; in
+            // the memset reset the chain has no wrapped entries, so it never
+            // fires. Below-floor (`< floor_idx`) entries are NOT a break: a
+            // chain-slot collision can put an in-window entry after one.
             if candidate_idx >= current_idx {
                 break;
             }
             if candidate_idx >= floor_idx {
-                // `candidate_idx < current_idx` (checked above), so the
-                // subtraction never underflows. `new_offset == abs_pos -
-                // candidate_abs`.
-                let new_offset = current_idx - candidate_idx;
-                // Speculative tail gate — full rationale (backward-extension
-                // bound + walk-order/offset-monotonicity precondition) is in
-                // the comment block right above this loop.
-                let mut skip = false;
-                if let Some(best_ref) = best
-                    && new_offset >= best_ref.offset
-                    && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
-                {
-                    let m_end = candidate_idx + tail_off + 4;
-                    let i_end = current_idx + tail_off + 4;
-                    // Bounds-fail is a SAFE skip — see longer rationale in the
-                    // gate's git history. Briefly: under the monotonicity
-                    // precondition above, bounds-fail proves no in-range
-                    // candidate at this `current_idx` can outscore `best`.
-                    // Raw unaligned `u32` load+compare (upstream zstd `MEM_read32`)
-                    // instead of a bounds-checked slice equality — same 4-byte
-                    // tail test, one load each, no `[a..b]` bounds panic path.
-                    if i_end > history_tail || m_end > history_tail {
-                        skip = true;
-                    } else {
-                        // SAFETY: both `+ tail_off` reads are `<= history_tail`
-                        // (checked above), so 4 bytes are in range.
-                        let m = unsafe {
-                            MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx + tail_off))
-                        };
-                        let i = unsafe {
-                            MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
-                        };
-                        skip = m != i;
-                    }
-                }
-
-                // Cheap 4-byte equality gate before the wider SIMD count
-                // (upstream zstd `MEM_read32` gate in `ZSTD_HcFindBestMatch`).
-                // `HC_MIN_MATCH_LEN == 4`, so a first-4-byte mismatch can never
-                // reach the match floor — reject without the vector
-                // load+count+tzcnt. On dict-primed chains over low-match
-                // (random) input, where `best` stays `None` so the speculative
-                // tail gate above never fires, this rejects the bulk of chain
-                // candidates on a scalar compare instead of a full
-                // `common_prefix_len`. Raw unaligned `u32` load+compare (upstream zstd
-                // `MEM_read32`), not a bounds-checked slice equality. Falls
-                // through to the full count when either side lacks a 4-byte
-                // lookahead (the count handles short tails), so the accepted
-                // set is byte-identical.
-                let four_byte_ok = candidate_idx + 4 > history_tail
-                    || current_idx + 4 > history_tail
-                    || unsafe {
-                        // SAFETY: both `+ 4` reads are `<= history_tail` (checked
-                        // above), so 4 bytes are in range.
-                        MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx))
-                            == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
-                    };
-                if !skip && four_byte_ok {
-                    let match_len =
+                // Upstream zstd's single self-tightening gate (`zstd_lazy.c:714`):
+                //   MEM_read32(match + ml - 3) == MEM_read32(ip + ml - 3)
+                // proves the candidate can possibly reach `ml + 1` before paying
+                // for the full `common_prefix_len`. `ml >= MIN_MATCH - 1 = 3` so
+                // `gate_off >= 0`. The iLimit break below keeps
+                // `current_idx + ml < history_tail` on entry, so
+                // `current_idx + gate_off + 4 = current_idx + ml + 1 <= history_tail`,
+                // and `candidate_idx < current_idx` keeps the match-side read in
+                // range too -- no per-iteration bounds check (matches C's
+                // branchless gate).
+                let gate_off = ml - 3;
+                // SAFETY: both reads are `<= history_tail` per the bound above.
+                let gate_ok = unsafe {
+                    MatchTable::read_le_u32_ptr(base_ptr.add(candidate_idx + gate_off))
+                        == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + gate_off))
+                };
+                if gate_ok {
+                    let current_ml =
                         common_prefix_len(&concat[candidate_idx..], &concat[current_idx..]);
-                    if match_len >= HC_MIN_MATCH_LEN {
-                        // Rare accept path: recover the absolute position only
-                        // here (the hot per-candidate body stays in relative
-                        // space). `candidate_abs == candidate_idx +
-                        // history_abs_start`.
-                        let candidate_abs = candidate_idx + history_abs_start;
-                        let candidate = Self::extend_backwards(
-                            table,
-                            candidate_abs,
-                            abs_pos,
-                            match_len,
-                            lit_len,
-                        );
-                        best = Self::better_candidate(best, Some(candidate));
-                        if best.is_some_and(|b| b.match_len >= self.target_len) {
-                            return best;
+                    // `currentMl > ml`: strictly longer forward match wins; ties
+                    // keep the first (closest, the walk is newest-first).
+                    if current_ml > ml {
+                        ml = current_ml;
+                        best_idx = candidate_idx;
+                        found = true;
+                        // Upstream `if (ip + currentMl == iLimit) break`: reached
+                        // the input end (best possible); also keeps the next gate
+                        // read in bounds.
+                        if current_idx + ml >= history_tail {
+                            break;
                         }
                     }
                 }
@@ -476,74 +384,83 @@ impl HcMatcher {
         }
 
         // Separate dictionary match state (upstream `ZSTD_dictMatchState`). The
-        // walk is OUT-OF-LINE (`dms_chain_walk`, `#[inline(never)]`) so the
-        // dict-only code never bloats this hot function on no-dict frames, where
-        // the `is_some` guard is a single not-taken branch. `dms_chain_walk`
-        // continues the SAME `steps` budget, so live + dms stay one bounded
-        // operation (upstream zstd's single `nbAttempts`).
-        if DICT && table.dms.is_primed() {
-            best = self.dms_chain_walk(
+        // walk is OUT-OF-LINE so the dict-only code never bloats this hot
+        // function on no-dict frames. It shares `ml` / `steps` (upstream's
+        // single `nbAttempts` across the live + dms loops). Skip it when the
+        // live walk already reached iLimit (`ml` maximal, and the dms
+        // self-tightening gate would read past `history_tail`).
+        if DICT && table.dms.is_primed() && current_idx + ml < history_tail {
+            let walk = self.dms_chain_walk(
                 table,
                 concat,
-                abs_pos,
-                lit_len,
                 current_idx,
-                history_abs_start,
                 history_tail,
+                base_ptr,
                 max_chain_steps,
                 steps,
-                best,
+                ml,
+                best_idx,
+                found,
             );
+            ml = walk.0;
+            best_idx = walk.1;
+            found = walk.2;
         }
-        best
+
+        if !found {
+            return None;
+        }
+        // Single backward extension on the winner (upstream does this once in
+        // the lazy loop after rep-vs-chain selection; folded into the find here
+        // so `find_best_match` / the lazy loop keep the `MatchCandidate`
+        // contract). The extension preserves the forward offset.
+        Some(Self::extend_backwards(
+            table,
+            best_idx + history_abs_start,
+            abs_pos,
+            ml,
+            lit_len,
+        ))
     }
 
     /// Out-of-line dms HC4 walk (upstream `ZSTD_HcFindBestMatch` dms loop,
-    /// `zstd_lazy.c:748-770`). Split from [`Self::hash_chain_candidate`] so the
-    /// no-dict hot path keeps its small body / register budget. Continues the
-    /// caller's `steps` against the shared `max_chain_steps` (upstream zstd:
-    /// the live + dms loops share one `nbAttempts`); the live walk's stale-tail
-    /// early-exit keeps `steps` small so the dms is not starved. The dict sits at the front of `concat`
+    /// `zstd_lazy.c:751-769`). Split from [`Self::hash_chain_candidate`] so the
+    /// no-dict hot path keeps its small body / register budget. Shares the
+    /// caller's forward-length state (`ml` / `best_idx` / `found`) and `steps`
+    /// budget -- the live + dms loops are one bounded operation (upstream's
+    /// single `nbAttempts`). The dict sits at the front of `concat`
     /// (`[0, region)`); a dms candidate is a concat index `< current_idx`, so
-    /// the offset / extension logic matches the live walk.
+    /// the offset / gate / count logic matches the live walk. Returns the
+    /// updated `(ml, best_idx, found)`.
     ///
-    /// `#[inline]`: with the `DICT` split the `DICT = false` monomorph never
-    /// references this (the `if DICT &&` gate is a compile-time false), so it is
-    /// dropped from the no-dict path entirely; the `DICT = true` monomorph
-    /// inlines it into the dict hot path.
+    /// `#[inline]`: the `DICT = false` monomorph never references this (the
+    /// `if DICT &&` gate is a compile-time false), so it is dropped from the
+    /// no-dict path; the `DICT = true` monomorph inlines it into the dict hot
+    /// path.
     #[inline]
     #[allow(clippy::too_many_arguments)]
     fn dms_chain_walk(
         &self,
         table: &MatchTable,
         concat: &[u8],
-        abs_pos: usize,
-        lit_len: usize,
         current_idx: usize,
-        history_abs_start: usize,
         history_tail: usize,
+        base_ptr: *const u8,
         max_chain_steps: usize,
         mut steps: usize,
-        mut best: Option<MatchCandidate>,
-    ) -> Option<MatchCandidate> {
+        mut ml: usize,
+        mut best_idx: usize,
+        mut found: bool,
+    ) -> (usize, usize, bool) {
         let dms = match table.dms.table() {
             Some(d) => d,
-            None => return best,
+            None => return (ml, best_idx, found),
         };
-        // Match upstream zstd's effective dict search depth: ZSTD's CDict path
-        // adjusts cParams for the dedicated dict search so it runs deeper than
-        // the bare level searchLog (measured: upstream needs nbAttempts >= 16 to
-        // surface the long dict match on the per-label-dict fixtures, vs the 8
-        // from L6's searchLog=3). Floor the dict-walk budget at 16.
+        // Match upstream's effective dict search depth: the CDict path runs the
+        // dedicated dict search deeper than the bare level searchLog (measured:
+        // upstream needs nbAttempts >= 16 to surface the long dict match on the
+        // per-label-dict fixtures). Floor the shared budget at 16.
         let dms_budget = max_chain_steps.max(16);
-        // SHARED step budget with the live-chain walk (upstream zstd parity:
-        // `ZSTD_HcFindBestMatch` runs the live loop then the dms loop off ONE
-        // `nbAttempts`). The caller's `steps` carries the live walk's count; the
-        // dms continues from there against `dms_budget`. The live walk's
-        // early-exit on the stale-tail wrap keeps `steps` small (it doesn't burn
-        // the budget on accumulated cross-frame entries), so the dms still gets
-        // its attempts without a dedicated counter.
-        let base_ptr = concat.as_ptr();
         let dms_hash = MatchTable::hash_position_at(concat, current_idx, dms.hash_log, dms.mls);
         let mut dcur = dms.hash_table[dms_hash];
         while steps < dms_budget {
@@ -558,60 +475,37 @@ impl HcMatcher {
             let new_offset = current_idx - dict_idx;
             // Out-of-window dict positions are unreachable to the decoder.
             if new_offset <= table.max_window_size {
-                let mut skip = false;
-                if let Some(best_ref) = best
-                    && new_offset >= best_ref.offset
-                    && let Some(tail_off) = best_ref.match_len.checked_sub(lit_len + 3)
-                {
-                    let m_end = dict_idx + tail_off + 4;
-                    let i_end = current_idx + tail_off + 4;
-                    if i_end > history_tail || m_end > history_tail {
-                        skip = true;
-                    } else {
-                        let m = unsafe {
-                            MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx + tail_off))
-                        };
-                        let i = unsafe {
-                            MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + tail_off))
-                        };
-                        skip = m != i;
-                    }
-                }
-                let four_byte_ok = dict_idx + 4 > history_tail
-                    || current_idx + 4 > history_tail
-                    || unsafe {
-                        MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx))
-                            == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx))
-                    };
-                if !skip && four_byte_ok {
-                    let match_len = common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
-                    if match_len >= HC_MIN_MATCH_LEN {
-                        let candidate = Self::extend_backwards(
-                            table,
-                            dict_idx + history_abs_start,
-                            abs_pos,
-                            match_len,
-                            lit_len,
-                        );
-                        best = Self::better_candidate(best, Some(candidate));
-                        // Match upstream zstd `ZSTD_HcFindBestMatch`: the find
-                        // breaks only when the match reaches the input end
-                        // (`ip+ml == iLimit`), NOT on a `target_len` threshold —
-                        // `target_len` gates the lazy lookahead, not the find.
-                        if best.is_some_and(|b| current_idx + b.match_len >= history_tail) {
-                            return best;
+                // Same self-tightening gate as the live walk; the caller's guard
+                // (`current_idx + ml < history_tail`) + the iLimit break keep
+                // `current_idx + (ml - 3) + 4 <= history_tail`, and
+                // `dict_idx < current_idx` keeps the dict-side read in range.
+                let gate_off = ml - 3;
+                // SAFETY: both reads are `<= history_tail` per the bound above.
+                let gate_ok = unsafe {
+                    MatchTable::read_le_u32_ptr(base_ptr.add(dict_idx + gate_off))
+                        == MatchTable::read_le_u32_ptr(base_ptr.add(current_idx + gate_off))
+                };
+                if gate_ok {
+                    let current_ml =
+                        common_prefix_len(&concat[dict_idx..], &concat[current_idx..]);
+                    if current_ml > ml {
+                        ml = current_ml;
+                        best_idx = dict_idx;
+                        found = true;
+                        if current_idx + ml >= history_tail {
+                            break;
                         }
                     }
                 }
             }
-            // Chain links are strictly decreasing (head insert); `dnext == 0`
-            // ends the walk at the loop top.
+            // Chain links are strictly decreasing (head insert); `dnext == dcur`
+            // (or the `dcur == 0` at the top) ends the walk.
             if dnext == dcur {
                 break;
             }
             dcur = dnext;
         }
-        best
+        (ml, best_idx, found)
     }
 
     /// Combine the rep-code and chain-walk candidates and pick the
@@ -1019,59 +913,24 @@ mod hc_tests {
         assert!(hc.find_best_match::<false>(&t, 0, 1).is_none());
     }
 
-    /// Regression test for the speculative tail check's
-    /// backward-extension bound. The pre-fix gate used `tail_off =
-    /// best.match_len − 3` and was unaware that `extend_backwards`
-    /// could have added up to `lit_len` backward bytes to
-    /// `best.match_len`. The post-fix formula subtracts `lit_len`
-    /// via `checked_sub(lit_len + 3)`.
+    /// Forward-length selection (upstream `ZSTD_HcFindBestMatch`): the chain
+    /// walk keeps the longest FORWARD match (`currentMl > ml`) and applies the
+    /// single backward extension to THAT winner — a shorter-forward candidate
+    /// is NOT promoted just because it has more backward (`lit_len`) room.
+    /// Backward "catch up" happens once, on the forward winner, after the walk;
+    /// it never changes which candidate wins.
     ///
-    /// To actually fail for the pre-fix gate (Copilot review on
-    /// `c16ca32b` flagged that an earlier round of this test did
-    /// not), the fixture is constructed so the first LIFO candidate
-    /// cannot extend backward but a later candidate can — only the
-    /// later candidate's *total* match length (`forward +
-    /// backward_extension`) reaches the new best.
-    ///
-    /// Fixture (40 bytes, indices `0..=39`):
-    ///   `"AAAabcdefZMQabcdefIJBAAAabcdefIJKKKKKKKK"`
-    ///    0123456789012345678901234567890123456789   (ones digit)
-    ///              1111111111222222222233333333     (tens digit, aligned)
-    ///
-    /// Probing `abs_pos = 24, lit_len = 3`:
-    ///   - The 4-byte hash at `idx 24` ("abcd") collides with the
-    ///     hashes at `idx 3` and `idx 12` (also "abcd"). All other
-    ///     positions in `0..24` hash to other buckets, so the chain
-    ///     walker visits exactly `[12, 3]` in LIFO order.
-    ///   - Candidate at `idx 12`: forward 8 bytes (`"abcdefIJ"`
-    ///     matches the probe `"abcdefIJ"` at `24..32` exactly), but
-    ///     the byte right before — `concat[11] = 'Q'` — does NOT
-    ///     equal `concat[23] = 'A'`, so `extend_backwards` cannot
-    ///     extend even one byte despite `lit_len = 3` of available
-    ///     headroom. Total `match_len = 8`, offset = 12.
-    ///   - Candidate at `idx 3`: forward only 6 bytes (`"abcdef"`
-    ///     matches, byte 7 at `idx 9 = 'Z'` differs from probe byte
-    ///     7 at `idx 30 = 'I'`). But the 3 bytes before it —
-    ///     `concat[0..3] = "AAA"` — exactly match `concat[21..24] =
-    ///     "AAA"`, so `extend_backwards` adds 3 backward bytes.
-    ///     Total `match_len = 6 + 3 = 9`, offset = 21.
-    ///
-    /// Gate behaviour at `lit_len = 3`:
-    ///   - Pre-fix: `tail_off = best.match_len - 3 = 5`. For
-    ///     candidate at `idx 3` the gate reads `concat[3+5..3+5+4]
-    ///     = concat[8..12] = "fZMQ"` and compares to probe
-    ///     `concat[29..33] = "fIJK"`. Mismatch → gate SKIPS. The
-    ///     helper never runs `common_prefix_len` on candidate `3`,
-    ///     never extends backwards, and returns `match_len = 8`
-    ///     (the first candidate's match) — losing the 9-byte
-    ///     backward-extended win.
-    ///   - Post-fix: `tail_off = best.match_len - lit_len - 3 = 2`.
-    ///     The gate reads `concat[3+2..3+2+4] = concat[5..9] =
-    ///     "cdef"` and compares to probe `concat[26..30] = "cdef"`.
-    ///     Match → gate PASSES → full count runs, finds forward 6,
-    ///     extends backwards 3, returns `match_len = 9`.
+    /// Fixture (40 bytes): `"AAAabcdefZMQabcdefIJBAAAabcdefIJKKKKKKKK"`.
+    /// Probing `abs_pos = 24`: the 4-byte hash at `idx 24` ("abcd") collides
+    /// with `idx 3` and `idx 12`, so the walk visits `[12, 3]` (LIFO).
+    ///   - `idx 12`: forward 8 (`"abcdefIJ"`), `concat[11] = 'Q'` !=
+    ///     `concat[23] = 'A'` so no backward room. Total 8, offset 12.
+    ///   - `idx 3`: forward only 6 (`"abcdef"`), but `concat[0..3] = "AAA"` ==
+    ///     `concat[21..24]` so it could backward-extend 3 to a TOTAL of 9 — yet
+    ///     its forward length (6) loses to candidate 12's (8), so it is never
+    ///     selected. The forward winner (12) wins at both `lit_len`s.
     #[test]
-    fn hash_chain_candidate_speculative_gate_handles_lit_len_backward_extension() {
+    fn hash_chain_candidate_picks_longest_forward_over_shorter_with_backward_room() {
         let mut t = MatchTable::new(64);
         t.history = b"AAAabcdefZMQabcdefIJBAAAabcdefIJKKKKKKKK".to_vec();
         t.history_start = 0;
@@ -1087,97 +946,52 @@ mod hc_tests {
 
         let hc = HcMatcher::new(2, 16, 64);
 
-        // `lit_len = 0`: no backward extension headroom — neither
-        // candidate can grow past its forward match length, so the
-        // best wins at forward-only length 8. Both pre-fix and
-        // post-fix gates produce the same answer here.
-        let result_lit0 = hc.hash_chain_candidate::<false>(&t, 24, 0);
-        let len0 = result_lit0.map(|c| c.match_len).unwrap_or(0);
+        // The forward winner (idx 12, forward 8) has no backward room.
+        let c0 = hc
+            .hash_chain_candidate::<false>(&t, 24, 0)
+            .expect("forward match must be found");
+        assert_eq!(c0.match_len, 8, "longest forward match is 8 (idx 12)");
         assert_eq!(
-            len0, 8,
-            "lit_len=0 must return the forward-only 8-byte match at offset 12, \
-             got {len0}"
+            c0.offset, 12,
+            "winner is the forward-8 candidate at offset 12"
         );
 
-        // `lit_len = 3`: the second candidate (`idx 3`) can extend 3
-        // bytes backwards, giving a total length of 9. Pre-fix gate
-        // would skip it; post-fix gate lets it through.
-        let result_lit3 = hc.hash_chain_candidate::<false>(&t, 24, 3);
-        let len3 = result_lit3.map(|c| c.match_len).unwrap_or(0);
+        // With lit_len=3 the SHORTER-forward candidate (idx 3) could reach a
+        // total of 9 via backward extension, but forward-length selection keeps
+        // candidate 12 (forward 8) — backward room never promotes a shorter
+        // forward match. Result stays 8, not 9.
+        let c3 = hc
+            .hash_chain_candidate::<false>(&t, 24, 3)
+            .expect("forward match must be found");
         assert_eq!(
-            len3, 9,
-            "lit_len=3 must return the backward-extended 9-byte match \
-             (forward 6 + backward 3); a value of 8 means the gate over-rejected \
-             the second LIFO candidate and the helper missed the backward-extension \
-             win (pre-fix regression). Got {len3}"
+            c3.match_len, 8,
+            "forward-length selection must keep the forward-8 winner (idx 12); \
+             a value of 9 would mean a shorter-forward candidate was promoted \
+             by its backward room (non-upstream gain-based selection)"
         );
-
-        // Strict-increase between `lit_len=0` and `lit_len=3` is the
-        // signal the pre-fix gate would NOT have produced. Keep this
-        // assertion explicitly so the test's failure message points
-        // at exactly the regression it guards.
-        assert!(
-            len3 > len0,
-            "speculative gate must allow `lit_len`-dependent strict gains: \
-             lit_len=0 → {len0}, lit_len=3 → {len3}. Equal values means the \
-             gate skipped the backward-extending candidate."
-        );
+        assert_eq!(c3.offset, 12, "winner unchanged by lit_len");
     }
 
-    /// Regression test for the non-monotonic-walk fallback. When the
-    /// cyclic `chain_table & chain_mask` mask overwrites a slot, the
-    /// chain walker can surface a candidate with a SMALLER offset than
-    /// ones it has already returned. The speculative gate's
-    /// monotonicity precondition (`new.offset_bits ≥ best.offset_bits`)
-    /// is enforced per-iteration via the `new_offset ≥ best.offset`
-    /// check: when monotonicity breaks the gate falls through to
-    /// `common_prefix_len` so the offset-bits advantage is given a
-    /// chance to win.
+    /// Forward-length ties keep the FIRST-visited candidate (upstream
+    /// `ZSTD_HcFindBestMatch` uses `currentMl > ml`, strictly-longer, so an
+    /// equal-length later candidate never displaces the earlier one). The walk
+    /// is newest-first, so in organic chains "first visited" is the closest
+    /// (smallest-offset) position anyway; this test hand-wires the chain into a
+    /// non-monotonic order to pin the tie-break rule itself.
     ///
-    /// Construction: organic LIFO insertion order would never produce
-    /// this layout — when positions are inserted in monotonic order
-    /// the chain links naturally point at strictly older positions
-    /// (the previous `hash_table[hash]`). To force the bug-prone
-    /// scenario this test reaches into `MatchTable` and hand-wires the
-    /// chain so the walker visits `pos 9` first (offset 18) and then
-    /// `pos 18` second (offset 9). The fixture sits four 8-byte
-    /// `"abcdefgh"` chunks at positions `0 / 9 / 18 / 27` (each chunk
-    /// followed by a unique terminator byte that caps cross-chunk
-    /// forward matches at exactly 8); the probe at `abs_pos = 27`
-    /// hashes the same prefix as the earlier chunks, so all chain
-    /// candidates produce an 8-byte forward match and only the
-    /// offset-bits difference can decide the winner.
-    ///
-    /// With the new `new_offset >= best.offset` precondition:
-    ///   * Iter 1: cand_abs 9, offset 18. `best = None` → no gate,
-    ///     full count, `best = (len 8, offset 18)`.
-    ///   * Iter 2: cand_abs 18, offset 9. `new_offset = 9 <
-    ///     best.offset = 18` → gate skipped → full count runs →
-    ///     `better_candidate` picks the smaller-offset winner (equal
-    ///     length, smaller offset_bits → strictly higher gain).
-    ///
-    /// Final `best.offset` must be `9` (the smaller-offset winner).
-    /// Pre-fix code (gate applied unconditionally) would have
-    /// inspected the tail at `tail_off = 8 − 0 − 3 = 5` and the
-    /// 4-byte read at offsets `5..9` covers the chunk-terminator byte
-    /// (different `'A' / 'B' / 'C' / 'D'` per chunk) — gate fails on
-    /// the mismatching terminator and the second candidate gets
-    /// skipped, leaving `best.offset = 18`.
+    /// Fixture: four 8-byte `"abcdefgh"` chunks at `0 / 9 / 18 / 27`, each
+    /// followed by a unique terminator (`'A'/'B'/'C'/'D'`) capping cross-chunk
+    /// forward matches at exactly 8. Probing `abs_pos = 27` with the chain
+    /// hand-wired to visit pos 9 (offset 18) THEN pos 18 (offset 9): both have
+    /// forward length 8, so the first-visited (pos 9, offset 18) wins. The
+    /// self-tightening gate at `ml = 8` also rejects pos 18 (its tail byte is a
+    /// different chunk terminator), so the equal-length later candidate is
+    /// skipped before the count — consistent with ties-keep-first.
     #[test]
-    fn hash_chain_candidate_non_monotonic_walk_accepts_smaller_offset() {
-        // Four 8-byte `"abcdefgh"` chunks, each followed by a unique
-        // terminator byte (`'A' / 'B' / 'C' / 'D'`). The terminators
-        // are part of the same 40-byte stream, so each chunk start
-        // sits 9 bytes after the previous one — chunk starts are at
-        // `0`, `9`, `18`, `27` (not `0/8/16/24` as a naive
-        // chunk-width calculation would suggest). The cross-chunk
-        // forward match between any two chunks caps at exactly 8
-        // because the byte right after each chunk is unique.
+    fn hash_chain_candidate_forward_ties_keep_first_visited() {
         let mut t = MatchTable::new(64);
         t.history = b"abcdefghAabcdefghBabcdefghCabcdefghDZZZZ".to_vec();
         assert_eq!(t.history.len(), 40);
-        // After each "abcdefgh" the next byte is unique ('A'/'B'/'C'
-        // /'D'), capping cross-chunk forward matches at length 8.
         t.history_start = 0;
         t.history_abs_start = 0;
         t.window_size = t.history.len();
@@ -1188,46 +1002,29 @@ mod hc_tests {
         t.ensure_tables();
         t.chunk_lens.push_back(t.history.len());
 
-        // The probe is at abs_pos 27 (start of the fourth
-        // "abcdefgh" chunk). Hand-wire the chain so the walker
-        // visits pos 9 first and pos 18 second.
-        //
-        // Layout: chunks at 0..8, 9..17, 18..26, 27..35. The byte
-        // BEFORE each chunk is the terminator from the previous
-        // chunk's match. Probing at abs_pos 27:
-        //   * candidate 9 → offset 27 − 9 = 18
-        //   * candidate 18 → offset 27 − 18 = 9 (SMALLER — second
-        //     visit, non-monotonic)
         let abs_pos = 27usize;
         let concat = t.live_history();
         let probe_hash = t.hash_position(&concat[abs_pos..]);
-        // `stored = pos + 1` per `MatchTable::stored_abs_position_fast`.
-        // Hand-wire the chain head and the link OUT of pos 9 so the
-        // walk surfaces 9 first, then 18.
+        // Hand-wire the chain head + link so the walk surfaces pos 9 first
+        // (offset 18) then pos 18 (offset 9). `stored = pos + 1`.
         t.hash_table[probe_hash] = 9 + 1;
         let chain_mask = (1usize << t.chain_log) - 1;
         t.chain_table[9 & chain_mask] = 18 + 1;
-        // Terminate the walk after pos 18.
         t.chain_table[18 & chain_mask] = HC_EMPTY;
 
         let hc = HcMatcher::new(2, 16, 64);
-        let result = hc.hash_chain_candidate::<false>(&t, abs_pos, 0);
-        let cand = result.expect("non-monotonic walk must still produce a match");
+        let cand = hc
+            .hash_chain_candidate::<false>(&t, abs_pos, 0)
+            .expect("walk must still produce a match");
         assert_eq!(
             cand.match_len, 8,
-            "both chain candidates have an 8-byte forward prefix match — \
-             expected match_len = 8, got {}",
-            cand.match_len
+            "both candidates have an 8-byte forward prefix"
         );
         assert_eq!(
-            cand.offset, 9,
-            "non-monotonic fallback must surface the smaller-offset winner: \
-             expected offset = 9 (cand_abs 18), got offset = {}. \
-             A regression in the `new_offset >= best.offset` check would \
-             keep the gate active for the smaller-offset second candidate, \
-             skip its full count, and leave best.offset at 18 (the \
-             larger-offset first-visited candidate).",
-            cand.offset
+            cand.offset, 18,
+            "forward-length ties keep the first-visited candidate (pos 9, \
+             offset 18); a value of 9 would mean the equal-length later \
+             candidate displaced it (non-upstream gain-based tie-break)"
         );
     }
 }

--- a/zstd/src/encoding/levels/fastest.rs
+++ b/zstd/src/encoding/levels/fastest.rs
@@ -81,12 +81,20 @@ pub(crate) fn compress_block_encoded<M: Matcher>(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if should_emit_raw_fast_path(
-        compression_level,
-        state.matcher.window_size(),
-        &uncompressed_data,
-        dict_active,
-    ) && !(dict_active && state.matcher.block_samples_match_dict(&uncompressed_data))
+    } else if !(dict_active && state.matcher.block_samples_match_dict(&uncompressed_data))
+        // Evaluation order matters: the dict-match guard is cheap (a constant
+        // `true` for the conservative backends — HC / Row / BT — and a small
+        // table probe for Fast), whereas `should_emit_raw_fast_path` runs a
+        // WHOLE-BLOCK incompressibility scan on the dict path. When a primed
+        // dictionary forces the raw-skip off anyway (guard is `false`), this
+        // short-circuit skips that scan entirely instead of computing it and
+        // throwing the result away. Boolean result is unchanged (AND commutes).
+        && should_emit_raw_fast_path(
+            compression_level,
+            state.matcher.window_size(),
+            &uncompressed_data,
+            dict_active,
+        )
     {
         #[cfg(feature = "lsm")]
         if let Some(sink) = block_decompressed_sizes {
@@ -278,12 +286,16 @@ pub(crate) fn compress_block_encoded_borrowed(
         header.serialize(output);
         output.push(rle_byte);
         BlockType::RLE
-    } else if should_emit_raw_fast_path(
-        compression_level,
-        state.matcher.window_size(),
-        block,
-        dict_active,
-    ) && !(dict_active && state.matcher.block_samples_match_dict(block))
+    } else if !(dict_active && state.matcher.block_samples_match_dict(block))
+        // Same cheap-guard-first short-circuit as the owned path: skip the
+        // whole-block dict-incompressibility scan when a primed dict already
+        // forces the raw-skip off. Boolean result unchanged (AND commutes).
+        && should_emit_raw_fast_path(
+            compression_level,
+            state.matcher.window_size(),
+            block,
+            dict_active,
+        )
     {
         #[cfg(feature = "lsm")]
         if let Some(sink) = block_decompressed_sizes {

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6722,6 +6722,20 @@ impl HcMatchGenerator {
         let current_ptr = self.table.get_last_space().as_ptr();
         let current: &[u8] = unsafe { core::slice::from_raw_parts(current_ptr, current_len) };
 
+        // Full live history (dict + committed blocks + current block), hoisted
+        // ONCE for the whole position scan and threaded into every
+        // `find_best_match` / `pick_lazy_match` call. `live_history()` is
+        // loop-invariant here (the scan mutates the hash/chain tables +
+        // `offset_hist` but never the history bytes or length), so re-fetching
+        // it per find — inside `hash_chain_candidate` + the rep probe, plus
+        // again for each lazy lookahead at pos+1 / pos+2 — was pure
+        // per-position overhead. Same raw-slice detach as `current` so the
+        // loop's `&mut self.table` inserts coexist with this `&[u8]`.
+        let concat: &[u8] = {
+            let lh = self.table.live_history();
+            unsafe { core::slice::from_raw_parts(lh.as_ptr(), lh.len()) }
+        };
+
         let current_abs_end = current_abs_start + current_len;
         self.table
             .backfill_boundary_positions(current_abs_start, current_abs_end);
@@ -6734,10 +6748,10 @@ impl HcMatchGenerator {
 
             let best = self
                 .hc
-                .find_best_match::<DICT>(&self.table, abs_pos, lit_len);
+                .find_best_match::<DICT>(concat, &self.table, abs_pos, lit_len);
             if let Some(candidate) =
                 self.hc
-                    .pick_lazy_match::<DICT>(&self.table, abs_pos, lit_len, best)
+                    .pick_lazy_match::<DICT>(concat, &self.table, abs_pos, lit_len, best)
             {
                 self.table
                     .insert_match_span(abs_pos, candidate.start + candidate.match_len);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6735,6 +6735,12 @@ impl HcMatchGenerator {
             let lh = self.table.live_history();
             unsafe { core::slice::from_raw_parts(lh.as_ptr(), lh.len()) }
         };
+        // Dict-match-state primed flag, hoisted ONCE for the scan: it is
+        // block-invariant (the dict is primed before the block) and lives on the
+        // cold `dms` cacheline, so the per-find `dms.is_primed()` load was a
+        // measurable hot-path cost (~8% of `hash_chain_candidate` on the
+        // dict-over-random fixture). The `DICT = false` monomorph ignores it.
+        let dms_primed = self.table.dms.is_primed();
 
         let current_abs_end = current_abs_start + current_len;
         self.table
@@ -6746,13 +6752,17 @@ impl HcMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            let best = self
-                .hc
-                .find_best_match::<DICT>(concat, &self.table, abs_pos, lit_len);
-            if let Some(candidate) =
+            let best =
                 self.hc
-                    .pick_lazy_match::<DICT>(concat, &self.table, abs_pos, lit_len, best)
-            {
+                    .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len);
+            if let Some(candidate) = self.hc.pick_lazy_match::<DICT>(
+                concat,
+                dms_primed,
+                &self.table,
+                abs_pos,
+                lit_len,
+                best,
+            ) {
                 self.table
                     .insert_match_span(abs_pos, candidate.start + candidate.match_len);
                 let start = candidate.start - current_abs_start;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -1096,8 +1096,46 @@ pub fn estimated_bt_strategy_extra_bytes(strategy_ordinal: u32, window_log: u32)
     super::bt::BtMatcher::estimated_workspace_bytes() + hash3
 }
 
-/// Resolve a [`CompressionLevel`] to internal tuning parameters,
-/// optionally adjusted for a known source size.
+/// Resolve a [`CompressionLevel`] (+ optional source-size hint) to the
+/// concrete [`LevelParams`] the matcher runs: strategy tag, search method
+/// (match-finder), window log, and per-backend config.
+///
+/// ## CRITICAL: input size changes the match-finder (and can change strategy)
+///
+/// The resolved geometry is a function of the SOURCE SIZE, not the level
+/// alone. This is the easy-to-miss part (so read this before assuming a level
+/// maps to one fixed match-finder). It mirrors three upstream zstd stages:
+///
+/// 1. [`LEVEL_TABLE`] holds the tier-0 (source > 256 KiB) base row per level
+///    (upstream `ZSTD_defaultCParameters[0]`). L6-L12 carry
+///    `SearchMethod::RowHash` (the Row match-finder), like upstream's
+///    greedy/lazy default.
+/// 2. [`apply_cparams_tier`] overrides the table-shaping widths for the
+///    smaller source tiers (upstream `ZSTD_getCParams_internal` tier table).
+///    NOTE: upstream ALSO switches STRATEGY in some tiers (L2 → dfast, L4 →
+///    greedy on small sources); those backend switches are NOT yet replicated,
+///    so those levels keep their base strategy on small inputs.
+/// 3. [`adjust_params_for_source_size`] caps `window_log` to
+///    ~`ceil_log2(source_size)` (upstream `ZSTD_adjustCParams_internal`).
+///
+/// THEN, in the matcher `reset`, the greedy/lazy band falls back from
+/// `RowHash` to `SearchMethod::HashChain` when the resolved `window_log <= 14`
+/// — exactly upstream's `ZSTD_resolveRowMatchFinderMode` (the Row match-finder
+/// is used for greedy/lazy/lazy2 ONLY when `windowLog > 14`). Net effect for
+/// the SAME level:
+///
+/// * small input (e.g. a 10 KiB fixture → `window_log` 14) → **HashChain**
+///   (`ZSTD_HcFindBestMatch`, scalar chain walk);
+/// * large input (e.g. 1 MiB → `window_log` 20) → **RowHash** (the SIMD-tag
+///   row match-finder).
+///
+/// A dictionary does NOT change the match-finder: it only downsizes the
+/// prepared tables (`cdict_table_logs`, mirroring `ZSTD_createCDict`'s
+/// small-source assumption), while `window_log` stays source-derived. So
+/// `(L6, 10 KiB, +dict)` is HashChain and `(L6, 1 MiB, +dict)` is RowHash,
+/// both matching upstream. When comparing against C on a fixture, resolve the
+/// match-finder from the fixture's size first, or you may optimise/benchmark a
+/// path C does not even take for that input.
 fn resolve_level_params(level: CompressionLevel, source_size: Option<u64>) -> LevelParams {
     if matches!(level, CompressionLevel::Level(22)) {
         return level22_btultra2_params_for_source_size(source_size);

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -447,52 +447,43 @@ impl LevelParams {
         }
     }
 
-    /// Cheap fingerprint pre-splitter level, the C-like `blockSplitterLevel`
-    /// knob. Mirrors the upstream zstd `splitLevels[]` table indexed by strategy in
-    /// `ZSTD_optimalBlockSize` (`{0,0,1,2,2,3,3,4,4,4}` over fast..btultra2):
-    /// fast=0, dfast=1, greedy=2, lazy=2, lazy2=3, btlazy2=3,
-    /// btopt/btultra/btultra2=4. We collapse the upstream zstd `lazy2` and `btlazy2`
-    /// strategies into the hash-chain `Lazy` tag, distinguished here by
-    /// `lazy_depth` (the level table runs both at depth 2), so depth 2 routes
-    /// to split level 3 to match the upstream zstd. `split_level == 0` routes to the
-    /// cheap from-borders heuristic; `1..=4` to byChunks with internal
-    /// sampling level `split_level - 1`. The `savings >= 3` gate in
-    /// `optimal_block_size` keeps incompressible data and the first full block
-    /// whole, so homogeneous frames are not over-split.
+    /// Cheap fingerprint pre-splitter level (the C-like `blockSplitterLevel`):
+    /// the EFFECTIVE upstream `ZSTD_splitBlock` level that
+    /// `ZSTD_optimalBlockSize` dispatches, i.e. `splitLevels[strategy] - 2`
+    /// (clamped at 0), NOT the raw `splitLevels[]` value. `split_level == 0`
+    /// routes to the cheap from-borders heuristic; `1..=4` to byChunks with
+    /// internal sampling level `split_level - 1`. See the body for the
+    /// per-strategy tier table and why the raw-table mapping was wrong.
     fn pre_split(&self) -> Option<u8> {
-        match self.strategy_tag {
-            super::strategy::StrategyTag::Fast => Some(0),
-            super::strategy::StrategyTag::Dfast => Some(1),
-            super::strategy::StrategyTag::Greedy => Some(2),
-            // The lazy2 / btlazy2 band (Lazy at lazy_depth >= 2, and Btlazy2)
-            // uses the rate-1 full-scan chunk splitter (4), NOT the rate-5
-            // sampler (3). The rate-5 sampler combined with the larger
-            // hash_log is sensitive enough to register a phantom statistical
-            // transition on perfectly homogeneous but periodic input (e.g. a
-            // repeating log-line stream whose period does not divide the 8 KB
-            // chunk size): the sampled bytes land on a different phase in each
-            // chunk, so two identical-distribution chunks look different and
-            // the block is split at 8 KB, then re-split on every window,
-            // cascading a large stream into hundreds of tiny blocks whose
-            // per-block headers dwarf the payload. The rate-1 scan reads every
-            // byte, so it sees periodic data as uniform and declines to split,
-            // while still finding genuine content boundaries (measured better
-            // ratio on the real decode corpus, and no longer expands a
-            // periodic stream vs a single full block). lazy/greedy keep the
-            // coarse samplers (lower hash_log => not sensitive enough to
-            // alias here).
-            super::strategy::StrategyTag::Lazy => {
+        use super::strategy::StrategyTag;
+        // Effective upstream `ZSTD_splitBlock` level = `splitLevels[strat] - 2`
+        // (clamped at 0). Upstream `splitLevels[] = {0,0,1,2,2,3,3,4,4,4}` then
+        // subtracts 2 before dispatch, so the byChunks sampling tier is two
+        // steps coarser than the raw table: greedy/lazy(d1)=0 (from-borders),
+        // lazy2/btlazy2=1 (byChunks rate 43), btopt+=2 (byChunks rate 11).
+        // An earlier version mirrored the RAW table AND bumped lazy2 to the
+        // rate-1 full scan (split 4) to dodge a periodic-input phantom-split —
+        // that ran the pre-splitter at up to 43x upstream's sampling cost
+        // (~87% of L9 encode time on the decode corpus). Per the drop-in
+        // contract ratio only needs to stay <= upstream, so matching upstream's
+        // sampling tier (and accepting upstream's identical over-split on
+        // periodic input) is the dominant large-input encode-speed win.
+        Some(match self.strategy_tag {
+            // splitLevels 0/1 -> 0: upstream does not pre-split fast/dfast at
+            // all; from-borders is the cheapest stand-in and rarely splits.
+            StrategyTag::Fast | StrategyTag::Dfast => 0,
+            // greedy / lazy(depth 1): splitLevels 2 -> 0 (from-borders).
+            StrategyTag::Greedy => 0,
+            StrategyTag::Lazy => {
                 if self.lazy_depth >= 2 {
-                    Some(4)
+                    1 // lazy2: splitLevels 3 -> 1 (byChunks rate 43)
                 } else {
-                    Some(2)
+                    0 // lazy depth 1: splitLevels 2 -> 0 (from-borders)
                 }
             }
-            super::strategy::StrategyTag::Btlazy2 => Some(4),
-            super::strategy::StrategyTag::BtOpt
-            | super::strategy::StrategyTag::BtUltra
-            | super::strategy::StrategyTag::BtUltra2 => Some(4),
-        }
+            StrategyTag::Btlazy2 => 1, // splitLevels 3 -> 1 (byChunks rate 43)
+            StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2 => 2,
+        })
     }
 }
 

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6751,35 +6751,44 @@ impl HcMatchGenerator {
             if let Some(best) =
                 self.hc
                     .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len)
-                && self.hc.pick_lazy_match::<DICT>(
+            {
+                if self.hc.pick_lazy_match::<DICT>(
                     concat,
                     dms_primed,
                     &self.table,
                     abs_pos,
                     lit_len,
                     best,
-                )
-            {
-                self.table
-                    .insert_match_span(abs_pos, best.start + best.match_len);
-                let start = best.start - current_abs_start;
-                let literals = &current[literals_start..start];
-                handle_sequence(Sequence::Triple {
-                    literals,
-                    offset: best.offset,
-                    match_len: best.match_len,
-                });
-                let _ = encode_offset_with_history(
-                    best.offset as u32,
-                    literals.len() as u32,
-                    &mut self.table.offset_hist,
-                );
-                pos = start + best.match_len;
-                literals_start = pos;
+                ) {
+                    self.table
+                        .insert_match_span(abs_pos, best.start + best.match_len);
+                    let start = best.start - current_abs_start;
+                    let literals = &current[literals_start..start];
+                    handle_sequence(Sequence::Triple {
+                        literals,
+                        offset: best.offset,
+                        match_len: best.match_len,
+                    });
+                    let _ = encode_offset_with_history(
+                        best.offset as u32,
+                        literals.len() as u32,
+                        &mut self.table.offset_hist,
+                    );
+                    pos = start + best.match_len;
+                    literals_start = pos;
+                    continue;
+                }
+                // Lazy lookahead found a better match at `abs_pos + 1` / `+ 2`
+                // (defer): advance exactly ONE byte (upstream
+                // `ZSTD_compressBlock_lazy_generic`) so the deferred candidate is
+                // re-evaluated at its own position. The no-match skip below
+                // accelerates by `step`, which once the literal run reaches 256+
+                // bytes is `> 1` and would jump past the deferred candidate.
+                self.table.insert_position(abs_pos);
+                pos += 1;
                 continue;
             }
-            // No match found, or the lazy lookahead deferred to a later
-            // position.
+            // No match found.
             self.table.insert_position(abs_pos);
             // Lazy skipping (upstream zstd `ZSTD_compressBlock_lazy_generic`,
             // zstd_lazy.c:1614): advance faster over runs with no match.

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6751,33 +6751,32 @@ impl HcMatchGenerator {
             if let Some(best) =
                 self.hc
                     .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len)
-            {
-                if self.hc.pick_lazy_match::<DICT>(
+                && self.hc.pick_lazy_match::<DICT>(
                     concat,
                     dms_primed,
                     &self.table,
                     abs_pos,
                     lit_len,
                     best,
-                ) {
-                    self.table
-                        .insert_match_span(abs_pos, best.start + best.match_len);
-                    let start = best.start - current_abs_start;
-                    let literals = &current[literals_start..start];
-                    handle_sequence(Sequence::Triple {
-                        literals,
-                        offset: best.offset,
-                        match_len: best.match_len,
-                    });
-                    let _ = encode_offset_with_history(
-                        best.offset as u32,
-                        literals.len() as u32,
-                        &mut self.table.offset_hist,
-                    );
-                    pos = start + best.match_len;
-                    literals_start = pos;
-                    continue;
-                }
+                )
+            {
+                self.table
+                    .insert_match_span(abs_pos, best.start + best.match_len);
+                let start = best.start - current_abs_start;
+                let literals = &current[literals_start..start];
+                handle_sequence(Sequence::Triple {
+                    literals,
+                    offset: best.offset,
+                    match_len: best.match_len,
+                });
+                let _ = encode_offset_with_history(
+                    best.offset as u32,
+                    literals.len() as u32,
+                    &mut self.table.offset_hist,
+                );
+                pos = start + best.match_len;
+                literals_start = pos;
+                continue;
             }
             // No match found, or the lazy lookahead deferred to a later
             // position.

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6743,15 +6743,15 @@ impl HcMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            // `best` is unwrapped here (not threaded into `pick_lazy_match` as
-            // an `Option`) so the 24-byte candidate stays in the caller's frame
-            // and is reused on commit — `pick_lazy_match` only returns a
-            // commit/defer `bool`, avoiding a per-position 32-byte
-            // `Option<MatchCandidate>` stack-arg copy across the call boundary.
-            if let Some(best) =
+            // `find_best_match` returns the forward `(offset, length)` in
+            // registers (`HcMatch`, 16 bytes) — no 24-byte `MatchCandidate` /
+            // 32-byte `Option` spilled-and-copied per position. The backward
+            // extension that yields `start` runs ONCE here, after the lazy
+            // decision settles, exactly like upstream's lazy loop.
+            let best =
                 self.hc
-                    .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len)
-            {
+                    .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len);
+            if best.is_match() {
                 if self.hc.pick_lazy_match::<DICT>(
                     concat,
                     dms_primed,
@@ -6760,30 +6760,47 @@ impl HcMatchGenerator {
                     lit_len,
                     best,
                 ) {
-                    self.table
-                        .insert_match_span(abs_pos, best.start + best.match_len);
-                    let start = best.start - current_abs_start;
+                    // Backward-extend over the literal run (upstream `zstd_lazy.c`
+                    // after rep-vs-chain selection). The offset is preserved;
+                    // `start` and `match_len` grow by the same amount, bounded by
+                    // `literals_start` (the `min_abs` floor) so it never crosses
+                    // an already-emitted sequence.
+                    let history_abs_start = self.table.history_abs_start;
+                    let min_abs = abs_pos - lit_len;
+                    let mut start_abs = abs_pos;
+                    let mut cand_abs = abs_pos - best.offset;
+                    let mut match_len = best.match_len;
+                    while start_abs > min_abs
+                        && cand_abs > history_abs_start
+                        && concat[cand_abs - history_abs_start - 1]
+                            == concat[start_abs - history_abs_start - 1]
+                    {
+                        start_abs -= 1;
+                        cand_abs -= 1;
+                        match_len += 1;
+                    }
+                    self.table.insert_match_span(abs_pos, start_abs + match_len);
+                    let start = start_abs - current_abs_start;
                     let literals = &current[literals_start..start];
                     handle_sequence(Sequence::Triple {
                         literals,
                         offset: best.offset,
-                        match_len: best.match_len,
+                        match_len,
                     });
                     let _ = encode_offset_with_history(
                         best.offset as u32,
                         literals.len() as u32,
                         &mut self.table.offset_hist,
                     );
-                    pos = start + best.match_len;
+                    pos = start + match_len;
                     literals_start = pos;
                     continue;
                 }
                 // Lazy lookahead found a better match at `abs_pos + 1` / `+ 2`
                 // (defer): advance exactly ONE byte (upstream
                 // `ZSTD_compressBlock_lazy_generic`) so the deferred candidate is
-                // re-evaluated at its own position. The no-match skip below
-                // accelerates by `step`, which once the literal run reaches 256+
-                // bytes is `> 1` and would jump past the deferred candidate.
+                // re-evaluated at its own position; the no-match skip below could
+                // jump past it once the literal run reaches 256+ bytes.
                 self.table.insert_position(abs_pos);
                 pos += 1;
                 continue;

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -6743,56 +6743,65 @@ impl HcMatchGenerator {
             let abs_pos = current_abs_start + pos;
             let lit_len = pos - literals_start;
 
-            let best =
+            // `best` is unwrapped here (not threaded into `pick_lazy_match` as
+            // an `Option`) so the 24-byte candidate stays in the caller's frame
+            // and is reused on commit — `pick_lazy_match` only returns a
+            // commit/defer `bool`, avoiding a per-position 32-byte
+            // `Option<MatchCandidate>` stack-arg copy across the call boundary.
+            if let Some(best) =
                 self.hc
-                    .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len);
-            if let Some(candidate) = self.hc.pick_lazy_match::<DICT>(
-                concat,
-                dms_primed,
-                &self.table,
-                abs_pos,
-                lit_len,
-                best,
-            ) {
-                self.table
-                    .insert_match_span(abs_pos, candidate.start + candidate.match_len);
-                let start = candidate.start - current_abs_start;
-                let literals = &current[literals_start..start];
-                handle_sequence(Sequence::Triple {
-                    literals,
-                    offset: candidate.offset,
-                    match_len: candidate.match_len,
-                });
-                let _ = encode_offset_with_history(
-                    candidate.offset as u32,
-                    literals.len() as u32,
-                    &mut self.table.offset_hist,
-                );
-                pos = start + candidate.match_len;
-                literals_start = pos;
-            } else {
-                self.table.insert_position(abs_pos);
-                // Lazy skipping (upstream zstd `ZSTD_compressBlock_lazy_generic`,
-                // zstd_lazy.c:1614): advance faster over runs with no match.
-                // `step = ((ip - anchor) >> kSearchStrength) + 1` with
-                // kSearchStrength = 8, where `ip - anchor` is the current
-                // literal-run length. On compressible input the run stays short
-                // (step == 1, identical to a 1-byte advance); on incompressible
-                // / dict-over-random input the run grows so the parser skips
-                // ahead (one search per `step` positions) instead of searching
-                // every byte. Skipped positions are not inserted, mirroring
-                // upstream (it inserts only searched positions during a no-match
-                // run). Ratio follows upstream (not byte-identical).
-                let step = ((pos - literals_start) >> 8) + 1;
-                pos += step;
-                // No clamp needed before the tail loop: the search bound and the
-                // hashable bound are both `pos + HC_MIN_MATCH_LEN <= current_len`
-                // (HC_MIN_MATCH_LEN == 4 == the insert width), so there is no
-                // non-searchable-but-hashable anchor to miss. Positions the skip
-                // jumps over inside the searchable region are intentionally not
-                // inserted — same as upstream zstd, which advances past them via
-                // the identical `ip += step` and never hashes them either.
+                    .find_best_match::<DICT>(concat, dms_primed, &self.table, abs_pos, lit_len)
+            {
+                if self.hc.pick_lazy_match::<DICT>(
+                    concat,
+                    dms_primed,
+                    &self.table,
+                    abs_pos,
+                    lit_len,
+                    best,
+                ) {
+                    self.table
+                        .insert_match_span(abs_pos, best.start + best.match_len);
+                    let start = best.start - current_abs_start;
+                    let literals = &current[literals_start..start];
+                    handle_sequence(Sequence::Triple {
+                        literals,
+                        offset: best.offset,
+                        match_len: best.match_len,
+                    });
+                    let _ = encode_offset_with_history(
+                        best.offset as u32,
+                        literals.len() as u32,
+                        &mut self.table.offset_hist,
+                    );
+                    pos = start + best.match_len;
+                    literals_start = pos;
+                    continue;
+                }
             }
+            // No match found, or the lazy lookahead deferred to a later
+            // position.
+            self.table.insert_position(abs_pos);
+            // Lazy skipping (upstream zstd `ZSTD_compressBlock_lazy_generic`,
+            // zstd_lazy.c:1614): advance faster over runs with no match.
+            // `step = ((ip - anchor) >> kSearchStrength) + 1` with
+            // kSearchStrength = 8, where `ip - anchor` is the current
+            // literal-run length. On compressible input the run stays short
+            // (step == 1, identical to a 1-byte advance); on incompressible
+            // / dict-over-random input the run grows so the parser skips
+            // ahead (one search per `step` positions) instead of searching
+            // every byte. Skipped positions are not inserted, mirroring
+            // upstream (it inserts only searched positions during a no-match
+            // run). Ratio follows upstream (not byte-identical).
+            let step = ((pos - literals_start) >> 8) + 1;
+            pos += step;
+            // No clamp needed before the tail loop: the search bound and the
+            // hashable bound are both `pos + HC_MIN_MATCH_LEN <= current_len`
+            // (HC_MIN_MATCH_LEN == 4 == the insert width), so there is no
+            // non-searchable-but-hashable anchor to miss. Positions the skip
+            // jumps over inside the searchable region are intentionally not
+            // inserted — same as upstream zstd, which advances past them via
+            // the identical `ip += step` and never hashes them either.
         }
 
         // Insert remaining hashable positions in the tail (the matching loop

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1027,6 +1027,7 @@ impl MatchTable {
     /// The live (post-`history_start`) slice of the contiguous history
     /// mirror. Match finders operate on this slice rather than the raw
     /// `history` Vec.
+    #[inline]
     pub(crate) fn live_history(&self) -> &[u8] {
         // Borrowed one-shot: expose `[0, block_end)` of the caller's input so
         // candidate/cursor reads land in place (the owned `history` mirror is

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1301,18 +1301,36 @@ impl MatchTable {
             // (every bump clamps to it), so `headroom >= 0` — no `saturating_*`.
             let headroom = MAX_PRIMED_WINDOW_SIZE - self.max_window_size;
             self.max_window_size += region.min(headroom);
-            self.history_abs_start = 0;
-            self.position_base = 0;
-            self.index_shift = 0;
-            // Dict is in the dms; the live tables carry only input — memset them,
-            // keep the dms. Cursors reproduce `skip_matching_dict_bt`'s post-prime
-            // state (skip re-inserting the resident dict region).
-            self.hash_table.fill(HC_EMPTY);
-            self.hash3_table.fill(HC_EMPTY);
-            self.chain_table.fill(HC_EMPTY);
-            self.skip_insert_until_abs = region;
-            self.next_to_update3 = region;
-            self.dictionary_limit_abs = Some(region);
+            // The dict bytes stay at the buffer front `[0, region)`; the dms is
+            // concat-keyed (abs-invariant), so its candidates + extension are
+            // independent of the abs base. The live tables carry only input.
+            // Retire the previous frame's input entries one of two ways:
+            if next_floor <= REBASE_RESET_FLOOR_CEILING {
+                // Floor-advance (no memset): keep the climbing abs base + the
+                // position encoding. The dict sits AT the floor — its abs
+                // `[next_floor, next_floor+region)` is `>= window_low`, so it
+                // stays in-window via the bump above; the previous frame's input
+                // entries are `< next_floor` and wrap out of range on read (the
+                // non-dict fast path's reject-by-wrap, reused for the resident
+                // dict). Skip cursors move into the climbed abs space.
+                self.history_abs_start = next_floor;
+                self.skip_insert_until_abs = next_floor + region;
+                self.next_to_update3 = next_floor + region;
+                self.dictionary_limit_abs = Some(next_floor + region);
+            } else {
+                // Bounded fallback: the floor would climb past the 32-bit
+                // headroom ceiling, so rewind to the origin and zero the live
+                // tables (the dict region is re-pinned at abs `[0, region)`).
+                self.history_abs_start = 0;
+                self.position_base = 0;
+                self.index_shift = 0;
+                self.hash_table.fill(HC_EMPTY);
+                self.hash3_table.fill(HC_EMPTY);
+                self.chain_table.fill(HC_EMPTY);
+                self.skip_insert_until_abs = region;
+                self.next_to_update3 = region;
+                self.dictionary_limit_abs = Some(region);
+            }
             self.dict_resident = true;
             return;
         }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -1084,10 +1084,17 @@ macro_rules! row_probe_body {
             // zstd decrements one `nbAttempts` across both rows,
             // zstd_lazy.c:1308): the dict probe only spends what the live
             // walk left over.
-            if attempts < max_walk
+            // Match upstream zstd's effective dict search depth: the CDict path
+            // adjusts cParams (dict-size-aware searchLog) so the dict probe runs
+            // deeper than the bare level searchLog — measured nbAttempts >= 16 to
+            // surface the long dict match on the per-label-dict fixtures, vs the
+            // 8 from L6's searchLog=3. Floor the dict budget at 16 (a full
+            // rowLog-4 row); the dpending mask still bounds it to the row width.
+            let dict_budget = max_walk.max(16);
+            if attempts < dict_budget
                 && let Some(dict) = $m.dict.table()
             {
-                let dict_walk = max_walk - attempts;
+                let dict_walk = dict_budget - attempts;
                 let dict_end = $m.dict.region_len();
                 let drow_base = row << $rl;
                 let dhead = dict.heads[row] as usize;


### PR DESCRIPTION
## Summary

Closes the L6-L9 hash-chain (lazy/lazy2) dictionary compress-speed gap, plus
the block pre-splitter sampling-tier regression that surfaced alongside it.
Every change keeps the compressed output a valid zstd frame that round-trips,
and ratio stays `<=` the C reference on the measured fixtures (verified
byte-identical where claimed).

## Changes

**Block pre-splitter sampling tier.** `pre_split` returned the raw
`splitLevels[]` index instead of `splitLevels[strat] - 2`, over-sampling every
split decision. Mapped to the upstream tier. decodecorpus L9 compress: **3.16x
faster** than the C reference, ratio-neutral.

**HC dictionary hot path** (small-10k-random compress-dict, L6, i9 figures):

- `pick_lazy_match` returns `bool` and takes the candidate by value, dropping a
  per-position 32-byte `Option<MatchCandidate>` stack-arg copy across the call
  boundary: **-9.9%** cycles.
- Hoist `live_history`, the dms-primed flag, and the chain-table base pointers
  out of the per-find loop. Through `&MatchTable` the optimizer reloads the
  `Vec` (ptr, len) header and re-checks bounds on every chain access; hoisting
  the raw base pointer once cuts that to a single in-bounds load: **-2.1%**
  cycles, **-6%** L1 loads.
- Inline the single-rep (offset_1) probe + `live_history` into the lazy find,
  matching the upstream lazy loop (the 3-rep rotation belongs to the optimal
  parser, not the lazy path).
- Drop a redundant loop-carried `found` bool from the dict monomorph
  (`ml >= MIN_MATCH` is exactly equivalent), freeing a register on the
  register-tight dict path.
- Short-circuit the whole-block dict incompressibility scan when a primed
  dictionary already forces the compress path. For the conservative backends
  (HC/Row/BT) that scan's result was computed and then discarded every frame;
  evaluating the cheap dict-match guard first skips it entirely. Boolean result
  unchanged (commutes): **-6.2%** cycles, **-5%** instructions.

Cumulative HC dict gap vs the C reference on the i9: **~2.0x -> ~1.6x**.

## Testing

- `cargo nextest run -p structured-zstd` -- 789 pass
- `cargo nextest run -p ffi-bench` (FFI cross-validation, incl. the L22
  ratio-bound check) -- 26 pass
- `cargo clippy --all-targets` -- clean
- Ratio `<=` C reference on small-10k-random + decodecorpus; HC output
  byte-identical where a change claims it.

Closes #434


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional dictionary input support to sequence comparison benchmarks (automatic format detection)
  * Added an optional environment-variable debug dump for generated dictionary bytes
  * Added a new small 1 KiB log-lines benchmark fixture variant
* **Bug Fixes**
  * Updated bench-dashboard aggregate timeline to keep cohort comparisons consistent across snapshots
* **Tests**
  * Adjusted large-corpus sequence parity checks; updated compression split-dispatch expectations
  * Refreshed match-finding tests to reflect updated lazy/dictionary selection behavior
* **Refactor**
  * Reworked match-finding and lazy probing logic, including updated match handling and dictionary probing budgets
<!-- end of auto-generated comment: release notes by coderabbit.ai -->