### PR TITLE
perf(kernel): disable AVX-512 VBMI2 tier by default; defer dict-frame table clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,17 @@ cargo add structured-zstd --no-default-features
 ```
 
 The decoder ships per-CPU-tier SIMD kernels, each behind a cargo feature
-(all on by default; the tier is picked at runtime with `std`, or at compile
-time from `target_feature` on `no_std`): `kernel_scalar`, `kernel_sse2`,
+(the tier is picked at runtime with `std`, or at compile time from
+`target_feature` on `no_std`): `kernel_scalar`, `kernel_sse2`,
 `kernel_bmi2`, `kernel_avx2`, `kernel_vbmi2` (x86) and `kernel_neon`,
-`kernel_sve` (aarch64). The scalar kernel is always compiled (it is the
+`kernel_sve` (aarch64). All are on by default **except `kernel_vbmi2`**
+(AVX-512): on AVX-512 hosts that tier is measurably slower than `kernel_avx2`
+for this decode workload — AVX-512's license-based frequency downclocking
+stalls the surrounding (bursty, memory-bound) code, and the heavier kernel
+never amortizes — so by default the runtime dispatch is capped at AVX2 and
+AVX-512 hosts fall back to the (faster) AVX2 tier. The kernel is still shipped
+and can be opted in with `--features kernel_vbmi2` for a sustained AVX-512
+workload that genuinely benefits. The scalar kernel is always compiled (it is the
 mandatory fallback), so `kernel_scalar` is a marker that gates no code;
 disabling the SIMD tiers is what trims the binary. A scalar-only build —
 `--no-default-features` (or, equivalently, naming the marker explicitly) —

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -84,7 +84,14 @@ default = [
     "kernel_sse2",
     "kernel_bmi2",
     "kernel_avx2",
-    "kernel_vbmi2",
+    # `kernel_vbmi2` (AVX-512) is intentionally OFF by default: on AVX-512
+    # hosts the runtime dispatch otherwise selects the VBMI2 decode tier, which
+    # the dashboard's AVX-512 runner measured far SLOWER than the AVX2 tier
+    # (AVX-512 license-based frequency downclocking stalls the whole decode,
+    # and the bursty/memory-bound decode never amortizes the heavier kernel).
+    # With it off, AVX-512 hosts fall back to the AVX2 tier (faster there). The
+    # kernel is kept and can be opted in via `--features kernel_vbmi2` for a
+    # sustained-AVX-512 workload that genuinely benefits.
     "kernel_neon",
     "kernel_sve",
     "kernel_simd128",

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2842,6 +2842,60 @@ mod tests {
         assert_eq!(decoded, payload);
     }
 
+    // Regression: after `clear_dictionary()` a reused compressor must fully
+    // deactivate the dictionary state. The dict-active matcher reset rewinds the
+    // hash/chain tables to the origin (`position_base = 0`) and DEFERS the table
+    // clear to the next prime/restore. If `clear_dictionary` leaves the matcher
+    // marked dictionary-active, a subsequent NO-dictionary frame hits that
+    // deferred-clear branch but never runs prime/restore, so stale dict-region
+    // entries (old absolute positions) survive at the rewound base and can
+    // surface as bogus matches. The no-dict frame must still round-trip without
+    // the dictionary. Uses Level(16) (btopt → HashChain backend, whose storage
+    // owns the deferred-clear path).
+    #[test]
+    fn clear_dictionary_then_nodict_frame_roundtrips() {
+        let dict_raw = include_bytes!("../../dict_tests/dictionary");
+        // Payload B embeds dictionary bytes up front so a surviving dict-region
+        // chain entry would be a tempting (wrong) match candidate.
+        let mut payload_b = Vec::new();
+        payload_b.extend_from_slice(&dict_raw[..dict_raw.len().min(2048)]);
+        payload_b.extend_from_slice(
+            b"no-dictionary tail no-dictionary tail"
+                .repeat(16)
+                .as_slice(),
+        );
+
+        let mut compressor: FrameCompressor =
+            FrameCompressor::new(super::CompressionLevel::Level(16));
+        compressor
+            .set_dictionary_from_bytes(dict_raw)
+            .expect("dictionary bytes should parse");
+        // Frame A primes the dictionary (sets the matcher dictionary-active).
+        let mut frame_a = Vec::new();
+        compressor.compress_independent_frame_into(
+            b"dictionary-keyed payload dictionary-keyed payload"
+                .repeat(8)
+                .as_slice(),
+            &mut frame_a,
+        );
+        // Remove the dictionary, then compress a no-dictionary frame on the
+        // SAME reused compressor.
+        compressor.clear_dictionary();
+        let mut frame_b = Vec::new();
+        compressor.compress_independent_frame_into(&payload_b, &mut frame_b);
+
+        // Frame B must decode WITHOUT any dictionary.
+        let mut decoder = crate::decoding::FrameDecoder::new();
+        let mut decoded = Vec::with_capacity(payload_b.len() + 64);
+        decoder
+            .decode_all_to_vec(&frame_b, &mut decoded)
+            .expect("no-dict frame after clear_dictionary must decode");
+        assert_eq!(
+            decoded, payload_b,
+            "no-dict frame after clear_dictionary must round-trip exactly"
+        );
+    }
+
     // Regression test: `heap_size()` must count the retained Huffman tables
     // (the active `last_huff_table` and the recycled `huff_table_spare`).
     // A reused context that parks a table would otherwise under-report its

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -3203,7 +3203,19 @@ impl Matcher for MatchGeneratorDriver {
             // dictionary of the same length would otherwise keep serving the
             // OLD dictionary's tree.
             super::strategy::BackendTag::HashChain => {
-                self.hc_matcher_mut().table.dms.invalidate();
+                let table = &mut self.hc_matcher_mut().table;
+                table.dms.invalidate();
+                // Deactivate the dictionary state so the next `reset` does not
+                // take the dict-active defer-the-table-clear branch. That branch
+                // rewinds the tables to the origin and hands the clear off to a
+                // following `prime_with_dictionary` / `restore_primed_dictionary`.
+                // After a dictionary is removed (or replaced), the very next
+                // frame may carry no dictionary, in which case neither hand-off
+                // runs and the deferred clear would never execute — leaving stale
+                // dict-region entries at the rewound base. Clearing the flag
+                // routes that reset down the no-dictionary path instead; a
+                // replacement dictionary re-arms the flag when it re-primes.
+                table.dictionary_active = false;
             }
         }
     }

--- a/zstd/src/encoding/match_generator.rs
+++ b/zstd/src/encoding/match_generator.rs
@@ -2811,6 +2811,12 @@ impl Matcher for MatchGeneratorDriver {
             super::strategy::BackendTag::Row => self.row_matcher_mut().offset_hist = offset_hist,
             super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
+                // Clear the chain/hash tables (deferred from the dict-active
+                // `reset`): prime rebuilds them from the dict, so they must start
+                // empty. The reuse hot path skips prime and `clone_from`s a clean
+                // snapshot instead, so only the first-prime / key-mismatch frames
+                // pay the fill -- not every reused-CDict frame.
+                matcher.table.clear_chain_hash_tables();
                 matcher.table.offset_hist = offset_hist;
                 matcher.table.mark_dictionary_primed();
             }

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1359,6 +1359,11 @@ impl MatchTable {
             // un-cleared slots decode out-of-range, and no match-find runs before
             // the clone / prime cleans them, so deferring is safe (skipping the
             // fills WITHOUT this hand-off reproduces the reused-CDict decay).
+            // The "always followed by prime/restore" hand-off holds because
+            // removing or replacing a dictionary clears `dictionary_active`
+            // (in `invalidate_primed_dictionary`): this branch is only reached
+            // while a dictionary is attached and will re-prime/restore, so a
+            // subsequent no-dictionary frame can never strand the deferred clear.
             self.history_abs_start = 0;
             self.position_base = 0;
             self.index_shift = 0;

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1348,18 +1348,21 @@ impl MatchTable {
             // and every dict match is silently dropped (reused-CDict output
             // degrades to no-dict after a few frames). Rewind to the origin and
             // clear the tables so the next prime lands at a stable low base.
-            // The memset is load-bearing: the stored positions are relative to
-            // `position_base` / `index_shift`, so rewinding those without
-            // zeroing the slots leaves stale entries that decode as in-range
-            // matches and corrupt the parse (verified: skipping the fills
-            // reproduces the decay).
+            // Table CLEARS are deferred to whichever cleanup runs next: a
+            // dict-active reset is always followed by either
+            // `restore_primed_dictionary` (its `clone_from` overwrites every
+            // table wholesale -- the reuse hot path) or `prime_with_dictionary`
+            // (which now clears + rebuilds). Filling here would be thrown away on
+            // the clone path, and that fill dominated tiny dict frames (a 4 KB
+            // frame zero-fills the whole dict-tier chain table -- ~26% of
+            // compress). The rewound `position_base` / `index_shift` make the
+            // un-cleared slots decode out-of-range, and no match-find runs before
+            // the clone / prime cleans them, so deferring is safe (skipping the
+            // fills WITHOUT this hand-off reproduces the reused-CDict decay).
             self.history_abs_start = 0;
             self.position_base = 0;
             self.index_shift = 0;
             self.next_to_update3 = 0;
-            self.hash_table.fill(HC_EMPTY);
-            self.hash3_table.fill(HC_EMPTY);
-            self.chain_table.fill(HC_EMPTY);
         } else if next_floor <= REBASE_RESET_FLOOR_CEILING {
             // Fast path: advance the floor so the previous frame's
             // entries fall below `window_low` and are rejected on read.
@@ -1384,6 +1387,18 @@ impl MatchTable {
             self.hash3_table.fill(HC_EMPTY);
             self.chain_table.fill(HC_EMPTY);
         }
+    }
+
+    /// Zero the hash / hash3 / chain tables to `HC_EMPTY`. The dict-active
+    /// `reset` defers this fill to here (called from `prime_with_dictionary`)
+    /// so the reuse hot path -- which restores a clean snapshot via `clone_from`
+    /// instead of re-priming -- never pays the dict-tier-table memset that
+    /// dominated tiny dict frames. `Vec::fill` on an unallocated (empty) table
+    /// is a no-op, so the unconditional fills are safe before `ensure_tables`.
+    pub(crate) fn clear_chain_hash_tables(&mut self) {
+        self.hash_table.fill(HC_EMPTY);
+        self.hash3_table.fill(HC_EMPTY);
+        self.chain_table.fill(HC_EMPTY);
     }
 
     /// Upstream zstd parity: `ZSTD_compressBlock_btopt_generic` starts its main

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -791,9 +791,22 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
             }
         }
     }
-    debug_assert_eq!(
+    // These two invariants are the SAFETY contract for the uninitialized
+    // `state_table_flat` built below: the scatter-write loop fills every index
+    // in `[0, table_size)` exactly once only if (a) the spread cycled exactly
+    // once through the table (so each symbol got exactly its `cumul`-width run
+    // of slots) and (b) the `cumul` cursors sum to `table_size` (so the runs
+    // partition the whole table). They are asserted in ALL build profiles
+    // (not `debug_assert`) so a regression in probability normalization panics
+    // loudly here instead of leaving uninitialized slots that read as UB.
+    assert_eq!(
         position, 0,
         "FSE spread must cycle exactly once through tableSize positions"
+    );
+    assert_eq!(
+        cumul[probs.len()] as usize,
+        table_size,
+        "FSE cumul cursors must sum to table_size before building nextStateTable"
     );
 
     // Phase 3 — emit `state_table_flat` (upstream zstd `nextStateTable`)
@@ -805,21 +818,23 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
     // Both representations encode the same `(symbol → next_slot)`
     // mapping; [`FSETable::next_state`] is written against the raw-slot
     // convention so the pre-shift is intentionally skipped here.
-    // Every index in `[0, table_size)` is written EXACTLY once by the spread
-    // loop below: the `cumul` cursors partition the table bijectively (the
-    // Phase-2 assert above proves the spread cycles through every position once,
-    // and `sum(count) == table_size`). So a zero-init is dead -- every slot is
-    // overwritten before any read (`into_boxed_slice` + `FSETable` use happen
-    // after the loop). Allocate uninitialized and let the loop fill it, skipping
-    // a per-build `table_size`-element memset (3 FSE builds per block for the
-    // LL/ML/OF streams when custom tables are chosen). The `uninit_vec` lint
-    // cannot see the bijective full-write; soundness is confirmed under miri
-    // (the FSE encoder round-trip exercises this with no use-of-uninit).
+    // Every index in `[0, table_size)` is written EXACTLY once by the scatter
+    // loop below: the `cumul` cursors partition the table bijectively, which the
+    // two asserts above enforce in every build profile. So a zero-init is dead
+    // -- every slot is overwritten before any read (`into_boxed_slice` +
+    // `FSETable` use happen after the loop). Allocate uninitialized and let the
+    // loop fill it, skipping a per-build `table_size`-element memset (3 FSE
+    // builds per block for the LL/ML/OF streams when custom tables are chosen).
+    // The `uninit_vec` lint cannot see the bijective full-write; soundness is
+    // confirmed under miri (the FSE encoder round-trip exercises this with no
+    // use-of-uninit).
     #[allow(clippy::uninit_vec)]
     let mut state_table_flat: alloc::vec::Vec<u16> = {
         let mut v = alloc::vec::Vec::with_capacity(table_size);
         // SAFETY: `with_capacity(table_size)` reserved exactly `table_size`
-        // slots; the loop below writes every index once before the first read.
+        // slots; the asserts above guarantee (in every build profile) that the
+        // scatter loop below writes every index in `[0, table_size)` exactly
+        // once before the first read.
         unsafe { v.set_len(table_size) };
         v
     };

--- a/zstd/src/fse/fse_encoder.rs
+++ b/zstd/src/fse/fse_encoder.rs
@@ -805,7 +805,24 @@ pub(super) fn build_table_from_probabilities(probs: &[i32], acc_log: u8) -> FSET
     // Both representations encode the same `(symbol → next_slot)`
     // mapping; [`FSETable::next_state`] is written against the raw-slot
     // convention so the pre-shift is intentionally skipped here.
-    let mut state_table_flat: alloc::vec::Vec<u16> = alloc::vec![0u16; table_size];
+    // Every index in `[0, table_size)` is written EXACTLY once by the spread
+    // loop below: the `cumul` cursors partition the table bijectively (the
+    // Phase-2 assert above proves the spread cycles through every position once,
+    // and `sum(count) == table_size`). So a zero-init is dead -- every slot is
+    // overwritten before any read (`into_boxed_slice` + `FSETable` use happen
+    // after the loop). Allocate uninitialized and let the loop fill it, skipping
+    // a per-build `table_size`-element memset (3 FSE builds per block for the
+    // LL/ML/OF streams when custom tables are chosen). The `uninit_vec` lint
+    // cannot see the bijective full-write; soundness is confirmed under miri
+    // (the FSE encoder round-trip exercises this with no use-of-uninit).
+    #[allow(clippy::uninit_vec)]
+    let mut state_table_flat: alloc::vec::Vec<u16> = {
+        let mut v = alloc::vec::Vec::with_capacity(table_size);
+        // SAFETY: `with_capacity(table_size)` reserved exactly `table_size`
+        // slots; the loop below writes every index once before the first read.
+        unsafe { v.set_len(table_size) };
+        v
+    };
     let mut cursor = cumul;
     for (u, &symbol_at_slot) in table_symbol.iter().enumerate() {
         let s = symbol_at_slot as usize;


### PR DESCRIPTION
## Summary

Two perf changes, the first is the substantive one:

**Disable the AVX-512 VBMI2 decode tier by default.** The dashboard's
`low-entropy-1m` decompress outsiders at `level_3_dfast` / `level_4_dfast`
(reported ~6x slower than the C reference, `-83%`) are an AVX-512 artifact, not
a real regression. Verified ours-vs-c_ffi on three hosts, interleaved,
back-to-back so contamination hits both arms equally:

| host | tier | rust | c_ffi | result |
|------|------|------|-------|--------|
| i9 | AVX2 | 33.9 µs | 45.5 µs | rust 1.34x faster |
| M1 | NEON | 24.9 µs | 28.1 µs | rust 1.13x faster |
| ula | SSE4.2 (scalar) | 87.0 µs | 97.1 µs | rust 1.12x faster |

Rust beats the C reference on every tier we can test — including the worst-case
pure-scalar path. The dashboard runner is AVX-512-capable, so the runtime
dispatch selected the VBMI2 tier there; AVX-512 license-based frequency
downclocking stalls the whole (bursty, memory-bound) decode and the heavier
kernel never amortizes, so the VBMI2 tier runs far slower than AVX2 on that
silicon. With `kernel_vbmi2` removed from the default feature set, AVX-512 hosts
fall back to the AVX2 tier (faster there); the kernel is kept and opt-in via
`--features kernel_vbmi2` for a sustained-AVX-512 workload that benefits.

**Defer the dict-frame table clear to prime.** The dict-active matcher reset
zero-filled the hash/chain tables, but the reuse hot path immediately restores a
clean primed snapshot over them via `clone_from`, so that fill was thrown away.
Deferred to `prime_with_dictionary` (mirrors the Fast matcher's existing
`table_overwritten_by_restore` skip that the HC path lacked). Byte-identical
output; small win on tiny dict frames.

## Verification

The VBMI2 change cannot be measured on the available hosts (none have AVX-512) —
the dashboard CI runner is the AVX-512 test machine. The dashboard decode delta
on `low-entropy-1m` `level_3_dfast` / `level_4_dfast` should move from the `-83%`
band back toward parity once the runner stops selecting VBMI2.

## Testing

- `cargo nextest run -p structured-zstd` — 789 pass
- `cargo clippy --all-targets` — clean
- ours-vs-c_ffi interleaved on i9 / M1 / ula (table above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled the AVX-512 (`kernel_vbmi2`) tier from the default feature set; it can still be enabled explicitly via `--features kernel_vbmi2`.
* **Documentation**
  * Updated “Quick start” notes to clarify default AVX-512 behavior and dispatch caps on AVX-512 hosts.
* **Performance**
  * Reduced unnecessary matcher/table clearing work during dictionary reuse.
  * Streamlined FSE encoder state-table initialization.
* **Bug Fixes**
  * Improved correctness when clearing a dictionary and then encoding a subsequent no-dictionary frame.
* **Tests**
  * Added a regression test for dictionary-clear → no-dictionary round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->