### PR TITLE
ci(bench): record per-target host machine info in the run JSON

### DIFF
--- a/.github/scripts/aggregate-bench-levels.py
+++ b/.github/scripts/aggregate-bench-levels.py
@@ -76,10 +76,18 @@ def merge_relative_json(target):
     payload = None
     seen = set()
     records = []
+    machines = []
+    machine_sigs = set()
     for p in files_for(target, "relative", "json"):
         shard = json.loads(p.read_text())
         if payload is None:
             payload = {k: v for k, v in shard.items() if k != "records"}
+        machine = (shard.get("target") or {}).get("machine")
+        if machine is not None:
+            sig = json.dumps(machine, sort_keys=True)
+            if sig not in machine_sigs:
+                machine_sigs.add(sig)
+                machines.append(machine)
         for rec in shard.get("records", []):
             sig = (rec.get("metric"), rec.get("key"), rec.get("level"))
             if sig in seen:
@@ -90,6 +98,12 @@ def merge_relative_json(target):
         print(f"WARN[{target}]: no benchmark-relative.*.json shards found", file=sys.stderr)
         payload = {"version": 1, "target": {"id": target}, "records": []}
     payload["records"] = records
+    # GitHub assigns each (target, level) job its own runner, so a target's
+    # shards can land on different hosts. `target.machine` keeps the first
+    # shard's fingerprint; if any shard differed, record every distinct one
+    # under `machine_variants` so the divergence is visible, not masked.
+    if len(machines) > 1 and isinstance(payload.get("target"), dict):
+        payload["target"]["machine_variants"] = machines
     Path(f"benchmark-relative.{target}.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 

--- a/.github/scripts/merge-benchmarks.py
+++ b/.github/scripts/merge-benchmarks.py
@@ -48,6 +48,16 @@ def register_target(target, target_meta=None):
             "label": target_meta.get("label") or existing.get("label") or target,
             "triple": target_meta.get("triple") if target_meta.get("triple") is not None else existing.get("triple"),
         }
+        # Carry the per-target kernel + host fingerprint onto targets_meta so
+        # the dashboard can map every record to the CPU kernel that produced it
+        # and the hardware it ran on. `machine_variants` is present only when a
+        # target's level shards ran on more than one distinct host.
+        for opt_key in ("kernel", "machine", "machine_variants"):
+            value = target_meta.get(opt_key)
+            if value is None:
+                value = existing.get(opt_key)
+            if value is not None:
+                merged_meta[opt_key] = value
         targets_meta[target] = merged_meta
 
 

--- a/.github/scripts/run-benchmarks.sh
+++ b/.github/scripts/run-benchmarks.sh
@@ -131,6 +131,89 @@ def markdown_table_escape(value):
     escaped = escaped.replace("%", "&#37;")
     return escaped.replace("\n", "<br>")
 
+def _read_sysfs(path):
+    try:
+        with open(path) as _f:
+            return _f.read().strip()
+    except OSError:
+        return None
+
+
+def collect_machine_info():
+    """Best-effort host fingerprint for the shard that ran this bench: CPU
+    model plus the ISA flags that drive our kernel dispatch (so an AVX-512
+    host is visible even when the AVX2 tier was selected), core count,
+    frequency, cpufreq governor, and memory. Every field is optional —
+    missing ones are dropped so a locked-down runner still yields a valid
+    (smaller) block instead of failing the run."""
+    import platform
+    import subprocess
+
+    def _cmd(args):
+        try:
+            return subprocess.run(
+                args, capture_output=True, text=True, timeout=10
+            ).stdout
+        except Exception:
+            return ""
+
+    info = {
+        "os": platform.system(),
+        "arch": platform.machine(),
+        "hostname": platform.node() or None,
+        "cpus_logical": os.cpu_count(),
+    }
+    system = platform.system()
+    if system == "Linux":
+        cpuinfo = _read_sysfs("/proc/cpuinfo") or ""
+        m = re.search(r"^model name\s*:\s*(.+)$", cpuinfo, re.M)
+        if m:
+            info["cpu_model"] = m.group(1).strip()
+        flags_m = re.search(r"^flags\s*:\s*(.+)$", cpuinfo, re.M)
+        if flags_m:
+            flags = set(flags_m.group(1).split())
+            info["isa"] = {
+                f: (f in flags)
+                for f in ("sse2", "bmi2", "avx2", "avx512f", "avx512vbmi2")
+            }
+        gov = _read_sysfs("/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor")
+        if gov:
+            info["governor"] = gov
+        for key, path in (
+            ("max_freq_mhz", "/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"),
+            ("cur_freq_mhz", "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"),
+        ):
+            raw = _read_sysfs(path)
+            if raw and raw.isdigit():
+                info[key] = round(int(raw) / 1000)
+        meminfo = _read_sysfs("/proc/meminfo") or ""
+        mm = re.search(r"^MemTotal:\s*(\d+)\s*kB", meminfo, re.M)
+        if mm:
+            info["mem_total_mb"] = round(int(mm.group(1)) / 1024)
+        # Memory type/speed need DMI (root): try `sudo -n` then bare, ignore
+        # failures (most hosted runners deny dmidecode — that is fine).
+        dmi = _cmd(["sudo", "-n", "dmidecode", "-t", "memory"]) or _cmd(
+            ["dmidecode", "-t", "memory"]
+        )
+        tm = re.search(r"^\s*Type:\s*(DDR\S+)", dmi, re.M)
+        if tm:
+            info["mem_type"] = tm.group(1)
+        sm = re.search(r"Configured Memory Speed:\s*(\d+)\s*MT/s", dmi)
+        if sm:
+            info["mem_speed_mts"] = int(sm.group(1))
+    elif system == "Darwin":
+        model = _cmd(["sysctl", "-n", "machdep.cpu.brand_string"]).strip()
+        if model:
+            info["cpu_model"] = model
+        freq = _cmd(["sysctl", "-n", "hw.cpufrequency"]).strip()
+        if freq.isdigit() and int(freq) > 0:
+            info["max_freq_mhz"] = round(int(freq) / 1_000_000)
+        memsize = _cmd(["sysctl", "-n", "hw.memsize"]).strip()
+        if memsize.isdigit():
+            info["mem_total_mb"] = round(int(memsize) / 1024 / 1024)
+    return {k: v for k, v in info.items() if v is not None}
+
+
 benchmark_results = []
 timings = []
 ratios = []
@@ -138,6 +221,7 @@ memory_rows = []
 dictionary_rows = []
 dictionary_training_rows = []
 kernel_info = None
+machine_info = collect_machine_info()
 timing_rows = []
 scenario_input_bytes = {}
 scenario_training_bytes = {}
@@ -871,6 +955,11 @@ relative_payload = {
         # reading this can attribute every record to the kernel that
         # produced it. `None` if the bench binary predates REPORT_KERNEL.
         "kernel": kernel_info,
+        # Host fingerprint of the shard that ran this target (CPU model, ISA
+        # flags, governor, frequency, memory). Records which hardware produced
+        # the numbers — e.g. surfaces an AVX-512 runner even when the AVX2
+        # kernel was selected, so a divergence from another arch is explainable.
+        "machine": machine_info,
     },
     "reference_band": {
         "delta_low": DELTA_LOW,


### PR DESCRIPTION
## Summary

Each bench matrix job now records, in the run JSON, **both** the runtime-selected CPU kernel (already emitted) and a fingerprint of **the hardware it ran on**. This makes a cross-host benchmark divergence explainable instead of a mystery — e.g. it surfaces an AVX-512 runner even when the AVX2 kernel was selected.

New `target.machine` block (best-effort; every field optional, so a locked-down runner still yields a valid smaller block):
- CPU model + ISA flags (`sse2 / bmi2 / avx2 / avx512f / avx512vbmi2`)
- logical core count, cpufreq governor, max/current frequency
- total memory, plus DDR type / speed when DMI is readable

## Pipeline

- `run-benchmarks.sh` — `collect_machine_info()` gathers it on the shard (the actual bench hardware) → `target.machine`.
- `aggregate-bench-levels.py` — dedupes across a target's level shards (GitHub assigns each job its own runner); if any shard ran on a different host, all distinct fingerprints are kept under `machine_variants` rather than masked behind the first.
- `merge-benchmarks.py` — carries `kernel` + `machine` + `machine_variants` into `targets_meta`, so the dashboard can map each record to the kernel and hardware that produced it.

## Testing

- All three scripts syntax-check (`py_compile`).
- `collect_machine_info()` verified on real hosts:
  - Linux (i9-9900K): `cpu_model`, `isa` (avx512f=false), `governor=powersave`, `5000/3400 MHz`, `DDR4 3200`.
  - Darwin (M1 Max): `cpu_model`, cores, memory.
- aggregate dedup → `machine_variants:[HostA,HostB]` when shards differ; single `machine` when uniform.
- merge `register_target` → `targets_meta` carries kernel + machine + machine_variants.

CI-tooling only; no Rust code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced benchmark infrastructure to collect machine fingerprint data including OS, CPU, and RAM details during benchmark runs
  * Updated benchmark aggregation to track and record distinct machine configurations across result shards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->