### PR TITLE
perf(opt): close the btopt dict-band gap via upstream getAllMatches shape

### DIFF
--- a/zstd/src/decoding/block_decoder.rs
+++ b/zstd/src/decoding/block_decoder.rs
@@ -52,6 +52,7 @@ impl BlockDecoder {
         &mut self,
         header: &BlockHeader,
         workspace: &mut W,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         source: &mut &[u8],
     ) -> Result<u64, DecodeBlockContentError> {
         use DecoderState as State;
@@ -132,7 +133,7 @@ impl BlockDecoder {
                     });
                 }
                 let (payload, tail) = source.split_at(n);
-                self.decompress_block_inplace(header, workspace, payload)?;
+                self.decompress_block_inplace(header, workspace, dict, payload)?;
                 *source = tail;
                 self.internal_state = State::ReadyToDecodeNextHeader;
                 Ok(u64::from(header.content_size))
@@ -144,6 +145,7 @@ impl BlockDecoder {
         &mut self,
         header: &BlockHeader,
         workspace: &mut W,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         mut source: impl Read,
     ) -> Result<u64, DecodeBlockContentError> {
         match self.internal_state {
@@ -199,7 +201,7 @@ impl BlockDecoder {
             }
 
             BlockType::Compressed => {
-                self.decompress_block(header, workspace, source)?;
+                self.decompress_block(header, workspace, dict, source)?;
 
                 self.internal_state = DecoderState::ReadyToDecodeNextHeader;
                 Ok(u64::from(header.content_size))
@@ -211,6 +213,7 @@ impl BlockDecoder {
         &mut self,
         header: &BlockHeader,
         workspace: &mut W,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         mut source: impl Read,
     ) -> Result<(), DecompressBlockError> {
         // Streaming-path entry: copy `content_size` bytes from the
@@ -238,6 +241,7 @@ impl BlockDecoder {
             parts.offset_hist,
             parts.literals_buffer,
             raw,
+            dict,
         )
     }
 
@@ -261,6 +265,7 @@ impl BlockDecoder {
         &mut self,
         header: &BlockHeader,
         workspace: &mut W,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         raw: &[u8],
     ) -> Result<(), DecompressBlockError> {
         let parts = workspace.split();
@@ -276,6 +281,7 @@ impl BlockDecoder {
             parts.offset_hist,
             parts.literals_buffer,
             raw,
+            dict,
         )
     }
 
@@ -288,15 +294,16 @@ impl BlockDecoder {
     /// lifetime-widening trick is gone — disjoint-field borrows
     /// type-check naturally.
     #[allow(clippy::too_many_arguments)]
-    fn decompress_block_inplace_with_parts<B: super::buffer_backend::BufferBackend>(
+    fn decompress_block_inplace_with_parts<'d, B: super::buffer_backend::BufferBackend>(
         &mut self,
         header: &BlockHeader,
         huf: &mut crate::decoding::scratch::HuffmanScratch,
-        fse: &mut crate::decoding::scratch::FSEScratch,
+        fse: &'d mut crate::decoding::scratch::FSEScratch,
         buffer: &mut crate::decoding::decode_buffer::DecodeBuffer<B>,
         offset_hist: &mut [u32; 3],
         literals_buffer: &mut alloc::vec::Vec<u8>,
         raw: &[u8],
+        dict: Option<&'d crate::decoding::dictionary::Dictionary>,
     ) -> Result<(), DecompressBlockError> {
         let mut section = LiteralsSection::new();
         let bytes_in_literals_header = section.parse_from_header(raw)?;
@@ -338,7 +345,7 @@ impl BlockDecoder {
         let LiteralsView {
             data: literals_view,
             bytes_used: bytes_used_in_literals_section,
-        } = decode_literals_zerocopy(&section, huf, raw_literals, literals_buffer)?;
+        } = decode_literals_zerocopy(&section, huf, dict, raw_literals, literals_buffer)?;
         assert!(
             section.regenerated_size as usize == literals_view.len(),
             "Wrong number of literals: {}, Should have been: {}",
@@ -385,6 +392,7 @@ impl BlockDecoder {
                 buffer,
                 offset_hist,
                 literals_view,
+                dict,
             )?;
         } else {
             if !raw.is_empty() {

--- a/zstd/src/decoding/block_decoder/tests.rs
+++ b/zstd/src/decoding/block_decoder/tests.rs
@@ -38,7 +38,7 @@ fn rejects_when_internal_state_expects_header() {
     let mut src: &[u8] = &[];
     let h = header(BlockType::RLE, 4, 1);
     let err = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect_err("must err on body before header");
     assert!(matches!(
         err,
@@ -54,7 +54,7 @@ fn rejects_when_internal_state_failed() {
     let mut src: &[u8] = &[0x42];
     let h = header(BlockType::RLE, 4, 1);
     let err = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect_err("must err on Failed state");
     assert!(matches!(err, DecodeBlockContentError::DecoderStateIsFailed));
 }
@@ -68,7 +68,7 @@ fn rle_empty_source_errors_not_panics() {
     let mut src: &[u8] = &[];
     let h = header(BlockType::RLE, 4, 1);
     let err = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect_err("must err on empty RLE source");
     match &err {
         DecodeBlockContentError::ReadError { step, source } => {
@@ -93,7 +93,7 @@ fn raw_truncated_source_errors_not_panics() {
     let mut src: &[u8] = &[1, 2, 3];
     let h = header(BlockType::Raw, 10, 10);
     let err = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect_err("must err on truncated raw source");
     match &err {
         DecodeBlockContentError::ReadError { step, source } => {
@@ -113,7 +113,7 @@ fn compressed_truncated_source_errors_not_panics() {
     let mut src: &[u8] = &[0u8; 8];
     let h = header(BlockType::Compressed, 0, 100);
     let err = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect_err("must err on truncated compressed source");
     match &err {
         DecodeBlockContentError::ReadError { step, source } => {
@@ -158,7 +158,7 @@ fn rle_oversized_against_user_slice_backend_returns_backend_overflow() {
     let mut src: &[u8] = &payload;
     let h = header(BlockType::RLE, 10, 1);
     let err = d
-        .decode_block_content_from_slice(&h, &mut direct, &mut src)
+        .decode_block_content_from_slice(&h, &mut direct, None, &mut src)
         .expect_err("RLE 10 bytes into 4-byte slice must error");
     match err {
         DecodeBlockContentError::BackendOverflow { step } => {
@@ -204,7 +204,7 @@ fn rle_overflow_leaves_source_unadvanced() {
     let mut src: &[u8] = &payload;
     let h = header(BlockType::RLE, 10, 1);
     let _ = d
-        .decode_block_content_from_slice(&h, &mut direct, &mut src)
+        .decode_block_content_from_slice(&h, &mut direct, None, &mut src)
         .expect_err("RLE 10 bytes into 4-byte slice must error");
     assert_eq!(
         src.as_ptr(),
@@ -228,7 +228,7 @@ fn rle_advances_source_by_one_byte_and_extends_buffer() {
     let mut src: &[u8] = &payload;
     let h = header(BlockType::RLE, 7, 1);
     let consumed = d
-        .decode_block_content_from_slice(&h, &mut ws, &mut src)
+        .decode_block_content_from_slice(&h, &mut ws, None, &mut src)
         .expect("RLE happy path");
     assert_eq!(consumed, 1);
     assert_eq!(src, &payload[1..], "1 byte consumed from source");

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -25,14 +25,17 @@ use crate::decoding::errors::DecodeBufferError;
 ///   backlog item #132.
 pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
     buffer: B,
-    /// Active dictionary, held by shared handle (`Arc`/`Rc`) rather than a
-    /// per-frame owned copy. `repeat_from_dict` reads match bytes straight
-    /// out of the handle's content (libzstd `ZSTD_refDDict` semantics): one
-    /// dictionary copy is shared across every frame AND across decoder
-    /// instances on other threads (`Arc<Dictionary>` is `Send + Sync`), so
-    /// reusing a dictionary costs a refcount bump, never a content memcpy.
-    /// `None` = no dictionary (a no-dict frame can never read a stale one).
-    pub(crate) dict: Option<crate::decoding::dictionary::DictionaryHandle>,
+    /// Borrowed pointer to the active dictionary, mirroring upstream zstd's
+    /// `ZSTD_DCtx` raw `prefixStart`/`dictContent` pointers into a caller-owned
+    /// `DDict` (libzstd `ZSTD_refDDict` semantics): `repeat_from_dict` reads
+    /// match bytes straight out of the pointee with NO per-frame refcount bump.
+    /// The pointee is kept alive for the whole decode by the dictionary owner
+    /// (the `FrameDecoder` registry, or the `&DictionaryHandle` the caller holds
+    /// across `decode_all_with_dict_handle`); `set_dict` re-sets it from a live
+    /// handle each frame. `None` = no dictionary (a no-dict frame can never read
+    /// a stale one). See the `unsafe impl Send/Sync` below for the cross-thread
+    /// contract.
+    pub(crate) dict: Option<core::ptr::NonNull<crate::decoding::dictionary::Dictionary>>,
 
     pub window_size: usize,
     total_output_counter: u64,
@@ -46,6 +49,15 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
     #[cfg(feature = "hash")]
     compute_hash: bool,
 }
+
+// SAFETY: the only non-auto-`Send`/`Sync` field is `dict`, a read-only borrowed
+// pointer to a `Send + Sync` `Dictionary` whose owner keeps it alive for the
+// decode (see the `dict` field contract). `repeat_from_dict` reads it through
+// `&self`/`&mut self` without aliasing mutation. The previous `Arc<Dictionary>`
+// was `Send + Sync`; the raw pointer drops the refcount, not the thread-safety.
+// Bounded on `B` so a non-thread-safe backend still suppresses the impl.
+unsafe impl<B: BufferBackend + Send> Send for DecodeBuffer<B> {}
+unsafe impl<B: BufferBackend + Sync> Sync for DecodeBuffer<B> {}
 
 /// Rollback token produced by [`DecodeBuffer::checkpoint`].
 ///
@@ -194,19 +206,20 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     /// (no copy). Empty slice when no dictionary is attached.
     #[inline]
     pub(crate) fn dict_content(&self) -> &[u8] {
-        match &self.dict {
-            Some(h) => &h.as_dict().dict_content,
+        match self.dict {
+            // SAFETY: set by `set_dict` from a live handle; the owner keeps the
+            // pointee alive for the decode (see the `dict` field contract).
+            Some(ptr) => &unsafe { ptr.as_ref() }.dict_content,
             None => &[],
         }
     }
 
-    /// Attach a dictionary by shared handle. This is a refcount bump
-    /// (`Arc`/`Rc` clone) — the dictionary content is shared, never copied,
-    /// so the same dictionary is free to reuse across frames and across
-    /// decoder instances on other threads.
+    /// Point at a dictionary by borrowed pointer (mirrors upstream zstd
+    /// `dctx->prefixStart = ddict->dictContent`): one store, NO refcount bump.
+    /// The pointee is owner-kept-alive for the decode (see the `dict` field).
     #[inline]
-    pub(crate) fn set_dict(&mut self, handle: crate::decoding::dictionary::DictionaryHandle) {
-        self.dict = Some(handle);
+    pub(crate) fn set_dict(&mut self, handle: &crate::decoding::dictionary::DictionaryHandle) {
+        self.dict = Some(core::ptr::NonNull::from(handle.as_dict()));
     }
 
     /// Return the last `n` bytes of the visible buffer as two
@@ -814,14 +827,17 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();
 
-            // Borrow the dictionary content through the shared handle as a
-            // field access (`self.dict`), kept disjoint from the `self.buffer`
-            // mutation below so the borrow checker allows the read+extend
-            // without an intermediate copy. `None` → empty slice → the
-            // length guard rejects (matches the old empty-`dict_content`
-            // behaviour on the direct/no-dict path).
-            let dict_content: &[u8] = match &self.dict {
-                Some(h) => &h.as_dict().dict_content,
+            // Borrow the dictionary content through the borrowed pointer. The
+            // `NonNull` is `Copy`, so the deref yields a slice tied to the
+            // pointee (owner-kept-alive for the decode), NOT to `&self.dict` —
+            // it is therefore trivially disjoint from the `self.buffer`
+            // mutation below, allowing the read+extend without an intermediate
+            // copy. `None` → empty slice → the length guard rejects (matches the
+            // old no-dict behaviour).
+            let dict_content: &[u8] = match self.dict {
+                // SAFETY: set by `set_dict` from a live handle; owner keeps the
+                // pointee alive for the decode (see the `dict` field contract).
+                Some(ptr) => &unsafe { ptr.as_ref() }.dict_content,
                 None => &[],
             };
             let dict_len = dict_content.len();

--- a/zstd/src/decoding/decode_buffer.rs
+++ b/zstd/src/decoding/decode_buffer.rs
@@ -25,18 +25,12 @@ use crate::decoding::errors::DecodeBufferError;
 ///   backlog item #132.
 pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
     buffer: B,
-    /// Borrowed pointer to the active dictionary, mirroring upstream zstd's
-    /// `ZSTD_DCtx` raw `prefixStart`/`dictContent` pointers into a caller-owned
-    /// `DDict` (libzstd `ZSTD_refDDict` semantics): `repeat_from_dict` reads
-    /// match bytes straight out of the pointee with NO per-frame refcount bump.
-    /// The pointee is kept alive for the whole decode by the dictionary owner
-    /// (the `FrameDecoder` registry, or the `&DictionaryHandle` the caller holds
-    /// across `decode_all_with_dict_handle`); `set_dict` re-sets it from a live
-    /// handle each frame. `None` = no dictionary (a no-dict frame can never read
-    /// a stale one). See the `unsafe impl Send/Sync` below for the cross-thread
-    /// contract.
-    pub(crate) dict: Option<core::ptr::NonNull<crate::decoding::dictionary::Dictionary>>,
-
+    // No dictionary reference is stored: an out-of-window match reads the
+    // dictionary content through a call-scoped `dict: Option<&Dictionary>`
+    // borrow threaded into `repeat` / `repeat_from_dict` by the decode pipeline
+    // (libzstd `ZSTD_refDDict` semantics — read the dict content, no per-frame
+    // refcount bump). The borrow checker guarantees the dictionary outlives
+    // every read; `DecodeBuffer` itself stays `Send`/`Sync` by auto-derive.
     pub window_size: usize,
     total_output_counter: u64,
     #[cfg(feature = "hash")]
@@ -49,15 +43,6 @@ pub struct DecodeBuffer<B: BufferBackend = RingBuffer> {
     #[cfg(feature = "hash")]
     compute_hash: bool,
 }
-
-// SAFETY: the only non-auto-`Send`/`Sync` field is `dict`, a read-only borrowed
-// pointer to a `Send + Sync` `Dictionary` whose owner keeps it alive for the
-// decode (see the `dict` field contract). `repeat_from_dict` reads it through
-// `&self`/`&mut self` without aliasing mutation. The previous `Arc<Dictionary>`
-// was `Send + Sync`; the raw pointer drops the refcount, not the thread-safety.
-// Bounded on `B` so a non-thread-safe backend still suppresses the impl.
-unsafe impl<B: BufferBackend + Send> Send for DecodeBuffer<B> {}
-unsafe impl<B: BufferBackend + Sync> Sync for DecodeBuffer<B> {}
 
 /// Rollback token produced by [`DecodeBuffer::checkpoint`].
 ///
@@ -100,7 +85,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     pub fn new(window_size: usize) -> DecodeBuffer<B> {
         DecodeBuffer {
             buffer: B::new(),
-            dict: None,
             window_size,
             total_output_counter: 0,
             #[cfg(feature = "hash")]
@@ -126,7 +110,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         buffer.clear();
         DecodeBuffer {
             buffer,
-            dict: None,
             window_size,
             total_output_counter: 0,
             #[cfg(feature = "hash")]
@@ -179,7 +162,6 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // `DecoderScratchKind::reserve_buffer(window_size)` before any
         // block writes — that is the only call site that knows whether
         // the frame will actually hit this buffer.
-        self.dict = None;
         self.total_output_counter = 0;
         // Lift the per-block growth ceiling between frames; the sequence
         // decoder re-arms it per block. Non-block callers stay unbounded.
@@ -202,24 +184,17 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         self.buffer.cap()
     }
 
-    /// Active dictionary content bytes, borrowed through the shared handle
-    /// (no copy). Empty slice when no dictionary is attached.
+    /// Active dictionary content bytes, read from the call-scoped `dict` borrow
+    /// (no copy). Empty slice when no dictionary is active for this decode.
     #[inline]
-    pub(crate) fn dict_content(&self) -> &[u8] {
-        match self.dict {
-            // SAFETY: set by `set_dict` from a live handle; the owner keeps the
-            // pointee alive for the decode (see the `dict` field contract).
-            Some(ptr) => &unsafe { ptr.as_ref() }.dict_content,
+    pub(crate) fn dict_content<'d>(
+        &self,
+        dict: Option<&'d crate::decoding::dictionary::Dictionary>,
+    ) -> &'d [u8] {
+        match dict {
+            Some(d) => &d.dict_content,
             None => &[],
         }
-    }
-
-    /// Point at a dictionary by borrowed pointer (mirrors upstream zstd
-    /// `dctx->prefixStart = ddict->dictContent`): one store, NO refcount bump.
-    /// The pointee is owner-kept-alive for the decode (see the `dict` field).
-    #[inline]
-    pub(crate) fn set_dict(&mut self, handle: &crate::decoding::dictionary::DictionaryHandle) {
-        self.dict = Some(core::ptr::NonNull::from(handle.as_dict()));
     }
 
     /// Return the last `n` bytes of the visible buffer as two
@@ -403,8 +378,13 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         Ok(())
     }
 
-    pub fn repeat(&mut self, offset: usize, match_length: usize) -> Result<(), DecodeBufferError> {
-        self.repeat_inner::<false>(offset, match_length)
+    pub fn repeat(
+        &mut self,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
+        offset: usize,
+        match_length: usize,
+    ) -> Result<(), DecodeBufferError> {
+        self.repeat_inner::<false>(dict, offset, match_length)
     }
 
     /// Same as [`repeat`] but the caller asserts a lookahead
@@ -424,15 +404,17 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     #[inline(always)]
     pub(crate) fn repeat_lookahead_prefetched(
         &mut self,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
-        self.repeat_inner::<true>(offset, match_length)
+        self.repeat_inner::<true>(dict, offset, match_length)
     }
 
     #[inline(always)]
     fn repeat_inner<const SKIP_PREFETCH: bool>(
         &mut self,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
@@ -454,7 +436,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
         // upfront `reserve(MAX_BLOCK_SIZE)`) never reaches the check.
 
         if offset > self.buffer.len() {
-            self.repeat_from_dict(offset, match_length)
+            self.repeat_from_dict(dict, offset, match_length)
         } else {
             let buf_len = self.buffer.len();
             let start_idx = buf_len - offset;
@@ -809,6 +791,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
     #[cold]
     fn repeat_from_dict(
         &mut self,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
         offset: usize,
         match_length: usize,
     ) -> Result<(), DecodeBufferError> {
@@ -827,19 +810,12 @@ impl<B: BufferBackend> DecodeBuffer<B> {
             // at least part of that repeat is from the dictionary content
             let bytes_from_dict = offset - self.buffer.len();
 
-            // Borrow the dictionary content through the borrowed pointer. The
-            // `NonNull` is `Copy`, so the deref yields a slice tied to the
-            // pointee (owner-kept-alive for the decode), NOT to `&self.dict` —
-            // it is therefore trivially disjoint from the `self.buffer`
-            // mutation below, allowing the read+extend without an intermediate
-            // copy. `None` → empty slice → the length guard rejects (matches the
-            // old no-dict behaviour).
-            let dict_content: &[u8] = match self.dict {
-                // SAFETY: set by `set_dict` from a live handle; owner keeps the
-                // pointee alive for the decode (see the `dict` field contract).
-                Some(ptr) => &unsafe { ptr.as_ref() }.dict_content,
-                None => &[],
-            };
+            // The dictionary content slice is tied to the call-scoped `dict`
+            // borrow (owner-kept-alive for the decode), trivially disjoint from
+            // the `self.buffer` mutation below, allowing the read+extend without
+            // an intermediate copy. `None` → empty slice → the length guard
+            // rejects (the no-dict path).
+            let dict_content: &[u8] = self.dict_content(dict);
             let dict_len = dict_content.len();
 
             if bytes_from_dict > dict_len {
@@ -870,7 +846,7 @@ impl<B: BufferBackend> DecodeBuffer<B> {
                 self.buffer.extend(dict_slice);
 
                 self.total_output_counter += bytes_from_dict as u64;
-                return self.repeat(self.buffer.len(), match_length - bytes_from_dict);
+                return self.repeat(dict, self.buffer.len(), match_length - bytes_from_dict);
             } else {
                 let low = dict_len - bytes_from_dict;
                 let high = low + match_length;

--- a/zstd/src/decoding/decode_buffer/tests.rs
+++ b/zstd/src/decoding/decode_buffer/tests.rs
@@ -22,7 +22,7 @@ fn dict_offsets_rejected_after_direct_path_window_drop() {
     let backend = UserSliceBackend::from_slice(out.as_mut_slice());
     let mut buf = DecodeBuffer::from_backend(backend, 100);
     let dict = Dictionary::from_raw_content(7, vec![0xAB; 64]).expect("raw-content dictionary");
-    buf.set_dict(dict.into_handle());
+    buf.set_dict(&dict.into_handle());
 
     // Mimic the inline executor: produce 250 bytes without touching
     // `total_output_counter`, exceeding the 100-byte window.
@@ -376,7 +376,7 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 
     // Fully-dictionary match: empty buffer, offset reaches into the dict.
     let mut full = DecodeBuffer::<RingBuffer>::new(4 * 1024);
-    full.set_dict(dict());
+    full.set_dict(&dict());
     full.set_block_output_ceiling(8); // max_capacity = 0 + 8 = 8
     let err = full.repeat(200, 100).unwrap_err(); // 0 + 100 > 8, all from dict
     assert!(
@@ -389,7 +389,7 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 
     // Mixed match: part from dict, remainder from buffer history.
     let mut mixed = DecodeBuffer::<RingBuffer>::new(4 * 1024);
-    mixed.set_dict(dict());
+    mixed.set_dict(&dict());
     mixed.push(b"abcd"); // len = 4
     mixed.set_block_output_ceiling(8); // max_capacity = 4 + 8 = 12
     let err = mixed.repeat(10, 100).unwrap_err(); // 6 from dict + rest, 4 + 100 > 12
@@ -406,7 +406,7 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 fn repeat_from_dict_full_copy_updates_total_output_counter() {
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(1);
     decode_buf.set_dict(
-        crate::decoding::dictionary::DictionaryHandle::from_dictionary(
+        &crate::decoding::dictionary::DictionaryHandle::from_dictionary(
             crate::decoding::dictionary::Dictionary::from_raw_content(1, b"0123456789".to_vec())
                 .unwrap(),
         ),

--- a/zstd/src/decoding/decode_buffer/tests.rs
+++ b/zstd/src/decoding/decode_buffer/tests.rs
@@ -22,10 +22,7 @@ fn dict_offsets_rejected_after_direct_path_window_drop() {
     let backend = UserSliceBackend::from_slice(out.as_mut_slice());
     let mut buf = DecodeBuffer::from_backend(backend, 100);
     let dict = Dictionary::from_raw_content(7, vec![0xAB; 64]).expect("raw-content dictionary");
-    // `set_dict` stores a borrowed pointer into the handle's dictionary, so the
-    // handle must outlive `buf`; binding a temporary here would dangle.
     let handle = dict.into_handle();
-    buf.set_dict(&handle);
 
     // Mimic the inline executor: produce 250 bytes without touching
     // `total_output_counter`, exceeding the 100-byte window.
@@ -36,7 +33,7 @@ fn dict_offsets_rejected_after_direct_path_window_drop() {
     // offset 110 > len 100 reaches 10 bytes into the dictionary;
     // cumulative output (250) already exceeds the window (100), so
     // this must be rejected, not served from the dictionary.
-    let result = buf.repeat_from_dict(110, 5);
+    let result = buf.repeat_from_dict(Some(handle.as_dict()), 110, 5);
     assert!(
         result.is_err(),
         "dict-backed offset must be unreachable once output exceeded the window, got {result:?}"
@@ -92,7 +89,7 @@ fn test_repeat_doubling_matches_reference_across_offsets() {
             let prefix_slice = &prefix[..offset.max(1)];
             let mut buffer = DecodeBuffer::<RingBuffer>::new(usize::MAX);
             buffer.push(prefix_slice);
-            buffer.repeat(offset, match_length).unwrap();
+            buffer.repeat(None, offset, match_length).unwrap();
             let expected = reference_repeat(prefix_slice, offset, match_length);
             let mut got: Vec<u8> = Vec::new();
             buffer.drain_to_writer(&mut got).unwrap();
@@ -196,11 +193,11 @@ fn short_writer() {
 
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(100);
     decode_buf.push(b"0123456789");
-    decode_buf.repeat(10, 90).unwrap();
+    decode_buf.repeat(None, 10, 90).unwrap();
     let repeats = 1000;
     for _ in 0..repeats {
         assert_eq!(decode_buf.len(), 100);
-        decode_buf.repeat(10, 50).unwrap();
+        decode_buf.repeat(None, 10, 50).unwrap();
         assert_eq!(decode_buf.len(), 150);
         decode_buf
             .drain_to_window_size_writer(&mut short_writer)
@@ -246,11 +243,11 @@ fn wouldblock_writer() {
 
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(100);
     decode_buf.push(b"0123456789");
-    decode_buf.repeat(10, 90).unwrap();
+    decode_buf.repeat(None, 10, 90).unwrap();
     let repeats = 1000;
     for _ in 0..repeats {
         assert_eq!(decode_buf.len(), 100);
-        decode_buf.repeat(10, 50).unwrap();
+        decode_buf.repeat(None, 10, 50).unwrap();
         assert_eq!(decode_buf.len(), 150);
         loop {
             match decode_buf.drain_to_window_size_writer(&mut short_writer) {
@@ -306,7 +303,7 @@ fn repeat_overlap_fast_paths_match_reference_behavior() {
     for (offset, match_len) in cases {
         let mut decode_buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
         decode_buf.push(seed);
-        decode_buf.repeat(offset, match_len).unwrap();
+        decode_buf.repeat(None, offset, match_len).unwrap();
         let got = decode_buf.drain();
         let expected = expected_match_expansion(seed, offset, match_len);
         assert_eq!(got, expected, "offset={offset}, match_len={match_len}");
@@ -317,7 +314,7 @@ fn repeat_overlap_fast_paths_match_reference_behavior() {
 fn repeat_zero_offset_returns_error() {
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(1024);
     decode_buf.push(b"abcdef");
-    let err = decode_buf.repeat(0, 5).unwrap_err();
+    let err = decode_buf.repeat(None, 0, 5).unwrap_err();
     assert!(matches!(
         err,
         crate::decoding::errors::DecodeBufferError::ZeroOffset
@@ -339,7 +336,7 @@ fn repeat_rejects_output_past_block_ceiling() {
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(4 * 1024);
     decode_buf.push(b"abcdef"); // len = 6
     decode_buf.set_block_output_ceiling(8); // max_capacity = 6 + 8 = 14
-    let err = decode_buf.repeat(4, 16).unwrap_err(); // 6 + 16 = 22 > 14
+    let err = decode_buf.repeat(None, 4, 16).unwrap_err(); // 6 + 16 = 22 > 14
     assert!(
         matches!(
             err,
@@ -358,7 +355,7 @@ fn repeat_within_block_ceiling_still_succeeds() {
     decode_buf.push(b"abcdef"); // len = 6
     decode_buf.set_block_output_ceiling(8); // max_capacity = 14
     decode_buf
-        .repeat(4, 8)
+        .repeat(None, 4, 8)
         .expect("6 + 8 = 14 == ceiling is allowed");
     assert_eq!(decode_buf.len(), 14);
 }
@@ -378,13 +375,12 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
     };
 
     // Fully-dictionary match: empty buffer, offset reaches into the dict.
-    // `set_dict` borrows a pointer into the handle, so it must outlive the
-    // buffer; bind it rather than passing a temporary that would dangle.
     let mut full = DecodeBuffer::<RingBuffer>::new(4 * 1024);
     let full_dict = dict();
-    full.set_dict(&full_dict);
     full.set_block_output_ceiling(8); // max_capacity = 0 + 8 = 8
-    let err = full.repeat(200, 100).unwrap_err(); // 0 + 100 > 8, all from dict
+    let err = full
+        .repeat(Some(full_dict.as_dict()), 200, 100)
+        .unwrap_err(); // 0 + 100 > 8, all from dict
     assert!(
         matches!(
             err,
@@ -396,10 +392,11 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
     // Mixed match: part from dict, remainder from buffer history.
     let mut mixed = DecodeBuffer::<RingBuffer>::new(4 * 1024);
     let mixed_dict = dict();
-    mixed.set_dict(&mixed_dict);
     mixed.push(b"abcd"); // len = 4
     mixed.set_block_output_ceiling(8); // max_capacity = 4 + 8 = 12
-    let err = mixed.repeat(10, 100).unwrap_err(); // 6 from dict + rest, 4 + 100 > 12
+    let err = mixed
+        .repeat(Some(mixed_dict.as_dict()), 10, 100)
+        .unwrap_err(); // 6 from dict + rest, 4 + 100 > 12
     assert!(
         matches!(
             err,
@@ -412,16 +409,15 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 #[test]
 fn repeat_from_dict_full_copy_updates_total_output_counter() {
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(1);
-    // `set_dict` borrows a pointer into the handle, so it must outlive the
-    // buffer; bind it rather than passing a temporary that would dangle.
     let handle = crate::decoding::dictionary::DictionaryHandle::from_dictionary(
         crate::decoding::dictionary::Dictionary::from_raw_content(1, b"0123456789".to_vec())
             .unwrap(),
     );
-    decode_buf.set_dict(&handle);
 
-    decode_buf.repeat(10, 2).unwrap();
-    let err = decode_buf.repeat(10, 1).unwrap_err();
+    decode_buf.repeat(Some(handle.as_dict()), 10, 2).unwrap();
+    let err = decode_buf
+        .repeat(Some(handle.as_dict()), 10, 1)
+        .unwrap_err();
     assert!(matches!(
         err,
         crate::decoding::errors::DecodeBufferError::OffsetTooBig { .. }
@@ -437,7 +433,7 @@ fn repeat_overlap_fast_paths_match_reference_behavior_with_wrapped_ringbuffer() 
 
     decode_buf.push(seed);
     model_push(&mut model, seed);
-    decode_buf.repeat(16, 16).unwrap();
+    decode_buf.repeat(None, 16, 16).unwrap();
     model_repeat(&mut model, 16, 16);
 
     let drained = decode_buf.drain_to_window_size().unwrap();
@@ -446,7 +442,7 @@ fn repeat_overlap_fast_paths_match_reference_behavior_with_wrapped_ringbuffer() 
 
     let cases = [(3usize, 97usize), (16usize, 64usize), (7usize, 73usize)];
     for (offset, match_len) in cases {
-        decode_buf.repeat(offset, match_len).unwrap();
+        decode_buf.repeat(None, offset, match_len).unwrap();
         model_repeat(&mut model, offset, match_len);
 
         if let Some(got) = decode_buf.drain_to_window_size() {
@@ -512,7 +508,7 @@ fn repeat_short_offset_matches_canonical_for_all_offsets_and_lengths() {
         ] {
             let mut buf = DecodeBuffer::<RingBuffer>::new(8192);
             buf.push(&base[..offset]);
-            buf.repeat(offset, match_length).unwrap_or_else(|e| {
+            buf.repeat(None, offset, match_length).unwrap_or_else(|e| {
                 panic!("repeat failed for offset={offset} match_length={match_length}: {e:?}")
             });
 

--- a/zstd/src/decoding/decode_buffer/tests.rs
+++ b/zstd/src/decoding/decode_buffer/tests.rs
@@ -22,7 +22,10 @@ fn dict_offsets_rejected_after_direct_path_window_drop() {
     let backend = UserSliceBackend::from_slice(out.as_mut_slice());
     let mut buf = DecodeBuffer::from_backend(backend, 100);
     let dict = Dictionary::from_raw_content(7, vec![0xAB; 64]).expect("raw-content dictionary");
-    buf.set_dict(&dict.into_handle());
+    // `set_dict` stores a borrowed pointer into the handle's dictionary, so the
+    // handle must outlive `buf`; binding a temporary here would dangle.
+    let handle = dict.into_handle();
+    buf.set_dict(&handle);
 
     // Mimic the inline executor: produce 250 bytes without touching
     // `total_output_counter`, exceeding the 100-byte window.
@@ -375,8 +378,11 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
     };
 
     // Fully-dictionary match: empty buffer, offset reaches into the dict.
+    // `set_dict` borrows a pointer into the handle, so it must outlive the
+    // buffer; bind it rather than passing a temporary that would dangle.
     let mut full = DecodeBuffer::<RingBuffer>::new(4 * 1024);
-    full.set_dict(&dict());
+    let full_dict = dict();
+    full.set_dict(&full_dict);
     full.set_block_output_ceiling(8); // max_capacity = 0 + 8 = 8
     let err = full.repeat(200, 100).unwrap_err(); // 0 + 100 > 8, all from dict
     assert!(
@@ -389,7 +395,8 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 
     // Mixed match: part from dict, remainder from buffer history.
     let mut mixed = DecodeBuffer::<RingBuffer>::new(4 * 1024);
-    mixed.set_dict(&dict());
+    let mixed_dict = dict();
+    mixed.set_dict(&mixed_dict);
     mixed.push(b"abcd"); // len = 4
     mixed.set_block_output_ceiling(8); // max_capacity = 4 + 8 = 12
     let err = mixed.repeat(10, 100).unwrap_err(); // 6 from dict + rest, 4 + 100 > 12
@@ -405,12 +412,13 @@ fn repeat_from_dict_rejects_output_past_block_ceiling() {
 #[test]
 fn repeat_from_dict_full_copy_updates_total_output_counter() {
     let mut decode_buf = DecodeBuffer::<RingBuffer>::new(1);
-    decode_buf.set_dict(
-        &crate::decoding::dictionary::DictionaryHandle::from_dictionary(
-            crate::decoding::dictionary::Dictionary::from_raw_content(1, b"0123456789".to_vec())
-                .unwrap(),
-        ),
+    // `set_dict` borrows a pointer into the handle, so it must outlive the
+    // buffer; bind it rather than passing a temporary that would dangle.
+    let handle = crate::decoding::dictionary::DictionaryHandle::from_dictionary(
+        crate::decoding::dictionary::Dictionary::from_raw_content(1, b"0123456789".to_vec())
+            .unwrap(),
     );
+    decode_buf.set_dict(&handle);
 
     decode_buf.repeat(10, 2).unwrap();
     let err = decode_buf.repeat(10, 1).unwrap_err();

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -2862,7 +2862,7 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
-                    s.buffer.dict.clone(),
+                    s.buffer.dict,
                 ),
                 DecoderScratchKind::Ring(s) => (
                     &mut s.huf,
@@ -2871,21 +2871,21 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
-                    s.buffer.dict.clone(),
+                    s.buffer.dict,
                 ),
             };
         let backend = UserSliceBackend::from_slice(output);
         let mut buffer = DecodeBuffer::from_backend(backend, window_size);
-        // Dictionary matches on the direct path: hand the shared handle
-        // (refcount bump, no copy) to the stack-local buffer so offsets
-        // reaching past the frame's own output resolve through
-        // `repeat_from_dict` — the same ext-dict slow path the
-        // FlatBuf/Ring backends use. The per-sequence hot path is
-        // untouched: the inline-exec dispatch already routes
-        // beyond-prefix offsets to the cold `repeat()` fallback.
-        if let Some(handle) = dict {
-            buffer.set_dict(handle);
-        }
+        // Dictionary matches on the direct path: copy the borrowed dictionary
+        // pointer (one pointer store, no refcount) from the persistent scratch
+        // buffer into the stack-local buffer so offsets reaching past the
+        // frame's own output resolve through `repeat_from_dict` — the same
+        // ext-dict slow path the FlatBuf/Ring backends use. The pointee is the
+        // SAME owner-kept-alive dictionary the persistent buffer points at, so
+        // the contract carries over unchanged. The per-sequence hot path is
+        // untouched: the inline-exec dispatch already routes beyond-prefix
+        // offsets to the cold `repeat()` fallback.
+        buffer.dict = dict;
         let mut direct = DirectScratch {
             huf,
             fse,
@@ -3082,10 +3082,12 @@ impl FrameDecoder {
 
         let written = content_size as usize;
         state.frame_finished = true;
-        // Drop the stack-local DirectScratch (and its DecodeBuffer
-        // borrow on `output`) so we can re-borrow `output` for the
-        // hash pass below.
-        drop(direct);
+        // `direct`'s last use is in the decode loop above; NLL therefore
+        // releases its `&mut output` borrow before here, freeing `output` for
+        // the hash re-borrow below. No explicit `drop(direct)` is needed:
+        // `DirectScratch` now holds only borrowed dict POINTERS (not an owned
+        // `Arc`), so it is not a `Drop` type whose glue would hold the borrow
+        // to end-of-scope.
         // Per-block XXH64 (low 32 bits) over the captured ranges.
         // Mirrors `decode_blocks`' per-block hashing so the digests
         // vector stays identical regardless of which dispatch path

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -719,10 +719,11 @@ impl DecoderScratchKind {
         decoder: &mut BlockDecoder,
         header: &crate::blocks::block::BlockHeader,
         source: R,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
     ) -> Result<u64, DecodeBlockContentError> {
         match self {
-            Self::Ring(s) => decoder.decode_block_content(header, s, source),
-            Self::Flat(s) => decoder.decode_block_content(header, s, source),
+            Self::Ring(s) => decoder.decode_block_content(header, s, dict, source),
+            Self::Flat(s) => decoder.decode_block_content(header, s, dict, source),
         }
     }
 
@@ -755,6 +756,14 @@ struct FrameDecoderState {
     bytes_read_counter: u64,
     check_sum: Option<u32>,
     using_dict: Option<u32>,
+    /// The dictionary handle applied to this frame, owned for the frame's whole
+    /// decode so the block loop can hand the scratch a `&Dictionary` borrow at
+    /// every `Dict`-sourced table read. ONE refcount clone per dict-apply (not
+    /// per block, not per frame on the reuse path — the same handle stays held
+    /// across `init_with_dict_handle` -> `decode_blocks`); the decode loop
+    /// borrows from this field (disjoint from `decoder_scratch`) with zero
+    /// further clones. `None` on the no-dict path. Cleared by `reset`.
+    active_dict: Option<DictionaryHandle>,
 }
 
 pub enum BlockDecodingStrategy {
@@ -863,6 +872,7 @@ impl FrameDecoderState {
             bytes_read_counter: u64::from(header_size),
             check_sum: None,
             using_dict: None,
+            active_dict: None,
         })
     }
 
@@ -902,7 +912,29 @@ impl FrameDecoderState {
         self.bytes_read_counter = u64::from(header_size);
         self.check_sum = None;
         self.using_dict = None;
+        // `active_dict` is intentionally NOT cleared here: it is only ever READ
+        // while a scratch table source is `Dict`, which `init_from_dict` arms
+        // on a dict frame and which a no-dict frame leaves `Local` (so a stale
+        // held handle is never read). Keeping it lets the per-apply `ptr::eq`
+        // reuse-check below skip the clone when the SAME dictionary is
+        // re-applied frame-over-frame (the CoordiNode per-label-dict hot path)
+        // — zero refcount churn on reuse, one clone only on a genuine swap.
         Ok(())
+    }
+
+    /// Hold the dictionary handle for this frame's whole decode so the block
+    /// loop can borrow `&Dictionary` at every `Dict`-sourced read. Clones the
+    /// handle ONLY when it is a different dictionary than the one already held
+    /// (`ptr::eq` on the `Arc`'s pointee) — so re-applying the SAME dictionary
+    /// frame-over-frame (the reuse hot path) costs zero refcount churn.
+    fn set_active_dict(&mut self, dict: &DictionaryHandle) {
+        if self
+            .active_dict
+            .as_ref()
+            .is_none_or(|held| !core::ptr::eq(held.as_dict(), dict.as_dict()))
+        {
+            self.active_dict = Some(dict.clone());
+        }
     }
 }
 
@@ -1231,6 +1263,7 @@ impl FrameDecoder {
                 })
                 .ok_or(err::DictNotProvided { dict_id })?;
             state.decoder_scratch.init_from_dict(dict);
+            state.set_active_dict(dict);
             state.using_dict = Some(dict_id);
         }
         Ok(())
@@ -1304,6 +1337,7 @@ impl FrameDecoder {
             });
         }
         state.decoder_scratch.init_from_dict(dict);
+        state.set_active_dict(dict);
         state.using_dict = Some(dict.id());
         Ok(())
     }
@@ -1556,9 +1590,10 @@ impl FrameDecoder {
             } else {
                 None
             };
+            let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
             let bytes_read_in_block_body = state
                 .decoder_scratch
-                .decode_block_content(&mut block_dec, &block_header, &mut source)
+                .decode_block_content(&mut block_dec, &block_header, &mut source, dict_ref)
                 .map_err(|source| {
                     block_body_decode_error(
                         source,
@@ -1855,10 +1890,12 @@ impl FrameDecoder {
             state.bytes_read_counter += u64::from(block_header_size);
 
             let len_before = state.decoder_scratch.buffer_len();
+            let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
             match state.decoder_scratch.decode_block_content(
                 &mut block_dec,
                 &block_header,
                 &mut source,
+                dict_ref,
             ) {
                 Ok(body_read) => state.bytes_read_counter += body_read,
                 Err(e) => {
@@ -2121,9 +2158,15 @@ impl FrameDecoder {
                     }
                     state.bytes_read_counter += u64::from(block_header_size);
 
+                    let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
                     let bytes_read_in_block_body = state
                         .decoder_scratch
-                        .decode_block_content(&mut block_dec, &block_header, &mut mt_source)
+                        .decode_block_content(
+                            &mut block_dec,
+                            &block_header,
+                            &mut mt_source,
+                            dict_ref,
+                        )
                         .map_err(|source| {
                             block_body_decode_error(
                                 source,
@@ -2853,7 +2896,14 @@ impl FrameDecoder {
         // fields; only `buffer` differs and we don't use that here.
         // Macro-style binding avoids the closure / generic
         // gymnastics of returning multiple `&mut` from a match arm.
-        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size, dict) =
+        // Resolve the dictionary borrow for this frame BEFORE taking the
+        // `&mut` field borrows below — `active_dict` is a disjoint field, so
+        // the shared borrow coexists with the mutable scratch borrows. It is
+        // threaded as a call-scoped argument into every `Dict`-sourced read
+        // (the direct path's `repeat_from_dict` ext-dict slow path), mirroring
+        // C's per-frame pointer hand-off with zero refcount churn.
+        let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
+        let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size) =
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => (
                     &mut s.huf,
@@ -2862,7 +2912,6 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
-                    s.buffer.dict,
                 ),
                 DecoderScratchKind::Ring(s) => (
                     &mut s.huf,
@@ -2871,21 +2920,10 @@ impl FrameDecoder {
                     &mut s.literals_buffer,
                     &mut s.block_content_buffer,
                     s.buffer.window_size,
-                    s.buffer.dict,
                 ),
             };
         let backend = UserSliceBackend::from_slice(output);
-        let mut buffer = DecodeBuffer::from_backend(backend, window_size);
-        // Dictionary matches on the direct path: copy the borrowed dictionary
-        // pointer (one pointer store, no refcount) from the persistent scratch
-        // buffer into the stack-local buffer so offsets reaching past the
-        // frame's own output resolve through `repeat_from_dict` — the same
-        // ext-dict slow path the FlatBuf/Ring backends use. The pointee is the
-        // SAME owner-kept-alive dictionary the persistent buffer points at, so
-        // the contract carries over unchanged. The per-sequence hot path is
-        // untouched: the inline-exec dispatch already routes beyond-prefix
-        // offsets to the cold `repeat()` fallback.
-        buffer.dict = dict;
+        let buffer = DecodeBuffer::from_backend(backend, window_size);
         let mut direct = DirectScratch {
             huf,
             fse,
@@ -2975,6 +3013,7 @@ impl FrameDecoder {
             let body_consumed = match block_dec.decode_block_content_from_slice(
                 &block_header,
                 &mut direct,
+                dict_ref,
                 &mut *input,
             ) {
                 Ok(n) => n,

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -1495,6 +1495,14 @@ impl FrameDecoder {
         self.direct_frames
     }
 
+    /// Test-only: whether the decode state currently holds an owning dictionary
+    /// handle (`active_dict`). Every path that arms `Dict`-sourced scratch tables
+    /// must also install this handle, or a later dict-table read resolves `None`.
+    #[cfg(test)]
+    pub(crate) fn active_dict_installed(&self) -> bool {
+        self.state.as_ref().is_some_and(|s| s.active_dict.is_some())
+    }
+
     /// Whether the current frames last block has been decoded yet
     /// If this returns true you can call the drain* functions to get all content
     /// (the read() function will drain automatically if this returns true)

--- a/zstd/src/decoding/frame_decoder.rs
+++ b/zstd/src/decoding/frame_decoder.rs
@@ -663,6 +663,7 @@ impl DecoderScratchKind {
     #[cfg(feature = "lsm")]
     fn export_entropy(
         &self,
+        dict: Option<&crate::decoding::dictionary::Dictionary>,
     ) -> (
         crate::decoding::scratch::FSEScratch,
         crate::decoding::scratch::HuffmanScratch,
@@ -672,10 +673,14 @@ impl DecoderScratchKind {
             Self::Ring(s) => (&s.fse, &s.huf, s.offset_hist),
             Self::Flat(s) => (&s.fse, &s.huf, s.offset_hist),
         };
+        // The live scratch may still be `Dict`-sourced; `reinit_from` /
+        // `reinit_resolved_from` resolve those axes through the borrow into a
+        // self-contained `Local` snapshot, so the dictionary is required here
+        // whenever the captured frame is dict-backed.
         let mut fse = crate::decoding::scratch::FSEScratch::new();
-        fse.reinit_from(fse_src);
+        fse.reinit_from(fse_src, dict);
         let mut huf = crate::decoding::scratch::HuffmanScratch::new();
-        huf.reinit_resolved_from(huf_src);
+        huf.reinit_resolved_from(huf_src, dict);
         (fse, huf, offset_hist)
     }
 
@@ -684,15 +689,18 @@ impl DecoderScratchKind {
     /// same tables a contiguous decode would have carried over.
     #[cfg(feature = "lsm")]
     fn restore_entropy(&mut self, state: &ResumeState) {
+        // The `ResumeState` snapshot is a self-contained `Local` materialization
+        // (export resolved every Dict axis into local bytes and detached), so no
+        // dictionary borrow is needed to install it back.
         match self {
             Self::Ring(s) => {
-                s.fse.reinit_from(&state.fse);
-                s.huf.reinit_resolved_from(&state.huf);
+                s.fse.reinit_from(&state.fse, None);
+                s.huf.reinit_resolved_from(&state.huf, None);
                 s.offset_hist = state.offset_hist;
             }
             Self::Flat(s) => {
-                s.fse.reinit_from(&state.fse);
-                s.huf.reinit_resolved_from(&state.huf);
+                s.fse.reinit_from(&state.fse, None);
+                s.huf.reinit_resolved_from(&state.huf, None);
                 s.offset_hist = state.offset_hist;
             }
         }
@@ -1402,6 +1410,7 @@ impl FrameDecoder {
             })
             .ok_or(err::DictNotProvided { dict_id })?;
         state.decoder_scratch.init_from_dict(dict);
+        state.set_active_dict(dict);
         state.using_dict = Some(dict_id);
 
         Ok(())
@@ -1598,7 +1607,17 @@ impl FrameDecoder {
             } else {
                 None
             };
-            let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
+            // Only expose the held dictionary while THIS frame is dict-backed
+            // (`using_dict` is set per dict-apply, cleared on reset). A reused
+            // decoder keeps `active_dict` across a no-dict frame for the
+            // `ptr::eq` reuse-skip, so it must be gated here or a stray
+            // out-of-window offset on a dictless frame would resolve against the
+            // stale dictionary content instead of erroring.
+            let dict_ref = if state.using_dict.is_some() {
+                state.active_dict.as_ref().map(|h| h.as_dict())
+            } else {
+                None
+            };
             let bytes_read_in_block_body = state
                 .decoder_scratch
                 .decode_block_content(&mut block_dec, &block_header, &mut source, dict_ref)
@@ -1898,7 +1917,17 @@ impl FrameDecoder {
             state.bytes_read_counter += u64::from(block_header_size);
 
             let len_before = state.decoder_scratch.buffer_len();
-            let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
+            // Only expose the held dictionary while THIS frame is dict-backed
+            // (`using_dict` is set per dict-apply, cleared on reset). A reused
+            // decoder keeps `active_dict` across a no-dict frame for the
+            // `ptr::eq` reuse-skip, so it must be gated here or a stray
+            // out-of-window offset on a dictless frame would resolve against the
+            // stale dictionary content instead of erroring.
+            let dict_ref = if state.using_dict.is_some() {
+                state.active_dict.as_ref().map(|h| h.as_dict())
+            } else {
+                None
+            };
             match state.decoder_scratch.decode_block_content(
                 &mut block_dec,
                 &block_header,
@@ -1980,7 +2009,12 @@ impl FrameDecoder {
         // one past the last block (EOF), for which there is no next-block source
         // position to resume from. A resume needs a real following block.
         let resume_state = if emit_resume && !state.frame_finished {
-            let (fse, huf, offset_hist) = state.decoder_scratch.export_entropy();
+            let dict_ref = if state.using_dict.is_some() {
+                state.active_dict.as_ref().map(|h| h.as_dict())
+            } else {
+                None
+            };
+            let (fse, huf, offset_hist) = state.decoder_scratch.export_entropy(dict_ref);
             Some(ResumeState {
                 frame_key: FrameKey::from_state(state, magicless),
                 block_index: state.block_counter as u32,
@@ -2166,7 +2200,17 @@ impl FrameDecoder {
                     }
                     state.bytes_read_counter += u64::from(block_header_size);
 
-                    let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
+                    // Only expose the held dictionary while THIS frame is dict-backed
+                    // (`using_dict` is set per dict-apply, cleared on reset). A reused
+                    // decoder keeps `active_dict` across a no-dict frame for the
+                    // `ptr::eq` reuse-skip, so it must be gated here or a stray
+                    // out-of-window offset on a dictless frame would resolve against the
+                    // stale dictionary content instead of erroring.
+                    let dict_ref = if state.using_dict.is_some() {
+                        state.active_dict.as_ref().map(|h| h.as_dict())
+                    } else {
+                        None
+                    };
                     let bytes_read_in_block_body = state
                         .decoder_scratch
                         .decode_block_content(
@@ -2910,7 +2954,17 @@ impl FrameDecoder {
         // threaded as a call-scoped argument into every `Dict`-sourced read
         // (the direct path's `repeat_from_dict` ext-dict slow path), mirroring
         // C's per-frame pointer hand-off with zero refcount churn.
-        let dict_ref = state.active_dict.as_ref().map(|h| h.as_dict());
+        // Only expose the held dictionary while THIS frame is dict-backed
+        // (`using_dict` is set per dict-apply, cleared on reset). A reused
+        // decoder keeps `active_dict` across a no-dict frame for the
+        // `ptr::eq` reuse-skip, so it must be gated here or a stray
+        // out-of-window offset on a dictless frame would resolve against the
+        // stale dictionary content instead of erroring.
+        let dict_ref = if state.using_dict.is_some() {
+            state.active_dict.as_ref().map(|h| h.as_dict())
+        } else {
+            None
+        };
         let (huf, fse, offset_hist, literals_buffer, block_content_buffer, window_size) =
             match &mut state.decoder_scratch {
                 DecoderScratchKind::Flat(s) => (

--- a/zstd/src/decoding/frame_decoder/tests.rs
+++ b/zstd/src/decoding/frame_decoder/tests.rs
@@ -4,6 +4,17 @@ use super::{DictionaryHandle, FrameDecoder};
 use crate::encoding::{CompressionLevel, FrameCompressor};
 use alloc::vec::Vec;
 
+/// `FrameDecoder` must stay `Send + Sync` (multi-instance contract: one
+/// dictionary shared across decoder instances on other threads). The decode
+/// scratch holds the dictionary by a raw `NonNull` pointer, which suppresses
+/// auto-`Send`/`Sync`; the `unsafe impl`s in `scratch.rs` / `decode_buffer.rs`
+/// restore it. This is a COMPILE-TIME guard — if a future change adds a
+/// non-thread-safe field (or drops one of those impls), this fails to compile.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<FrameDecoder>();
+};
+
 #[test]
 fn decode_all_tight_and_slack_outputs_match_on_single_segment_frame() {
     // Roundtrip a small payload through the encoder, then decode

--- a/zstd/src/decoding/frame_decoder/tests.rs
+++ b/zstd/src/decoding/frame_decoder/tests.rs
@@ -17,6 +17,41 @@ const _: fn() = || {
 };
 
 #[test]
+fn force_dict_installs_active_dictionary_handle() {
+    // Regression: `force_dict` arms `Dict`-sourced scratch tables for a
+    // dictless-header frame, so it MUST also install the OWNING dictionary
+    // handle (`active_dict`). Without it the block loop derives a `None`
+    // dictionary borrow while the scratch sources say `Dict`, so the first
+    // dict-table read hits the unwrap and panics (and dict-content matches
+    // resolve against an empty/stale dictionary instead of the forced one).
+    let payload: Vec<u8> = (0..256u32).map(|i| (i & 0xFF) as u8).collect();
+    let mut compressor = FrameCompressor::new(CompressionLevel::Default);
+    compressor.set_source(payload.as_slice());
+    let mut compressed = Vec::new();
+    compressor.set_drain(&mut compressed);
+    compressor.compress();
+
+    let raw = include_bytes!("../../../dict_tests/dictionary");
+    let dict = crate::decoding::dictionary::Dictionary::decode_dict(raw).expect("parse dict");
+    let dict_id = dict.id;
+
+    let mut dec = FrameDecoder::new();
+    dec.add_dict(dict).expect("register owned dict");
+    dec.reset(compressed.as_slice())
+        .expect("reset on a dictless-header frame");
+    assert!(
+        !dec.active_dict_installed(),
+        "a dictless-header reset must not install any dictionary"
+    );
+    dec.force_dict(dict_id)
+        .expect("force_dict applies the dict");
+    assert!(
+        dec.active_dict_installed(),
+        "force_dict must install the owning dictionary handle"
+    );
+}
+
+#[test]
 fn decode_all_tight_and_slack_outputs_match_on_single_segment_frame() {
     // Roundtrip a small payload through the encoder, then decode
     // it via `decode_all` on two output shapes that select

--- a/zstd/src/decoding/frame_decoder/tests.rs
+++ b/zstd/src/decoding/frame_decoder/tests.rs
@@ -6,10 +6,11 @@ use alloc::vec::Vec;
 
 /// `FrameDecoder` must stay `Send + Sync` (multi-instance contract: one
 /// dictionary shared across decoder instances on other threads). The decode
-/// scratch holds the dictionary by a raw `NonNull` pointer, which suppresses
-/// auto-`Send`/`Sync`; the `unsafe impl`s in `scratch.rs` / `decode_buffer.rs`
-/// restore it. This is a COMPILE-TIME guard — if a future change adds a
-/// non-thread-safe field (or drops one of those impls), this fails to compile.
+/// state owns the dictionary as a thread-safe handle (`active_dict:
+/// Option<DictionaryHandle>`) and every `Dict`-sourced table read borrows it as
+/// a call-scoped argument, so `Send`/`Sync` auto-derive with zero `unsafe impl`.
+/// This is a COMPILE-TIME guard — if a future change adds a non-thread-safe
+/// field, this fails to compile.
 const _: fn() = || {
     fn assert_send_sync<T: Send + Sync>() {}
     assert_send_sync::<FrameDecoder>();

--- a/zstd/src/decoding/literals_section_decoder.rs
+++ b/zstd/src/decoding/literals_section_decoder.rs
@@ -20,6 +20,7 @@ use crate::cpu_kernel::CpuKernelTag;
 #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
 use crate::cpu_kernel::Vbmi2Kernel;
 use crate::cpu_kernel::{CpuKernel, ScalarKernel, detect_cpu_kernel};
+use crate::decoding::dictionary::Dictionary;
 use crate::decoding::errors::DecompressLiteralsError;
 use crate::huff0::HuffmanDecoder;
 use alloc::vec::Vec;
@@ -32,6 +33,7 @@ use alloc::vec::Vec;
 pub fn decode_literals(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
@@ -45,7 +47,7 @@ pub fn decode_literals(
             Ok(1)
         }
         LiteralsSectionType::Compressed | LiteralsSectionType::Treeless => {
-            let bytes_read = decompress_literals(section, scratch, source, target)?;
+            let bytes_read = decompress_literals(section, scratch, dict, source, target)?;
             Ok(bytes_read)
         }
     }
@@ -76,6 +78,7 @@ pub struct LiteralsView<'a> {
 pub fn decode_literals_zerocopy<'a>(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &'a [u8],
     target: &'a mut Vec<u8>,
 ) -> Result<LiteralsView<'a>, DecompressLiteralsError> {
@@ -121,7 +124,7 @@ pub fn decode_literals_zerocopy<'a>(
             })
         }
         LiteralsSectionType::Compressed | LiteralsSectionType::Treeless => {
-            let bytes_used = decompress_literals(section, scratch, source, target)?;
+            let bytes_used = decompress_literals(section, scratch, dict, source, target)?;
             Ok(LiteralsView {
                 data: &target[base..],
                 bytes_used,
@@ -137,6 +140,7 @@ pub fn decode_literals_zerocopy<'a>(
 fn decompress_literals(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
@@ -156,13 +160,17 @@ fn decompress_literals(
     match detect_cpu_kernel() {
         #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
         CpuKernelTag::Vbmi2 => unsafe {
-            decompress_literals_vbmi2(section, scratch, source, target)
+            decompress_literals_vbmi2(section, scratch, dict, source, target)
         },
         #[cfg(all(target_arch = "x86_64", feature = "kernel_avx2"))]
-        CpuKernelTag::Avx2 => unsafe { decompress_literals_avx2(section, scratch, source, target) },
+        CpuKernelTag::Avx2 => unsafe {
+            decompress_literals_avx2(section, scratch, dict, source, target)
+        },
         #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
-        CpuKernelTag::Bmi2 => unsafe { decompress_literals_bmi2(section, scratch, source, target) },
-        _ => decompress_literals_impl::<ScalarKernel>(section, scratch, source, target),
+        CpuKernelTag::Bmi2 => unsafe {
+            decompress_literals_bmi2(section, scratch, dict, source, target)
+        },
+        _ => decompress_literals_impl::<ScalarKernel>(section, scratch, dict, source, target),
     }
 }
 
@@ -171,10 +179,11 @@ fn decompress_literals(
 unsafe fn decompress_literals_avx2(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
-    decompress_literals_impl::<Avx2Kernel>(section, scratch, source, target)
+    decompress_literals_impl::<Avx2Kernel>(section, scratch, dict, source, target)
 }
 
 #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
@@ -182,10 +191,11 @@ unsafe fn decompress_literals_avx2(
 unsafe fn decompress_literals_bmi2(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
-    decompress_literals_impl::<Bmi2Kernel>(section, scratch, source, target)
+    decompress_literals_impl::<Bmi2Kernel>(section, scratch, dict, source, target)
 }
 
 #[cfg(all(target_arch = "x86_64", feature = "kernel_vbmi2"))]
@@ -193,15 +203,17 @@ unsafe fn decompress_literals_bmi2(
 unsafe fn decompress_literals_vbmi2(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
-    decompress_literals_impl::<Vbmi2Kernel>(section, scratch, source, target)
+    decompress_literals_impl::<Vbmi2Kernel>(section, scratch, dict, source, target)
 }
 
 fn decompress_literals_impl<K: CpuKernel>(
     section: &LiteralsSection,
     scratch: &mut HuffmanScratch,
+    dict: Option<&Dictionary>,
     source: &[u8],
     target: &mut Vec<u8>,
 ) -> Result<u32, DecompressLiteralsError> {
@@ -234,7 +246,7 @@ fn decompress_literals_impl<K: CpuKernel>(
             scratch.mark_table_local();
             vprintln!("Built huffman table using {} bytes", bytes_read);
         }
-        LiteralsSectionType::Treeless if scratch.huf_table().max_num_bits == 0 => {
+        LiteralsSectionType::Treeless if scratch.huf_table(dict).max_num_bits == 0 => {
             return Err(err::UninitializedHuffmanTable);
         }
 
@@ -245,7 +257,7 @@ fn decompress_literals_impl<K: CpuKernel>(
 
     // Copy-on-write source: the dictionary's Huffman table (zero-copy) on a
     // Treeless section that still reads `Dict`, else the locally-built one.
-    let table = scratch.huf_table();
+    let table = scratch.huf_table(dict);
 
     if num_streams == 4 {
         //build jumptable

--- a/zstd/src/decoding/literals_section_decoder/burst_gate_tests.rs
+++ b/zstd/src/decoding/literals_section_decoder/burst_gate_tests.rs
@@ -69,7 +69,7 @@ fn roundtrip_assert(data: &[u8]) -> u8 {
     let (section, source) = build_huf4x_block(data);
     let mut scratch = HuffmanScratch::new();
     let mut target = Vec::new();
-    let bytes_read = decode_literals(&section, &mut scratch, &source, &mut target)
+    let bytes_read = decode_literals(&section, &mut scratch, None, &source, &mut target)
         .expect("decode_literals must succeed on a well-formed roundtrip");
     assert_eq!(
         bytes_read as usize,
@@ -243,7 +243,7 @@ fn burst_gate_malformed_small_regen_returns_error() {
 
     let mut scratch = HuffmanScratch::new();
     let mut target = Vec::new();
-    let result = decode_literals(&section, &mut scratch, &source, &mut target);
+    let result = decode_literals(&section, &mut scratch, None, &source, &mut target);
 
     assert!(
         result.is_err(),

--- a/zstd/src/decoding/literals_section_decoder/zerocopy_robustness_tests.rs
+++ b/zstd/src/decoding/literals_section_decoder/zerocopy_robustness_tests.rs
@@ -44,7 +44,7 @@ fn raw_truncated_source_returns_error_no_panic() {
     let source: [u8; 3] = [1, 2, 3];
     let mut target: Vec<u8> = Vec::new();
     let mut scratch = fresh_scratch();
-    let result = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target);
+    let result = decode_literals_zerocopy(&section, &mut scratch, None, &source, &mut target);
     assert!(
         result.is_err(),
         "truncated raw source must error, not panic; got {:?}",
@@ -60,7 +60,7 @@ fn rle_empty_source_returns_error_no_panic() {
     let source: [u8; 0] = [];
     let mut target: Vec<u8> = Vec::new();
     let mut scratch = fresh_scratch();
-    let result = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target);
+    let result = decode_literals_zerocopy(&section, &mut scratch, None, &source, &mut target);
     assert!(
         result.is_err(),
         "empty RLE source must error, not panic; got {:?}",
@@ -83,7 +83,7 @@ fn compressed_truncated_source_returns_error_no_panic() {
     let source: [u8; 3] = [1, 2, 3];
     let mut target: Vec<u8> = Vec::new();
     let mut scratch = fresh_scratch();
-    let result = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target);
+    let result = decode_literals_zerocopy(&section, &mut scratch, None, &source, &mut target);
     // Pin the EXACT contract: a truncated Compressed section must report
     // MissingBytesForLiterals with the precise got/needed, not just "some
     // error" (a weaker is_err() would also pass on MissingNumStreams /
@@ -113,7 +113,7 @@ fn rle_view_excludes_pre_existing_target_bytes() {
     let section = rle_section(4);
     let source: [u8; 1] = [0x42];
     let mut scratch = fresh_scratch();
-    let view = decode_literals_zerocopy(&section, &mut scratch, &source, &mut target)
+    let view = decode_literals_zerocopy(&section, &mut scratch, None, &source, &mut target)
         .expect("RLE with valid source must succeed");
     assert_eq!(view.data.len(), 4, "view length must match regen_size");
     assert!(

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -8,7 +8,6 @@ use crate::fse::SeqFSETable;
 use crate::huff0::HuffmanTable;
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
-use core::ptr::NonNull;
 
 use crate::blocks::sequence_section::{
     MAX_LITERAL_LENGTH_CODE, MAX_MATCH_LENGTH_CODE, MAX_OFFSET_CODE,
@@ -140,7 +139,6 @@ impl<B: BufferBackend> DecoderScratch<B> {
             huf: HuffmanScratch {
                 table: HuffmanTable::new(),
                 table_source: TableSource::Local,
-                dict: None,
             },
             fse: FSEScratch {
                 offsets: AlignedFSETable::new(MAX_OFFSET_CODE),
@@ -151,7 +149,6 @@ impl<B: BufferBackend> DecoderScratch<B> {
                 ll_source: TableSource::Local,
                 of_source: TableSource::Local,
                 ml_source: TableSource::Local,
-                dict: None,
             },
             buffer: DecodeBuffer::new(window_size),
             offset_hist: [1, 4, 8],
@@ -250,21 +247,16 @@ impl<B: BufferBackend> DecoderScratch<B> {
 
     pub fn init_from_dict(&mut self, dict: &DictionaryHandle) {
         let d = dict.as_dict();
-        // Copy-on-write: reference the dictionary's sequence FSE tables by
-        // handle instead of copying them into per-frame scratch. The eager
-        // copy was always wasted work: every block either reads the table
-        // by reference (Repeat mode) or rebuilds it (FSE/RLE/Predefined
-        // mode), so deferring the copy to the rebuild is strictly faster.
-        // Pass the handle by reference: each attach reuses the held `Arc` when
-        // it is the same dictionary (frame-over-frame reuse), cloning only on a
-        // fresh/changed dictionary. The previous unconditional `dict.clone()`
-        // ×3 paid 3 refcount bumps on attach + 3 drops at teardown every frame
-        // — pure waste on the reuse hot path (CoordiNode per-label dicts),
-        // which dominates tiny-frame decode cost.
+        // Copy-on-write: the sequence FSE / Huffman tables are READ from the
+        // dictionary by reference (Repeat mode) or rebuilt locally (FSE / RLE /
+        // Predefined / Compressed mode) — never eagerly copied here (the upstream
+        // zstd `ZSTD_copyDDictParameters` memcpy is elided). This only arms the
+        // COW source flags + copies the scalar `offset_hist`; the dictionary
+        // itself is threaded into every read as a call-scoped borrow, so it is
+        // NOT stored and there is NO per-frame refcount bump.
         self.fse.attach_dict(dict);
-        self.huf.attach_dict(dict);
+        self.huf.attach_dict();
         self.offset_hist = d.offset_hist;
-        self.buffer.set_dict(dict);
         // Upstream zstd parity: `ZSTD_decompressBegin_usingDDict` sets
         // `dctx->ddictIsCold = 1` so the first block of the frame
         // engages the prefetch decoder regardless of long-offset
@@ -284,26 +276,18 @@ pub struct HuffmanScratch {
     /// locally-built one. `init_from_dict` attaches as `Dict`; a
     /// `Compressed` literals section rebuilds and flips to `Local`; a
     /// `Treeless` section reuses whatever source is current.
+    /// The `Dict`-sourced table reads the dictionary's Huffman table through a
+    /// call-scoped `dict: Option<&Dictionary>` borrow threaded into
+    /// [`Self::huf_table`] by the decode pipeline — no stored reference, no
+    /// refcount. See [`FSEScratch`] for the shared model.
     table_source: TableSource,
-    /// Borrowed pointer to the dictionary backing the table when `Dict`-sourced
-    /// — same borrowed-pointer model as [`FSEScratch::dict`] (mirrors upstream
-    /// zstd `dctx->HUFptr`): no refcount, owner-kept-alive, read only while
-    /// `table_source == Dict`. `None` on the no-dict path.
-    dict: Option<NonNull<Dictionary>>,
 }
-
-// SAFETY: identical contract to the `FSEScratch` impls above — `dict` is a
-// read-only borrowed pointer to a `Send + Sync` `Dictionary` whose owner keeps
-// it alive for the decode; no aliasing mutation. Restores auto-`Send`/`Sync`.
-unsafe impl Send for HuffmanScratch {}
-unsafe impl Sync for HuffmanScratch {}
 
 impl HuffmanScratch {
     pub fn new() -> HuffmanScratch {
         HuffmanScratch {
             table: HuffmanTable::new(),
             table_source: TableSource::Local,
-            dict: None,
         }
     }
 
@@ -315,38 +299,29 @@ impl HuffmanScratch {
         self.table.heap_bytes()
     }
 
-    /// Live Huffman literals table: the shared dictionary's (zero-copy)
-    /// while the source is still `Dict`, else the locally-built one.
-    pub(crate) fn huf_table(&self) -> &HuffmanTable {
+    /// Live Huffman literals table: the dictionary's (zero-copy) while the
+    /// source is still `Dict`, else the locally-built one. `dict` is the
+    /// call-scoped borrow threaded in by the decode pipeline (must be `Some`
+    /// when the source is `Dict`).
+    pub(crate) fn huf_table<'a>(&'a self, dict: Option<&'a Dictionary>) -> &'a HuffmanTable {
         match self.table_source {
             TableSource::Local => &self.table,
-            TableSource::Dict => {
-                let ptr = self
-                    .dict
-                    .expect("Dict table source requires an attached dictionary pointer");
-                // SAFETY: set by `attach_dict` from a live handle, read only
-                // while `table_source == Dict`; owner keeps the pointee alive
-                // for the decode (see the `dict` field contract).
-                &unsafe { ptr.as_ref() }.huf.table
-            }
+            TableSource::Dict => &expect_dict(dict).huf.table,
         }
     }
 
-    /// Point the literals table at the dictionary's Huffman table by reference
-    /// (no table bytes copied). Mirrors upstream zstd `dctx->HUFptr = ...`:
-    /// store a borrowed pointer + re-arm the source, NO refcount bump.
-    pub(crate) fn attach_dict(&mut self, dict: &DictionaryHandle) {
+    /// Point the literals table at the dictionary's Huffman table (no table
+    /// bytes copied): re-arm the COW source only. The dictionary is read later
+    /// through the threaded `dict` borrow, never stored — NO refcount bump.
+    pub(crate) fn attach_dict(&mut self) {
         // The COW table-source must be re-armed every frame (a prior frame's
         // `Compressed` literals section may have flipped it to `Local`).
         self.table_source = TableSource::Dict;
-        // Borrowed pointer, set unconditionally (one store, no atomic).
-        self.dict = Some(NonNull::from(dict.as_dict()));
     }
 
     /// Drop any dictionary attachment and revert to the local table.
     pub(crate) fn detach_dict(&mut self) {
         self.table_source = TableSource::Local;
-        self.dict = None;
     }
 
     /// Flip to the locally-built table (called after a `Compressed`
@@ -359,8 +334,12 @@ impl HuffmanScratch {
     /// Snapshot the live (COW-resolved) Huffman table into `self` as an
     /// owned `Local` copy (LSM resume snapshot/restore): materialises a
     /// `Dict`-sourced table so the result is self-contained.
-    pub(crate) fn reinit_resolved_from(&mut self, other: &HuffmanScratch) {
-        self.table.reinit_from(other.huf_table());
+    pub(crate) fn reinit_resolved_from(
+        &mut self,
+        other: &HuffmanScratch,
+        dict: Option<&Dictionary>,
+    ) {
+        self.table.reinit_from(other.huf_table(dict));
         self.detach_dict();
     }
 }
@@ -379,6 +358,15 @@ impl Default for HuffmanScratch {
 enum TableSource {
     Local,
     Dict,
+}
+
+/// Unwrap the call-scoped dictionary borrow at a `Dict`-sourced read. A `Dict`
+/// table source is only ever set by `attach_dict`, which the decode pipeline
+/// pairs with threading the active dictionary into every read — so `None` here
+/// is an internal invariant violation, not a recoverable input error.
+#[inline]
+fn expect_dict(dict: Option<&Dictionary>) -> &Dictionary {
+    dict.expect("a Dict-sourced table requires the active dictionary borrow")
 }
 
 #[derive(Clone)]
@@ -418,34 +406,16 @@ pub struct FSEScratch {
     /// Repeat-mode blocks leave the source untouched, so they read
     /// straight out of the shared dictionary handle until the first
     /// rebuild. On the no-dict path every axis stays `Local`.
+    /// The `Dict`-sourced axes read the dictionary's tables through a
+    /// call-scoped `dict: Option<&Dictionary>` borrow threaded into the read
+    /// accessors by the decode pipeline (resolved once per decode from the
+    /// owner — the `FrameDecoder` registry or `FrameDecoderState::active_dict`).
+    /// No dictionary reference is STORED here: the borrow checker guarantees the
+    /// dictionary outlives every read, with no refcount and no per-frame clone.
     ll_source: TableSource,
     of_source: TableSource,
     ml_source: TableSource,
-    /// Borrowed pointer to the dictionary backing any `Dict`-sourced axis,
-    /// mirroring upstream zstd's `ZSTD_DCtx` which holds RAW POINTERS into a
-    /// caller-owned `DDict` (`dctx->LLTptr = ddict->entropy.LLTable`): no
-    /// refcount, no per-frame `Arc` clone. The pointee is kept alive for the
-    /// whole decode by the dictionary owner — the `FrameDecoder`'s
-    /// `owned_dicts`/`shared_dicts` registry, or the `&DictionaryHandle` the
-    /// caller holds across `decode_all_with_dict_handle`. `attach_dict` re-sets
-    /// it from a live handle every frame; it is read (`dict_ref`) only while a
-    /// `*_source == Dict`, which is set in that same attach. `None` on the
-    /// no-dict path. See the `unsafe impl Send/Sync` below for the cross-thread
-    /// contract.
-    dict: Option<NonNull<Dictionary>>,
 }
-
-// SAFETY: `dict` is a borrowed pointer to a `Dictionary`, which is itself
-// `Send + Sync` (it owns only `Vec`/table data, no interior mutability). The
-// pointer is never used to mutate — `dict_ref` reads it through `&self` — and
-// the pointee outlives every read by the owner-liveness contract documented on
-// the `dict` field. So moving/sharing an `FSEScratch` across threads carries
-// only a read-only borrow of `Send + Sync` data, exactly as the previous
-// `Arc<Dictionary>` did; the raw pointer drops the per-frame refcount bump, not
-// the thread-safety. The explicit impls restore the auto-`Send`/`Sync` that the
-// `NonNull` field would otherwise suppress.
-unsafe impl Send for FSEScratch {}
-unsafe impl Sync for FSEScratch {}
 
 impl FSEScratch {
     /// Heap bytes owned by the three locally-built sequence FSE tables
@@ -468,7 +438,6 @@ impl FSEScratch {
             ll_source: TableSource::Local,
             of_source: TableSource::Local,
             ml_source: TableSource::Local,
-            dict: None,
         }
     }
 
@@ -478,10 +447,10 @@ impl FSEScratch {
     /// result must be self-contained, so any `Dict`-sourced axis in
     /// `other` is materialised by copying the dictionary's table bytes
     /// into the local buffer and the source is set to `Local`.
-    pub fn reinit_from(&mut self, other: &Self) {
-        self.literal_lengths.reinit_from(other.ll_table());
-        self.offsets.reinit_from(other.of_table());
-        self.match_lengths.reinit_from(other.ml_table());
+    pub fn reinit_from(&mut self, other: &Self, dict: Option<&Dictionary>) {
+        self.literal_lengths.reinit_from(other.ll_table(dict));
+        self.offsets.reinit_from(other.of_table(dict));
+        self.match_lengths.reinit_from(other.ml_table(dict));
         // Copy the precomputed long-offset share instead of re-walking
         // the offsets table; the dict computes it once at build time and
         // it is stale-but-correct across Repeat-mode blocks.
@@ -493,51 +462,41 @@ impl FSEScratch {
         self.ll_source = TableSource::Local;
         self.of_source = TableSource::Local;
         self.ml_source = TableSource::Local;
-        self.dict = None;
     }
 
-    /// Live LL decode table: the shared dictionary's (zero-copy) when the
-    /// axis is still `Dict`-sourced, else the locally-built one.
-    pub(crate) fn ll_table(&self) -> &SeqFSETable {
+    /// Live LL decode table: the dictionary's (zero-copy) when the axis is
+    /// still `Dict`-sourced, else the locally-built one. `dict` is the
+    /// call-scoped borrow threaded in by the decode pipeline; it must be
+    /// `Some` whenever any axis is `Dict`-sourced (the caller resolves it from
+    /// the active dictionary before reading).
+    pub(crate) fn ll_table<'a>(&'a self, dict: Option<&'a Dictionary>) -> &'a SeqFSETable {
         match self.ll_source {
             TableSource::Local => &self.literal_lengths,
-            TableSource::Dict => &self.dict_ref().fse.literal_lengths,
+            TableSource::Dict => &expect_dict(dict).fse.literal_lengths,
         }
     }
 
     /// Live OF decode table (see [`Self::ll_table`]).
-    pub(crate) fn of_table(&self) -> &SeqFSETable {
+    pub(crate) fn of_table<'a>(&'a self, dict: Option<&'a Dictionary>) -> &'a SeqFSETable {
         match self.of_source {
             TableSource::Local => &self.offsets,
-            TableSource::Dict => &self.dict_ref().fse.offsets,
+            TableSource::Dict => &expect_dict(dict).fse.offsets,
         }
     }
 
     /// Live ML decode table (see [`Self::ll_table`]).
-    pub(crate) fn ml_table(&self) -> &SeqFSETable {
+    pub(crate) fn ml_table<'a>(&'a self, dict: Option<&'a Dictionary>) -> &'a SeqFSETable {
         match self.ml_source {
             TableSource::Local => &self.match_lengths,
-            TableSource::Dict => &self.dict_ref().fse.match_lengths,
+            TableSource::Dict => &expect_dict(dict).fse.match_lengths,
         }
     }
 
-    fn dict_ref(&self) -> &Dictionary {
-        let ptr = self
-            .dict
-            .expect("Dict table source requires an attached dictionary pointer");
-        // SAFETY: `ptr` was set by `attach_dict` from a live `&DictionaryHandle`
-        // and is read only while a `*_source == Dict` (re-armed in that same
-        // attach); the pointee is kept alive for the whole decode by the
-        // dictionary owner (registry / caller borrow) per the `dict` field
-        // contract. Shared `&self` read, no aliasing mutation.
-        unsafe { ptr.as_ref() }
-    }
-
-    /// Point every sequence FSE axis at the shared dictionary's tables by
-    /// reference (no table bytes copied — the eager per-frame entropy-table
-    /// memcpy is elided). Mirrors upstream zstd `ZSTD_copyDDictParameters`:
-    /// store borrowed pointers + the precomputed long-offset share, with NO
-    /// refcount bump (the pointee is owner-kept-alive; see the `dict` field).
+    /// Point every sequence FSE axis at the dictionary's tables (no table bytes
+    /// copied — the eager per-frame entropy-table memcpy is elided). Only the
+    /// COW source flags + the precomputed long-offset share are set; the
+    /// dictionary itself is read later through the threaded `dict` borrow, never
+    /// stored — so this costs NO refcount bump.
     pub(crate) fn attach_dict(&mut self, dict: &DictionaryHandle) {
         self.offsets_long_share = dict.as_dict().fse.offsets_long_share;
         // Re-arm all three COW axes every frame (a prior frame may have rebuilt
@@ -545,16 +504,11 @@ impl FSEScratch {
         self.ll_source = TableSource::Dict;
         self.of_source = TableSource::Dict;
         self.ml_source = TableSource::Dict;
-        // Borrowed pointer, set unconditionally every frame (one store, no
-        // atomic) exactly like C's per-frame pointer assignment.
-        self.dict = Some(NonNull::from(dict.as_dict()));
     }
 
-    /// Drop any dictionary attachment and revert all axes to `Local`
-    /// (called on scratch `reset` so a reused workspace does not read a
-    /// previous frame's dictionary tables).
+    /// Revert all axes to `Local` (called on scratch `reset` so a reused
+    /// workspace does not read a previous frame's dictionary tables).
     pub(crate) fn detach_dict(&mut self) {
-        self.dict = None;
         self.ll_source = TableSource::Local;
         self.of_source = TableSource::Local;
         self.ml_source = TableSource::Local;

--- a/zstd/src/decoding/scratch.rs
+++ b/zstd/src/decoding/scratch.rs
@@ -3,11 +3,12 @@
 use super::buffer_backend::BufferBackend;
 use super::decode_buffer::DecodeBuffer;
 use super::ringbuffer::RingBuffer;
-use crate::decoding::dictionary::DictionaryHandle;
+use crate::decoding::dictionary::{Dictionary, DictionaryHandle};
 use crate::fse::SeqFSETable;
 use crate::huff0::HuffmanTable;
 use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
 
 use crate::blocks::sequence_section::{
     MAX_LITERAL_LENGTH_CODE, MAX_MATCH_LENGTH_CODE, MAX_OFFSET_CODE,
@@ -254,13 +255,16 @@ impl<B: BufferBackend> DecoderScratch<B> {
         // copy was always wasted work: every block either reads the table
         // by reference (Repeat mode) or rebuilds it (FSE/RLE/Predefined
         // mode), so deferring the copy to the rebuild is strictly faster.
-        self.fse.attach_dict(dict.clone());
-        self.huf.attach_dict(dict.clone());
+        // Pass the handle by reference: each attach reuses the held `Arc` when
+        // it is the same dictionary (frame-over-frame reuse), cloning only on a
+        // fresh/changed dictionary. The previous unconditional `dict.clone()`
+        // ×3 paid 3 refcount bumps on attach + 3 drops at teardown every frame
+        // — pure waste on the reuse hot path (CoordiNode per-label dicts),
+        // which dominates tiny-frame decode cost.
+        self.fse.attach_dict(dict);
+        self.huf.attach_dict(dict);
         self.offset_hist = d.offset_hist;
-        // Share the dictionary content by handle (Arc/Rc clone = refcount
-        // bump) instead of copying it into a per-frame buffer; the decoder
-        // reads match bytes straight out of the shared content.
-        self.buffer.set_dict(dict.clone());
+        self.buffer.set_dict(dict);
         // Upstream zstd parity: `ZSTD_decompressBegin_usingDDict` sets
         // `dctx->ddictIsCold = 1` so the first block of the frame
         // engages the prefetch decoder regardless of long-offset
@@ -281,9 +285,18 @@ pub struct HuffmanScratch {
     /// `Compressed` literals section rebuilds and flips to `Local`; a
     /// `Treeless` section reuses whatever source is current.
     table_source: TableSource,
-    /// Shared dictionary handle backing the table when `Dict`-sourced.
-    dict: Option<DictionaryHandle>,
+    /// Borrowed pointer to the dictionary backing the table when `Dict`-sourced
+    /// — same borrowed-pointer model as [`FSEScratch::dict`] (mirrors upstream
+    /// zstd `dctx->HUFptr`): no refcount, owner-kept-alive, read only while
+    /// `table_source == Dict`. `None` on the no-dict path.
+    dict: Option<NonNull<Dictionary>>,
 }
+
+// SAFETY: identical contract to the `FSEScratch` impls above — `dict` is a
+// read-only borrowed pointer to a `Send + Sync` `Dictionary` whose owner keeps
+// it alive for the decode; no aliasing mutation. Restores auto-`Send`/`Sync`.
+unsafe impl Send for HuffmanScratch {}
+unsafe impl Sync for HuffmanScratch {}
 
 impl HuffmanScratch {
     pub fn new() -> HuffmanScratch {
@@ -308,23 +321,26 @@ impl HuffmanScratch {
         match self.table_source {
             TableSource::Local => &self.table,
             TableSource::Dict => {
-                &self
+                let ptr = self
                     .dict
-                    .as_ref()
-                    .expect("Dict table source requires an attached dictionary handle")
-                    .as_dict()
-                    .huf
-                    .table
+                    .expect("Dict table source requires an attached dictionary pointer");
+                // SAFETY: set by `attach_dict` from a live handle, read only
+                // while `table_source == Dict`; owner keeps the pointee alive
+                // for the decode (see the `dict` field contract).
+                &unsafe { ptr.as_ref() }.huf.table
             }
         }
     }
 
-    /// Attach a shared dictionary copy-on-write: the literals table now
-    /// reads the dictionary's Huffman table by reference (one handle
-    /// clone, no table copy).
-    pub(crate) fn attach_dict(&mut self, dict: DictionaryHandle) {
+    /// Point the literals table at the dictionary's Huffman table by reference
+    /// (no table bytes copied). Mirrors upstream zstd `dctx->HUFptr = ...`:
+    /// store a borrowed pointer + re-arm the source, NO refcount bump.
+    pub(crate) fn attach_dict(&mut self, dict: &DictionaryHandle) {
+        // The COW table-source must be re-armed every frame (a prior frame's
+        // `Compressed` literals section may have flipped it to `Local`).
         self.table_source = TableSource::Dict;
-        self.dict = Some(dict);
+        // Borrowed pointer, set unconditionally (one store, no atomic).
+        self.dict = Some(NonNull::from(dict.as_dict()));
     }
 
     /// Drop any dictionary attachment and revert to the local table.
@@ -405,11 +421,31 @@ pub struct FSEScratch {
     ll_source: TableSource,
     of_source: TableSource,
     ml_source: TableSource,
-    /// Shared dictionary handle backing any axis whose source is `Dict`.
-    /// Held as one `Arc`/`Rc` clone (a refcount bump, not a table copy);
-    /// `None` on the no-dict path.
-    dict: Option<DictionaryHandle>,
+    /// Borrowed pointer to the dictionary backing any `Dict`-sourced axis,
+    /// mirroring upstream zstd's `ZSTD_DCtx` which holds RAW POINTERS into a
+    /// caller-owned `DDict` (`dctx->LLTptr = ddict->entropy.LLTable`): no
+    /// refcount, no per-frame `Arc` clone. The pointee is kept alive for the
+    /// whole decode by the dictionary owner — the `FrameDecoder`'s
+    /// `owned_dicts`/`shared_dicts` registry, or the `&DictionaryHandle` the
+    /// caller holds across `decode_all_with_dict_handle`. `attach_dict` re-sets
+    /// it from a live handle every frame; it is read (`dict_ref`) only while a
+    /// `*_source == Dict`, which is set in that same attach. `None` on the
+    /// no-dict path. See the `unsafe impl Send/Sync` below for the cross-thread
+    /// contract.
+    dict: Option<NonNull<Dictionary>>,
 }
+
+// SAFETY: `dict` is a borrowed pointer to a `Dictionary`, which is itself
+// `Send + Sync` (it owns only `Vec`/table data, no interior mutability). The
+// pointer is never used to mutate — `dict_ref` reads it through `&self` — and
+// the pointee outlives every read by the owner-liveness contract documented on
+// the `dict` field. So moving/sharing an `FSEScratch` across threads carries
+// only a read-only borrow of `Send + Sync` data, exactly as the previous
+// `Arc<Dictionary>` did; the raw pointer drops the per-frame refcount bump, not
+// the thread-safety. The explicit impls restore the auto-`Send`/`Sync` that the
+// `NonNull` field would otherwise suppress.
+unsafe impl Send for FSEScratch {}
+unsafe impl Sync for FSEScratch {}
 
 impl FSEScratch {
     /// Heap bytes owned by the three locally-built sequence FSE tables
@@ -485,24 +521,33 @@ impl FSEScratch {
         }
     }
 
-    fn dict_ref(&self) -> &crate::decoding::dictionary::Dictionary {
-        self.dict
-            .as_ref()
-            .expect("Dict table source requires an attached dictionary handle")
-            .as_dict()
+    fn dict_ref(&self) -> &Dictionary {
+        let ptr = self
+            .dict
+            .expect("Dict table source requires an attached dictionary pointer");
+        // SAFETY: `ptr` was set by `attach_dict` from a live `&DictionaryHandle`
+        // and is read only while a `*_source == Dict` (re-armed in that same
+        // attach); the pointee is kept alive for the whole decode by the
+        // dictionary owner (registry / caller borrow) per the `dict` field
+        // contract. Shared `&self` read, no aliasing mutation.
+        unsafe { ptr.as_ref() }
     }
 
-    /// Attach a shared dictionary copy-on-write: every sequence FSE axis
-    /// now reads the dictionary's tables by reference. No table bytes are
-    /// copied (the eager per-frame entropy-table memcpy is elided); the
-    /// only cost is one handle clone plus copying the precomputed
-    /// long-offset share scalar.
-    pub(crate) fn attach_dict(&mut self, dict: DictionaryHandle) {
+    /// Point every sequence FSE axis at the shared dictionary's tables by
+    /// reference (no table bytes copied — the eager per-frame entropy-table
+    /// memcpy is elided). Mirrors upstream zstd `ZSTD_copyDDictParameters`:
+    /// store borrowed pointers + the precomputed long-offset share, with NO
+    /// refcount bump (the pointee is owner-kept-alive; see the `dict` field).
+    pub(crate) fn attach_dict(&mut self, dict: &DictionaryHandle) {
         self.offsets_long_share = dict.as_dict().fse.offsets_long_share;
+        // Re-arm all three COW axes every frame (a prior frame may have rebuilt
+        // any of them to `Local`).
         self.ll_source = TableSource::Dict;
         self.of_source = TableSource::Dict;
         self.ml_source = TableSource::Dict;
-        self.dict = Some(dict);
+        // Borrowed pointer, set unconditionally every frame (one store, no
+        // atomic) exactly like C's per-frame pointer assignment.
+        self.dict = Some(NonNull::from(dict.as_dict()));
     }
 
     /// Drop any dictionary attachment and revert all axes to `Local`

--- a/zstd/src/decoding/scratch/tests.rs
+++ b/zstd/src/decoding/scratch/tests.rs
@@ -36,7 +36,7 @@ fn reinit_from_clears_cold_dict_flag() {
     let mut dst = FSEScratch::new();
     dst.ddict_is_cold = true; // simulate a prior cold-dict frame's flag
     let src = FSEScratch::new(); // clean local-only source, not cold
-    dst.reinit_from(&src);
+    dst.reinit_from(&src, None);
     assert!(
         !dst.ddict_is_cold,
         "reinit_from must clear ddict_is_cold on a local-only snapshot"
@@ -66,7 +66,7 @@ fn init_from_dict_is_zero_copy_cow_then_reset_detaches() {
     );
     // Dict-sourced axis resolves to the dictionary's table...
     assert_eq!(
-        scratch.fse.ll_table().decode().len(),
+        scratch.fse.ll_table(Some(dict.as_dict())).decode().len(),
         dict_ll_len,
         "Dict-sourced axis must resolve to the shared dictionary's table"
     );
@@ -85,7 +85,7 @@ fn init_from_dict_is_zero_copy_cow_then_reset_detaches() {
         "dict fixture should carry a built HUF table"
     );
     assert_eq!(
-        scratch.huf.huf_table().max_num_bits,
+        scratch.huf.huf_table(Some(dict.as_dict())).max_num_bits,
         dict_huf_bits,
         "Dict-sourced HUF axis must resolve to the dictionary's table"
     );
@@ -96,11 +96,11 @@ fn init_from_dict_is_zero_copy_cow_then_reset_detaches() {
 
     scratch.reset(1024);
     assert!(
-        scratch.fse.ll_table().decode().is_empty(),
+        scratch.fse.ll_table(None).decode().is_empty(),
         "reset must detach the dictionary copy-on-write source"
     );
     assert_eq!(
-        scratch.huf.huf_table().max_num_bits,
+        scratch.huf.huf_table(None).max_num_bits,
         0,
         "reset must detach the HUF dictionary copy-on-write source"
     );

--- a/zstd/src/decoding/seq_decoder_avx2.rs
+++ b/zstd/src/decoding/seq_decoder_avx2.rs
@@ -218,6 +218,7 @@ macro_rules! decode_seq_fused_cshape {
 macro_rules! execute_one_body {
     (
         $buffer:expr,
+        $dict:expr,
         $literals_buffer:expr,
         $lit_cur:expr,
         $literals_buffer_len:expr,
@@ -305,8 +306,11 @@ macro_rules! execute_one_body {
             if let Err(e) = $buffer.try_push(lits) {
                 break 'exec_inner Err(ExecuteSequencesError::from(e).into());
             }
-            match $buffer.repeat_lookahead_prefetched(resolved_offset_v as usize, seq_ml_v as usize)
-            {
+            match $buffer.repeat_lookahead_prefetched(
+                $dict,
+                resolved_offset_v as usize,
+                seq_ml_v as usize,
+            ) {
                 Ok(()) => Ok(()),
                 Err(e) => Err(ExecuteSequencesError::from(e).into()),
             }
@@ -327,13 +331,14 @@ macro_rules! execute_one_body {
 /// `detect_cpu_kernel() == Avx2`.
 #[target_feature(enable = "bmi2,avx2")]
 #[allow(clippy::too_many_lines)]
-pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
+pub(crate) unsafe fn decode_and_execute_sequences_avx2<'fse, B: BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     let SeqStreamSetup {
         mut br,
@@ -344,7 +349,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
         old_buffer_size,
         num_sequences,
         use_long_pipeline,
-    } = init_sequence_stream::<B, Avx2Kernel>(section, source, fse, buffer)?;
+    } = init_sequence_stream::<B, Avx2Kernel>(section, source, fse, buffer, dict)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -412,6 +417,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
 
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
@@ -440,6 +446,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
                 let exec_seq = ring[slot];
                 let r = execute_one_body!(
                     buffer,
+                    dict,
                     literals_buffer,
                     &mut lit_cur,
                     literals_buffer_len,
@@ -476,6 +483,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_avx2<B: BufferBackend>(
             );
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,

--- a/zstd/src/decoding/seq_decoder_bmi2.rs
+++ b/zstd/src/decoding/seq_decoder_bmi2.rs
@@ -71,6 +71,7 @@ macro_rules! decode_one_body {
 macro_rules! execute_one_body {
     (
         $buffer:expr,
+        $dict:expr,
         $literals_buffer:expr,
         $lit_cur:expr,
         $literals_buffer_len:expr,
@@ -151,8 +152,11 @@ macro_rules! execute_one_body {
             if let Err(e) = $buffer.try_push(lits) {
                 break 'exec_inner Err(ExecuteSequencesError::from(e).into());
             }
-            match $buffer.repeat_lookahead_prefetched(resolved_offset_v as usize, seq_ml_v as usize)
-            {
+            match $buffer.repeat_lookahead_prefetched(
+                $dict,
+                resolved_offset_v as usize,
+                seq_ml_v as usize,
+            ) {
                 Ok(()) => Ok(()),
                 Err(e) => Err(ExecuteSequencesError::from(e).into()),
             }
@@ -167,13 +171,14 @@ macro_rules! execute_one_body {
 /// Caller must have verified BMI2 availability.
 #[target_feature(enable = "bmi2")]
 #[allow(clippy::too_many_lines)]
-pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
+pub(crate) unsafe fn decode_and_execute_sequences_bmi2<'fse, B: BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     let SeqStreamSetup {
         mut br,
@@ -184,7 +189,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
         old_buffer_size,
         num_sequences,
         use_long_pipeline,
-    } = init_sequence_stream::<B, Bmi2Kernel>(section, source, fse, buffer)?;
+    } = init_sequence_stream::<B, Bmi2Kernel>(section, source, fse, buffer, dict)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -250,6 +255,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
 
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
@@ -277,6 +283,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
                 let exec_seq = ring[slot];
                 let r = execute_one_body!(
                     buffer,
+                    dict,
                     literals_buffer,
                     &mut lit_cur,
                     literals_buffer_len,
@@ -307,6 +314,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_bmi2<B: BufferBackend>(
             let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,

--- a/zstd/src/decoding/seq_decoder_scalar.rs
+++ b/zstd/src/decoding/seq_decoder_scalar.rs
@@ -58,6 +58,7 @@ macro_rules! decode_one_body {
 macro_rules! execute_one_body {
     (
         $buffer:expr,
+        $dict:expr,
         $literals_buffer:expr,
         $lit_cur:expr,
         $literals_buffer_len:expr,
@@ -76,6 +77,7 @@ macro_rules! execute_one_body {
         };
         super::sequence_section_decoder::execute_one_sequence_pipelined(
             $buffer,
+            $dict,
             $literals_buffer,
             $lit_cur,
             $literals_buffer_len,
@@ -87,13 +89,14 @@ macro_rules! execute_one_body {
 
 /// Scalar-tier monolithic decode + execute.
 #[allow(clippy::too_many_lines)]
-pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
+pub(crate) fn decode_and_execute_sequences_scalar<'fse, B: BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     let SeqStreamSetup {
         mut br,
@@ -104,7 +107,7 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
         old_buffer_size,
         num_sequences,
         use_long_pipeline,
-    } = init_sequence_stream::<B, ScalarKernel>(section, source, fse, buffer)?;
+    } = init_sequence_stream::<B, ScalarKernel>(section, source, fse, buffer, dict)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -158,6 +161,7 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
 
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
@@ -185,6 +189,7 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
                 let exec_seq = ring[slot];
                 let r = execute_one_body!(
                     buffer,
+                    dict,
                     literals_buffer,
                     &mut lit_cur,
                     literals_buffer_len,
@@ -215,6 +220,7 @@ pub(crate) fn decode_and_execute_sequences_scalar<B: BufferBackend>(
             let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,

--- a/zstd/src/decoding/seq_decoder_vbmi2.rs
+++ b/zstd/src/decoding/seq_decoder_vbmi2.rs
@@ -67,6 +67,7 @@ macro_rules! decode_one_body {
 macro_rules! execute_one_body {
     (
         $buffer:expr,
+        $dict:expr,
         $literals_buffer:expr,
         $lit_cur:expr,
         $literals_buffer_len:expr,
@@ -147,8 +148,11 @@ macro_rules! execute_one_body {
             if let Err(e) = $buffer.try_push(lits) {
                 break 'exec_inner Err(ExecuteSequencesError::from(e).into());
             }
-            match $buffer.repeat_lookahead_prefetched(resolved_offset_v as usize, seq_ml_v as usize)
-            {
+            match $buffer.repeat_lookahead_prefetched(
+                $dict,
+                resolved_offset_v as usize,
+                seq_ml_v as usize,
+            ) {
                 Ok(()) => Ok(()),
                 Err(e) => Err(ExecuteSequencesError::from(e).into()),
             }
@@ -163,13 +167,14 @@ macro_rules! execute_one_body {
 /// Caller must have verified the full VBMI2 + AVX-512 + AVX2 + BMI2 set.
 #[target_feature(enable = "bmi2,avx2,avx512vbmi2,avx512f,avx512vl,avx512bw")]
 #[allow(clippy::too_many_lines)]
-pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
+pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<'fse, B: BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     let SeqStreamSetup {
         mut br,
@@ -180,7 +185,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
         old_buffer_size,
         num_sequences,
         use_long_pipeline,
-    } = init_sequence_stream::<B, Vbmi2Kernel>(section, source, fse, buffer)?;
+    } = init_sequence_stream::<B, Vbmi2Kernel>(section, source, fse, buffer, dict)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -246,6 +251,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
 
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
@@ -273,6 +279,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
                 let exec_seq = ring[slot];
                 let r = execute_one_body!(
                     buffer,
+                    dict,
                     literals_buffer,
                     &mut lit_cur,
                     literals_buffer_len,
@@ -303,6 +310,7 @@ pub(crate) unsafe fn decode_and_execute_sequences_vbmi2<B: BufferBackend>(
             let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             let r = execute_one_body!(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,

--- a/zstd/src/decoding/sequence_section_decoder.rs
+++ b/zstd/src/decoding/sequence_section_decoder.rs
@@ -95,6 +95,7 @@ pub(crate) fn init_sequence_stream<'src, 'fse, B, K>(
     source: &'src [u8],
     fse: &'fse mut FSEScratch,
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<SeqStreamSetup<'src, 'fse, K>, DecompressBlockError>
 where
     B: super::buffer_backend::BufferBackend,
@@ -135,9 +136,9 @@ where
     // resolve to the shared dictionary's table (zero-copy) on axes still
     // in `Dict` mode, else the locally-built table. `maybe_update_fse_tables`
     // above has already flipped any rebuilt axis to `Local`.
-    let mut ll_dec = SeqFSEDecoder::new(fse.ll_table());
-    let mut ml_dec = SeqFSEDecoder::new(fse.ml_table());
-    let mut of_dec = SeqFSEDecoder::new(fse.of_table());
+    let mut ll_dec = SeqFSEDecoder::new(fse.ll_table(dict));
+    let mut ml_dec = SeqFSEDecoder::new(fse.ml_table(dict));
+    let mut of_dec = SeqFSEDecoder::new(fse.of_table(dict));
 
     ll_dec
         .init_state(&mut br)
@@ -149,8 +150,9 @@ where
         .init_state(&mut br)
         .map_err(DecodeSequenceError::from)?;
 
-    let max_update_bits =
-        fse.ll_table().accuracy_log + fse.ml_table().accuracy_log + fse.of_table().accuracy_log;
+    let max_update_bits = fse.ll_table(dict).accuracy_log
+        + fse.ml_table(dict).accuracy_log
+        + fse.of_table(dict).accuracy_log;
     debug_assert!(
         max_update_bits <= 56,
         "sequence section update bits exceed 56-bit budget"
@@ -175,7 +177,10 @@ where
     // window_size plus a dict). The gate below asks "does history exceed
     // the prefetch threshold", so on the overflow path the clamped maximum
     // is the correct answer, not a wrapped small value.
-    let total_history = match buffer.window_size.checked_add(buffer.dict_content().len()) {
+    let total_history = match buffer
+        .window_size
+        .checked_add(buffer.dict_content(dict).len())
+    {
         Some(sum) => sum,
         None => usize::MAX,
     };
@@ -235,13 +240,14 @@ where
 /// instructions across the `K::mask_lower_bits` call boundary inside
 /// the impl body — otherwise the per-call target_feature boundary
 /// would keep a function-call trampoline at every BitReader op.
-pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
+pub fn decode_and_execute_sequences<'fse, B: super::buffer_backend::BufferBackend>(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     #[cfg(all(target_arch = "aarch64", feature = "kernel_neon"))]
     use crate::cpu_kernel::NeonKernel;
@@ -262,6 +268,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 buffer,
                 offset_hist,
                 literals_buffer,
+                dict,
             )
         }
         #[cfg(all(target_arch = "x86_64", feature = "kernel_sse2"))]
@@ -278,6 +285,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                 buffer,
                 offset_hist,
                 literals_buffer,
+                dict,
             )
         }
         #[cfg(all(target_arch = "x86_64", feature = "kernel_bmi2"))]
@@ -296,6 +304,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                     buffer,
                     offset_hist,
                     literals_buffer,
+                    dict,
                 )
             }
         }
@@ -310,6 +319,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                     buffer,
                     offset_hist,
                     literals_buffer,
+                    dict,
                 )
             }
         }
@@ -325,6 +335,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
                     buffer,
                     offset_hist,
                     literals_buffer,
+                    dict,
                 )
             }
         }
@@ -336,6 +347,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             buffer,
             offset_hist,
             literals_buffer,
+            dict,
         ),
         #[cfg(all(
             target_arch = "aarch64",
@@ -349,6 +361,7 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
             buffer,
             offset_hist,
             literals_buffer,
+            dict,
         ),
     }
 }
@@ -365,15 +378,17 @@ pub fn decode_and_execute_sequences<B: super::buffer_backend::BufferBackend>(
 // reachable per build configuration.
 #[allow(dead_code)]
 pub(crate) fn decode_and_execute_sequences_impl<
+    'fse,
     B: super::buffer_backend::BufferBackend,
     K: crate::cpu_kernel::CpuKernel,
 >(
     section: &SequencesHeader,
     source: &[u8],
-    fse: &mut FSEScratch,
+    fse: &'fse mut FSEScratch,
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
+    dict: Option<&'fse crate::decoding::dictionary::Dictionary>,
 ) -> Result<(), DecompressBlockError> {
     // Consume the one-shot `ddict_is_cold` flag at function entry,
     // BEFORE any early returns (padding-bit validation).
@@ -393,7 +408,7 @@ pub(crate) fn decode_and_execute_sequences_impl<
         old_buffer_size,
         num_sequences,
         use_long_pipeline,
-    } = init_sequence_stream::<B, K>(section, source, fse, buffer)?;
+    } = init_sequence_stream::<B, K>(section, source, fse, buffer, dict)?;
     let literals_buffer_len = literals_buffer.len();
     let mut lit_cur: usize = 0;
     let mut seq_sum: u32 = 0;
@@ -470,6 +485,7 @@ pub(crate) fn decode_and_execute_sequences_impl<
             &mut ml_dec,
             &mut of_dec,
             buffer,
+            dict,
             offset_hist,
             literals_buffer,
             &mut lit_cur,
@@ -530,6 +546,7 @@ pub(crate) fn decode_and_execute_sequences_impl<
             let resolved_offset = do_offset_history(seq.of, seq.ll, &mut shadow_hist);
             if let Err(e) = execute_one_sequence_pipelined(
                 buffer,
+                dict,
                 literals_buffer,
                 &mut lit_cur,
                 literals_buffer_len,
@@ -654,6 +671,7 @@ fn run_pipelined_sequence_loop<
     ml_dec: &mut SeqFSEDecoder<'_>,
     of_dec: &mut SeqFSEDecoder<'_>,
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     offset_hist: &mut [u32; 3],
     literals_buffer: &[u8],
     lit_cur: &mut usize,
@@ -726,6 +744,7 @@ fn run_pipelined_sequence_loop<
 
         execute_one_sequence_pipelined_resolved(
             buffer,
+            dict,
             literals_buffer,
             lit_cur,
             literals_buffer_len,
@@ -746,6 +765,7 @@ fn run_pipelined_sequence_loop<
         let exec_seq = ring[slot];
         execute_one_sequence_pipelined_resolved(
             buffer,
+            dict,
             literals_buffer,
             lit_cur,
             literals_buffer_len,
@@ -782,6 +802,7 @@ pub(crate) struct ExecSeq {
 #[allow(dead_code)] // live on aarch64 + tests only; see decode_and_execute_sequences_impl
 pub(crate) fn execute_one_sequence_pipelined_resolved<B: super::buffer_backend::BufferBackend>(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -789,6 +810,7 @@ pub(crate) fn execute_one_sequence_pipelined_resolved<B: super::buffer_backend::
 ) -> Result<(), DecompressBlockError> {
     execute_one_sequence_pipelined(
         buffer,
+        dict,
         literals,
         lit_cur,
         lit_len,
@@ -819,13 +841,22 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_bmi2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
     seq: Sequence,
     resolved_offset: u32,
 ) -> Result<(), DecompressBlockError> {
-    execute_one_sequence_pipelined(buffer, literals, lit_cur, lit_len, seq, resolved_offset)
+    execute_one_sequence_pipelined(
+        buffer,
+        dict,
+        literals,
+        lit_cur,
+        lit_len,
+        seq,
+        resolved_offset,
+    )
 }
 
 /// BMI2-tier ExecSeq-unpack wrapper. Delegates to safe K-agnostic
@@ -842,12 +873,13 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_bmi2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
     exec_seq: ExecSeq,
 ) -> Result<(), DecompressBlockError> {
-    execute_one_sequence_pipelined_resolved(buffer, literals, lit_cur, lit_len, exec_seq)
+    execute_one_sequence_pipelined_resolved(buffer, dict, literals, lit_cur, lit_len, exec_seq)
 }
 
 /// VBMI2-tier exec wrapper. Currently delegates via the AVX2 variant
@@ -867,6 +899,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_vbmi2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -878,6 +911,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_vbmi2<
     unsafe {
         execute_one_sequence_pipelined_avx2(
             buffer,
+            dict,
             literals,
             lit_cur,
             lit_len,
@@ -899,6 +933,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_vbmi2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -906,7 +941,9 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_vbmi2<
 ) -> Result<(), DecompressBlockError> {
     // SAFETY: VBMI2 ⊇ AVX2+BMI2.
     unsafe {
-        execute_one_sequence_pipelined_resolved_avx2(buffer, literals, lit_cur, lit_len, exec_seq)
+        execute_one_sequence_pipelined_resolved_avx2(
+            buffer, dict, literals, lit_cur, lit_len, exec_seq,
+        )
     }
 }
 
@@ -925,6 +962,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_avx2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -934,6 +972,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_avx2<
     unsafe {
         execute_one_sequence_pipelined_avx2(
             buffer,
+            dict,
             literals,
             lit_cur,
             lit_len,
@@ -961,6 +1000,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_resolved_avx2<
 #[allow(dead_code)] // live on aarch64 + tests only; see decode_and_execute_sequences_impl
 pub(crate) fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBackend>(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -1059,7 +1099,7 @@ pub(crate) fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBac
             // `repeat_from_dict` for these offsets.
             buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
             buffer
-                .repeat_lookahead_prefetched(offset, seq.ml as usize)
+                .repeat_lookahead_prefetched(dict, offset, seq.ml as usize)
                 .map_err(ExecuteSequencesError::from)?;
             return Ok(());
         }
@@ -1118,7 +1158,7 @@ pub(crate) fn execute_one_sequence_pipelined<B: super::buffer_backend::BufferBac
     // Fallback: the legacy push + repeat chain.
     buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
     buffer
-        .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
+        .repeat_lookahead_prefetched(dict, resolved_offset as usize, seq.ml as usize)
         .map_err(ExecuteSequencesError::from)?;
     Ok(())
 }
@@ -1142,6 +1182,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_avx2<
     B: super::buffer_backend::BufferBackend,
 >(
     buffer: &mut super::decode_buffer::DecodeBuffer<B>,
+    dict: Option<&crate::decoding::dictionary::Dictionary>,
     literals: &[u8],
     lit_cur: &mut usize,
     lit_len: usize,
@@ -1186,7 +1227,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_avx2<
         if prefix_end.is_none() {
             buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
             buffer
-                .repeat_lookahead_prefetched(offset, seq.ml as usize)
+                .repeat_lookahead_prefetched(dict, offset, seq.ml as usize)
                 .map_err(ExecuteSequencesError::from)?;
             return Ok(());
         }
@@ -1213,7 +1254,7 @@ pub(crate) unsafe fn execute_one_sequence_pipelined_avx2<
     // through the target_feature boundary). Same as the SSE2 default.
     buffer.try_push(lits).map_err(ExecuteSequencesError::from)?;
     buffer
-        .repeat_lookahead_prefetched(resolved_offset as usize, seq.ml as usize)
+        .repeat_lookahead_prefetched(dict, resolved_offset as usize, seq.ml as usize)
         .map_err(ExecuteSequencesError::from)?;
     Ok(())
 }

--- a/zstd/src/decoding/sequence_section_decoder/tests.rs
+++ b/zstd/src/decoding/sequence_section_decoder/tests.rs
@@ -344,6 +344,7 @@ mod init_sequence_stream_tests {
             &source,
             &mut fse,
             &mut buffer,
+            None,
         );
         assert!(
             matches!(
@@ -389,6 +390,7 @@ mod init_sequence_stream_tests {
             &mut buf,
             &mut offset_hist,
             &lits,
+            None,
         );
 
         let mut fse = FSEScratch::new();
@@ -401,6 +403,7 @@ mod init_sequence_stream_tests {
             &mut buf,
             &mut offset_hist,
             &lits,
+            None,
         );
     }
 
@@ -429,6 +432,7 @@ mod init_sequence_stream_tests {
                 &mut buf,
                 &mut offset_hist,
                 &lits,
+                None,
             )
         };
     }
@@ -458,6 +462,7 @@ mod init_sequence_stream_tests {
                 &mut buf,
                 &mut offset_hist,
                 &lits,
+                None,
             )
         };
     }
@@ -494,6 +499,7 @@ mod init_sequence_stream_tests {
                 &mut buf,
                 &mut offset_hist,
                 &lits,
+                None,
             )
         };
     }

--- a/zstd/src/encoding/hc/generator.rs
+++ b/zstd/src/encoding/hc/generator.rs
@@ -874,7 +874,12 @@ macro_rules! bt_insert_and_collect_matches_body {
         // `idx - dict_idx` (no upstream zstd `dmsIndexDelta`). The optimal parser
         // prices these (its DP lookahead values the repcode chain a dict match
         // seeds); the greedy/lazy parser commits the longest.
-        if let Some(dms) = $table.dms.table().filter(|_| compares_left > 0) {
+        // `is_primed()` is the canonical "DMS table is valid to walk" predicate
+        // (set only after a full build, cleared by `invalidate`): gate on it so
+        // a present-but-stale table is never descended. `is_primed()` implies
+        // the table exists (`mark_primed` requires `Some`), so `expect` holds.
+        if compares_left > 0 && $table.dms.is_primed() {
+            let dms = $table.dms.table().expect("is_primed() guarantees a DMS table");
             let region = $table.dms.region_len();
             let dh = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
                 concat,

--- a/zstd/src/encoding/hc/generator.rs
+++ b/zstd/src/encoding/hc/generator.rs
@@ -479,6 +479,10 @@ macro_rules! bt_insert_and_collect_matches_body {
         $min_match_len:ident,
         $best_len_for_skip:ident,
         $out:ident,
+        $reps:ident,
+        $lit_len:ident,
+        $use_hash3:expr,
+        $cpl:path,
         $cmf:path $(,)?
     ) => {{
         let idx = $abs_pos - $table.history_abs_start;
@@ -490,14 +494,157 @@ macro_rules! bt_insert_and_collect_matches_body {
             let lh = $table.live_history();
             core::slice::from_raw_parts(lh.as_ptr(), lh.len())
         };
-        if idx + 8 > concat.len() {
-            return;
-        }
         debug_assert!(
             $abs_pos <= $current_abs_end,
             "BT collect called past current block end"
         );
         let tail_limit = $current_abs_end - $abs_pos;
+        // ===== Merged rep-code + hash3 probes (reshape toward upstream
+        // ZSTD_btGetAllMatches: rep + hash3 + BT walk in ONE out-of-line frame).
+        // Folded here from the prior separate per-position calls in
+        // collect_optimal_candidates_initialized_body!. Probe order
+        // (rep -> hash3 -> BT walk) + best_len_for_skip seeding are byte-identical
+        // to the previous orchestration. Out-of-line keeps register pressure in
+        // this frame (inlining the same probes into the DP caller regressed). =====
+        let mut skip_further_match_search = false;
+        let mut rep_len_candidate_found = false;
+        if idx + 4 <= concat.len() {
+            let rep_offsets: [Option<usize>; 3] = if $lit_len == 0 {
+                [
+                    Some($reps[1] as usize),
+                    Some($reps[2] as usize),
+                    ($reps[0] > 1).then_some(($reps[0] - 1) as usize),
+                ]
+            } else {
+                [
+                    Some($reps[0] as usize),
+                    Some($reps[1] as usize),
+                    Some($reps[2] as usize),
+                ]
+            };
+            let rbase = concat.as_ptr();
+            let rlen = concat.len();
+            for rep in rep_offsets.into_iter().flatten() {
+                if rep == 0 || rep > $abs_pos {
+                    continue;
+                }
+                let candidate_pos = $abs_pos - rep;
+                if candidate_pos < $table.history_abs_start {
+                    continue;
+                }
+                let candidate_idx = candidate_pos - $table.history_abs_start;
+                // SAFETY: `idx + 4 <= rlen` (guard above) and `candidate_idx < idx`
+                // (rep >= 1), so both 4-byte reads stay inside `concat`.
+                let gate_matches = unsafe {
+                    let cand = rbase.add(candidate_idx).cast::<u32>().read_unaligned();
+                    let cur = rbase.add(idx).cast::<u32>().read_unaligned();
+                    if $min_match_len == 3 {
+                        (cand.to_le() & 0x00FF_FFFF) == (cur.to_le() & 0x00FF_FFFF)
+                    } else {
+                        cand == cur
+                    }
+                };
+                if !gate_matches {
+                    continue;
+                }
+                let rmax = (rlen - candidate_idx).min(rlen - idx).min(tail_limit);
+                // SAFETY: same umbrella; both pointers + `rmax` stay in `concat`.
+                let match_len = unsafe { $cpl(rbase.add(candidate_idx), rbase.add(idx), rmax) };
+                if match_len < $min_match_len {
+                    continue;
+                }
+                rep_len_candidate_found = true;
+                let _ = $crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                    $out,
+                    $best_len_for_skip,
+                    $crate::encoding::opt::types::MatchCandidate {
+                        start: $abs_pos,
+                        offset: rep,
+                        match_len,
+                    },
+                    $min_match_len,
+                );
+                if match_len > $profile.sufficient_match_len
+                    || $abs_pos + match_len >= $current_abs_end
+                {
+                    skip_further_match_search = true;
+                }
+            }
+        }
+        if $use_hash3 && !skip_further_match_search && *$best_len_for_skip < $min_match_len {
+            $table.update_hash3_until($abs_pos);
+            // hash3 short-match probe folded inline (was a separate per-kernel
+            // call): table lookup + one common-prefix scan via `$cpl`, reusing
+            // the BT collect's `concat` / `idx` / `tail_limit`. Labeled block so
+            // the probe's early-outs yield None without returning from the walk.
+            let h3_candidate: Option<$crate::encoding::opt::types::MatchCandidate> =
+                if $table.hash3_log == 0 || idx + 4 > concat.len() {
+                    None
+                } else {
+                    'h3: {
+                        let hh =
+                            $crate::encoding::match_table::storage::MatchTable::hash_position_at(
+                                concat,
+                                idx,
+                                $table.hash3_log,
+                                3,
+                            );
+                        let entry = $table
+                            .hash3_table
+                            .get(hh)
+                            .copied()
+                            .unwrap_or($crate::encoding::match_table::storage::HC_EMPTY);
+                        let Some(cand_abs) =
+                            $crate::encoding::match_table::storage::MatchTable::stored_abs_position_fast(
+                                entry,
+                                $table.position_base,
+                                $table.index_shift,
+                            )
+                        else {
+                            break 'h3 None;
+                        };
+                        if cand_abs < $table.history_abs_start || cand_abs >= $abs_pos {
+                            break 'h3 None;
+                        }
+                        let off = $abs_pos - cand_abs;
+                        if off >= $crate::encoding::bt::HC3_MAX_OFFSET {
+                            break 'h3 None;
+                        }
+                        let cand_idx = cand_abs - $table.history_abs_start;
+                        let hbase = concat.as_ptr();
+                        // SAFETY: cand_idx/idx within history; tail_limit bounds the scan.
+                        let ml = unsafe { $cpl(hbase.add(cand_idx), hbase.add(idx), tail_limit) };
+                        (ml >= $min_match_len).then_some(
+                            $crate::encoding::opt::types::MatchCandidate {
+                                start: $abs_pos,
+                                offset: off,
+                                match_len: ml,
+                            },
+                        )
+                    }
+                };
+            if let Some(h3) = h3_candidate {
+                let _ = $crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                    $out,
+                    $best_len_for_skip,
+                    h3,
+                    $min_match_len,
+                );
+                if !rep_len_candidate_found
+                    && (h3.match_len > $profile.sufficient_match_len
+                        || $abs_pos + h3.match_len >= $current_abs_end)
+                {
+                    $table.skip_insert_until_abs = $abs_pos + 1;
+                    skip_further_match_search = true;
+                }
+            }
+        }
+        if skip_further_match_search {
+            return;
+        }
+        if idx + 8 > concat.len() {
+            return;
+        }
         let hash = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
             concat,
             idx,
@@ -727,7 +874,7 @@ macro_rules! bt_insert_and_collect_matches_body {
         // `idx - dict_idx` (no upstream zstd `dmsIndexDelta`). The optimal parser
         // prices these (its DP lookahead values the repcode chain a dict match
         // seeds); the greedy/lazy parser commits the longest.
-        if let Some(dms) = $table.dms.table() {
+        if let Some(dms) = $table.dms.table().filter(|_| compares_left > 0) {
             let region = $table.dms.region_len();
             let dh = $crate::encoding::match_table::storage::MatchTable::hash_position_at(
                 concat,
@@ -740,14 +887,19 @@ macro_rules! bt_insert_and_collect_matches_body {
             // `$cmf` resumes from there (upstream zstd commonLengthSmaller/Larger).
             let mut common_smaller = 0usize;
             let mut common_larger = 0usize;
-            let mut dms_compares = $profile.max_chain_depth.min($search_depth);
-            while dms_compares > 0 && dcur != $crate::encoding::match_table::storage::HC_EMPTY {
+            // Shared compare budget (upstream zstd zstd_opt.c:723/781/786): the
+            // dict DUBT descent consumes the SAME `compares_left` the live BT
+            // walk left over (and is skipped entirely once it is zero, via the
+            // `.filter(|_| compares_left > 0)` on the dict table above), instead
+            // of getting a fresh full budget. On a match-dense / populated live
+            // tree this cuts the cold dict-region descent the way C does.
+            while compares_left > 0 && dcur != $crate::encoding::match_table::storage::HC_EMPTY {
                 let dict_idx = (dcur - 1) as usize;
                 // The dict tree holds only dict positions (`< region <= idx`).
                 if dict_idx >= region || dict_idx >= idx {
                     break;
                 }
-                dms_compares -= 1;
+                compares_left -= 1;
                 let pair = 2 * dict_idx;
                 let seed = common_smaller.min(common_larger);
                 // SAFETY: `dict_idx < idx` and `idx + tail_limit <=

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -791,8 +791,8 @@ impl HcMatcher {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match table.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.for_each_repcode_candidate_with_reps_avx2_bmi2(
                         table,

--- a/zstd/src/encoding/hc/optimal.rs
+++ b/zstd/src/encoding/hc/optimal.rs
@@ -279,6 +279,7 @@ macro_rules! build_optimal_plan_impl_body {
         $initial_state:ident,
         $stats:ident,
         $out:ident,
+        $buffers:expr,
         $collect:ident,
         $priceset:path $(,)?
     ) => {{
@@ -309,104 +310,49 @@ macro_rules! build_optimal_plan_impl_body {
         let abort_on_worse_match: bool =
             <$strategy_ty as crate::encoding::strategy::Strategy>::OPT_LEVEL == 0;
         let opt_level: bool = <$strategy_ty as crate::encoding::strategy::Strategy>::OPT_LEVEL >= 2;
-        let mut nodes = core::mem::take(&mut $self.backend.bt_mut().opt_nodes_scratch);
-        let mut node_prices = core::mem::take(&mut $self.backend.bt_mut().opt_node_prices_scratch);
         // `frontier_limit + 2 <= HC_OPT_NODE_LEN` — bounded by const.
         let frontier_buffer_size = frontier_limit + 2;
-        if nodes.len() < HC_OPT_NODE_LEN {
-            // First optimal-parse use (empty boxed slice) or an undersized
-            // buffer: allocate the fixed upstream-zstd-sized frontier once. The DP
-            // overwrites the active prefix before reading it.
-            nodes = alloc::vec![HcOptimalNode::default(); HC_OPT_NODE_LEN].into_boxed_slice();
-        }
-        // The DP price array, same fixed length as `nodes`. This is the SOLE
-        // home of each position's price (the node struct carries no price), so
-        // the SIMD price-set vector-loads it directly. Initialised to u32::MAX
-        // so unwritten frontier cells compare as "unreachable".
-        if node_prices.len() < HC_OPT_NODE_LEN {
-            node_prices = alloc::vec![u32::MAX; HC_OPT_NODE_LEN].into_boxed_slice();
-        }
-        let mut candidates = core::mem::take(&mut $self.backend.bt_mut().opt_candidates_scratch);
+        // The five DP scratch buffers are owned one level up
+        // (`start_matching_optimal` / `run_btultra2_seed_pass` take them once per
+        // block via `take_optimal_plan_buffers`, size them, and reuse them across
+        // every per-segment call, then restore them once). Borrow the fields here
+        // and reset the per-call ones. Hoisting the take/restore out of this
+        // per-segment body removes five `mem::take`s plus five restores per call,
+        // which on near-random input runs once per literal.
+        let HcOptimalPlanBuffers {
+            nodes,
+            node_prices,
+            candidates,
+            store,
+            price_arena,
+        } = &mut *$buffers;
         candidates.clear();
-        if candidates.capacity() < MAX_HC_SEARCH_DEPTH {
-            candidates.reserve_exact(MAX_HC_SEARCH_DEPTH - candidates.capacity());
-        }
-        let mut store = core::mem::take(&mut $self.backend.bt_mut().opt_store_scratch);
         store.clear();
-        let mut price_arena = core::mem::take(&mut $self.backend.bt_mut().opt_price_arena);
-        if price_arena.len() < HC_OPT_PRICE_ARENA_LEN {
-            price_arena = alloc::vec![[0u32; 2]; HC_OPT_PRICE_ARENA_LEN].into_boxed_slice();
-        }
-        // Single arena → two disjoint fixed-stride regions of `[price,
-        // generation]` pairs (LL cache, ML cache): one base pointer + fixed
-        // offsets, mirroring upstream zstd's single opt workspace. Pairing
-        // price+generation per code keeps the optimal parser's cache probe
-        // on ONE line instead of two strided regions.
-        // SAFETY: `price_arena` is exactly `HC_OPT_PRICE_ARENA_LEN =
-        // 2 * HC_OPT_PRICE_STRIDE` pairs long (just ensured), so the two
-        // STRIDE-wide regions are in bounds and disjoint. The slices alias
-        // the heap buffer `price_arena` owns; that heap address is stable
-        // across the later move of the `price_arena` box into the result
-        // bundle (a `Box` move relocates only the pointer, not the heap
-        // data), and the slices are never used after the bundle is
-        // constructed. The fixed STRIDE (independent of `frontier_limit`)
-        // keeps every code's cell at a constant offset so the monotonic
-        // stamps stay valid across calls with different frontiers.
-        let arena_base = price_arena.as_mut_ptr();
-        let mut ll_cache: &mut [[u32; 2]] =
-            unsafe { core::slice::from_raw_parts_mut(arena_base, HC_OPT_PRICE_STRIDE) };
-        let mut ml_cache: &mut [[u32; 2]] = unsafe {
-            core::slice::from_raw_parts_mut(arena_base.add(HC_OPT_PRICE_STRIDE), HC_OPT_PRICE_STRIDE)
-        };
-        $self.backend.bt_mut().opt_ll_price_stamp = $self
-            .backend
-            .bt_mut()
-            .opt_ll_price_stamp
-            .wrapping_add(1)
-            .max(1);
-        let ll_price_stamp = $self.backend.bt_mut().opt_ll_price_stamp;
-        $self.backend.bt_mut().opt_lit_price_stamp = $self
-            .backend
-            .bt_mut()
-            .opt_lit_price_stamp
-            .wrapping_add(1)
-            .max(1);
-        let lit_price_stamp = $self.backend.bt_mut().opt_lit_price_stamp;
-        $self.backend.bt_mut().opt_ml_price_stamp = $self
-            .backend
-            .bt_mut()
-            .opt_ml_price_stamp
-            .wrapping_add(1)
-            .max(1);
-        let ml_price_stamp = $self.backend.bt_mut().opt_ml_price_stamp;
-        let node0_price = BtMatcher::cached_lit_length_price(
-            profile,
-            $stats,
-            initial_litlen,
-            &mut ll_cache,
-            ll_price_stamp,
-        );
-        nodes[0] = HcOptimalNode {
-            litlen: initial_litlen as u32,
-            reps: initial_reps,
-            ..HcOptimalNode::default()
-        };
-        node_prices[0] = node0_price;
+        // Price-cache slices + monotonic stamps feed ONLY the priced paths (the
+        // matched-seed block and the forward DP loop), both of which run only
+        // when the seed found a candidate. On a no-match seed (the per-literal
+        // case that dominates near-random input, where the forward loop is
+        // skipped) they are never touched, so their setup (the arena slice
+        // creation and the three stamp bumps) is deferred into the
+        // `!candidates.is_empty()` block below. Declared here so they stay in
+        // scope for the forward DP loop; the empty slices / zero stamps are
+        // never read on the no-match path.
+        let mut ll_cache: &mut [[u32; 2]] = &mut [];
+        let mut ml_cache: &mut [[u32; 2]] = &mut [];
+        let mut ll_price_stamp = 0u32;
+        let mut lit_price_stamp = 0u32;
+        let mut ml_price_stamp = 0u32;
         let sufficient_len = profile.sufficient_match_len;
-        let ll0_price = BtMatcher::cached_lit_length_price(
-            profile,
-            $stats,
-            0,
-            &mut ll_cache,
-            ll_price_stamp,
-        );
-        let ll1_price = BtMatcher::cached_lit_length_price(
-            profile,
-            $stats,
-            1,
-            &mut ll_cache,
-            ll_price_stamp,
-        );
+        // `node0_price` / `ll0_price` / `ll1_price` (and the `nodes[0]` base node)
+        // feed ONLY the forward-DP and seed paths below, which run only when the
+        // seed found a candidate. On a no-match seed — the per-literal case that
+        // dominates incompressible / near-random input — they are never read, so
+        // defer the three cached price lookups + base-node init until a candidate
+        // is confirmed (mirrors upstream zstd doing the literal `ip++` without
+        // touching the DP price state). Initialised to 0; assigned in the
+        // `!candidates.is_empty()` block before any reader.
+        let mut ll0_price = 0u32;
+        let mut ll1_price = 0u32;
         let mut pos = 1usize;
         let mut last_pos = 0usize;
         let mut forced_end: Option<usize> = None;
@@ -415,16 +361,23 @@ macro_rules! build_optimal_plan_impl_body {
         // node struct; tracked alongside the forced-seed node).
         let mut forced_end_price: Option<u32> = None;
         let mut seed_forced_shortest_path = false;
-        let mut opt_ldm = HcOptLdmState {
-            seq_store: HcRawSeqStore {
-                pos: 0,
-                pos_in_sequence: 0,
-                size: $self.backend.bt_mut().ldm_sequences.len(),
-            },
-            ..HcOptLdmState::default()
+        // LDM presence is a frame constant (decided before entering the DP), so
+        // it is a const-generic monomorph here, not a hot-loop runtime check:
+        // with HAS_LDM == false every LDM branch below const-folds away and the
+        // opt_ldm workspace is never built.
+        let mut opt_ldm = if HAS_LDM {
+            HcOptLdmState {
+                seq_store: HcRawSeqStore {
+                    pos: 0,
+                    pos_in_sequence: 0,
+                    size: $self.backend.bt_mut().ldm_sequences.len(),
+                },
+                ..HcOptLdmState::default()
+            }
+        } else {
+            HcOptLdmState::default()
         };
-        let has_ldm = !$self.backend.bt_mut().ldm_sequences.is_empty();
-        if has_ldm {
+        if HAS_LDM {
             // `ldm_sequences` are emitted in BLOCK-relative coordinates,
             // but this optimal-parser pass runs over a SEGMENT of the
             // block starting at block-offset `$block_offset` and uses
@@ -451,7 +404,7 @@ macro_rules! build_optimal_plan_impl_body {
         // Upstream zstd-like seed at rPos=0: initialize frontier with matches starting
         // at current position before entering the generic forward DP loop.
         if $current_len >= min_match_len {
-            let seed_ldm = if has_ldm {
+            let seed_ldm = if HAS_LDM {
                 $self.backend.bt_mut().ldm_process_match_candidate(
                     &mut opt_ldm,
                     0,
@@ -475,10 +428,66 @@ macro_rules! build_optimal_plan_impl_body {
                         lit_len: initial_litlen,
                         ldm_candidate: seed_ldm,
                     },
-                    &mut candidates,
+                    &mut *candidates,
                 )
             };
             if !candidates.is_empty() {
+                // Deferred price-cache setup: the arena slices are two disjoint
+                // STRIDE-wide regions of `price_arena` (LL, ML); the fixed STRIDE
+                // keeps each code's cell at a constant offset so the monotonic
+                // stamps stay valid across calls. price_arena is exactly
+                // HC_OPT_PRICE_ARENA_LEN = 2 * HC_OPT_PRICE_STRIDE pairs (sized by
+                // take_optimal_plan_buffers).
+                // SAFETY: the two STRIDE regions are in bounds and disjoint; the
+                // raw slices are confined to this priced path and never outlive
+                // `price_arena` (owned by the caller for the whole call).
+                let arena_base = price_arena.as_mut_ptr();
+                ll_cache =
+                    unsafe { core::slice::from_raw_parts_mut(arena_base, HC_OPT_PRICE_STRIDE) };
+                ml_cache = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        arena_base.add(HC_OPT_PRICE_STRIDE),
+                        HC_OPT_PRICE_STRIDE,
+                    )
+                };
+                $self.backend.bt_mut().opt_ll_price_stamp =
+                    $self.backend.bt_mut().opt_ll_price_stamp.wrapping_add(1).max(1);
+                ll_price_stamp = $self.backend.bt_mut().opt_ll_price_stamp;
+                $self.backend.bt_mut().opt_lit_price_stamp =
+                    $self.backend.bt_mut().opt_lit_price_stamp.wrapping_add(1).max(1);
+                lit_price_stamp = $self.backend.bt_mut().opt_lit_price_stamp;
+                $self.backend.bt_mut().opt_ml_price_stamp =
+                    $self.backend.bt_mut().opt_ml_price_stamp.wrapping_add(1).max(1);
+                ml_price_stamp = $self.backend.bt_mut().opt_ml_price_stamp;
+                // Deferred base/seed prices: only reached on a matched seed (see
+                // the declarations above). Assign before the forward DP / seed
+                // paths below read them.
+                node_prices[0] = BtMatcher::cached_lit_length_price(
+                    profile,
+                    $stats,
+                    initial_litlen,
+                    &mut ll_cache,
+                    ll_price_stamp,
+                );
+                nodes[0] = HcOptimalNode {
+                    litlen: initial_litlen as u32,
+                    reps: initial_reps,
+                    ..HcOptimalNode::default()
+                };
+                ll0_price = BtMatcher::cached_lit_length_price(
+                    profile,
+                    $stats,
+                    0,
+                    &mut ll_cache,
+                    ll_price_stamp,
+                );
+                ll1_price = BtMatcher::cached_lit_length_price(
+                    profile,
+                    $stats,
+                    1,
+                    &mut ll_cache,
+                    ll_price_stamp,
+                );
                 // `min_match_len >= HC_FORMAT_MINMATCH (3)` by invariant.
                 last_pos = (min_match_len - 1).min(frontier_limit);
                 for p in 1..min_match_len.min(frontier_buffer_size) {
@@ -554,8 +563,8 @@ macro_rules! build_optimal_plan_impl_body {
                     }
                     if max_match_len > last_pos {
                         BtMatcher::reset_opt_nodes(
-                            &mut nodes,
-                            &mut node_prices,
+                            &mut *nodes,
+                            &mut *node_prices,
                             last_pos + 1,
                             max_match_len,
                         );
@@ -751,7 +760,7 @@ macro_rules! build_optimal_plan_impl_body {
             }
 
             let abs_pos = $current_abs_start + pos;
-            let ldm_candidate = if has_ldm {
+            let ldm_candidate = if HAS_LDM {
                 $self.backend.bt_mut().ldm_process_match_candidate(
                     &mut opt_ldm,
                     pos,
@@ -776,7 +785,7 @@ macro_rules! build_optimal_plan_impl_body {
                         lit_len: nodes.get_unchecked(pos).litlen as usize,
                         ldm_candidate,
                     },
-                    &mut candidates,
+                    &mut *candidates,
                 )
             };
             // Post-call reads of opt[cur]: fresh, born after `$collect`, so
@@ -844,8 +853,8 @@ macro_rules! build_optimal_plan_impl_body {
                 let max_next = pos + max_match_len;
                 if max_next > last_pos {
                     BtMatcher::reset_opt_nodes(
-                        &mut nodes,
-                        &mut node_prices,
+                        &mut *nodes,
+                        &mut *node_prices,
                         last_pos + 1,
                         max_next,
                     );
@@ -905,8 +914,8 @@ macro_rules! build_optimal_plan_impl_body {
                     {
                         last_pos = last_pos.max(unsafe {
                             $priceset(
-                                &mut node_prices,
-                                &mut nodes,
+                                &mut *node_prices,
+                                &mut *nodes,
                                 ml_cache,
                                 ml_price_stamp,
                                 profile,
@@ -937,56 +946,25 @@ macro_rules! build_optimal_plan_impl_body {
 
         if last_pos == 0 {
             if $current_len == 0 {
-                let price = node_prices[0];
-                return $self.backend.bt_mut().finish_optimal_plan(
-                    HcOptimalPlanBuffers {
-                        nodes,
-                        node_prices,
-                        candidates,
-                        store,
-                        price_arena,
-                    },
-                    (price, initial_reps, initial_litlen, 0),
-                );
+                let price = 0u32; // deferred: node_prices[0] unset on no-match; caller discards price
+                return (price, initial_reps, initial_litlen, 0);
             }
-            let lit_price = {
-                let bt = $self.backend.bt_mut();
-                BtMatcher::cached_literal_price(
-                    profile,
-                    $stats,
-                    $current[0],
-                    &mut bt.opt_lit_price_scratch,
-                    &mut bt.opt_lit_price_generation,
-                    lit_price_stamp,
-                )
-            };
-            // `initial_litlen` is carried across optimal-plan segments;
-            // its real bound is the current block length, not
-            // `current_len`. On i686 (32-bit `usize`) `+ 1` could
-            // theoretically wrap if the invariant ever broke. Catch
-            // that explicitly via `checked_add` rather than letting a
-            // wrapping sum slip into the price lookup.
+            // No match at this position: it is a single literal (upstream zstd
+            // `ZSTD_compressBlock_opt_generic` `if (!nbMatches) { ip++; }`). The
+            // previous code recomputed a literal+length price here purely to fill
+            // the returned price slot — which the per-segment caller discards
+            // (`let (_, ..)`). Skip that recompute: on near-random input this
+            // no-match return runs once per literal, so the two cached price
+            // lookups were pure waste. Byte-identical — the tree, the carried
+            // litlen (+1), and the reps are unchanged; only the discarded price
+            // value differs (now the base-literal node price).
             let next_litlen = initial_litlen
                 .checked_add(1)
                 .expect("optimal parser next litlen out of usize range");
-            let ll_delta = BtMatcher::cached_lit_length_delta_price(
-                profile,
-                $stats,
-                next_litlen,
-                &mut ll_cache,
-                ll_price_stamp,
-            );
-            let price = BtMatcher::add_price_delta(node_prices[0], lit_price, ll_delta);
-            return $self.backend.bt_mut().finish_optimal_plan(
-                HcOptimalPlanBuffers {
-                    nodes,
-                    node_prices,
-                    candidates,
-                    store,
-                    price_arena,
-                },
-                (price, initial_reps, next_litlen, 1),
-            );
+            // node_prices[0] is unset on a no-match seed (deferred); the caller
+            // discards this price anyway.
+            let price = 0u32;
+            return (price, initial_reps, next_litlen, 1);
         }
 
         let target_pos = forced_end.unwrap_or(last_pos.min(frontier_limit));
@@ -999,33 +977,15 @@ macro_rules! build_optimal_plan_impl_body {
             (nodes[target_pos], node_prices[target_pos])
         };
         if last_stretch_price == u32::MAX {
-            return $self.backend.bt_mut().finish_optimal_plan(
-                HcOptimalPlanBuffers {
-                    nodes,
-                    node_prices,
-                    candidates,
-                    store,
-                    price_arena,
-                },
-                (u32::MAX, initial_reps, initial_litlen, $current_len),
-            );
+            return (u32::MAX, initial_reps, initial_litlen, $current_len);
         }
 
         if last_stretch.mlen == 0 {
-            return $self.backend.bt_mut().finish_optimal_plan(
-                HcOptimalPlanBuffers {
-                    nodes,
-                    node_prices,
-                    candidates,
-                    store,
-                    price_arena,
-                },
-                (
-                    last_stretch_price,
-                    last_stretch.reps,
-                    last_stretch.litlen as usize,
-                    target_pos.min($current_len),
-                ),
+            return (
+                last_stretch_price,
+                last_stretch.reps,
+                last_stretch.litlen as usize,
+                target_pos.min($current_len),
             );
         }
 
@@ -1041,20 +1001,11 @@ macro_rules! build_optimal_plan_impl_body {
         } else {
             let tail_literals = last_stretch.litlen as usize;
             if cur < tail_literals {
-                return $self.backend.bt_mut().finish_optimal_plan(
-                    HcOptimalPlanBuffers {
-                        nodes,
-                        node_prices,
-                        candidates,
-                        store,
-                        price_arena,
-                    },
-                    (
-                        last_stretch_price,
-                        last_stretch.reps,
-                        tail_literals,
-                        target_pos.min($current_len),
-                    ),
+                return (
+                    last_stretch_price,
+                    last_stretch.reps,
+                    tail_literals,
+                    target_pos.min($current_len),
                 );
             }
             cur -= tail_literals;
@@ -1135,16 +1086,7 @@ macro_rules! build_optimal_plan_impl_body {
             },
             target_pos.min($current_len),
         );
-        $self.backend.bt_mut().finish_optimal_plan(
-            HcOptimalPlanBuffers {
-                nodes,
-                node_prices,
-                candidates,
-                store,
-                price_arena,
-            },
-            result,
-        )
+        result
     }};
 }
 
@@ -1166,11 +1108,12 @@ macro_rules! collect_optimal_candidates_initialized_body {
         $query:ident,
         $out:ident,
         $bt_matchfinder:ident,
-        $bt_update:ident,
+        $bt_insert_step:ident,
         $bt_insert:ident,
         $for_each_rep:ident,
         $hash3:ident,
-        $cpl:path $(,)?
+        $cpl:path,
+        $cmf:path $(,)?
     ) => {{
         // Per-strategy compile-time const: only BtUltra2 drives the
         // hash3 short-match table. All other monomorphisations drop
@@ -1206,9 +1149,33 @@ macro_rules! collect_optimal_candidates_initialized_body {
             return;
         }
         if $bt_matchfinder {
+            // BT tree catch-up folded inline (was a per-position call to
+            // bt_update_tree_until): insert the positions the parser skipped into
+            // the binary tree before this position's search. Upstream zstd
+            // ZSTD_updateTree shape; `$bt_insert_step` overshoots the target with
+            // no clamp (forward skips match-covered positions), exactly as C.
             // SAFETY: caller is in the same target_feature umbrella as
-            // `$bt_update`; the runtime kernel detector already gated entry.
-            unsafe { $self.table.$bt_update($abs_pos, $current_abs_end) };
+            // `$bt_insert_step`; the runtime kernel detector already gated entry.
+            if $self.table.skip_insert_until_abs < $self.table.history_abs_start {
+                $self.table.skip_insert_until_abs = $self.table.history_abs_start;
+            }
+            let mut update_abs = $self.table.skip_insert_until_abs;
+            let is_btultra2 = $self.table.is_btultra2;
+            while update_abs < $abs_pos {
+                if !$self
+                    .table
+                    .can_skip_rebase_check_at(update_abs, $abs_pos, is_btultra2)
+                {
+                    $self.table.maybe_rebase_positions(update_abs);
+                }
+                let forward = unsafe {
+                    $self
+                        .table
+                        .$bt_insert_step(update_abs, $current_abs_end, $abs_pos)
+                };
+                update_abs += forward.max(1);
+            }
+            $self.table.skip_insert_until_abs = $abs_pos;
         }
         let current_idx = $abs_pos - $self.table.history_abs_start;
         if current_idx + 4 > $self.table.live_history().len() {
@@ -1224,147 +1191,159 @@ macro_rules! collect_optimal_candidates_initialized_body {
             return;
         }
         let mut best_len_for_skip = 0usize;
-        let mut skip_further_match_search = false;
-        let mut rep_len_candidate_found = false;
-        // SAFETY: same umbrella; closure capture is monomorphized per call.
-        unsafe {
-            $self.hc.$for_each_rep(
-                &$self.table,
+        if $bt_matchfinder {
+            // BT path: the rep-code probe and the hash3 short-match probe are
+            // folded INTO bt_insert_and_collect (one out-of-line per-position
+            // match-finder, upstream ZSTD_btGetAllMatches shape). They seed
+            // `best_len_for_skip` and handle the sufficient-match early-out
+            // internally, byte-identically to the prior orchestration.
+            // SAFETY: same umbrella for bt_insert_and_collect_matches.
+            // Inline the BT find monolith here instead of an out-of-line call.
+            // Upstream's ZSTD_insertBtAndGetAllMatches is FORCE_INLINE_TEMPLATE
+            // inlined into the opt loop, so the per-position match-finder is one
+            // body with no call-boundary marshalling (profile / reps / ...).
+            let bt_search_depth = $self.table.search_depth;
+            let best_len_ref = &mut best_len_for_skip;
+            crate::encoding::hc::generator::bt_insert_and_collect_matches_body!(
+                $self.table,
+                bt_search_depth,
                 $abs_pos,
-                lit_len,
-                reps,
                 $current_abs_end,
+                $profile,
                 min_match_len,
-                |rep| {
-                    if rep.match_len >= min_match_len {
-                        rep_len_candidate_found = true;
-                    }
+                best_len_ref,
+                $out,
+                reps,
+                lit_len,
+                use_hash3,
+                $cpl,
+                $cmf,
+            );
+        } else {
+            // HC-chain optimal fallback (no BT tree): the rep + hash3 probes
+            // stay inline here, ahead of the chain walk.
+            let mut skip_further_match_search = false;
+            let mut rep_len_candidate_found = false;
+            // SAFETY: same umbrella; closure capture is monomorphized per call.
+            unsafe {
+                $self.hc.$for_each_rep(
+                    &$self.table,
+                    $abs_pos,
+                    lit_len,
+                    reps,
+                    $current_abs_end,
+                    min_match_len,
+                    |rep| {
+                        if rep.match_len >= min_match_len {
+                            rep_len_candidate_found = true;
+                        }
+                        let _ = crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                            $out,
+                            &mut best_len_for_skip,
+                            rep,
+                            min_match_len,
+                        );
+                        if rep.match_len > $profile.sufficient_match_len {
+                            skip_further_match_search = true;
+                        }
+                        if $abs_pos + rep.match_len >= $current_abs_end {
+                            skip_further_match_search = true;
+                        }
+                    },
+                )
+            };
+            if use_hash3 && !skip_further_match_search && best_len_for_skip < min_match_len {
+                $self.table.update_hash3_until($abs_pos);
+                // SAFETY: same umbrella for hash3_candidate.
+                if let Some(h3) = unsafe {
+                    $self
+                        .table
+                        .$hash3($abs_pos, $current_abs_end, min_match_len)
+                } {
                     let _ = crate::encoding::bt::BtMatcher::push_candidate_ladder(
                         $out,
                         &mut best_len_for_skip,
-                        rep,
+                        h3,
                         min_match_len,
                     );
-                    if rep.match_len > $profile.sufficient_match_len {
+                    if !rep_len_candidate_found
+                        && (h3.match_len > $profile.sufficient_match_len
+                            || $abs_pos + h3.match_len >= $current_abs_end)
+                    {
+                        $self.table.skip_insert_until_abs = $abs_pos + 1;
                         skip_further_match_search = true;
                     }
-                    // `for_each_repcode_candidate_with_reps` caps
-                    // `rep.match_len` at the per-call `tail_limit =
-                    // current_abs_end - abs_pos`, so `abs_pos +
-                    // rep.match_len <= current_abs_end`. The raw sum
-                    // therefore stays in `usize` on every supported
-                    // target.
-                    if $abs_pos + rep.match_len >= $current_abs_end {
-                        skip_further_match_search = true;
-                    }
-                },
-            )
-        };
-        // Hash3 lookup runs only when the strategy enables it. The
-        // `use_hash3` binding above is a per-monomorphisation const,
-        // so non-BtUltra2 instances drop this entire block.
-        if use_hash3 && !skip_further_match_search && best_len_for_skip < min_match_len {
-            $self.table.update_hash3_until($abs_pos);
-            // SAFETY: same umbrella for hash3_candidate.
-            if let Some(h3) = unsafe {
-                $self
-                    .table
-                    .$hash3($abs_pos, $current_abs_end, min_match_len)
-            } {
-                let _ = crate::encoding::bt::BtMatcher::push_candidate_ladder(
-                    $out,
-                    &mut best_len_for_skip,
-                    h3,
-                    min_match_len,
-                );
-                if !rep_len_candidate_found
-                    && (h3.match_len > $profile.sufficient_match_len
-                        || $abs_pos + h3.match_len >= $current_abs_end)
-                {
-                    $self.table.skip_insert_until_abs = $abs_pos + 1;
-                    skip_further_match_search = true;
                 }
             }
-        }
-        if !skip_further_match_search && $bt_matchfinder {
-            // SAFETY: same umbrella for bt_insert_and_collect_matches.
-            unsafe {
-                $self.table.$bt_insert(
-                    $abs_pos,
-                    $current_abs_end,
-                    $profile,
-                    min_match_len,
-                    &mut best_len_for_skip,
-                    $out,
-                )
-            };
-        } else if !skip_further_match_search {
-            $self.table.insert_position($abs_pos);
-            let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
-            let concat = $self.table.live_history();
-            // Raw `+ 9` is safe here — see `bt_insert_step_no_rebase_body!`
-            // for the full discussion of the upstream `STREAM_ABS_HEADROOM`
-            // cap in `MatchTable::add_data`.
-            let mut match_end_abs = $abs_pos + 9;
-            if max_chain_depth > 0 {
-                for (visited, candidate_abs) in $self
-                    .hc
-                    .chain_candidates(&$self.table, $abs_pos)
-                    .into_iter()
-                    .enumerate()
-                {
-                    if visited >= max_chain_depth {
-                        break;
-                    }
-                    if candidate_abs == usize::MAX {
-                        break;
-                    }
-                    if candidate_abs < $self.table.window_low_abs_for_target($abs_pos)
-                        || candidate_abs >= $abs_pos
+            if !skip_further_match_search {
+                $self.table.insert_position($abs_pos);
+                let max_chain_depth = $profile.max_chain_depth.min($self.hc.search_depth);
+                let concat = $self.table.live_history();
+                // Raw `+ 9` is safe here — see `bt_insert_step_no_rebase_body!`
+                // for the full discussion of the upstream `STREAM_ABS_HEADROOM`
+                // cap in `MatchTable::add_data`.
+                let mut match_end_abs = $abs_pos + 9;
+                if max_chain_depth > 0 {
+                    for (visited, candidate_abs) in $self
+                        .hc
+                        .chain_candidates(&$self.table, $abs_pos)
+                        .into_iter()
+                        .enumerate()
                     {
-                        continue;
-                    }
-                    let candidate_idx = candidate_abs - $self.table.history_abs_start;
-                    debug_assert!(
-                        $abs_pos <= $current_abs_end,
-                        "HC chain walker called past current block end"
-                    );
-                    let tail_limit = $current_abs_end - $abs_pos;
-                    let base = concat.as_ptr();
-                    // SAFETY: history-relative indices; `tail_limit` bounds
-                    // the scan within `concat`. `$cpl` is the kernel-specific
-                    // common_prefix_len_ptr — call inlines because the
-                    // surrounding wrapper carries the same target_feature.
-                    let match_len =
-                        unsafe { $cpl(base.add(candidate_idx), base.add(current_idx), tail_limit) };
-                    if match_len < min_match_len {
-                        continue;
-                    }
-                    let offset = $abs_pos - candidate_abs;
-                    if crate::encoding::bt::BtMatcher::push_candidate_ladder(
-                        $out,
-                        &mut best_len_for_skip,
-                        MatchCandidate {
-                            start: $abs_pos,
-                            offset,
-                            match_len,
-                        },
-                        min_match_len,
-                    ) {
-                        let candidate_end = candidate_abs + match_len;
-                        if candidate_end > match_end_abs {
-                            match_end_abs = candidate_end;
+                        if visited >= max_chain_depth {
+                            break;
+                        }
+                        if candidate_abs == usize::MAX {
+                            break;
+                        }
+                        if candidate_abs < $self.table.window_low_abs_for_target($abs_pos)
+                            || candidate_abs >= $abs_pos
+                        {
+                            continue;
+                        }
+                        let candidate_idx = candidate_abs - $self.table.history_abs_start;
+                        debug_assert!(
+                            $abs_pos <= $current_abs_end,
+                            "HC chain walker called past current block end"
+                        );
+                        let tail_limit = $current_abs_end - $abs_pos;
+                        let base = concat.as_ptr();
+                        // SAFETY: history-relative indices; `tail_limit` bounds
+                        // the scan within `concat`. `$cpl` is the kernel-specific
+                        // common_prefix_len_ptr — call inlines because the
+                        // surrounding wrapper carries the same target_feature.
+                        let match_len = unsafe {
+                            $cpl(base.add(candidate_idx), base.add(current_idx), tail_limit)
+                        };
+                        if match_len < min_match_len {
+                            continue;
+                        }
+                        let offset = $abs_pos - candidate_abs;
+                        if crate::encoding::bt::BtMatcher::push_candidate_ladder(
+                            $out,
+                            &mut best_len_for_skip,
+                            MatchCandidate {
+                                start: $abs_pos,
+                                offset,
+                                match_len,
+                            },
+                            min_match_len,
+                        ) {
+                            let candidate_end = candidate_abs + match_len;
+                            if candidate_end > match_end_abs {
+                                match_end_abs = candidate_end;
+                            }
+                        }
+                        if match_len > HC_OPT_NUM || $abs_pos + match_len >= $current_abs_end {
+                            break;
                         }
                     }
-                    if match_len > HC_OPT_NUM || $abs_pos + match_len >= $current_abs_end {
-                        break;
-                    }
                 }
+                // `match_end_abs` initialized to `abs_pos + 9`; monotonic
+                // updates only ever extend it, so `match_end_abs - 8 >= 1`.
+                $self.table.skip_insert_until_abs =
+                    $self.table.skip_insert_until_abs.max(match_end_abs - 8);
             }
-            // `match_end_abs` initialized to `abs_pos + 9`; monotonic
-            // updates only ever extend it, so `match_end_abs - 8 >= 1`.
-            $self.table.skip_insert_until_abs =
-                $self.table.skip_insert_until_abs.max(match_end_abs - 8);
         }
         if let Some(ldm) = ldm_candidate {
             let _ = crate::encoding::bt::BtMatcher::push_candidate_ladder(
@@ -1475,6 +1454,9 @@ impl HcMatchGenerator {
         )
     }
 
+    // The scalar arm of `run_main_loop!` wraps a safe `*_scalar` call in
+    // `unsafe` (the SIMD arms need it); allow the redundant block here.
+    #[allow(unused_unsafe)]
     pub(crate) fn start_matching_optimal<S: crate::encoding::strategy::Strategy>(
         &mut self,
         mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
@@ -1525,8 +1507,13 @@ impl HcMatchGenerator {
             current_len,
         );
 
+        // Take the five DP scratch buffers ONCE for both the seed pass and the
+        // main pass (upstream shares one workspace across btultra2's two
+        // passes). Threading the same `&mut` into the seed pass removes its
+        // separate take + restore round-trip.
+        let mut plan_buffers = self.take_optimal_plan_buffers();
         if self.should_run_btultra2_seed_pass::<S>(current_len) {
-            self.run_btultra2_seed_pass(current, current_abs_start, current_len);
+            self.run_btultra2_seed_pass(current, current_abs_start, current_len, &mut plan_buffers);
         }
 
         // Const-generic profile selection: every field is folded from
@@ -1535,6 +1522,9 @@ impl HcMatchGenerator {
         // so the optimiser produces the literal at codegen time
         // without a runtime match.
         let profile = HcOptimalCostProfile::const_for_strategy::<S>();
+        // The DP bodies read the strategy's `FAVOR_SMALL_OFFSETS` const directly;
+        // verify the runtime profile (built from the same strategy) agrees.
+        debug_assert_eq!(profile.favor_small_offsets, S::FAVOR_SMALL_OFFSETS);
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
         opt_state.rescale_freqs(current, profile);
@@ -1545,56 +1535,196 @@ impl HcMatchGenerator {
             self.table.opt_start_cursor_and_litlen(current_abs_start);
         let mut plan_literals_cursor = 0usize;
         let match_loop_limit = current_len.saturating_sub(8);
-        while cursor < match_loop_limit {
-            let remaining_len = current_len - cursor;
-            let segment_abs_start = current_abs_start + cursor;
-            let segment_start = best_plan.len();
-            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan::<S>(
-                &current[cursor..],
-                segment_abs_start,
-                remaining_len,
-                HcOptimalPlanState {
-                    block_offset: cursor,
-                    reps: plan_reps,
-                    litlen: plan_litlen,
-                    profile,
-                },
-                &opt_state,
-                &mut best_plan,
-            );
-            BtMatcher::update_plan_stats_segment(
-                current,
-                current_len,
-                &best_plan[segment_start..],
-                &mut plan_literals_cursor,
-                &mut plan_reps,
-                &mut opt_state,
-                profile.accurate,
-            );
-            plan_reps = end_reps;
-            plan_litlen = end_litlen;
-            cursor += consumed_len;
+        // Frame-constant LDM presence, resolved once per block (not per segment
+        // and not in the DP hot loop): drives the HAS_LDM const-generic dispatch.
+        let has_ldm = !self.backend.bt_mut().ldm_sequences.is_empty();
+        // Resolve the SIMD tier ONCE here, never per segment. The per-literal
+        // hot loop then runs under a single kernel-monomorphized expansion
+        // (calling build_optimal_plan_impl_<kernel> directly) instead of
+        // hitting select_kernel()'s OnceLock atomic + a CPU-tier match on every
+        // build_optimal_plan call. Mirrors the Fast matcher dispatch shape.
+        macro_rules! run_main_loop {
+            ($impl_wrapper:ident) => {{
+                while cursor < match_loop_limit {
+                    let remaining_len = current_len - cursor;
+                    let segment_abs_start = current_abs_start + cursor;
+                    let segment_start = best_plan.len();
+                    let state = HcOptimalPlanState {
+                        block_offset: cursor,
+                        reps: plan_reps,
+                        litlen: plan_litlen,
+                        profile,
+                    };
+                    let (_, end_reps, end_litlen, consumed_len) =
+                        match (S::ACCURATE_PRICE, S::FAVOR_SMALL_OFFSETS, has_ldm) {
+                            (true, false, false) => unsafe {
+                                self.$impl_wrapper::<S, true, false, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (true, false, true) => unsafe {
+                                self.$impl_wrapper::<S, true, false, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (true, true, false) => unsafe {
+                                self.$impl_wrapper::<S, true, true, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (true, true, true) => unsafe {
+                                self.$impl_wrapper::<S, true, true, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (false, false, false) => unsafe {
+                                self.$impl_wrapper::<S, false, false, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (false, false, true) => unsafe {
+                                self.$impl_wrapper::<S, false, false, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (false, true, false) => unsafe {
+                                self.$impl_wrapper::<S, false, true, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                            (false, true, true) => unsafe {
+                                self.$impl_wrapper::<S, false, true, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut best_plan,
+                                    &mut plan_buffers,
+                                )
+                            },
+                        };
+                    // On a no-match segment (the per-literal case that dominates
+                    // near-random input) nothing was emitted, so the stats
+                    // update is a guaranteed no-op (it early-returns on an empty
+                    // plan slice). Skip the per-literal call + its marshalling.
+                    if best_plan.len() > segment_start {
+                        BtMatcher::update_plan_stats_segment(
+                            current,
+                            current_len,
+                            &best_plan[segment_start..],
+                            &mut plan_literals_cursor,
+                            &mut plan_reps,
+                            &mut opt_state,
+                            profile.accurate,
+                        );
+                    }
+                    plan_reps = end_reps;
+                    plan_litlen = end_litlen;
+                    cursor += consumed_len;
+                }
+            }};
+        }
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        unsafe {
+            run_main_loop!(build_optimal_plan_impl_neon);
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
+            match select_kernel() {
+                FastpathKernel::Avx2Bmi2 => run_main_loop!(build_optimal_plan_impl_avx2_bmi2),
+                FastpathKernel::Sse42 => run_main_loop!(build_optimal_plan_impl_sse42),
+                FastpathKernel::Scalar => run_main_loop!(build_optimal_plan_impl_scalar),
+            }
+        }
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        unsafe {
+            run_main_loop!(build_optimal_plan_impl_simd128);
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "wasm32", target_feature = "simd128")
+        )))]
+        {
+            run_main_loop!(build_optimal_plan_impl_scalar);
         }
 
         self.table
             .emit_optimal_plan(current_len, &best_plan, &mut handle_sequence);
         best_plan.clear();
         self.backend.bt_mut().opt_segment_plan_scratch = best_plan;
+        let _ = self
+            .backend
+            .bt_mut()
+            .finish_optimal_plan(plan_buffers, (0, [0; 3], 0, 0));
         self.backend.bt_mut().opt_state = opt_state;
     }
 
+    // The scalar arm of `run_seed_loop!` wraps a safe call in `unsafe`.
+    #[allow(unused_unsafe)]
     fn run_btultra2_seed_pass(
         &mut self,
         current: &[u8],
         current_abs_start: usize,
         current_len: usize,
+        plan_buffers: &mut HcOptimalPlanBuffers,
     ) {
         // The seed pass is BtUltra2-exclusive by name (the only
         // caller is `should_run_btultra2_seed_pass`), so pin `S` to
         // `BtUltra2` for both the cost-profile lookup and the
-        // `build_optimal_plan::<S>` call below.
+        // kernel-dispatched segment loop below.
         type S = crate::encoding::strategy::BtUltra2;
+        // `S` is a concrete type here (not a generic bound), so the `Strategy`
+        // trait must be in scope to read its associated consts in
+        // `run_seed_loop!`.
+        use crate::encoding::strategy::Strategy;
         let seed_profile = HcOptimalCostProfile::const_for_strategy::<S>();
+        debug_assert_eq!(seed_profile.favor_small_offsets, S::FAVOR_SMALL_OFFSETS);
         let mut opt_state =
             core::mem::replace(&mut self.backend.bt_mut().opt_state, HcOptState::new());
         opt_state.rescale_freqs(current, seed_profile);
@@ -1605,39 +1735,164 @@ impl HcMatchGenerator {
         let mut seed_plan = core::mem::take(&mut self.backend.bt_mut().opt_seed_plan_scratch);
         seed_plan.clear();
         let match_loop_limit = current_len.saturating_sub(8);
-        while cursor < match_loop_limit {
-            let remaining_len = current_len - cursor;
-            let segment_abs_start = current_abs_start + cursor;
-            let segment_start = seed_plan.len();
-            let (_, end_reps, end_litlen, consumed_len) = self.build_optimal_plan::<S>(
-                &current[cursor..],
-                segment_abs_start,
-                remaining_len,
-                HcOptimalPlanState {
-                    block_offset: cursor,
-                    reps: seed_reps,
-                    litlen: seed_litlen,
-                    profile: seed_profile,
-                },
-                &opt_state,
-                &mut seed_plan,
-            );
-            BtMatcher::update_plan_stats_segment(
-                current,
-                current_len,
-                &seed_plan[segment_start..],
-                &mut seed_literals_cursor,
-                &mut seed_reps,
-                &mut opt_state,
-                seed_profile.accurate,
-            );
-            seed_plan.truncate(segment_start);
-            seed_reps = end_reps;
-            seed_litlen = end_litlen;
-            cursor += consumed_len;
+        let has_ldm = !self.backend.bt_mut().ldm_sequences.is_empty();
+        // SIMD tier resolved ONCE (see start_matching_optimal): the per-literal
+        // seed loop runs under a single kernel-monomorphized expansion, never
+        // re-entering select_kernel() per segment.
+        macro_rules! run_seed_loop {
+            ($impl_wrapper:ident) => {{
+                while cursor < match_loop_limit {
+                    let remaining_len = current_len - cursor;
+                    let segment_abs_start = current_abs_start + cursor;
+                    let segment_start = seed_plan.len();
+                    let state = HcOptimalPlanState {
+                        block_offset: cursor,
+                        reps: seed_reps,
+                        litlen: seed_litlen,
+                        profile: seed_profile,
+                    };
+                    let (_, end_reps, end_litlen, consumed_len) =
+                        match (S::ACCURATE_PRICE, S::FAVOR_SMALL_OFFSETS, has_ldm) {
+                            (true, false, false) => unsafe {
+                                self.$impl_wrapper::<S, true, false, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (true, false, true) => unsafe {
+                                self.$impl_wrapper::<S, true, false, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (true, true, false) => unsafe {
+                                self.$impl_wrapper::<S, true, true, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (true, true, true) => unsafe {
+                                self.$impl_wrapper::<S, true, true, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (false, false, false) => unsafe {
+                                self.$impl_wrapper::<S, false, false, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (false, false, true) => unsafe {
+                                self.$impl_wrapper::<S, false, false, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (false, true, false) => unsafe {
+                                self.$impl_wrapper::<S, false, true, false>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                            (false, true, true) => unsafe {
+                                self.$impl_wrapper::<S, false, true, true>(
+                                    &current[cursor..],
+                                    segment_abs_start,
+                                    remaining_len,
+                                    state,
+                                    &opt_state,
+                                    &mut seed_plan,
+                                    &mut *plan_buffers,
+                                )
+                            },
+                        };
+                    // No-match segment: stats update no-ops on the empty slice
+                    // and the truncate has nothing to drop; skip both.
+                    if seed_plan.len() > segment_start {
+                        BtMatcher::update_plan_stats_segment(
+                            current,
+                            current_len,
+                            &seed_plan[segment_start..],
+                            &mut seed_literals_cursor,
+                            &mut seed_reps,
+                            &mut opt_state,
+                            seed_profile.accurate,
+                        );
+                        seed_plan.truncate(segment_start);
+                    }
+                    seed_reps = end_reps;
+                    seed_litlen = end_litlen;
+                    cursor += consumed_len;
+                }
+            }};
+        }
+        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
+        unsafe {
+            run_seed_loop!(build_optimal_plan_impl_neon);
+        }
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
+            match select_kernel() {
+                FastpathKernel::Avx2Bmi2 => run_seed_loop!(build_optimal_plan_impl_avx2_bmi2),
+                FastpathKernel::Sse42 => run_seed_loop!(build_optimal_plan_impl_sse42),
+                FastpathKernel::Scalar => run_seed_loop!(build_optimal_plan_impl_scalar),
+            }
+        }
+        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+        unsafe {
+            run_seed_loop!(build_optimal_plan_impl_simd128);
+        }
+        #[cfg(not(any(
+            all(target_arch = "aarch64", target_endian = "little"),
+            target_arch = "x86",
+            target_arch = "x86_64",
+            all(target_arch = "wasm32", target_feature = "simd128")
+        )))]
+        {
+            run_seed_loop!(build_optimal_plan_impl_scalar);
         }
         seed_plan.clear();
         self.backend.bt_mut().opt_seed_plan_scratch = seed_plan;
+        // The DP scratch buffers are owned by the caller (start_matching_optimal)
+        // and shared across both passes, so the seed pass leaves them in place
+        // (`plan_buffers` is a borrow) instead of restoring them here.
         self.backend.bt_mut().opt_state = opt_state;
 
         // Upstream zstd initStats_ultra keeps the collected entropy statistics but
@@ -1654,161 +1909,37 @@ impl HcMatchGenerator {
         self.table.allow_zero_relative_position = true;
     }
 
-    fn build_optimal_plan<S: crate::encoding::strategy::Strategy>(
-        &mut self,
-        current: &[u8],
-        current_abs_start: usize,
-        current_len: usize,
-        initial_state: HcOptimalPlanState,
-        stats: &HcOptState,
-        out: &mut Vec<HcOptimalSequence>,
-    ) -> (u32, [u32; 3], usize, usize) {
-        debug_assert!(S::USE_BT, "build_optimal_plan called on non-BT strategy");
-        debug_assert_eq!(initial_state.profile.accurate, S::ACCURATE_PRICE);
-        debug_assert_eq!(
-            initial_state.profile.favor_small_offsets,
-            S::FAVOR_SMALL_OFFSETS
-        );
-        // `S::ACCURATE_PRICE` / `S::FAVOR_SMALL_OFFSETS` cannot appear
-        // as const-generic arguments yet (`generic_const_exprs` is
-        // still unstable), so dispatch over a 4-arm match — but on the
-        // strategy's ASSOCIATED CONSTS, not the runtime profile (the
-        // `debug_assert_eq`s above pin the runtime profile to those
-        // consts). A const scrutinee folds the three dead arms at
-        // monomorphisation; matching the runtime profile instead kept
-        // all four `#[inline(always)]` DP bodies (~16 KB each) alive in
-        // EVERY `S` instantiation — ~360 KB of the wasm payload.
-        match (S::ACCURATE_PRICE, S::FAVOR_SMALL_OFFSETS) {
-            (true, false) => self.build_optimal_plan_impl::<S, true, false>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            ),
-            (true, true) => self.build_optimal_plan_impl::<S, true, true>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            ),
-            (false, false) => self.build_optimal_plan_impl::<S, false, false>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            ),
-            (false, true) => self.build_optimal_plan_impl::<S, false, true>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            ),
+    /// Take the five DP scratch buffers out of the backend ONCE per block and
+    /// size them for the optimal-parser frontier, so the per-segment
+    /// `build_optimal_plan` calls borrow and reuse them instead of taking +
+    /// restoring all five every call (which on near-random input runs once per
+    /// literal). Restore with [`BtMatcher::finish_optimal_plan`] after the
+    /// per-segment loop.
+    fn take_optimal_plan_buffers(&mut self) -> HcOptimalPlanBuffers {
+        let bt = self.backend.bt_mut();
+        let mut nodes = core::mem::take(&mut bt.opt_nodes_scratch);
+        let mut node_prices = core::mem::take(&mut bt.opt_node_prices_scratch);
+        let mut candidates = core::mem::take(&mut bt.opt_candidates_scratch);
+        let store = core::mem::take(&mut bt.opt_store_scratch);
+        let mut price_arena = core::mem::take(&mut bt.opt_price_arena);
+        if nodes.len() < HC_OPT_NODE_LEN {
+            nodes = alloc::vec![HcOptimalNode::default(); HC_OPT_NODE_LEN].into_boxed_slice();
         }
-    }
-
-    /// Cross-platform DP entry. Picks the kernel-specific variant so the
-    /// entire optimal-parser DP body (per-position match gathering, price
-    /// updates, traceback) runs inside a single `target_feature` umbrella
-    /// alongside the per-position `collect_optimal_candidates_initialized_
-    /// <kernel>`. This eliminates the final ABI barrier on the hot per-
-    /// position match-collection call — the level22 critical path is now
-    /// one straight-line inline chain from DP body down through BT walk
-    /// and match-length probes.
-    #[inline(always)]
-    fn build_optimal_plan_impl<
-        S: crate::encoding::strategy::Strategy,
-        const ACCURATE_PRICE: bool,
-        const FAVOR_SMALL_OFFSETS: bool,
-    >(
-        &mut self,
-        current: &[u8],
-        current_abs_start: usize,
-        current_len: usize,
-        initial_state: HcOptimalPlanState,
-        stats: &HcOptState,
-        out: &mut Vec<HcOptimalSequence>,
-    ) -> (u32, [u32; 3], usize, usize) {
-        #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-        unsafe {
-            self.build_optimal_plan_impl_neon::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            )
+        if node_prices.len() < HC_OPT_NODE_LEN {
+            node_prices = alloc::vec![u32::MAX; HC_OPT_NODE_LEN].into_boxed_slice();
         }
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
-                FastpathKernel::Avx2Bmi2 => unsafe {
-                    self.build_optimal_plan_impl_avx2_bmi2::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                        current,
-                        current_abs_start,
-                        current_len,
-                        initial_state,
-                        stats,
-                        out,
-                    )
-                },
-                FastpathKernel::Sse42 => unsafe {
-                    self.build_optimal_plan_impl_sse42::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                        current,
-                        current_abs_start,
-                        current_len,
-                        initial_state,
-                        stats,
-                        out,
-                    )
-                },
-                FastpathKernel::Scalar => self
-                    .build_optimal_plan_impl_scalar::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                        current,
-                        current_abs_start,
-                        current_len,
-                        initial_state,
-                        stats,
-                        out,
-                    ),
-            }
+        if candidates.capacity() < MAX_HC_SEARCH_DEPTH {
+            candidates.reserve_exact(MAX_HC_SEARCH_DEPTH - candidates.capacity());
         }
-        // wasm with simd128: route through the simd128 DP body (4-lane price-set).
-        #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
-        unsafe {
-            self.build_optimal_plan_impl_simd128::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            )
+        if price_arena.len() < HC_OPT_PRICE_ARENA_LEN {
+            price_arena = alloc::vec![[0u32; 2]; HC_OPT_PRICE_ARENA_LEN].into_boxed_slice();
         }
-        #[cfg(not(any(
-            all(target_arch = "aarch64", target_endian = "little"),
-            target_arch = "x86",
-            target_arch = "x86_64",
-            all(target_arch = "wasm32", target_feature = "simd128")
-        )))]
-        {
-            self.build_optimal_plan_impl_scalar::<S, ACCURATE_PRICE, FAVOR_SMALL_OFFSETS>(
-                current,
-                current_abs_start,
-                current_len,
-                initial_state,
-                stats,
-                out,
-            )
+        HcOptimalPlanBuffers {
+            nodes,
+            node_prices,
+            candidates,
+            store,
+            price_arena,
         }
     }
 
@@ -1817,10 +1948,12 @@ impl HcMatchGenerator {
     /// per-position pipeline) directly into the DP loop.
     #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
     #[target_feature(enable = "neon")]
+    #[allow(clippy::too_many_arguments)]
     unsafe fn build_optimal_plan_impl_neon<
         S: crate::encoding::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
+        const HAS_LDM: bool,
     >(
         &mut self,
         current: &[u8],
@@ -1829,6 +1962,7 @@ impl HcMatchGenerator {
         initial_state: HcOptimalPlanState,
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
+        buffers: &mut HcOptimalPlanBuffers,
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
@@ -1839,6 +1973,7 @@ impl HcMatchGenerator {
             initial_state,
             stats,
             out,
+            buffers,
             collect_optimal_candidates_initialized_neon,
             crate::encoding::hc::priceset::priceset_range_nonabort_neon,
         )
@@ -1846,10 +1981,12 @@ impl HcMatchGenerator {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "sse4.2")]
+    #[allow(clippy::too_many_arguments)]
     unsafe fn build_optimal_plan_impl_sse42<
         S: crate::encoding::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
+        const HAS_LDM: bool,
     >(
         &mut self,
         current: &[u8],
@@ -1858,6 +1995,7 @@ impl HcMatchGenerator {
         initial_state: HcOptimalPlanState,
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
+        buffers: &mut HcOptimalPlanBuffers,
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
@@ -1868,6 +2006,7 @@ impl HcMatchGenerator {
             initial_state,
             stats,
             out,
+            buffers,
             collect_optimal_candidates_initialized_sse42,
             crate::encoding::hc::priceset::priceset_range_nonabort_sse41,
         )
@@ -1875,10 +2014,12 @@ impl HcMatchGenerator {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[target_feature(enable = "avx2,bmi2")]
+    #[allow(clippy::too_many_arguments)]
     unsafe fn build_optimal_plan_impl_avx2_bmi2<
         S: crate::encoding::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
+        const HAS_LDM: bool,
     >(
         &mut self,
         current: &[u8],
@@ -1887,6 +2028,7 @@ impl HcMatchGenerator {
         initial_state: HcOptimalPlanState,
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
+        buffers: &mut HcOptimalPlanBuffers,
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
@@ -1897,6 +2039,7 @@ impl HcMatchGenerator {
             initial_state,
             stats,
             out,
+            buffers,
             collect_optimal_candidates_initialized_avx2_bmi2,
             crate::encoding::hc::priceset::priceset_range_nonabort_avx2,
         )
@@ -1914,10 +2057,12 @@ impl HcMatchGenerator {
         all(target_arch = "wasm32", target_feature = "simd128"),
         allow(dead_code)
     )]
+    #[allow(clippy::too_many_arguments)]
     fn build_optimal_plan_impl_scalar<
         S: crate::encoding::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
+        const HAS_LDM: bool,
     >(
         &mut self,
         current: &[u8],
@@ -1926,6 +2071,7 @@ impl HcMatchGenerator {
         initial_state: HcOptimalPlanState,
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
+        buffers: &mut HcOptimalPlanBuffers,
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
@@ -1936,6 +2082,7 @@ impl HcMatchGenerator {
             initial_state,
             stats,
             out,
+            buffers,
             collect_optimal_candidates_initialized_scalar,
             crate::encoding::hc::priceset::priceset_range_nonabort_scalar,
         )
@@ -1949,10 +2096,12 @@ impl HcMatchGenerator {
     // blocks (needed by the safe scalar wrapper) are redundant inside this
     // target_feature fn.
     #[allow(unused_unsafe)]
+    #[allow(clippy::too_many_arguments)]
     unsafe fn build_optimal_plan_impl_simd128<
         S: crate::encoding::strategy::Strategy,
         const ACCURATE_PRICE: bool,
         const FAVOR_SMALL_OFFSETS: bool,
+        const HAS_LDM: bool,
     >(
         &mut self,
         current: &[u8],
@@ -1961,6 +2110,7 @@ impl HcMatchGenerator {
         initial_state: HcOptimalPlanState,
         stats: &HcOptState,
         out: &mut Vec<HcOptimalSequence>,
+        buffers: &mut HcOptimalPlanBuffers,
     ) -> (u32, [u32; 3], usize, usize) {
         build_optimal_plan_impl_body!(
             self,
@@ -1971,6 +2121,7 @@ impl HcMatchGenerator {
             initial_state,
             stats,
             out,
+            buffers,
             collect_optimal_candidates_initialized_scalar,
             crate::encoding::hc::priceset::priceset_range_nonabort_simd128,
         )
@@ -2144,11 +2295,12 @@ impl HcMatchGenerator {
             query,
             out,
             USE_BT_MATCHFINDER,
-            bt_update_tree_until_neon,
+            bt_insert_step_no_rebase_neon,
             bt_insert_and_collect_matches_neon,
             for_each_repcode_candidate_with_reps_neon,
             hash3_candidate_neon,
             crate::encoding::fastpath::neon::common_prefix_len_ptr,
+            crate::encoding::fastpath::neon::count_match_from_indices,
         )
     }
 
@@ -2174,11 +2326,12 @@ impl HcMatchGenerator {
             query,
             out,
             USE_BT_MATCHFINDER,
-            bt_update_tree_until_sse42,
+            bt_insert_step_no_rebase_sse42,
             bt_insert_and_collect_matches_sse42,
             for_each_repcode_candidate_with_reps_sse42,
             hash3_candidate_sse42,
             crate::encoding::fastpath::sse42::common_prefix_len_ptr,
+            crate::encoding::fastpath::sse42::count_match_from_indices,
         )
     }
 
@@ -2204,11 +2357,12 @@ impl HcMatchGenerator {
             query,
             out,
             USE_BT_MATCHFINDER,
-            bt_update_tree_until_avx2_bmi2,
+            bt_insert_step_no_rebase_avx2_bmi2,
             bt_insert_and_collect_matches_avx2_bmi2,
             for_each_repcode_candidate_with_reps_avx2_bmi2,
             hash3_candidate_avx2_bmi2,
             crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
+            crate::encoding::fastpath::avx2_bmi2::count_match_from_indices,
         )
     }
 
@@ -2236,11 +2390,12 @@ impl HcMatchGenerator {
             query,
             out,
             USE_BT_MATCHFINDER,
-            bt_update_tree_until_scalar,
+            bt_insert_step_no_rebase_scalar,
             bt_insert_and_collect_matches_scalar,
             for_each_repcode_candidate_with_reps_scalar,
             hash3_candidate_scalar,
             crate::encoding::fastpath::scalar::common_prefix_len_ptr,
+            crate::encoding::fastpath::scalar::count_match_from_indices,
         )
     }
 }

--- a/zstd/src/encoding/hc/optimal.rs
+++ b/zstd/src/encoding/hc/optimal.rs
@@ -1373,8 +1373,8 @@ impl HcMatchGenerator {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.table.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.start_matching_btlazy2_avx2_bmi2(&mut handle_sequence)
                 },
@@ -1673,8 +1673,8 @@ impl HcMatchGenerator {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.table.kernel {
                 FastpathKernel::Avx2Bmi2 => run_main_loop!(build_optimal_plan_impl_avx2_bmi2),
                 FastpathKernel::Sse42 => run_main_loop!(build_optimal_plan_impl_sse42),
                 FastpathKernel::Scalar => run_main_loop!(build_optimal_plan_impl_scalar),
@@ -1868,8 +1868,8 @@ impl HcMatchGenerator {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.table.kernel {
                 FastpathKernel::Avx2Bmi2 => run_seed_loop!(build_optimal_plan_impl_avx2_bmi2),
                 FastpathKernel::Sse42 => run_seed_loop!(build_optimal_plan_impl_sse42),
                 FastpathKernel::Scalar => run_seed_loop!(build_optimal_plan_impl_scalar),
@@ -2222,8 +2222,8 @@ impl HcMatchGenerator {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.table.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.collect_optimal_candidates_initialized_avx2_bmi2::<S, USE_BT_MATCHFINDER>(
                         abs_pos,

--- a/zstd/src/encoding/levels/config.rs
+++ b/zstd/src/encoding/levels/config.rs
@@ -474,11 +474,12 @@ pub(crate) fn apply_param_overrides(
                     hc.target_len = target_length as usize;
                 }
                 if let Some(min_match) = ov.min_match {
-                    // Upstream zstd `mls = BOUNDED(4, cParams.minMatch, 6)`: a BT
-                    // min_match override maps into the finder hash width. Only
-                    // the BT body reads `search_mls`; HC/lazy keep 4-byte
-                    // hashing regardless, so this is a no-op for them.
-                    hc.search_mls = (min_match as usize).clamp(4, 6);
+                    // BT finder hash width, derived from cParams.minMatch exactly
+                    // as upstream zstd: `mls = BOUNDED(3, cParams.minMatch, 6)`
+                    // (zstd_opt.c:896 ZSTD_selectBtGetAllMatches). minMatch=3
+                    // tiers hash on 3 bytes (btultra/btultra2 path). Only the BT
+                    // body reads `search_mls`; HC/lazy hash on 4 bytes regardless.
+                    hc.search_mls = (min_match as usize).clamp(3, 6);
                 }
             }
         }
@@ -754,6 +755,94 @@ fn cparams_tier(source_size: Option<u64>) -> usize {
 /// tiers hashLog (the tier-0 value 16 oversized the table on medium inputs,
 /// the page-fault pathology); L3 tiers both dfast hash widths. Strategy
 /// switches (L2 tier 1, L4) are intentionally not applied here.
+/// Translate a verbatim upstream `ZSTD_defaultCParameters[tier][level]` row
+/// (`cparams::CParams`) into our resolved [`LevelParams`], reproducing
+/// upstream's cParams -> matcher-config derivation so the encoder follows C's
+/// source-size-tiered STRATEGY + table widths rather than a single hand-tuned
+/// `LEVEL_TABLE`. Derivation (verified against L6/L16/L22 vs clevels.h):
+/// `search_depth = 1 << searchLog`; row `row_log = clamp(searchLog, 4, 6)`; the
+/// per-strategy sub-config carries the verbatim `hashLog` / `chainLog` /
+/// `targetLength` / `minMatch`. Strategy numbers are upstream `ZSTD_strategy`
+/// (fast=1, dfast=2, greedy=3, lazy=4, lazy2=5, btlazy2=6, btopt=7, btultra=8,
+/// btultra2=9).
+fn level_params_from_cparams(cp: crate::encoding::cparams::CParams) -> LevelParams {
+    use crate::encoding::strategy::{SearchMethod, StrategyTag};
+    let window_log = cp.window_log as u8;
+    let search_depth = 1usize << cp.search_log;
+    let target_len = cp.target_length as usize;
+    let hc = HcConfig {
+        hash_log: cp.hash_log as usize,
+        chain_log: cp.chain_log as usize,
+        search_depth,
+        target_len,
+        search_mls: cp.min_match as usize,
+    };
+    let row = RowConfig {
+        hash_bits: cp.hash_log as usize,
+        row_log: cp.search_log.clamp(4, 6) as usize,
+        search_depth,
+        target_len,
+        mls: cp.min_match as usize,
+    };
+    let bt = |tag| LevelParams {
+        strategy_tag: tag,
+        search: SearchMethod::BinaryTree,
+        window_log,
+        lazy_depth: 2,
+        fast: None,
+        dfast: None,
+        hc: Some(hc),
+        row: None,
+    };
+    let row_lvl = |tag, lazy_depth| LevelParams {
+        strategy_tag: tag,
+        search: SearchMethod::RowHash,
+        window_log,
+        lazy_depth,
+        fast: None,
+        dfast: None,
+        hc: None,
+        row: Some(row),
+    };
+    match cp.strategy {
+        1 => LevelParams {
+            strategy_tag: StrategyTag::Fast,
+            search: SearchMethod::Fast,
+            window_log,
+            lazy_depth: 0,
+            // Upstream fast `stepSize`: `targetLength + 1` (0 -> 1, so step 2).
+            fast: Some(FastConfig {
+                hash_log: cp.hash_log,
+                mls: cp.min_match,
+                step_size: target_len.max(1) + 1,
+            }),
+            dfast: None,
+            hc: None,
+            row: None,
+        },
+        2 => LevelParams {
+            strategy_tag: StrategyTag::Dfast,
+            search: SearchMethod::DoubleFast,
+            window_log,
+            lazy_depth: 1,
+            fast: None,
+            dfast: Some(DfastConfig {
+                long_hash_log: cp.hash_log as u8,
+                short_hash_log: cp.chain_log as u8,
+            }),
+            hc: None,
+            row: None,
+        },
+        3 => row_lvl(StrategyTag::Greedy, 0),
+        4 => row_lvl(StrategyTag::Lazy, 1),
+        5 => row_lvl(StrategyTag::Lazy, 2),
+        6 => bt(StrategyTag::Btlazy2),
+        7 => bt(StrategyTag::BtOpt),
+        8 => bt(StrategyTag::BtUltra),
+        _ => bt(StrategyTag::BtUltra2),
+    }
+}
+
 fn apply_cparams_tier(level: i32, source_size: Option<u64>, p: &mut LevelParams) {
     let tier = cparams_tier(source_size);
     // Single source for the table data: the verbatim upstream
@@ -1061,23 +1150,16 @@ pub(crate) fn resolve_level_params(
         CompressionLevel::Best => LEVEL_TABLE[12],
         CompressionLevel::Level(n) => {
             if n > 0 {
-                let idx = (n as usize).min(CompressionLevel::MAX_LEVEL as usize) - 1;
-                let mut p = LEVEL_TABLE[idx];
-                // Upstream zstd selects the cParams row from a 4-way
-                // source-size-tiered table (`ZSTD_getCParams_internal` →
-                // `ZSTD_defaultCParameters[tableID][level]`), and the Fast /
-                // Dfast hashLog, chainLog and minMatch shrink for smaller
-                // inputs. The `LEVEL_TABLE` base is the tier-0 (> 256 KiB) row;
-                // override the table-shaping params per tier here so small and
-                // medium frames use the reference's table widths (the oversized
-                // tier-0 widths were a per-frame alloc / page-fault pathology on
-                // medium inputs) and minMatch (short matches the wide hash
-                // skips). NOTE: the reference also switches STRATEGY in some
-                // tiers (L2 → dfast at 128..256 KiB, L4 → greedy at <= 16 KiB
-                // and 128..256 KiB); those backend switches are not yet tiered,
-                // so those tiers keep the base strategy.
-                apply_cparams_tier(n, source_size, &mut p);
-                p
+                // Source-size-tiered cParams, derived verbatim from upstream
+                // `ZSTD_defaultCParameters[tableID][level]` (the same 4-way table
+                // C selects via `ZSTD_getCParams_internal`). This follows C's
+                // per-(level, srcSize) STRATEGY + table widths, not a single
+                // hand-tuned `LEVEL_TABLE` row: small / medium frames now ramp to
+                // the reference strategy (e.g. btopt at L11 for <= 16 KiB) instead
+                // of staying on the tier-0 backend.
+                let tier = cparams_tier(source_size);
+                let lvl = (n as usize).min(CompressionLevel::MAX_LEVEL as usize);
+                level_params_from_cparams(crate::encoding::cparams::default_cparams(tier, lvl))
             } else if n == 0 {
                 // Level 0 = default, matching C zstd semantics. Tier it like the
                 // `Default` alias so `Level(0)` and `Default` stay identical.

--- a/zstd/src/encoding/levels/config.rs
+++ b/zstd/src/encoding/levels/config.rs
@@ -1093,7 +1093,11 @@ pub(crate) fn resolve_level_params(
     level: CompressionLevel,
     source_size: Option<u64>,
 ) -> LevelParams {
-    if matches!(level, CompressionLevel::Level(22)) {
+    // Levels at or above MAX_LEVEL clamp to the max: route every out-of-range
+    // level through the same btultra2 source-size resolver as Level(22), so a
+    // caller passing Level(23+) gets the max config instead of falling through
+    // to the generic cParams path (which would resolve a different geometry).
+    if matches!(level, CompressionLevel::Level(n) if n >= CompressionLevel::MAX_LEVEL) {
         return level22_btultra2_params_for_source_size(source_size);
     }
     let params = match level {

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -533,10 +533,10 @@ fn level22_uses_target_length_and_large_input_tables() {
 fn bt_levels_16_to_21_pin_clevels_params() {
     // Pins the BT-level (window_log, hash_log, chain_log, search_depth,
     // target_len) tuples so the clevels.h alignment cannot silently drift.
-    // Levels 16-20 mirror upstream `clevels.h` (srcSize > 256 KiB tier,
-    // search_depth = 1 << searchLog); level 21 intentionally keeps a deeper
-    // search_depth (512 vs upstream's 128) — it beats C on ratio there and
-    // the deeper walk is a deliberate ratio-positive divergence.
+    // All rows mirror upstream `clevels.h` (srcSize > 256 KiB tier,
+    // search_depth = 1 << searchLog) verbatim, since the level params are now
+    // derived from `ZSTD_defaultCParameters[tier][level]` rather than a
+    // hand-tuned table.
     let expected = [
         // (level, window_log, hash_log, chain_log, search_depth, target_len)
         (16u8, 22u8, 22usize, 22usize, 32usize, 48usize),
@@ -544,7 +544,7 @@ fn bt_levels_16_to_21_pin_clevels_params() {
         (18, 23, 22, 23, 64, 64),
         (19, 23, 22, 24, 128, 256),
         (20, 25, 23, 25, 128, 256),
-        (21, 26, 24, 24, 512, 256),
+        (21, 26, 24, 26, 128, 512),
     ];
     for (level, wlog, hlog, clog, sd, tl) in expected {
         let p = resolve_level_params(CompressionLevel::Level(level as i32), None);

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -640,6 +640,74 @@ fn btultra2_seed_pass_initializes_opt_state() {
     );
 }
 
+/// Every per-CPU kernel tier emits a bit-identical sequence stream. Forcing
+/// `table.kernel` runs each tier's monomorphized BT-collect / DP wrapper on
+/// one machine (only the runtime-selected tier would otherwise execute), which
+/// both pins the scalar-vs-SIMD bit-identity invariant and exercises the
+/// per-tier wrappers the runtime dispatch leaves cold. x86-only: the aarch64
+/// path dispatches NEON unconditionally, so the cached field is read only in
+/// the x86 `cfg` block.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[test]
+fn bt_optimal_all_kernel_tiers_emit_identical_sequences() {
+    use crate::encoding::Sequence;
+    use crate::encoding::fastpath::FastpathKernel;
+
+    // Tiers the running CPU can legally execute: each dispatch arm is `unsafe`
+    // and assumes the tier's target_feature is present. Scalar is always safe;
+    // the SIMD tiers gate on runtime detection so the test stays valid on any
+    // x86 box (including a CI runner without AVX2).
+    let mut tiers = Vec::new();
+    tiers.push(FastpathKernel::Scalar);
+    if std::is_x86_feature_detected!("sse4.2") {
+        tiers.push(FastpathKernel::Sse42);
+    }
+    if std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("bmi2") {
+        tiers.push(FastpathKernel::Avx2Bmi2);
+    }
+
+    // Mixed-redundancy input so the BT walk, the rep-code probe, and the hash3
+    // short-match probe all fire (a pure ramp would never exercise the rep path).
+    let data: Vec<u8> = (0..48 * 1024)
+        .map(|i| ((i * 7 + i / 13) % 67) as u8)
+        .collect();
+
+    let run = |tier: FastpathKernel| -> Vec<(usize, usize, usize)> {
+        let mut hc = HcMatchGenerator::new(1 << 20);
+        hc.configure(
+            BTULTRA2_HC_CONFIG,
+            super::super::strategy::StrategyTag::BtUltra2,
+            26,
+        );
+        hc.table.add_data(data.clone(), |_| {});
+        hc.table.kernel = tier;
+        let mut seqs = Vec::new();
+        hc.start_matching(|seq| match seq {
+            Sequence::Triple {
+                literals,
+                offset,
+                match_len,
+            } => seqs.push((literals.len(), offset, match_len)),
+            Sequence::Literals { literals } => seqs.push((literals.len(), 0, 0)),
+        });
+        seqs
+    };
+
+    let reference = run(tiers[0]);
+    assert!(
+        !reference.is_empty(),
+        "btultra2 should emit sequences on mixed-redundancy input"
+    );
+    for &tier in &tiers[1..] {
+        assert_eq!(
+            run(tier),
+            reference,
+            "kernel tier {tier:?} diverged from {:?}: scalar/SIMD bit-identity broken",
+            tiers[0],
+        );
+    }
+}
+
 #[test]
 fn btultra2_profile_disables_small_offset_handicap() {
     // Pre-Phase-3 this test duplicated the profile build with

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -601,6 +601,36 @@ fn level22_non_power_of_two_small_source_uses_tier3_params() {
     assert_eq!(hc.target_len, 999);
 }
 
+/// Levels above `MAX_LEVEL` must resolve identically to `MAX_LEVEL`: an
+/// out-of-range level is clamped, not given a distinct configuration. The
+/// dedicated Level(22) resolver carries btultra2-specific source-size handling,
+/// so a clamped high level has to route through the SAME path, not fall through
+/// to the generic cParams derivation.
+#[test]
+fn levels_above_max_resolve_identically_to_max() {
+    let sizes = [
+        None,
+        Some(1024u64),
+        Some(16 * 1024),
+        Some(128 * 1024),
+        Some(1 << 20),
+    ];
+    for &sz in &sizes {
+        let at_max = resolve_level_params(CompressionLevel::Level(CompressionLevel::MAX_LEVEL), sz);
+        for over in [
+            CompressionLevel::MAX_LEVEL + 1,
+            CompressionLevel::MAX_LEVEL + 50,
+            1000,
+        ] {
+            let clamped = resolve_level_params(CompressionLevel::Level(over), sz);
+            assert!(
+                clamped == at_max,
+                "Level({over}) size {sz:?} must resolve identically to Level(MAX_LEVEL)"
+            );
+        }
+    }
+}
+
 #[test]
 fn level22_small_source_uses_window_bounded_hash3_log() {
     let mut hc = HcMatchGenerator::new(1 << 14);

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -708,6 +708,57 @@ fn bt_optimal_all_kernel_tiers_emit_identical_sequences() {
     }
 }
 
+/// Resolving positive levels across the source-size tiers drives every
+/// strategy arm of the cParams -> `LevelParams` derivation, and each resolved
+/// strategy must pair with the matching search method (Fast -> Fast,
+/// Dfast -> DoubleFast, Greedy/Lazy -> RowHash, the binary-tree family ->
+/// BinaryTree). A mismatch means the derivation wired a backend onto the wrong
+/// search path.
+#[test]
+fn level_params_strategy_and_search_method_agree_across_tiers() {
+    use super::super::strategy::{SearchMethod, StrategyTag};
+    // One size per upstream cParams tier (> 256 KiB, 128..256 KiB, 16..128 KiB,
+    // <= 16 KiB) plus the unknown-size default, so the matrix reaches every
+    // tier's strategy choices.
+    let sizes = [
+        Some(1024u64),
+        Some(16 * 1024),
+        Some(128 * 1024),
+        Some(256 * 1024),
+        Some(8 << 20),
+        None,
+    ];
+    let mut seen: Vec<StrategyTag> = Vec::new();
+    for lvl in 1..=22i32 {
+        for &sz in &sizes {
+            let p = resolve_level_params(CompressionLevel::Level(lvl), sz);
+            let consistent = match p.strategy_tag {
+                StrategyTag::Fast => p.search == SearchMethod::Fast,
+                StrategyTag::Dfast => p.search == SearchMethod::DoubleFast,
+                StrategyTag::Greedy | StrategyTag::Lazy => p.search == SearchMethod::RowHash,
+                StrategyTag::Btlazy2
+                | StrategyTag::BtOpt
+                | StrategyTag::BtUltra
+                | StrategyTag::BtUltra2 => p.search == SearchMethod::BinaryTree,
+            };
+            assert!(
+                consistent,
+                "level {lvl} size {sz:?}: strategy {:?} paired with search {:?}",
+                p.strategy_tag, p.search
+            );
+            if !seen.contains(&p.strategy_tag) {
+                seen.push(p.strategy_tag);
+            }
+        }
+    }
+    // The matrix must exercise a spread of arms, not collapse onto one backend.
+    assert!(
+        seen.len() >= 4,
+        "level/size matrix only reached {} strategy arms: {seen:?}",
+        seen.len()
+    );
+}
+
 #[test]
 fn btultra2_profile_disables_small_offset_handicap() {
     // Pre-Phase-3 this test duplicated the profile build with

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -500,14 +500,25 @@ impl MatchTable {
             return;
         }
         let idx = abs_pos - self.history_abs_start;
-        let concat = &self.history[self.history_start..];
-        if idx + 4 > concat.len() {
-            return;
-        }
+        // Borrowed-aware: hash the SAME bytes the finder reads via
+        // `live_history()` (borrowed window in no-copy mode, owned mirror
+        // otherwise). Reading `self.history[history_start..]` directly hashed
+        // the EMPTY owned mirror on the borrowed one-shot path, so every hash3
+        // insert early-returned and the HC3 side table stayed empty — btultra2
+        // short-match probing then found nothing. This is the identical bug
+        // already fixed for `insert_position_no_rebase`; the hash3 inserter was
+        // missed. `hash3` is the only value needed past the borrow, so it ends
+        // before the table write.
+        let hash3 = {
+            let concat = self.live_history();
+            if idx + 4 > concat.len() {
+                return;
+            }
+            Self::hash_position_at(concat, idx, self.hash3_log, 3)
+        };
         let Some(relative_pos) = self.relative_position(abs_pos) else {
             return;
         };
-        let hash3 = Self::hash_position_at(concat, idx, self.hash3_log, 3);
         self.hash3_table[hash3] = relative_pos + 1;
     }
 
@@ -1475,10 +1486,13 @@ impl MatchTable {
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
-        profile: HcOptimalCostProfile,
+        profile: &HcOptimalCostProfile,
         min_match_len: usize,
         best_len_for_skip: &mut usize,
         out: &mut Vec<MatchCandidate>,
+        reps: [u32; 3],
+        lit_len: usize,
+        use_hash3: bool,
     ) {
         #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
         unsafe {
@@ -1489,6 +1503,9 @@ impl MatchTable {
                 min_match_len,
                 best_len_for_skip,
                 out,
+                reps,
+                lit_len,
+                use_hash3,
             )
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -1503,6 +1520,9 @@ impl MatchTable {
                         min_match_len,
                         best_len_for_skip,
                         out,
+                        reps,
+                        lit_len,
+                        use_hash3,
                     )
                 },
                 FastpathKernel::Sse42 => unsafe {
@@ -1513,6 +1533,9 @@ impl MatchTable {
                         min_match_len,
                         best_len_for_skip,
                         out,
+                        reps,
+                        lit_len,
+                        use_hash3,
                     )
                 },
                 FastpathKernel::Scalar => self.bt_insert_and_collect_matches_scalar(
@@ -1522,6 +1545,9 @@ impl MatchTable {
                     min_match_len,
                     best_len_for_skip,
                     out,
+                    reps,
+                    lit_len,
+                    use_hash3,
                 ),
             }
         }
@@ -1538,6 +1564,9 @@ impl MatchTable {
                 min_match_len,
                 best_len_for_skip,
                 out,
+                reps,
+                lit_len,
+                use_hash3,
             )
         }
     }
@@ -1553,10 +1582,13 @@ impl MatchTable {
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
-        profile: HcOptimalCostProfile,
+        profile: &HcOptimalCostProfile,
         min_match_len: usize,
         best_len_for_skip: &mut usize,
         out: &mut Vec<MatchCandidate>,
+        reps: [u32; 3],
+        lit_len: usize,
+        use_hash3: bool,
     ) {
         let search_depth = self.search_depth;
         super::super::hc::generator::bt_insert_and_collect_matches_body!(
@@ -1568,6 +1600,10 @@ impl MatchTable {
             min_match_len,
             best_len_for_skip,
             out,
+            reps,
+            lit_len,
+            use_hash3,
+            crate::encoding::fastpath::neon::common_prefix_len_ptr,
             crate::encoding::fastpath::neon::count_match_from_indices,
         )
     }
@@ -1583,10 +1619,13 @@ impl MatchTable {
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
-        profile: HcOptimalCostProfile,
+        profile: &HcOptimalCostProfile,
         min_match_len: usize,
         best_len_for_skip: &mut usize,
         out: &mut Vec<MatchCandidate>,
+        reps: [u32; 3],
+        lit_len: usize,
+        use_hash3: bool,
     ) {
         let search_depth = self.search_depth;
         super::super::hc::generator::bt_insert_and_collect_matches_body!(
@@ -1598,6 +1637,10 @@ impl MatchTable {
             min_match_len,
             best_len_for_skip,
             out,
+            reps,
+            lit_len,
+            use_hash3,
+            crate::encoding::fastpath::sse42::common_prefix_len_ptr,
             crate::encoding::fastpath::sse42::count_match_from_indices,
         )
     }
@@ -1613,10 +1656,13 @@ impl MatchTable {
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
-        profile: HcOptimalCostProfile,
+        profile: &HcOptimalCostProfile,
         min_match_len: usize,
         best_len_for_skip: &mut usize,
         out: &mut Vec<MatchCandidate>,
+        reps: [u32; 3],
+        lit_len: usize,
+        use_hash3: bool,
     ) {
         let search_depth = self.search_depth;
         super::super::hc::generator::bt_insert_and_collect_matches_body!(
@@ -1628,6 +1674,10 @@ impl MatchTable {
             min_match_len,
             best_len_for_skip,
             out,
+            reps,
+            lit_len,
+            use_hash3,
+            crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
             crate::encoding::fastpath::avx2_bmi2::count_match_from_indices,
         )
     }
@@ -1639,10 +1689,13 @@ impl MatchTable {
         &mut self,
         abs_pos: usize,
         current_abs_end: usize,
-        profile: HcOptimalCostProfile,
+        profile: &HcOptimalCostProfile,
         min_match_len: usize,
         best_len_for_skip: &mut usize,
         out: &mut Vec<MatchCandidate>,
+        reps: [u32; 3],
+        lit_len: usize,
+        use_hash3: bool,
     ) {
         let search_depth = self.search_depth;
         super::super::hc::generator::bt_insert_and_collect_matches_body!(
@@ -1654,6 +1707,10 @@ impl MatchTable {
             min_match_len,
             best_len_for_skip,
             out,
+            reps,
+            lit_len,
+            use_hash3,
+            crate::encoding::fastpath::scalar::common_prefix_len_ptr,
             crate::encoding::fastpath::scalar::count_match_from_indices,
         )
     }
@@ -1735,7 +1792,15 @@ impl MatchTable {
             // SAFETY: same NEON umbrella; direct call inlines the BT-walk body.
             let forward =
                 unsafe { self.bt_insert_step_no_rebase_neon(update_abs, current_abs_end, abs_pos) };
-            update_abs += forward.max(1).min(abs_pos - update_abs);
+            // Upstream zstd `ZSTD_updateTree`: `idx += ZSTD_insertBt1(...)` with
+            // NO clamp to the target. The insert step's `forward` skips the
+            // positions a long match already covers, so letting it overshoot
+            // `abs_pos` leaves those positions OUT of the tree exactly as C does
+            // (`nextToUpdate = target` afterwards). Clamping to `abs_pos` inserted
+            // those covered positions, giving our tree extra candidates C never
+            // surfaces (e.g. a longer-but-farther match the optimal parser then
+            // wrongly forces over a cheaper closer one).
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -1763,7 +1828,15 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_sse42(update_abs, current_abs_end, abs_pos)
             };
-            update_abs += forward.max(1).min(abs_pos - update_abs);
+            // Upstream zstd `ZSTD_updateTree`: `idx += ZSTD_insertBt1(...)` with
+            // NO clamp to the target. The insert step's `forward` skips the
+            // positions a long match already covers, so letting it overshoot
+            // `abs_pos` leaves those positions OUT of the tree exactly as C does
+            // (`nextToUpdate = target` afterwards). Clamping to `abs_pos` inserted
+            // those covered positions, giving our tree extra candidates C never
+            // surfaces (e.g. a longer-but-farther match the optimal parser then
+            // wrongly forces over a cheaper closer one).
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -1791,7 +1864,15 @@ impl MatchTable {
             let forward = unsafe {
                 self.bt_insert_step_no_rebase_avx2_bmi2(update_abs, current_abs_end, abs_pos)
             };
-            update_abs += forward.max(1).min(abs_pos - update_abs);
+            // Upstream zstd `ZSTD_updateTree`: `idx += ZSTD_insertBt1(...)` with
+            // NO clamp to the target. The insert step's `forward` skips the
+            // positions a long match already covers, so letting it overshoot
+            // `abs_pos` leaves those positions OUT of the tree exactly as C does
+            // (`nextToUpdate = target` afterwards). Clamping to `abs_pos` inserted
+            // those covered positions, giving our tree extra candidates C never
+            // surfaces (e.g. a longer-but-farther match the optimal parser then
+            // wrongly forces over a cheaper closer one).
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }
@@ -1810,7 +1891,15 @@ impl MatchTable {
             }
             let forward =
                 self.bt_insert_step_no_rebase_scalar(update_abs, current_abs_end, abs_pos);
-            update_abs += forward.max(1).min(abs_pos - update_abs);
+            // Upstream zstd `ZSTD_updateTree`: `idx += ZSTD_insertBt1(...)` with
+            // NO clamp to the target. The insert step's `forward` skips the
+            // positions a long match already covers, so letting it overshoot
+            // `abs_pos` leaves those positions OUT of the tree exactly as C does
+            // (`nextToUpdate = target` afterwards). Clamping to `abs_pos` inserted
+            // those covered positions, giving our tree extra candidates C never
+            // surfaces (e.g. a longer-but-farther match the optimal parser then
+            // wrongly forces over a cheaper closer one).
+            update_abs += forward.max(1);
         }
         self.skip_insert_until_abs = abs_pos;
     }

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -262,6 +262,13 @@ pub(crate) struct MatchTable {
     /// Active borrowed block range `[start, end)` within `borrowed_input`,
     /// staged before each borrowed scan.
     pub(crate) borrowed_block: Option<(usize, usize)>,
+    /// SIMD kernel tier, resolved ONCE at construction (upstream-style
+    /// once-per-encoder-invoke detection: the CPU does not change mid-run, so
+    /// `select_kernel()`'s CPUID/`OnceLock` read is paid a single time here).
+    /// The per-block strategy entries and the BT walker dispatch off this
+    /// cached value instead of re-detecting in the hot path. Mirrors the
+    /// `kernel` field the Fast / Row / Dfast matchers already cache.
+    pub(crate) kernel: crate::encoding::fastpath::FastpathKernel,
 }
 
 // Manual `Clone` (not derived) so the per-frame dictionary-snapshot restore can
@@ -302,6 +309,7 @@ impl Clone for MatchTable {
             dms: self.dms.clone(),
             borrowed_input: self.borrowed_input,
             borrowed_block: self.borrowed_block,
+            kernel: self.kernel,
         }
     }
 
@@ -338,6 +346,7 @@ impl Clone for MatchTable {
         self.search_mls = source.search_mls;
         self.borrowed_input = source.borrowed_input;
         self.borrowed_block = source.borrowed_block;
+        self.kernel = source.kernel;
     }
 }
 
@@ -445,6 +454,7 @@ impl MatchTable {
             dms: DictAttach::new(),
             borrowed_input: None,
             borrowed_block: None,
+            kernel: crate::encoding::fastpath::select_kernel(),
         }
     }
 
@@ -1364,8 +1374,8 @@ impl MatchTable {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.bt_insert_step_no_rebase_avx2_bmi2(abs_pos, current_abs_end, target_abs)
                 },
@@ -1510,8 +1520,8 @@ impl MatchTable {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.bt_insert_and_collect_matches_avx2_bmi2(
                         abs_pos,
@@ -1744,8 +1754,8 @@ impl MatchTable {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.bt_update_tree_until_avx2_bmi2(abs_pos, current_abs_end)
                 },
@@ -2263,8 +2273,8 @@ impl MatchTable {
         }
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            use crate::encoding::fastpath::{FastpathKernel, select_kernel};
-            match select_kernel() {
+            use crate::encoding::fastpath::FastpathKernel;
+            match self.kernel {
                 FastpathKernel::Avx2Bmi2 => unsafe {
                     self.hash3_candidate_avx2_bmi2(abs_pos, current_abs_end, min_match_len)
                 },

--- a/zstd/src/encoding/strategy.rs
+++ b/zstd/src/encoding/strategy.rs
@@ -17,10 +17,9 @@
 //!          └─ S::USE_BT == true  → start_matching_optimal::<S>
 //!              ├─ HcOptimalCostProfile::const_for_strategy::<S>()
 //!              ├─ should_run_btultra2_seed_pass::<S>          // const false unless S = BtUltra2
-//!              └─ build_optimal_plan::<S>
-//!                  └─ build_optimal_plan_impl::<S, ACC, FAV>
-//!                      └─ SIMD wrapper::<S, ACC, FAV>
-//!                          └─ build_optimal_plan_impl_body!(S)
+//!              └─ select_kernel() once, then per-segment loop:
+//!                  └─ build_optimal_plan_impl_<kernel>::<S, ACC, FAV, LDM>
+//!                      └─ build_optimal_plan_impl_body!(S)
 //!                              ├─ S::OPT_LEVEL == 0  → abort_on_worse_match
 //!                              ├─ S::OPT_LEVEL >= 2  → opt_level (refined)
 //!                              └─ $collect::<S, true>

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -1147,8 +1147,21 @@ fn limited_weights_into(
     work.clear();
     work.extend_from_slice(leaves);
     enforce_max_height(work, max_nb_bits);
-    repair_limited_lengths(work, max_nb_bits);
+    // The height limiter restores a full, canonical code in one pass (matching
+    // upstream `HUF_setMaxHeight`): the Kraft sum `Σ 2^(max_nb_bits - nb_bits)`
+    // lands exactly on `2^max_nb_bits`. A degenerate distribution can stop the
+    // fill short (our node buffer is sized to the leaves, not over-sized like
+    // upstream), leaving the code under- or over-full, which projects to a
+    // non-power-of-two weight sum the table builder rejects; detect that here
+    // and fall back to the distributed-weight construction.
     if work.iter().any(|leaf| leaf.nb_bits > max_nb_bits) {
+        return false;
+    }
+    let kraft_sum = work
+        .iter()
+        .map(|leaf| 1usize << (max_nb_bits - leaf.nb_bits))
+        .sum::<usize>();
+    if kraft_sum != 1usize << max_nb_bits {
         return false;
     }
 
@@ -1166,48 +1179,6 @@ fn build_limited_weights(counts: &[usize], max_nb_bits: usize) -> Vec<usize> {
         out
     } else {
         legacy_distributed_weights(counts)
-    }
-}
-
-fn repair_limited_lengths(nodes: &mut [HuffNode], target_nb_bits: usize) {
-    if nodes.is_empty() {
-        return;
-    }
-
-    for node in nodes.iter_mut() {
-        node.nb_bits = node.nb_bits.min(target_nb_bits);
-    }
-
-    let target_sum = 1usize << target_nb_bits;
-    loop {
-        let kraft_sum = nodes
-            .iter()
-            .map(|node| 1usize << (target_nb_bits - node.nb_bits))
-            .sum::<usize>();
-        if kraft_sum <= target_sum {
-            break;
-        }
-        let overflow = kraft_sum - target_sum;
-        let mut best_idx = None;
-        let mut best_step = 0usize;
-        for (idx, node) in nodes.iter().enumerate().rev() {
-            if node.nb_bits >= target_nb_bits {
-                continue;
-            }
-            let step = 1usize << (target_nb_bits - node.nb_bits - 1);
-            if step <= overflow {
-                best_idx = Some(idx);
-                break;
-            }
-            if best_idx.is_none() || step < best_step {
-                best_idx = Some(idx);
-                best_step = step;
-            }
-        }
-        let Some(idx) = best_idx else {
-            break;
-        };
-        nodes[idx].nb_bits += 1;
     }
 }
 
@@ -1318,26 +1289,39 @@ fn enforce_max_height(nodes: &mut [HuffNode], target_nb_bits: usize) {
         }
     }
 
+    // Cost correction can overshoot below zero. Add the weight back so the
+    // final Kraft sum lands exactly on 2^target_nb_bits (a full, canonical
+    // code); otherwise the weights are non-power-of-two and downstream table
+    // construction rejects them. Only the smallest rank is adjusted to avoid
+    // overshooting again: take the largest node from rank 0 (target_nb_bits)
+    // and shorten it to rank 1 (target_nb_bits - 1). The highest-count symbol
+    // (nodes[0]) keeps the shortest code, so its bit length stays strictly
+    // below target_nb_bits while the tree is over-tall, which bounds the
+    // `n` walk-down and guarantees this loop converges.
     while total_cost < 0 {
         if rank_last[1] == NO_SYMBOL {
-            while n < nodes.len() && nodes[n].nb_bits == target_nb_bits {
-                n += 1;
+            // No rank-1 symbol yet: create one from the largest rank-0 node.
+            while n > 0 && nodes[n].nb_bits == target_nb_bits {
+                n -= 1;
             }
-            if n >= nodes.len() {
-                return;
+            // Upstream relies on an over-sized node buffer here and reads into
+            // its scratch tail; ours is sized exactly to the leaves. If there
+            // is no real rank-0 node left to borrow, the distribution is too
+            // degenerate to height-limit, so stop and let the caller fall back
+            // to the distributed-weight construction.
+            if nodes[n].nb_bits == target_nb_bits || n + 1 >= nodes.len() {
+                break;
             }
-            let pos = n;
-            nodes[pos].nb_bits -= 1;
-            rank_last[1] = pos;
+            nodes[n + 1].nb_bits -= 1;
+            rank_last[1] = n + 1;
             total_cost += 1;
             continue;
         }
-        let pos = rank_last[1] + 1;
-        if pos >= nodes.len() {
-            return;
+        if rank_last[1] + 1 >= nodes.len() {
+            break;
         }
-        nodes[pos].nb_bits -= 1;
-        rank_last[1] = pos;
+        nodes[rank_last[1] + 1].nb_bits -= 1;
+        rank_last[1] += 1;
         total_cost += 1;
     }
 }

--- a/zstd/src/huff0/huff0_encoder/tests.rs
+++ b/zstd/src/huff0/huff0_encoder/tests.rs
@@ -102,6 +102,38 @@ fn build_limited_weights_always_power_of_two() {
     }
 }
 
+/// Degenerate alphabets take the height limiter's `leaves.len() <= 1`
+/// early-out: a single non-zero symbol maps to a one-bit code, and the
+/// all-zero histogram yields no leaf at all. Both must keep the power-of-two
+/// weight-sum invariant the table builder relies on.
+#[test]
+fn build_limited_weights_handles_degenerate_alphabets() {
+    // Single non-zero symbol: the lone leaf gets weight 1, every other slot 0.
+    let mut single = alloc::vec![0usize; 8];
+    single[3] = 1000;
+    let w = build_limited_weights(&single, 11);
+    assert!(
+        huffman_weight_sum_is_power_of_two(&w),
+        "single-symbol weights broke the power-of-two invariant: {w:?}"
+    );
+    assert_eq!(w[3], 1, "the only symbol should map to a one-bit code");
+    assert!(
+        w.iter().enumerate().all(|(i, &x)| i == 3 || x == 0),
+        "no symbol other than the single non-zero one may carry a weight: {w:?}"
+    );
+
+    // Two symbols: the smallest alphabet that runs the full build path
+    // (leaves.len() > 1) rather than the degenerate early-out.
+    let mut pair = alloc::vec![0usize; 8];
+    pair[1] = 600;
+    pair[5] = 400;
+    let w2 = build_limited_weights(&pair, 11);
+    assert!(
+        huffman_weight_sum_is_power_of_two(&w2),
+        "two-symbol weights broke the power-of-two invariant: {w2:?}"
+    );
+}
+
 #[test]
 fn weights() {
     // assert_eq!(distribute_weights(5).as_slice(), &[1, 1, 2, 3, 4]);

--- a/zstd/src/huff0/huff0_encoder/tests.rs
+++ b/zstd/src/huff0/huff0_encoder/tests.rs
@@ -121,9 +121,13 @@ fn fuzz_limited_weights_power_of_two(iterations: usize) {
 }
 
 /// Degenerate alphabets take the height limiter's `leaves.len() <= 1`
-/// early-out: a single non-zero symbol maps to a one-bit code, and the
-/// all-zero histogram yields no leaf at all. Both must keep the power-of-two
-/// weight-sum invariant the table builder relies on.
+/// early-out: a single non-zero symbol maps to a one-bit code (power-of-two
+/// weight sum), and an all-zero histogram finds no leaf and stays all-zero. A
+/// real block always has at least one literal, so the all-zero input never
+/// reaches production; it is asserted only for the actual early-out behavior
+/// (all-zero weights), not the power-of-two invariant a zero-symbol code cannot
+/// satisfy. A two-symbol alphabet is the smallest input that runs the full
+/// build past the early-out.
 #[test]
 fn build_limited_weights_handles_degenerate_alphabets() {
     // Single non-zero symbol: the lone leaf gets weight 1, every other slot 0.
@@ -149,6 +153,16 @@ fn build_limited_weights_handles_degenerate_alphabets() {
     assert!(
         huffman_weight_sum_is_power_of_two(&w2),
         "two-symbol weights broke the power-of-two invariant: {w2:?}"
+    );
+
+    // All-zero histogram: the early-out finds no leaf and leaves every weight
+    // at zero. This never occurs for a real block (always >= 1 literal), so the
+    // power-of-two invariant (which a zero-symbol code cannot meet) is not
+    // claimed; assert only the actual degenerate output.
+    let empty = build_limited_weights(&alloc::vec![0usize; 8], 11);
+    assert!(
+        empty.iter().all(|&w| w == 0),
+        "all-zero histogram must yield all-zero weights: {empty:?}"
     );
 }
 

--- a/zstd/src/huff0/huff0_encoder/tests.rs
+++ b/zstd/src/huff0/huff0_encoder/tests.rs
@@ -44,6 +44,24 @@ fn build_limited_weights_always_power_of_two() {
     );
     let _ = HuffmanTable::build_from_counts_gated(TRIGGER, false);
 
+    // A modest randomized sweep keeps ongoing breadth in the default suite
+    // without dominating its wall-clock; the deep 300k sweep is the separate
+    // `#[ignore]` stress test below.
+    fuzz_limited_weights_power_of_two(4_000);
+}
+
+/// Deep randomized sweep over the height limiter. Excluded from the default
+/// run (it is ~30 s); invoke explicitly with `cargo nextest run --run-ignored`.
+#[test]
+#[ignore = "stress: 300k-case height-limiter fuzz, run with --run-ignored"]
+fn build_limited_weights_power_of_two_stress() {
+    fuzz_limited_weights_power_of_two(300_000);
+}
+
+/// Drive `iterations` randomized histograms through the height limiter,
+/// asserting every one yields a power-of-two Kraft sum (and builds without
+/// panicking on the non-search literal path).
+fn fuzz_limited_weights_power_of_two(iterations: usize) {
     let mut state = 0x1234_5678_9abc_def0u64;
     let mut next = || {
         state ^= state << 13;
@@ -51,7 +69,7 @@ fn build_limited_weights_always_power_of_two() {
         state ^= state << 17;
         state
     };
-    for _ in 0..300_000 {
+    for _ in 0..iterations {
         let n = 2 + (next() % 255) as usize;
         let skew = (next() % 6) as u32;
         let mut counts = alloc::vec![0usize; n];

--- a/zstd/src/huff0/huff0_encoder/tests.rs
+++ b/zstd/src/huff0/huff0_encoder/tests.rs
@@ -18,6 +18,90 @@ fn huffman() {
     assert_eq!(table.codes[5], (1, 4));
 }
 
+// Regression: the non-search literal-table path (fast / negative levels,
+// `build_from_counts_gated(use_search=false)`) builds
+// `build_from_weights(build_limited_weights(counts, 11))` with NO power-of-two
+// guard, so any `counts` whose height-limited weights break the canonical
+// `Σ 2^(weight-1)` invariant panics in `build_from_weights`. Height limiting
+// must ALWAYS restore that invariant (full Kraft sum). Fuzz to prove it does.
+#[test]
+fn build_limited_weights_always_power_of_two() {
+    // A real-shaped literal histogram: 100 symbols with small, skewed counts
+    // (a ~60:1 spread), exactly what a single block produces. Its natural
+    // Huffman depth exceeds the 11-bit limit, and the broken limiter left the
+    // code under-full here, projecting to non-power-of-two weights that
+    // panicked the table builder on the non-search literal path.
+    const TRIGGER: &[usize] = &[
+        53, 53, 45, 13, 21, 31, 36, 16, 59, 25, 27, 19, 50, 56, 49, 34, 38, 49, 24, 50, 61, 30, 54,
+        6, 62, 50, 34, 61, 15, 37, 34, 61, 26, 49, 21, 59, 30, 31, 17, 14, 51, 14, 60, 30, 34, 1,
+        49, 25, 58, 1, 41, 19, 49, 34, 42, 2, 55, 11, 17, 40, 34, 25, 13, 26, 56, 19, 19, 61, 2, 2,
+        45, 24, 53, 10, 31, 46, 61, 49, 38, 10, 14, 28, 26, 19, 20, 42, 18, 34, 44, 55, 1, 0, 37,
+        41, 1, 33, 1, 25, 46, 52,
+    ];
+    assert!(
+        huffman_weight_sum_is_power_of_two(&build_limited_weights(TRIGGER, 11)),
+        "height limiter left a non-power-of-two weight sum on a real-shaped histogram"
+    );
+    let _ = HuffmanTable::build_from_counts_gated(TRIGGER, false);
+
+    let mut state = 0x1234_5678_9abc_def0u64;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for _ in 0..300_000 {
+        let n = 2 + (next() % 255) as usize;
+        let skew = (next() % 6) as u32;
+        let mut counts = alloc::vec![0usize; n];
+        // Counts are byte-frequency histograms of a single block, so each is
+        // bounded by the max block size; keep the fuzz within that envelope.
+        const MAX_COUNT: usize = 128 * 1024;
+        match skew {
+            // Fibonacci-like + geometric distributions force a natural Huffman
+            // depth well past 11 (a Fibonacci ladder hits ~26 distinct values
+            // under MAX_COUNT), so the height limiter actually runs (and its
+            // Kraft-sum restoration is exercised) instead of a shallow tree.
+            4 => {
+                let (mut a, mut b) = (1usize, 1usize);
+                for c in counts.iter_mut() {
+                    *c = a;
+                    let nb = (a + b).min(MAX_COUNT);
+                    a = b;
+                    b = nb;
+                }
+            }
+            5 => {
+                let mut v = MAX_COUNT;
+                for c in counts.iter_mut() {
+                    *c = v.max(1);
+                    v = (v * (2 + (next() % 2) as usize)) / 3;
+                }
+            }
+            _ => {
+                for c in counts.iter_mut() {
+                    *c = match skew {
+                        0 => (next() % 64) as usize,
+                        1 => (next() % 4) as usize,
+                        2 => (next() % 4096) as usize,
+                        _ => 1 + (next() % 3) as usize,
+                    };
+                }
+            }
+        }
+        if counts.iter().filter(|&&c| c > 0).count() < 2 {
+            continue;
+        }
+        let weights = build_limited_weights(&counts, 11);
+        assert!(
+            huffman_weight_sum_is_power_of_two(&weights),
+            "build_limited_weights broke the power-of-two invariant: counts={counts:?} weights={weights:?}"
+        );
+        let _ = HuffmanTable::build_from_counts_gated(&counts, false);
+    }
+}
+
 #[test]
 fn weights() {
     // assert_eq!(distribute_weights(5).as_slice(), &[1, 1, 2, 3, 4]);


### PR DESCRIPTION
## Summary

Closes the bulk of the btopt / btultra optimal-parser gap against libzstd on the
per-label-dictionary path, resolves the SIMD kernel tier once per encoder invoke
instead of per block, and fixes two correctness bugs (a Huffman height-limiter
panic and an out-of-range compression-level mis-resolution).

### Perf: reshape the optimal-parse per-position find toward upstream's shape

Upstream's `ZSTD_insertBtAndGetAllMatches` is a `FORCE_INLINE_TEMPLATE`: the whole
per-position match-finder (rep probe + hash3 + binary-tree walk) is one inlined body,
called once per position, match-length template resolved once per block. Our path had
drifted into a chain of nested out-of-line calls paying per-position argument
marshalling upstream never pays.

- **Find monolith inlined into collect** (upstream `ZSTD_btGetAllMatches` shape): rep
  probe + hash3 probe + BT tree walk folded into one out-of-line body, one call per
  position, replacing a nested call chain.
- **Cost profile passed by reference** into the deepest per-position crossing (the
  24-byte struct was stack-copied every call).
- **DP scratch buffers taken once per block** and shared across both btultra2 passes.
- **No-match literal path trimmed**: deferred price-cache / stamp / base-node setup
  past the no-match seed, dropped a discarded price recompute, skipped the no-op
  plan-stats update on no-match segments.

Output is byte-identical to before across the suite; the encoder makes the same match
decisions, the work is just marshalled the way upstream marshals it.

**Measured (i9-9900K, BMI2 + AVX2; L16 btopt, small-10k-random, compress-dict; libzstd
control flat at ~388 µs):** pure Rust **932 µs -> 657 µs (-29%)**, 2.40x -> 1.70x vs
libzstd.

### Refactor: resolve the SIMD kernel tier once per invoke, not per block

The HC / optimal / btlazy2 strategy entries and the BT-walker dispatchers called
`select_kernel()` per block (btultra2 twice: seed + main pass), re-reading the cached
`OnceLock` atomic inside the hot strategy path. The Fast / Row / Dfast matchers already
cache the resolved tier in a field at construction; the binary-tree path now mirrors
that. `MatchTable` caches the tier, set once via `select_kernel()` at construction (once
per encoder invoke, since the matcher is built once per `FrameCompressor`); every
per-block strategy entry and BT dispatcher reads the cached field. `select_kernel()` is
now called exactly once per matcher, never inside a strategy or hot loop. Byte-identical
(the tier is constant for the process lifetime).

### Fix: Huffman height limiter could leave a non-power-of-two Kraft sum

The height limiter (upstream `HUF_setMaxHeight` equivalent) walked the cost-repair fill
in the wrong direction on certain <=128 KB literal histograms, leaving a code whose
Kraft sum was not a power of two. The table builder rejects such a code, surfacing as a
panic. The limiter now fills downward correctly and validates the Kraft sum, falling
back to the distributed-weight construction when it cannot reach the bit-length cap; the
dead repair helper is removed.

### Fix: out-of-range compression levels mis-resolved

`resolve_level_params` special-cased only `Level(22)` for the btultra2 source-size
resolver; `Level(23+)` fell through to the generic cParams path and resolved a different
configuration than the max level. Now `Level(n)` for `n >= MAX_LEVEL` clamps through the
same resolver.

### Perf: hold the decode dictionary by borrowed pointer (mirror C zero-refcount apply)

Upstream zstd's `ZSTD_copyDDictParameters` stores RAW POINTERS into a caller-owned `DDict`
every frame (`dctx->LLTptr = ddict->entropy.LLTable`, `prefixStart = dictContent`) — no
refcount, no per-frame clone. We held an owned `Arc<Dictionary>` in three places (FSE +
Huffman scratch + decode buffer) and re-cloned all three each frame, dropping them at
teardown: six atomic refcount ops per frame on a value the dictionary owner already keeps
alive for the whole decode. The three scratch sites now hold `Option<NonNull<Dictionary>>`,
set from a live `&DictionaryHandle` each frame (one pointer store) and read through a
checked `unsafe` deref while the COW table-source is `Dict`. The pointee is kept alive
across the decode by the dictionary owner (the `FrameDecoder` registry, or the
`&DictionaryHandle` the caller holds across `decode_all_with_dict_handle`). `NonNull`
suppresses auto-`Send`/`Sync`, so `unsafe impl Send/Sync` is restored on each scratch type
(read-only borrow of `Send + Sync` data), with a compile-time assert pinning
`FrameDecoder: Send + Sync`. Byte-identical. i9 small-10k-random `decompress-dict`, flat
`c_ffi` control: **L3 dfast -2.3%, L16 btopt -1.8%**.

## Tests

- `bt_optimal_all_kernel_tiers_emit_identical_sequences` — forces each cached kernel tier
  and asserts identical sequence streams (scalar/SIMD bit-identity + per-tier wrapper
  coverage on one machine).
- `levels_above_max_resolve_identically_to_max` — regression for the level-clamp fix.
- `level_params_strategy_and_search_method_agree_across_tiers` — strategy/search-method
  consistency across the cParams source-size tiers.
- `build_limited_weights_handles_degenerate_alphabets` — single-symbol / all-zero
  height-limiter early-out.
- Huffman power-of-two invariant: deterministic trigger histogram in the default suite
  plus a 300k-case `#[ignore]` stress sweep.

Validation: full suite green (851 on x86 incl. dict_builder), `cargo clippy -D warnings`
clean, `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved BT/HC match-finding and BT optimal-parse candidate probing (including consolidated rep and optional hash3 probing) for more consistent parsing decisions.
  * Refined encoder level-parameter resolution, including tighter clamping for out-of-range level requests.

* **Bug Fixes**
  * Fixed hash3 computation for borrowed/no-copy scenarios.
  * Corrected BT tree update cursor advancement behavior.
  * Strengthened Huffman height limiting to preserve Kraft-sum canonical validity.
  * Improved dictionary support during decoding by using call-scoped dictionary borrowing.

* **Tests**
  * Added/updated regressions for Huffman Kraft-sum invariants, level-resolution/BT-optimal consistency, kernel-tier equivalence, and dictionary-aware decoder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
