### PR TITLE
perf(row): port the lazy parse, row/chain search and dictionary plan from upstream

### DIFF
--- a/ffi-bench/Cargo.toml
+++ b/ffi-bench/Cargo.toml
@@ -261,3 +261,7 @@ path = "examples/encode_small.rs"
 [[example]]
 name = "ratio_parity"
 path = "examples/ratio_parity.rs"
+
+[[example]]
+name = "periodic_presplit"
+path = "examples/periodic_presplit.rs"

--- a/ffi-bench/examples/periodic_presplit.rs
+++ b/ffi-bench/examples/periodic_presplit.rs
@@ -1,0 +1,39 @@
+//! Pre-splitter behaviour on a homogeneous but periodic log stream: OUR
+//! one-shot frame vs the C reference's one-shot frame (`ZSTD_compress2` via
+//! the zstd crate) per level. Used to check that the byChunks sampling tier
+//! selected per strategy matches upstream's (an over-split shows up as a
+//! ballooned lazy2 / btlazy2 output next to the lazy level).
+
+use structured_zstd::encoding::{CompressionLevel, compress_slice_to_vec};
+
+fn main() {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let target: usize = std::env::args()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(512 * 1024);
+    let mut data = Vec::with_capacity(target);
+    let mut i = 0;
+    while data.len() < target {
+        let line = LINES[i % LINES.len()].as_bytes();
+        let take = line.len().min(target - data.len());
+        data.extend_from_slice(&line[..take]);
+        i += 1;
+    }
+    println!("periodic stream {} bytes", data.len());
+    for lvl in [3i32, 5, 7, 8, 11, 15, 16] {
+        let ours = compress_slice_to_vec(&data, CompressionLevel::Level(lvl));
+        let c = zstd::bulk::compress(&data, lvl).expect("c compress");
+        println!(
+            "L{lvl:<3} ours={:>7}B  C={:>7}B  ours/C={:.3}",
+            ours.len(),
+            c.len(),
+            ours.len() as f64 / c.len() as f64,
+        );
+    }
+}

--- a/ffi-bench/tests/frame_compressor_ffi.rs
+++ b/ffi-bench/tests/frame_compressor_ffi.rs
@@ -37,6 +37,43 @@ fn c_decode(compressed: &[u8]) -> Vec<u8> {
     decoded
 }
 
+/// The pre-splitter tier selected per strategy matches upstream's default
+/// `splitLevels[strategy]`: on a homogeneous but periodic 512 KB log stream
+/// the lazy2 / btlazy2 tier (byChunks rate 5) splits into more blocks than
+/// the lazy tier, exactly as `ZSTD_compress2` does, so every level's output
+/// is no larger than the reference's (a wrong tier shows up either as a
+/// ballooned lazy2 frame the reference does not produce, or as a larger
+/// frame on the levels where upstream splits and we would not).
+#[test]
+fn periodic_stream_presplit_matches_reference() {
+    const LINES: &[&str] = &[
+        "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:29Z level=INFO msg=\"rotate segment\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:30Z level=INFO msg=\"compact level\" tenant=demo table=orders region=eu-west\n",
+        "ts=2026-03-26T21:39:31Z level=INFO msg=\"write block\" tenant=demo table=orders region=eu-west\n",
+    ];
+    let target = 512 * 1024usize;
+    let mut data = Vec::with_capacity(target);
+    let mut i = 0;
+    while data.len() < target {
+        let line = LINES[i % LINES.len()].as_bytes();
+        let take = line.len().min(target - data.len());
+        data.extend_from_slice(&line[..take]);
+        i += 1;
+    }
+    for level in [3i32, 5, 7, 8, 11, 15, 16] {
+        let ours = compress_to_vec(&data[..], CompressionLevel::Level(level));
+        let reference = zstd::bulk::compress(&data[..], level).expect("C compress");
+        assert!(
+            ours.len() <= reference.len(),
+            "L{level}: ours {} bytes > reference {} bytes on the periodic stream",
+            ours.len(),
+            reference.len()
+        );
+        assert_eq!(c_decode(&ours[..]), data, "L{level} roundtrip through C");
+    }
+}
+
 /// Frame content size is written correctly and C zstd can decompress the output.
 #[test]
 fn fcs_header_written_and_c_zstd_compatible() {

--- a/zstd/benches/compare_ffi.rs
+++ b/zstd/benches/compare_ffi.rs
@@ -76,12 +76,12 @@ fn rust_encode_to_vec(input: &[u8], level: &LevelConfig) -> Vec<u8> {
     enc.compress_independent_frame(input)
 }
 
-/// FFI encode helper used by criterion's timing loop. Uses
-/// `ZSTD_compressStream2` into a growing-output `Vec` — same shape as
-/// the pure-Rust `compress_to_vec` so output-buffer growth profiles
-/// match cross-side. When `ldm` is set, `ZSTD_c_enableLongDistanceMatching`
-/// is turned on alongside the level so the FFI reference mirrors the Rust
-/// LDM variant (#362).
+/// FFI encode helper used by criterion's timing loop: one-shot
+/// `ZSTD_compress2` on a `ZSTD_compressBound`-sized `Vec`, the same
+/// single-call frame the pure-Rust `compress_independent_frame` produces
+/// (see the block-splitting note inside). When `ldm` is set,
+/// `ZSTD_c_enableLongDistanceMatching` is turned on alongside the level so
+/// the FFI reference mirrors the Rust LDM variant (#362).
 fn ffi_encode_to_vec(input: &[u8], level: i32, ldm: bool) -> Vec<u8> {
     use zstd::zstd_safe::zstd_sys;
     // SAFETY: `ZSTD_createCCtx` returns null on OOM, asserted below.
@@ -149,48 +149,29 @@ fn ffi_encode_to_vec(input: &[u8], level: i32, ldm: bool) -> Vec<u8> {
         let rc = zstd_sys::ZSTD_CCtx_setPledgedSrcSize(cctx, input.len() as u64);
         assert!(zstd_sys::ZSTD_isError(rc) == 0, "setPledgedSrcSize failed");
 
-        let recommended_in = zstd_sys::ZSTD_CStreamInSize();
-        let recommended_out = zstd_sys::ZSTD_CStreamOutSize();
-        let mut output: Vec<u8> = Vec::new();
-        let mut chunk = vec![0u8; recommended_out];
-        let mut in_pos: usize = 0;
-        loop {
-            let chunk_end = (in_pos + recommended_in).min(input.len());
-            let mut zin = zstd_sys::ZSTD_inBuffer {
-                src: input.as_ptr() as *const core::ffi::c_void,
-                size: chunk_end,
-                pos: in_pos,
-            };
-            let mode = if chunk_end == input.len() {
-                zstd_sys::ZSTD_EndDirective::ZSTD_e_end
-            } else {
-                zstd_sys::ZSTD_EndDirective::ZSTD_e_continue
-            };
-            loop {
-                let mut zout = zstd_sys::ZSTD_outBuffer {
-                    dst: chunk.as_mut_ptr() as *mut core::ffi::c_void,
-                    size: chunk.len(),
-                    pos: 0,
-                };
-                let remaining = zstd_sys::ZSTD_compressStream2(cctx, &mut zout, &mut zin, mode);
-                assert!(
-                    zstd_sys::ZSTD_isError(remaining) == 0,
-                    "ZSTD_compressStream2 failed (code = {remaining})"
-                );
-                output.extend_from_slice(&chunk[..zout.pos]);
-                let frame_complete =
-                    matches!(mode, zstd_sys::ZSTD_EndDirective::ZSTD_e_end) && remaining == 0;
-                let chunk_consumed = matches!(mode, zstd_sys::ZSTD_EndDirective::ZSTD_e_continue)
-                    && zin.pos == zin.size;
-                if frame_complete || chunk_consumed {
-                    break;
-                }
-            }
-            in_pos = zin.pos;
-            if in_pos == input.len() && matches!(mode, zstd_sys::ZSTD_EndDirective::ZSTD_e_end) {
-                break;
-            }
-        }
+        // One-shot `ZSTD_compress2`, the path `compress_independent_frame`
+        // mirrors. The streaming API (`ZSTD_compressStream2`) is NOT
+        // equivalent even when handed the whole input at once: it buffers
+        // `blockSizeMax` (128 KB) and runs `ZSTD_compress_frameChunk` per
+        // 128 KB, whose `ZSTD_optimalBlockSize` never splits a remainder
+        // below 128 KB, so streaming emits at most two blocks per 128 KB
+        // (14 on the 1 MB corpus) while one-shot keeps pre-splitting (~90
+        // blocks, ~5% smaller output, 7x the entropy work). Pairing our
+        // one-shot encoder with streaming C misstates both time and size.
+        let bound = zstd_sys::ZSTD_compressBound(input.len());
+        let mut output: Vec<u8> = vec![0u8; bound];
+        let written = zstd_sys::ZSTD_compress2(
+            cctx,
+            output.as_mut_ptr() as *mut core::ffi::c_void,
+            output.len(),
+            input.as_ptr() as *const core::ffi::c_void,
+            input.len(),
+        );
+        assert!(
+            zstd_sys::ZSTD_isError(written) == 0,
+            "ZSTD_compress2 failed (code = {written})"
+        );
+        output.truncate(written);
 
         zstd_sys::ZSTD_freeCCtx(cctx);
         output

--- a/zstd/benches/compare_ffi_sequences.rs
+++ b/zstd/benches/compare_ffi_sequences.rs
@@ -452,7 +452,7 @@ fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize, dict: Option<
     let mut differ = 0usize;
     let mut rust_only = 0usize;
     let mut ffi_only = 0usize;
-    for r in &rows {
+    for (_, r) in &rows {
         match r {
             DiffRow::Equal => equal += 1,
             DiffRow::Differ { .. } => differ += 1,
@@ -492,7 +492,7 @@ fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize, dict: Option<
     }
     let mut printed = 0usize;
     let mut header_printed = false;
-    for (idx, r) in rows.iter().enumerate() {
+    for (idx, (pos, r)) in rows.iter().enumerate() {
         if matches!(r, DiffRow::Equal) {
             continue;
         }
@@ -506,34 +506,37 @@ fn run_one(_name: &str, input: &[u8], level: i32, max_rows: usize, dict: Option<
         if !header_printed {
             println!();
             println!(
-                "  {:>5} | {:^28} | {:^28} | verdict",
-                "idx", "rust (blk:idx ll/of/ml)", "ffi  (blk:idx ll/of/ml)"
+                "  {:>5} | {:>8} | {:^28} | {:^28} | verdict",
+                "idx", "pos", "rust (blk:idx ll/of/ml)", "ffi  (blk:idx ll/of/ml)"
             );
-            println!("  {}", "-".repeat(80));
+            println!("  {}", "-".repeat(91));
             header_printed = true;
         }
         match r {
             DiffRow::Equal => unreachable!(),
             DiffRow::Differ { rust, ffi } => {
                 println!(
-                    "  {:>5} | {:<28} | {:<28} | DIFFER",
+                    "  {:>5} | {:>8} | {:<28} | {:<28} | DIFFER",
                     idx,
+                    pos,
                     fmt_rust(rust),
                     fmt_ffi(ffi),
                 );
             }
             DiffRow::RustOnly(rust) => {
                 println!(
-                    "  {:>5} | {:<28} | {:<28} | RUST_ONLY",
+                    "  {:>5} | {:>8} | {:<28} | {:<28} | RUST_ONLY",
                     idx,
+                    pos,
                     fmt_rust(rust),
                     "—",
                 );
             }
             DiffRow::FfiOnly(ffi) => {
                 println!(
-                    "  {:>5} | {:<28} | {:<28} | FFI_ONLY",
+                    "  {:>5} | {:>8} | {:<28} | {:<28} | FFI_ONLY",
                     idx,
+                    pos,
                     "—",
                     fmt_ffi(ffi),
                 );
@@ -604,7 +607,10 @@ fn align_and_diff(
     rust_tails: &[u32],
     ffi: &[FfiSeq],
     ffi_tails: &[u32],
-) -> Vec<DiffRow> {
+) -> Vec<(u64, DiffRow)> {
+    // Each row is tagged with the absolute input position it was emitted
+    // at (the start of the emitting side's literal run), so a divergence
+    // can be reproduced on a prefix of the input.
     let mut rust_iter = rust.iter().peekable();
     let mut ffi_iter = ffi.iter().peekable();
     let mut rust_pos: u64 = 0;
@@ -649,14 +655,14 @@ fn align_and_diff(
             (None, None) => break,
             (Some(r), None) => {
                 let r = **r;
+                out.push((rust_pos, DiffRow::RustOnly(r)));
                 rust_pos += r.ll as u64 + r.ml as u64;
-                out.push(DiffRow::RustOnly(r));
                 rust_iter.next();
             }
             (None, Some(f)) => {
                 let f = **f;
+                out.push((ffi_pos, DiffRow::FfiOnly(f)));
                 ffi_pos += f.ll as u64 + f.ml as u64;
-                out.push(DiffRow::FfiOnly(f));
                 ffi_iter.next();
             }
             (Some(r), Some(f)) => {
@@ -675,9 +681,9 @@ fn align_and_diff(
                     let r = **r;
                     let f = **f;
                     if r.ll == f.ll && r.of == f.of && r.ml == f.ml {
-                        out.push(DiffRow::Equal);
+                        out.push((rust_pos, DiffRow::Equal));
                     } else {
-                        out.push(DiffRow::Differ { rust: r, ffi: f });
+                        out.push((rust_pos, DiffRow::Differ { rust: r, ffi: f }));
                     }
                     rust_pos = r_next_pos;
                     ffi_pos = f_next_pos;
@@ -685,13 +691,13 @@ fn align_and_diff(
                     ffi_iter.next();
                 } else if rust_pos < ffi_pos {
                     let r = **r;
+                    out.push((rust_pos, DiffRow::RustOnly(r)));
                     rust_pos = r_next_pos;
-                    out.push(DiffRow::RustOnly(r));
                     rust_iter.next();
                 } else {
                     let f = **f;
+                    out.push((ffi_pos, DiffRow::FfiOnly(f)));
                     ffi_pos = f_next_pos;
-                    out.push(DiffRow::FfiOnly(f));
                     ffi_iter.next();
                 }
             }

--- a/zstd/src/decoding/ringbuffer.rs
+++ b/zstd/src/decoding/ringbuffer.rs
@@ -473,18 +473,12 @@ impl RingBuffer {
     /// by the buffer.
     // SAFETY: other code relies on this pointing to initialized halves of the buffer only
     fn data_slice_lengths(&self) -> (usize, usize) {
-        let len_after_head;
-        let len_to_tail;
-
         // TODO can we do this branchless?
         if self.tail >= self.head {
-            len_after_head = self.tail - self.head;
-            len_to_tail = 0;
+            (self.tail - self.head, 0)
         } else {
-            len_after_head = self.cap - self.head;
-            len_to_tail = self.tail;
+            (self.cap - self.head, self.tail)
         }
-        (len_after_head, len_to_tail)
     }
 
     // SAFETY: other code relies on this pointing to initialized halves of the buffer only
@@ -513,18 +507,12 @@ impl RingBuffer {
     // at the beginning/end of the buffer. Everything else must be initialized
     /// Returns the size of the two unoccupied sections of memory used by the buffer.
     fn free_slice_lengths(&self) -> (usize, usize) {
-        let len_to_head;
-        let len_after_tail;
-
         // TODO can we do this branchless?
         if self.tail < self.head {
-            len_after_tail = self.head - self.tail;
-            len_to_head = 0;
+            (0, self.head - self.tail)
         } else {
-            len_after_tail = self.cap - self.tail;
-            len_to_head = self.head;
+            (self.head, self.cap - self.tail)
         }
-        (len_to_head, len_after_tail)
     }
 
     /// Returns mutable references to the available space and the size of that available space,

--- a/zstd/src/encoding/cparams.rs
+++ b/zstd/src/encoding/cparams.rs
@@ -225,6 +225,68 @@ pub(crate) fn adjust_cparams(
 /// `ZSTD_getCParams_internal` (zstd_compress.c): tier + level row selection,
 /// negative-level acceleration, then `ZSTD_adjustCParams_internal`.
 pub(crate) fn get_cparams(compression_level: i32, src_size_hint: u64, dict_size: usize) -> CParams {
+    get_cparams_mode(compression_level, src_size_hint, dict_size, false)
+}
+
+/// The cParams a `ZSTD_CDict` is built with (`ZSTD_createCDict`:
+/// `ZSTD_getCParams_internal(level, ZSTD_CONTENTSIZE_UNKNOWN, dictSize,
+/// ZSTD_cpm_createCDict)`): the tier row is picked by `dictSize + 500 - 2`
+/// (the unknown-source row size), then the tables are down-sized for a
+/// `minSrcSize` source. A frame compressed with the dictionary takes its
+/// strategy, table widths, search depth and match-finder from THESE, not
+/// from the level's plain row (`ZSTD_resetCCtx_usingCDict`).
+pub(crate) fn get_cdict_cparams(compression_level: i32, dict_size: usize) -> CParams {
+    get_cparams_mode(compression_level, CONTENTSIZE_UNKNOWN, dict_size, true)
+}
+
+/// `ZSTD_resetCCtx_byAttachingCDict` cParams: the CDict's cParams re-adjusted
+/// for the frame's source alone (`ZSTD_cpm_attachDict` ignores the dictionary
+/// size, the dictionary keeps its own tables) with the frame's own
+/// `windowLog` kept.
+pub(crate) fn attach_cparams(cdict: CParams, src_size: u64, window_log: u32) -> CParams {
+    let mut cp = adjust_cparams(cdict, src_size, 0, false);
+    cp.window_log = window_log;
+    cp
+}
+
+/// `ZSTD_resetCCtx_byCopyingCDict` cParams: the CDict's cParams verbatim with
+/// the frame's own `windowLog`.
+pub(crate) fn copy_cparams(cdict: CParams, window_log: u32) -> CParams {
+    let mut cp = cdict;
+    cp.window_log = window_log;
+    cp
+}
+
+/// `ZSTD_resolveRowMatchFinderMode(ZSTD_ps_auto, cp)`: the greedy / lazy /
+/// lazy2 strategies search rows only above a 2^14 window. A CDict resolves
+/// this from its own cParams and the frame inherits the answer.
+pub(crate) fn uses_row_match_finder(cp: &CParams) -> bool {
+    (3..=5).contains(&cp.strategy) && cp.window_log > 14
+}
+
+/// `ZSTD_shouldAttachDict`: the CDict tables are referenced in place
+/// (`dictMatchState`) for sources up to the strategy's cutoff or of unknown
+/// size, and copied into the frame's tables above it.
+pub(crate) fn should_attach_dict(cdict: &CParams, src_size: Option<u64>) -> bool {
+    const KB: u64 = 1024;
+    // `attachDictSizeCutoffs[strategy]`: fast 8 KB, dfast 16 KB, greedy /
+    // lazy / lazy2 / btlazy2 / btopt 32 KB, btultra / btultra2 8 KB.
+    let cutoff = match cdict.strategy {
+        1 => 8 * KB,
+        2 => 16 * KB,
+        3..=7 => 32 * KB,
+        _ => 8 * KB,
+    };
+    src_size.is_none_or(|s| s <= cutoff)
+}
+
+/// `ZSTD_getCParams_internal` with the `ZSTD_cpm_createCDict` switch.
+fn get_cparams_mode(
+    compression_level: i32,
+    src_size_hint: u64,
+    dict_size: usize,
+    create_cdict: bool,
+) -> CParams {
     let r_size = cparam_row_size(src_size_hint, dict_size);
     let table_id = (u32::from(r_size <= KB_256)
         + u32::from(r_size <= KB_128)
@@ -260,8 +322,7 @@ pub(crate) fn get_cparams(compression_level: i32, src_size_hint: u64, dict_size:
         cp.target_length = (-clamped) as u32;
     }
 
-    // `ZSTD_cpm_unknown` (the public entry): no createCDict source assumption.
-    adjust_cparams(cp, src_size_hint, dict_size, /* create_cdict */ false)
+    adjust_cparams(cp, src_size_hint, dict_size, create_cdict)
 }
 
 /// Public `ZSTD_getCParams` entry: maps `src_size_hint == 0` to UNKNOWN,

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -110,6 +110,11 @@ pub struct FrameCompressor<
     /// time, so without `hash` no checksum is emitted regardless. Set via
     /// [`Self::set_content_checksum`].
     content_checksum: bool,
+    /// Diagnostic: skip the block pre-splitter and cut full blocks only
+    /// (upstream's block structure under `ZSTD_generateSequences`, whose
+    /// sequence-collecting mode never accrues the savings the splitter
+    /// requires). Set via [`Self::set_pre_split_disabled`]; default `false`.
+    pre_split_disabled: bool,
     /// Whether to record `Frame_Content_Size` in the frame header when the
     /// total size is known (semantics of upstream `ZSTD_c_contentSizeFlag`).
     /// Default `true`, matching upstream. With the flag off the header
@@ -642,7 +647,25 @@ pub(crate) fn optimal_block_size(
     block_size_max: usize,
     savings: i64,
 ) -> usize {
-    let Some(split_level) = crate::encoding::levels::config::level_pre_split(level) else {
+    optimal_block_size_with(
+        crate::encoding::levels::config::level_pre_split(level),
+        block,
+        remaining_src_size,
+        block_size_max,
+        savings,
+    )
+}
+
+/// [`optimal_block_size`] with the pre-split level already resolved
+/// (`None` = never split, only full blocks).
+pub(crate) fn optimal_block_size_with(
+    pre_split: Option<usize>,
+    block: &[u8],
+    remaining_src_size: usize,
+    block_size_max: usize,
+    savings: i64,
+) -> usize {
+    let Some(split_level) = pre_split else {
         return remaining_src_size.min(block_size_max);
     };
     if remaining_src_size < MAX_BLOCK_SIZE as usize || block_size_max < MAX_BLOCK_SIZE as usize {
@@ -990,6 +1013,7 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             },
             magicless: false,
             content_checksum: false,
+            pre_split_disabled: false,
             content_size_flag: true,
             dict_id_flag: true,
             target_block_size: None,
@@ -1334,16 +1358,16 @@ impl<R: Read, W: Write> FrameCompressor<R, W, MatchGeneratorDriver> {
             // splitter actually runs) — so non-pre-split levels, the first
             // block, and the trailing partial block pay nothing. See
             // `warm_presplit_window`.
+            let pre_split = self.pre_split_level();
             if savings >= 3
                 && input.len() - start >= MAX_BLOCK_SIZE as usize
                 && block_capacity >= MAX_BLOCK_SIZE as usize
-                && crate::encoding::levels::config::level_pre_split(self.compression_level)
-                    .is_some()
+                && pre_split.is_some()
             {
                 warm_presplit_window(&input[start..start + MAX_BLOCK_SIZE as usize]);
             }
-            let block_len = optimal_block_size(
-                self.compression_level,
+            let block_len = optimal_block_size_with(
+                pre_split,
                 &input[start..],
                 input.len() - start,
                 block_capacity,
@@ -1407,6 +1431,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             compression_level,
             magicless: false,
             content_checksum: false,
+            pre_split_disabled: false,
             content_size_flag: true,
             dict_id_flag: true,
             target_block_size: None,
@@ -1512,6 +1537,24 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
     /// history is primed separately and does not inflate the hinted size or
     /// advertised frame window.
     /// Must be called before [`compress`](Self::compress).
+    /// Diagnostic switch: cut full blocks only, never pre-split. Used by
+    /// the sequence capture so its block structure matches upstream's
+    /// `ZSTD_generateSequences` (see `pre_split_disabled`).
+    #[cfg(feature = "bench_internals")]
+    pub fn set_pre_split_disabled(&mut self, disabled: bool) {
+        self.pre_split_disabled = disabled;
+    }
+
+    /// The pre-split level the block loops apply: the level's tier unless
+    /// the diagnostic switch is on.
+    fn pre_split_level(&self) -> Option<usize> {
+        if self.pre_split_disabled {
+            None
+        } else {
+            crate::encoding::levels::config::level_pre_split(self.compression_level)
+        }
+    }
+
     pub fn set_source_size_hint(&mut self, size: u64) {
         self.source_size_hint = Some(size);
     }
@@ -1906,8 +1949,8 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
             if !matches!(self.compression_level, CompressionLevel::Uncompressed)
                 && uncompressed_data.len() == block_capacity
             {
-                let block_len = optimal_block_size(
-                    self.compression_level,
+                let block_len = optimal_block_size_with(
+                    self.pre_split_level(),
                     &uncompressed_data,
                     remaining_for_split,
                     block_capacity,

--- a/zstd/src/encoding/frame_compressor/tests.rs
+++ b/zstd/src/encoding/frame_compressor/tests.rs
@@ -2052,12 +2052,12 @@ fn split_block_from_borders_returns_midpoint_for_centred_transition() {
 }
 
 /// `level_pre_split` resolves the per-level split knob through the
-/// `LevelParams` table, returning the EFFECTIVE upstream `ZSTD_splitBlock`
-/// level (`splitLevels[strategy] - 2`, clamped at 0) that
-/// `ZSTD_optimalBlockSize` dispatches: fast/dfast/greedy/lazy(d1) → 0
-/// (from-borders), lazy2/btlazy2 → 1 (byChunks rate 43),
-/// btopt/btultra/btultra2 → 2 (byChunks rate 11). `Uncompressed` has no
-/// numeric level so it stays `None`.
+/// `LevelParams` table, returning the upstream `ZSTD_splitBlock` level that
+/// `ZSTD_optimalBlockSize` dispatches by default, `splitLevels[strategy] =
+/// {0,0,1,2,2,3,3,4,4,4}`: fast → 0 (from-borders), dfast → 1 (byChunks
+/// rate 43), greedy/lazy → 2 (rate 11), lazy2/btlazy2 → 3 (rate 5),
+/// btopt/btultra/btultra2 → 4 (rate 1). `Uncompressed` has no numeric
+/// level so it stays `None`.
 #[test]
 fn pre_split_level_dispatches_by_compression_level() {
     use crate::encoding::CompressionLevel;
@@ -2065,8 +2065,8 @@ fn pre_split_level_dispatches_by_compression_level() {
     assert_eq!(level_pre_split(CompressionLevel::Uncompressed), None);
     // Fastest = level 1 (fast) → 0 (from-borders).
     assert_eq!(level_pre_split(CompressionLevel::Fastest), Some(0));
-    // Default = level 3 (dfast) → 0 (splitLevels 1 - 2, clamped).
-    assert_eq!(level_pre_split(CompressionLevel::Default), Some(0));
+    // Default = level 3 (dfast) → 1 (byChunks rate 43).
+    assert_eq!(level_pre_split(CompressionLevel::Default), Some(1));
     // Better is a pure alias for level 7 (lazy): same as Level(7).
     assert_eq!(
         level_pre_split(CompressionLevel::Better),
@@ -2080,33 +2080,28 @@ fn pre_split_level_dispatches_by_compression_level() {
         level_pre_split(CompressionLevel::Level(13)),
     );
     assert_eq!(level_pre_split(CompressionLevel::Level(2)), Some(0)); // fast
-    assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(0)); // dfast
-    assert_eq!(level_pre_split(CompressionLevel::Level(5)), Some(0)); // greedy
-    assert_eq!(level_pre_split(CompressionLevel::Level(7)), Some(0)); // lazy (depth 1)
-    // lazy2 / btlazy2: splitLevels 3 - 2 = 1 (byChunks rate 43, hashLog 8).
-    // The coarse byte-histogram tier is robust to the periodic-input
-    // phantom-split the rate-5/hashLog-10 tier suffered, so it matches
-    // upstream AND stays whole on periodic input (`periodic_stream_not_oversplit`).
-    assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(1)); // lazy2 lower bound
-    assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(1)); // lazy2 (depth 2)
-    assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(1)); // lazy2 upper bound
-    assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(1)); // btlazy2 lower bound
-    assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(1)); // btlazy2 (depth 2)
-    assert_eq!(level_pre_split(CompressionLevel::Level(16)), Some(2)); // btopt
-    assert_eq!(level_pre_split(CompressionLevel::Level(22)), Some(2)); // btultra2
+    assert_eq!(level_pre_split(CompressionLevel::Level(4)), Some(1)); // dfast
+    assert_eq!(level_pre_split(CompressionLevel::Level(5)), Some(2)); // greedy
+    assert_eq!(level_pre_split(CompressionLevel::Level(7)), Some(2)); // lazy (depth 1)
+    assert_eq!(level_pre_split(CompressionLevel::Level(8)), Some(3)); // lazy2 lower bound
+    assert_eq!(level_pre_split(CompressionLevel::Level(11)), Some(3)); // lazy2 (depth 2)
+    assert_eq!(level_pre_split(CompressionLevel::Level(12)), Some(3)); // lazy2 upper bound
+    assert_eq!(level_pre_split(CompressionLevel::Level(13)), Some(3)); // btlazy2 lower bound
+    assert_eq!(level_pre_split(CompressionLevel::Level(15)), Some(3)); // btlazy2 (depth 2)
+    assert_eq!(level_pre_split(CompressionLevel::Level(16)), Some(4)); // btopt
+    assert_eq!(level_pre_split(CompressionLevel::Level(22)), Some(4)); // btultra2
 }
 
-/// Regression: a homogeneous but periodic multi-block stream must not be
-/// pre-split into tiny blocks at the lazy2 / btlazy2 levels. The rate-5
-/// chunk sampler used to phantom-split such input at every 8 KB chunk,
-/// cascading a large stream into hundreds of tiny blocks whose per-block
-/// headers ballooned the output (~5x vs the lazy level next door). With
-/// the rate-1 full-scan splitter the periodic stream is seen as uniform
-/// and stays a few full blocks. We assert the lazy2 (L8) and btlazy2 (L15)
-/// outputs stay within 2x of the lazy (L7) output on the same input, and
-/// that every output round-trips.
+/// A homogeneous but periodic multi-block stream at the lazy (L7), lazy2
+/// (L8) and btlazy2 (L15) levels round-trips. The lazy2 / btlazy2 tier
+/// (upstream `splitLevels` 3, byChunks rate 5) pre-splits this input into
+/// more blocks than the lazy tier, exactly as upstream does (528 vs 189
+/// bytes on 512 KB, byte-identical to `ZSTD_compress2`); the size parity
+/// with the reference is asserted in `ffi-bench`
+/// (`periodic_stream_presplit_matches_reference`), this test only pins the
+/// round-trip and that the outputs stay small.
 #[test]
-fn periodic_stream_not_oversplit() {
+fn periodic_stream_roundtrips_at_every_presplit_tier() {
     use crate::encoding::{CompressionLevel, compress_slice_to_vec};
     const LINES: &[&str] = &[
         "ts=2026-03-26T21:39:28Z level=INFO msg=\"flush memtable\" tenant=demo table=orders region=eu-west\n",
@@ -2127,18 +2122,15 @@ fn periodic_stream_not_oversplit() {
     let l7 = compress_slice_to_vec(&data, CompressionLevel::Level(7)); // lazy depth1
     let l8 = compress_slice_to_vec(&data, CompressionLevel::Level(8)); // lazy2
     let l15 = compress_slice_to_vec(&data, CompressionLevel::Level(15)); // btlazy2
-    assert!(
-        l8.len() < l7.len() * 2,
-        "lazy2 over-split periodic stream: l7={} l8={}",
-        l7.len(),
-        l8.len()
-    );
-    assert!(
-        l15.len() < l7.len() * 2,
-        "btlazy2 over-split periodic stream: l7={} l15={}",
-        l7.len(),
-        l15.len()
-    );
+    // 512 KB of four repeating lines: every tier stays within a few block
+    // headers of the ~190-byte single-block frame (upstream: 189 / 528 / 528).
+    for (level, out) in [(7, &l7), (8, &l8), (15, &l15)] {
+        assert!(
+            out.len() < 1024,
+            "L{level} periodic stream ballooned: {} bytes",
+            out.len()
+        );
+    }
     for out in [&l7, &l8, &l15] {
         let mut decoder = FrameDecoder::new();
         let mut round = Vec::with_capacity(data.len());

--- a/zstd/src/encoding/incompressible.rs
+++ b/zstd/src/encoding/incompressible.rs
@@ -239,10 +239,9 @@ fn sample_looks_incompressible_capped(block: &[u8], max_sample_len: usize) -> bo
     // head / middle / tail probes so capped samples still reject
     // mixed-entropy blocks whose center is compressible.
     let mut regions: [&[u8]; 3] = [&[], &[], &[]];
-    let region_count;
-    if sample_len == block.len() {
+    let region_count = if sample_len == block.len() {
         regions[0] = block;
-        region_count = 1;
+        1
     } else {
         let head_len = sample_len / 3;
         let mid_len = sample_len / 3;
@@ -251,8 +250,8 @@ fn sample_looks_incompressible_capped(block: &[u8], max_sample_len: usize) -> bo
         regions[0] = &block[..head_len];
         regions[1] = &block[mid_start..mid_start + mid_len];
         regions[2] = &block[block.len() - tail_len..];
-        region_count = 3;
-    }
+        3
+    };
 
     // `repeat_guard` is the FINAL verdict threshold, fixed before scanning.
     // It needs the total 4-byte-quad count up front (one quad per 4 bytes of

--- a/zstd/src/encoding/levels/config.rs
+++ b/zstd/src/encoding/levels/config.rs
@@ -51,6 +51,10 @@ pub(crate) struct RowConfig {
     /// 4 bytes (an internal detail), so this only tunes the acceptance
     /// floor, not the candidate hash distribution.
     pub(crate) mls: usize,
+    /// Upstream `cParams.chainLog`: the hash-chain table the greedy/lazy
+    /// parse searches instead of rows when the window is 2^14 or smaller
+    /// (upstream `ZSTD_resolveRowMatchFinderMode`).
+    pub(crate) chain_log: usize,
 }
 
 // Only used as the default HashChain config when the test-only parse×search
@@ -86,6 +90,7 @@ pub(crate) const ROW_CONFIG: RowConfig = RowConfig {
     search_depth: ROW_SEARCH_DEPTH,
     target_len: ROW_TARGET_LEN,
     mls: ROW_MIN_MATCH_LEN,
+    chain_log: ROW_HASH_BITS,
 };
 
 // Level-5 greedy is the ONLY strategy routed to the Row backend
@@ -110,6 +115,7 @@ pub(crate) const ROW_L5: RowConfig = RowConfig {
     search_depth: 8,
     target_len: 2,
     mls: ROW_MIN_MATCH_LEN,
+    chain_log: 18,
 };
 
 /// Per-level Double-Fast hash sizing, mirroring the upstream zstd `clevels.h` columns
@@ -318,11 +324,13 @@ pub(crate) fn apply_param_overrides(
         SearchMethod::RowHash => {
             if let Some(row) = params.row.as_mut() {
                 // Row hash-table width override (mirrors dfast `long_hash_log`
-                // / hc `hash_log`). Row has no separate chain table — the
-                // per-row depth comes from `search_log` below — so only
-                // `hash_log` maps here; `chain_log` has no Row analogue.
+                // / hc `hash_log`); `chain_log` sizes the hash chain the same
+                // backend searches on a <= 2^14 window.
                 if let Some(hash_log) = ov.hash_log {
                     row.hash_bits = hash_log as usize;
+                }
+                if let Some(chain_log) = ov.chain_log {
+                    row.chain_log = chain_log as usize;
                 }
                 if let Some(search_log) = ov.search_log {
                     // Upstream zstd: rowLog = clamp(searchLog, 4, 6);
@@ -457,12 +465,6 @@ pub(crate) const MAX_FAST_ATTACH_DICT_REGION: usize = 1 << 24;
 /// fast-loop levels (L3 / Default / L0) carry the dual-probe.
 pub(crate) const DFAST_ATTACH_DICT_CUTOFF_LOG: u8 = 14;
 
-/// `ZSTD_dictMatchState` attach cutoff for the Row (greedy/lazy) strategy is
-/// 32 KiB (`2^15`, upstream zstd `attachDictSizeCutoffs`): small / unknown-size inputs
-/// ATTACH the dict into the separate immutable row index (bounded dual-probe in
-/// `row_candidate_rl`), larger known-size inputs dense-COPY into the live rows.
-pub(crate) const ROW_ATTACH_DICT_CUTOFF_LOG: u8 = 15;
-
 /// 32 KiB (`2^15`, upstream zstd `attachDictSizeCutoffs[ZSTD_lazy2]`): small /
 /// unknown-size inputs ATTACH the dict as a separate hash-chain dms (the dual
 /// search in `find_best_match` walks the live input chain + the dms), larger
@@ -571,6 +573,7 @@ fn level_params_from_cparams(cp: crate::encoding::cparams::CParams) -> LevelPara
         search_depth,
         target_len,
         mls: cp.min_match as usize,
+        chain_log: cp.chain_log as usize,
     };
     let bt = |tag| LevelParams {
         strategy_tag: tag,
@@ -801,15 +804,16 @@ pub fn estimated_bt_strategy_extra_bytes(strategy_ordinal: u32, window_log: u32)
 /// 3. [`adjust_params_for_source_size`] caps `window_log` to
 ///    ~`ceil_log2(source_size)` (upstream `ZSTD_adjustCParams_internal`).
 ///
-/// THEN, in the matcher `reset`, the greedy/lazy band falls back from
-/// `RowHash` to `SearchMethod::HashChain` when the resolved `window_log <= 14`
-/// — exactly upstream's `ZSTD_resolveRowMatchFinderMode` (the Row match-finder
-/// is used for greedy/lazy/lazy2 ONLY when `windowLog > 14`). Net effect for
-/// the SAME level:
+/// THEN, inside the Row backend, the greedy/lazy band searches a hash chain
+/// instead of rows when the resolved `window_log <= 14`
+/// (`RowMatchGenerator::use_chain`) — exactly upstream's
+/// `ZSTD_resolveRowMatchFinderMode` (the Row match-finder is used for
+/// greedy/lazy/lazy2 ONLY when `windowLog > 14`); the parse itself is the
+/// same `lazy_generic` body either way. Net effect for the SAME level:
 ///
-/// * small input (e.g. a 10 KiB fixture → `window_log` 14) → **HashChain**
+/// * small input (e.g. a 10 KiB fixture → `window_log` 14) → hash chain
 ///   (`ZSTD_HcFindBestMatch`, scalar chain walk);
-/// * large input (e.g. 1 MiB → `window_log` 20) → **RowHash** (the SIMD-tag
+/// * large input (e.g. 1 MiB → `window_log` 20) → rows (the SIMD-tag
 ///   row match-finder).
 ///
 /// A dictionary does NOT change the match-finder: it only downsizes the
@@ -854,8 +858,15 @@ pub(crate) fn resolve_level_params(
     // never re-derives parameters from a parallel hand-tuned path. Named presets
     // map to their numeric level; the cParams source clamps out-of-range levels
     // (>22 to 22, negatives to MIN_CLEVEL) itself.
-    let numeric: i32 = match level {
-        CompressionLevel::Uncompressed => unreachable!("handled above"),
+    let numeric = numeric_level(level);
+    let src = source_size.unwrap_or(crate::encoding::cparams::CONTENTSIZE_UNKNOWN);
+    level_params_from_cparams(crate::encoding::cparams::get_cparams(numeric, src, 0))
+}
+
+/// The upstream numeric level a preset maps to.
+fn numeric_level(level: CompressionLevel) -> i32 {
+    match level {
+        CompressionLevel::Uncompressed => unreachable!("raw frames resolve no cParams"),
         // Fastest = upstream level 1 (fast strategy, smallest real-compression
         // tables).
         CompressionLevel::Fastest => 1,
@@ -870,9 +881,70 @@ pub(crate) fn resolve_level_params(
         // wins rather than on a hair-thin margin.
         CompressionLevel::Best => 13,
         CompressionLevel::Level(n) => n,
+    }
+}
+
+/// How a greedy / lazy frame compressed with a dictionary takes its
+/// match-finder from the dictionary's own cParams (upstream
+/// `ZSTD_resetCCtx_usingCDict`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct RowDictPlan {
+    /// `ZSTD_shouldAttachDict`: the dictionary tables are searched in place
+    /// (`dictMatchState`) instead of being copied into the frame's tables.
+    pub(crate) attach: bool,
+    /// The CDict's `useRowMatchFinder`, inherited by the frame.
+    pub(crate) use_row: bool,
+    /// The CDict's cParams: the geometry (`hash_log`, `chain_log`,
+    /// `search_log` → row width) and key width its tables were built with.
+    pub(crate) cdict: crate::encoding::cparams::CParams,
+}
+
+/// [`resolve_level_params`] for a frame that compresses with a dictionary of
+/// `dict_size` bytes. Upstream builds the CDict with
+/// `ZSTD_getCParams(level, UNKNOWN, dictSize, createCDict)` and the frame
+/// then runs the CDict's strategy / widths / search depth / match-finder:
+/// re-adjusted to the source when the dictionary is attached
+/// (`ZSTD_resetCCtx_byAttachingCDict`), verbatim when it is copied
+/// (`ZSTD_resetCCtx_byCopyingCDict`); only the frame's own `windowLog` is
+/// kept. Levels outside the greedy / lazy band, and dictionaries whose
+/// cParams leave that band, keep the plain level params (no plan).
+pub(crate) fn resolve_level_params_with_dict(
+    level: CompressionLevel,
+    source_size: Option<u64>,
+    dict_size: usize,
+) -> (LevelParams, Option<RowDictPlan>) {
+    use crate::encoding::cparams::{
+        CONTENTSIZE_UNKNOWN, attach_cparams, copy_cparams, get_cdict_cparams, should_attach_dict,
+        uses_row_match_finder,
     };
-    let src = source_size.unwrap_or(crate::encoding::cparams::CONTENTSIZE_UNKNOWN);
-    level_params_from_cparams(crate::encoding::cparams::get_cparams(numeric, src, 0))
+    let base = resolve_level_params(level, source_size);
+    if dict_size == 0 || base.backend() != crate::encoding::strategy::BackendTag::Row {
+        return (base, None);
+    }
+    let cdict = get_cdict_cparams(numeric_level(level), dict_size);
+    if !(3..=5).contains(&cdict.strategy) {
+        return (base, None);
+    }
+    let use_row = uses_row_match_finder(&cdict);
+    let attach = should_attach_dict(&cdict, source_size);
+    let window_log = u32::from(base.window_log);
+    let frame = if attach {
+        attach_cparams(
+            cdict,
+            source_size.unwrap_or(CONTENTSIZE_UNKNOWN),
+            window_log,
+        )
+    } else {
+        copy_cparams(cdict, window_log)
+    };
+    (
+        level_params_from_cparams(frame),
+        Some(RowDictPlan {
+            attach,
+            use_row,
+            cdict,
+        }),
+    )
 }
 
 /// The cheap fingerprint pre-splitter level for a compression level (the

--- a/zstd/src/encoding/levels/config.rs
+++ b/zstd/src/encoding/levels/config.rs
@@ -205,42 +205,28 @@ impl LevelParams {
         }
     }
 
-    /// Cheap fingerprint pre-splitter level (the C-like `blockSplitterLevel`):
-    /// the EFFECTIVE upstream `ZSTD_splitBlock` level that
-    /// `ZSTD_optimalBlockSize` dispatches, i.e. `splitLevels[strategy] - 2`
-    /// (clamped at 0), NOT the raw `splitLevels[]` value. `split_level == 0`
-    /// routes to the cheap from-borders heuristic; `1..=4` to byChunks with
-    /// internal sampling level `split_level - 1`. See the body for the
-    /// per-strategy tier table and why the raw-table mapping was wrong.
+    /// Cheap fingerprint pre-splitter level: the `ZSTD_splitBlock` level
+    /// upstream `ZSTD_optimalBlockSize` (zstd_compress.c:4552) dispatches by
+    /// default, `splitLevels[strategy] = {0,0,1,2,2,3,3,4,4,4}` indexed by
+    /// the upstream strategy ordinal. Only an EXPLICIT `blockSplitterLevel`
+    /// (2..=6) is shifted down by 2 there; the default table is used as is.
+    /// `0` routes to the from-borders heuristic; `1..=4` to byChunks with
+    /// sampling tier `level - 1` (rates 43 / 11 / 5 / 1).
     pub(crate) fn pre_split(&self) -> Option<u8> {
         use crate::encoding::strategy::StrategyTag;
-        // Effective upstream `ZSTD_splitBlock` level = `splitLevels[strat] - 2`
-        // (clamped at 0). Upstream `splitLevels[] = {0,0,1,2,2,3,3,4,4,4}` then
-        // subtracts 2 before dispatch, so the byChunks sampling tier is two
-        // steps coarser than the raw table: greedy/lazy(d1)=0 (from-borders),
-        // lazy2/btlazy2=1 (byChunks rate 43), btopt+=2 (byChunks rate 11).
-        // An earlier version mirrored the RAW table AND bumped lazy2 to the
-        // rate-1 full scan (split 4) to dodge a periodic-input phantom-split —
-        // that ran the pre-splitter at up to 43x upstream's sampling cost
-        // (~87% of L9 encode time on the decode corpus). Per the drop-in
-        // contract ratio only needs to stay <= upstream, so matching upstream's
-        // sampling tier (and accepting upstream's identical over-split on
-        // periodic input) is the dominant large-input encode-speed win.
         Some(match self.strategy_tag {
-            // splitLevels 0/1 -> 0: upstream does not pre-split fast/dfast at
-            // all; from-borders is the cheapest stand-in and rarely splits.
-            StrategyTag::Fast | StrategyTag::Dfast => 0,
-            // greedy / lazy(depth 1): splitLevels 2 -> 0 (from-borders).
-            StrategyTag::Greedy => 0,
+            StrategyTag::Fast => 0,
+            StrategyTag::Dfast => 1,
+            StrategyTag::Greedy => 2,
             StrategyTag::Lazy => {
                 if self.lazy_depth >= 2 {
-                    1 // lazy2: splitLevels 3 -> 1 (byChunks rate 43)
+                    3 // lazy2
                 } else {
-                    0 // lazy depth 1: splitLevels 2 -> 0 (from-borders)
+                    2 // lazy
                 }
             }
-            StrategyTag::Btlazy2 => 1, // splitLevels 3 -> 1 (byChunks rate 43)
-            StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2 => 2,
+            StrategyTag::Btlazy2 => 3,
+            StrategyTag::BtOpt | StrategyTag::BtUltra | StrategyTag::BtUltra2 => 4,
         })
     }
 }

--- a/zstd/src/encoding/match_generator/dict_prime.rs
+++ b/zstd/src/encoding/match_generator/dict_prime.rs
@@ -31,7 +31,7 @@ impl MatchGeneratorDriver {
                 self.dfast_matcher_mut().offset_hist = offset_hist
             }
             super::super::strategy::BackendTag::Row => {
-                self.row_matcher_mut().offset_hist = offset_hist
+                self.row_matcher_mut().set_offset_hist(offset_hist)
             }
             super::super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();
@@ -83,7 +83,7 @@ impl MatchGeneratorDriver {
                 self.dfast_matcher_mut().offset_hist = offset_hist
             }
             super::super::strategy::BackendTag::Row => {
-                self.row_matcher_mut().offset_hist = offset_hist
+                self.row_matcher_mut().set_offset_hist(offset_hist)
             }
             super::super::strategy::BackendTag::HashChain => {
                 let matcher = self.hc_matcher_mut();

--- a/zstd/src/encoding/match_generator/mod.rs
+++ b/zstd/src/encoding/match_generator/mod.rs
@@ -927,15 +927,10 @@ impl MatchGeneratorDriver {
                 // searches live + dict, avoiding the per-frame dict re-index),
                 // larger known-size inputs COPY (dense re-prime into the live
                 // rows).
-                let attach = self
-                    .reset_size_log
-                    .is_none_or(|log| log <= ROW_ATTACH_DICT_CUTOFF_LOG);
-                if attach {
-                    self.row_matcher_mut().prime_dict_attach_current_block();
-                } else {
-                    self.row_matcher_mut().invalidate_dict_cache();
-                    self.row_matcher_mut().skip_matching_with_hint(Some(false));
-                }
+                // The attach / copy decision was made with the CDict's cParams
+                // at `reset` (`RowDictPlan`); the backend indexes the dictionary
+                // block accordingly.
+                self.row_matcher_mut().prime_dictionary_current_block();
             }
             super::strategy::BackendTag::HashChain => {
                 // Lazy-HC AND BT/optimal both follow upstream zstd `ZSTD_shouldAttachDict`
@@ -1025,8 +1020,18 @@ impl Matcher for MatchGeneratorDriver {
         self.reset_dict_attach_ok =
             dict_hint.is_none_or(|size| size <= MAX_FAST_ATTACH_DICT_REGION);
         let hinted = hint.is_some();
+        // A dictionary frame on the greedy / lazy band takes its cParams and
+        // match-finder from the CDict's cParams (upstream
+        // `ZSTD_resetCCtx_usingCDict`); `dict_plan` carries that decision to
+        // the Row backend.
+        let (params, dict_plan) = match dict_hint.filter(|&size| size > 0) {
+            Some(dict_size) => crate::encoding::levels::config::resolve_level_params_with_dict(
+                level, hint, dict_size,
+            ),
+            None => (Self::level_params(level, hint), None),
+        };
         #[cfg_attr(not(test), allow(unused_mut))]
-        let mut params = Self::level_params(level, hint);
+        let mut params = params;
         // Test-only: apply a parse×search override so the matrix can be
         // exercised without editing `LEVEL_TABLE`. Mutating `params` here
         // (before `next_backend`) flows the override through storage
@@ -1140,112 +1145,11 @@ impl Matcher for MatchGeneratorDriver {
                 hc.chain_log = dict_chain_log;
             }
         }
-        // upstream zstd `ZSTD_resolveRowMatchFinderMode` (zstd_compress.c:238-245):
-        // the row matchfinder is used for greedy/lazy/lazy2 ONLY when
-        // `windowLog > 14`; at or below that upstream runs the hash-chain
-        // matcher (`ZSTD_HcFindBestMatch`). We previously hardcoded the Row
-        // backend for these strategies regardless of window, sending every
-        // small-window frame (hinted floor = windowLog 14, e.g. the small-4k/10k
-        // fixtures) through Row where upstream uses HC. Match it: fall back to
-        // the hash-chain matcher (lazy/greedy parse via `lazy_depth`) when the
-        // resolved window is <= 14. The HC config is synthesised from the
-        // level's RowConfig (HC and Row share the same cParams; only the
-        // matchfinder differs) — `hash_log` / `chain_log` are
-        // clamped to the (<= 14) window inside the HashChain reset arm, so the
-        // nominal width here only sets the clamp ceiling.
-        if params.search == super::strategy::SearchMethod::RowHash && params.window_log <= 14 {
-            let row = params
-                .row
-                .expect("a RowHash level row must carry a RowConfig");
-            params.search = super::strategy::SearchMethod::HashChain;
-            // For a dict-bearing frame, downsize the synthesised HC logs to the
-            // dictionary's content tier via `cdict_table_logs` (the same
-            // correction the native HC dict-prime path applies above), so a dict
-            // much smaller than the window doesn't prime a needlessly sparse
-            // table. Row-finder levels are never BinaryTree, so `uses_bt = false`.
-            //
-            // Feed `cdict_table_logs` the UN-hinted base Row width, not the
-            // resolved `row.hash_bits`: the latter is already source-capped on a
-            // hinted reset (the `row_cap = table_log + 1` clamp), so passing it
-            // here would double-cap exactly as the native HC dict path warns
-            // above — a small hinted source with a large dictionary would
-            // collapse the prepared table below what the dict needs.
-            // `cdict_table_logs` only ever downsizes, so deriving the ceiling
-            // from the un-hinted base (plus active public overrides) keeps the
-            // dict-tier geometry intact. No source hint => `row.hash_bits` is
-            // already the level's full width, so reuse it directly.
-            let row_cdict_hash_bits = match dict_hint.filter(|&size| size > 0) {
-                Some(_) => {
-                    let mut base_params = Self::level_params(level, None);
-                    if let Some(ov) = self.param_overrides
-                        && !ov.is_empty()
-                    {
-                        apply_param_overrides(&mut base_params, &ov);
-                    }
-                    base_params
-                        .row
-                        .map_or(row.hash_bits, |base_row| base_row.hash_bits)
-                }
-                None => row.hash_bits,
-            };
-            // Row-backed levels carry only `hash_bits`; the HC chain table they
-            // fall back to follows the upstream zstd cParams relationship `chainLog =
-            // hashLog - 1` for every Row level (L6 c18 h19 .. L12 c22 h23, see
-            // the ROW_L* tables). Synthesise the chain width as `hash_bits - 1`
-            // so the dict path doesn't leave the chain table one bit too wide
-            // (cdict_table_logs only downsizes, so passing the full hash width
-            // for both would keep a 2x-too-large chain table on dict frames).
-            // Raw `- 1` is underflow-safe: `hash_bits` is either a predefined
-            // ROW_L* width (>= 19) or a public `hash_log` override, and the
-            // override is range-validated to `ZSTD_HASHLOG_MIN = 6` at the
-            // parameter API, so the value is always >= 6 here.
-            //
-            // A public `chain_log` override (#27) is dropped by the RowHash
-            // override arm (Row has no chain table), but once this frame falls
-            // back to HC the chain table is live and must honour it — mirror
-            // the native HC dict path, which feeds the override-applied
-            // `base_hc.chain_log` into `cdict_table_logs`. Use the explicit
-            // override (also API-validated to ZSTD_CHAINLOG_MIN = 6) when set,
-            // else the upstream zstd `hashLog - 1` relationship.
-            let explicit_chain_log = self
-                .param_overrides
-                .filter(|ov| !ov.is_empty())
-                .and_then(|ov| ov.chain_log)
-                .map(|chain_log| chain_log as usize);
-            let row_cdict_chain_bits = explicit_chain_log.unwrap_or(row_cdict_hash_bits - 1);
-            let (mut hash_log, mut chain_log) = match dict_hint.filter(|&size| size > 0) {
-                Some(dict_size) => cdict_table_logs(
-                    params.window_log,
-                    row_cdict_hash_bits,
-                    row_cdict_chain_bits,
-                    false,
-                    dict_size,
-                ),
-                None => (
-                    row.hash_bits,
-                    explicit_chain_log.unwrap_or(row.hash_bits - 1),
-                ),
-            };
-            // No-dict path: the HashChain reset arm only clamps the logs to the
-            // window when `hinted`, but a public `window_log` override can lower
-            // this level to <= 14 with no source hint — clamp the level's full
-            // Row `hash_bits` to the window here too (upstream zstd `ZSTD_adjustCParams`:
-            // hashLog <= windowLog + 1, chainLog <= windowLog) so a 16 KiB window
-            // doesn't allocate Row-sized HC tables.
-            if dict_hint.filter(|&size| size > 0).is_none() {
-                let wlog = params.window_log as usize;
-                hash_log = hash_log.min(wlog + 1);
-                chain_log = chain_log.min(wlog);
-            }
-            params.hc = Some(HcConfig {
-                hash_log,
-                chain_log,
-                search_depth: row.search_depth,
-                target_len: row.target_len,
-                search_mls: 4,
-            });
-            params.row = None;
-        }
+        // Upstream `ZSTD_resolveRowMatchFinderMode` (zstd_compress.c:238): the
+        // greedy/lazy/lazy2 band searches rows only above a 2^14 window and a
+        // hash chain otherwise. The Row backend runs that switch itself
+        // (`RowMatchGenerator::use_chain`), so both finders share ONE parse
+        // (upstream's single `lazy_generic`) and the level stays on `RowHash`.
         let next_backend = params.backend();
         let max_window_size = 1usize << params.window_log;
         self.dictionary_retained_budget = 0;
@@ -1465,8 +1369,12 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::Row(row) => {
                 row.max_window_size = max_window_size;
                 row.lazy_depth = params.lazy_depth;
+                row.set_dict_plan(dict_plan);
                 let mut row_cfg = params.row.expect("Row level row carries a RowConfig");
-                if hinted {
+                // A dictionary frame's widths already come from the CDict's
+                // cParams (adjusted to the source when attached); only a plain
+                // hinted frame caps them by the window here.
+                if hinted && dict_plan.is_none() {
                     // Clamp the configured hash width by the hinted window
                     // (upstream zstd `ZSTD_adjustCParams` caps hashLog by windowLog) —
                     // `min`, not replace, so an explicit `hash_log` param
@@ -1938,13 +1846,10 @@ impl Matcher for MatchGeneratorDriver {
                 // the `pick_lazy_match` lookahead entry (reads `lazy_depth`).
                 // Both bare entries dispatch on `row_log` internally into the
                 // const-`ROW_LOG` hot loop (upstream zstd per-rowLog variant table).
-                let greedy = self.parse == super::strategy::ParseMode::Greedy;
-                let row = self.row_matcher_mut();
-                if greedy {
-                    row.start_matching_greedy(&mut handle_sequence);
-                } else {
-                    row.start_matching(&mut handle_sequence);
-                }
+                // Greedy is the same upstream `lazy_generic` body at depth 0
+                // (`lazy_depth == 0`: a repcode hit is stored without a
+                // search, no lookahead); lazy / lazy2 read `lazy_depth` 1 / 2.
+                self.row_matcher_mut().start_matching(&mut handle_sequence);
             }
             SearchMethod::HashChain => {
                 // Greedy/lazy/lazy2 all flow through the lazy parser; it

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -284,7 +284,7 @@ fn l4_greedy_round_trip(slice_size: usize, max_slices: usize, data: &[u8]) -> (u
     // early-return guard) gets exercised.
     if data.is_empty() {
         let mut space = driver.get_next_space();
-        space.truncate(0);
+        space.clear();
         driver.commit_space(space);
         driver.start_matching(|seq| match seq {
             Sequence::Literals { literals } => reconstructed.extend_from_slice(literals),
@@ -365,7 +365,7 @@ fn driver_level4_greedy_empty_input_emits_nothing() {
     // `window.back()` unwrap — that's a separate path covered by
     // existing reset tests).
     let mut space = driver.get_next_space();
-    space.truncate(0);
+    space.clear();
     driver.commit_space(space);
     let mut emitted_anything = false;
     driver.start_matching(|_| emitted_anything = true);
@@ -3248,7 +3248,7 @@ fn hash_mix_crc_path_is_available_and_matches_accelerated_impl_when_supported() 
 
 #[test]
 fn hc_hash3_position_matches_hash3_formula() {
-    let bytes = [b'a', b'b', b'c', b'd'];
+    let bytes = *b"abcd";
     let read32 = u32::from_le_bytes(bytes);
     let expected = (((read32 << 8).wrapping_mul(HC_PRIME3BYTES)) >> (32 - HC3_HASH_LOG)) as usize;
     assert_eq!(
@@ -3261,7 +3261,7 @@ fn hc_hash3_position_matches_hash3_formula() {
 fn hc_hash_position_matches_hash4_formula() {
     let mut hc = HcMatchGenerator::new(1 << 20);
     hc.configure(HC_CONFIG, super::super::strategy::StrategyTag::Lazy, 22);
-    let bytes = [b'a', b'b', b'c', b'd'];
+    let bytes = *b"abcd";
     let read32 = u32::from_le_bytes(bytes);
     let expected = ((read32.wrapping_mul(HC_PRIME4BYTES)) >> (32 - hc.table.hash_log)) as usize;
     assert_eq!(hc.table.hash_position(&bytes), expected);
@@ -3275,7 +3275,7 @@ fn btultra2_main_hash_uses_hash4_formula() {
         super::super::strategy::StrategyTag::BtUltra2,
         27,
     );
-    let bytes = [b'a', b'b', b'c', b'd', b'e', b'f', b'g', b'h'];
+    let bytes = *b"abcdefgh";
     let read32 = u32::from_le_bytes(bytes[..4].try_into().unwrap());
     let expected = ((read32.wrapping_mul(HC_PRIME4BYTES)) >> (32 - hc.table.hash_log)) as usize;
     let actual = super::super::match_table::storage::MatchTable::hash_position_with_mls(

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -3157,13 +3157,13 @@ fn row_hash_and_row_extracts_high_bits() {
 
     let idx = pos - matcher.history_abs_start;
     let concat = matcher.live_history();
-    // Mirror `row_key_value`: an mls-wide masked key when 8 lookahead bytes
-    // exist, the 4-byte key in the tail. `idx = 8` on a 16-byte history has
-    // exactly 8 bytes left, so the wide arm applies here.
+    // Mirror `row_hash_raw`: the mls-wide key is the top bytes of the shifted
+    // 8-byte read (the 4-byte key applies only in the last < 8 bytes of the
+    // window). `idx = 8` on a 16-byte history has exactly 8 bytes left, so
+    // the wide arm applies here.
     let key_len = matcher.mls.min(6);
-    let value = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap())
-        & ((1u64 << (key_len * 8)) - 1);
-    let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(matcher.hash_kernel, value);
+    let value = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap());
+    let hash = (value << (64 - 8 * key_len)).wrapping_mul(crate::encoding::row::ROW_HASH_PRIME);
     let total_bits = matcher.row_hash_log + ROW_TAG_BITS;
     let combined = hash >> (u64::BITS as usize - total_bits);
     let expected_row =

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -321,8 +321,11 @@ fn driver_level5_greedy_tail_rep_only_reachable() {
     // implicit anchor, no further because anchor itself is the
     // current `abs_pos`).
     let first: &[u8] = b"ABCDABCDABCDABCD"; // 16 bytes — strict period 4
-    let second: &[u8] = b"ABCDA"; // 5 bytes — exact GREEDY_MIN_LOOKAHEAD
-    let mut driver = MatchGeneratorDriver::new(16, 2);
+    // The parse never searches the last 16 bytes of a block (upstream
+    // `lazy_generic` `ilimit`), so the slice carries the period-4 rep past
+    // that tail: the rep probe at the first position finds offset 4.
+    let second: &[u8] = b"ABCDABCDABCDABCDABCDA"; // 21 bytes
+    let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.reset(CompressionLevel::Level(5));
 
     let mut first_space = driver.get_next_space();
@@ -1794,14 +1797,17 @@ fn driver_chain_log_override_survives_row_to_hc_fallback() {
     space.truncate(12);
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
-    // The override (10) is below the window cap (14), so the resolved HC chain
-    // table must reflect it — NOT the upstream zstd `hashLog - 1` (18, clamped to the
-    // window 14). Pre-fix this resolved to 14.
+    // The override (10) is below the window cap (14), so the resolved chain
+    // table must reflect it — NOT the level's `chainLog`.
+    assert!(
+        driver.row_matcher().uses_hash_chain(),
+        "windowLog <= 14 searches the hash chain"
+    );
     assert_eq!(
-        driver.hc_matcher().table.chain_log,
+        driver.row_matcher().hc_chain_log(),
         chain_log_override as usize,
-        "explicit chain_log override must survive the Row->HC fallback, got {}",
-        driver.hc_matcher().table.chain_log
+        "explicit chain_log override must reach the hash chain, got {}",
+        driver.row_matcher().hc_chain_log()
     );
 }
 
@@ -1853,8 +1859,12 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     assert_eq!(driver.window_size(), 1 << MIN_WINDOW_LOG);
     assert_eq!(
         driver.active_backend(),
-        super::super::strategy::BackendTag::HashChain,
-        "windowLog <= 14 must fall back to the upstream zstd hash-chain matchfinder",
+        super::super::strategy::BackendTag::Row,
+        "greedy/lazy stay on the Row backend; it switches the finder itself",
+    );
+    assert!(
+        driver.row_matcher().uses_hash_chain(),
+        "windowLog <= 14 must search the upstream zstd hash chain",
     );
 }
 
@@ -2816,12 +2826,13 @@ fn row_prime_with_dictionary_preserves_history_for_first_full_block() {
     let mut driver = MatchGeneratorDriver::new(8, 1);
     // Level(5) is the greedy Row backend (LEVEL_TABLE row 5: Greedy / RowHash).
     // Level(4) now routes to Dfast, so this test must use Level(5) to actually
-    // exercise `RowMatchGenerator`'s dictionary priming. The 16-byte dict +
-    // 16-byte block lets the whole block match the primed dict (offset = dict
-    // length = 16).
+    // exercise `RowMatchGenerator`'s dictionary priming. The 40-byte dict +
+    // 40-byte block lets the whole block match the primed dict (offset = dict
+    // length = 40); the block exceeds the 16-byte tail the parse never
+    // searches (upstream `lazy_generic` `ilimit`).
     driver.reset(CompressionLevel::Level(5));
 
-    let payload = b"abcdefghijklmnop";
+    let payload = b"abcdefghijklmnopqrstuvwxyz0123456789ABCD";
     driver.prime_with_dictionary(payload, [1, 4, 8]);
 
     let mut space = driver.get_next_space();

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -3157,13 +3157,15 @@ fn row_hash_and_row_extracts_high_bits() {
 
     let idx = pos - matcher.history_abs_start;
     let concat = matcher.live_history();
-    // Mirror `row_hash_raw`: the mls-wide key is the top bytes of the shifted
-    // 8-byte read (the 4-byte key applies only in the last < 8 bytes of the
-    // window). `idx = 8` on a 16-byte history has exactly 8 bytes left, so
-    // the wide arm applies here.
-    let key_len = matcher.mls.min(6);
+    // Mirror upstream `ZSTD_hash5PtrS` (the row levels hash a 5-byte key;
+    // `ROW_CONFIG` carries `mls = ROW_MIN_MATCH_LEN = 5`): the 8-byte read
+    // shifted so the key fills the top 40 bits, times `prime5bytes`, XOR the
+    // fresh-context salt, top `hashLog + 8` bits. `idx = 8` on a 16-byte
+    // history has exactly 8 bytes left, so the wide arm applies here.
+    assert_eq!(matcher.mls.min(6), 5, "test mirrors the 5-byte key hash");
     let value = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap());
-    let hash = (value << (64 - 8 * key_len)).wrapping_mul(crate::encoding::row::ROW_HASH_PRIME);
+    let hash = ((value << 24).wrapping_mul(crate::encoding::row::ROW_HASH_PRIME5))
+        ^ crate::encoding::row::ROW_HASH_SALT;
     let total_bits = matcher.row_hash_log + ROW_TAG_BITS;
     let combined = hash >> (u64::BITS as usize - total_bits);
     let expected_row =

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -1922,9 +1922,11 @@ fn row_short_block_emits_literals_only() {
     );
     assert_eq!(reconstructed, b"abcde");
 
-    // Then feed a clearly matchable block and ensure the Triple arm is reachable.
+    // Then feed a clearly matchable block and ensure the Triple arm is
+    // reachable. The block must exceed the 16-byte tail the lazy parse never
+    // searches (upstream zstd `lazy_generic` `ilimit`).
     saw_triple = false;
-    matcher.add_data(b"abcdeabcde".to_vec(), |_| {});
+    matcher.add_data(b"abcdeabcdeabcdeabcde-padding-past-ilimit".to_vec(), |_| {});
     matcher.start_matching(|seq| {
         if let Sequence::Triple { .. } = seq {
             saw_triple = true;
@@ -1968,7 +1970,10 @@ fn row_backfills_previous_block_tail_for_cross_boundary_match() {
 
     let mut first_block = alloc::vec![0xA5; 64];
     first_block.extend_from_slice(b"XYZ");
-    let second_block = b"XYZXYZtail".to_vec();
+    // Long enough for the lazy parse to search: upstream zstd
+    // `lazy_generic` stops 16 bytes before the block end, so a block shorter
+    // than that is emitted as literals regardless of history.
+    let second_block = b"XYZXYZtail-padding-past-ilimit".to_vec();
 
     let replay_sequence = |decoded: &mut Vec<u8>, seq: Sequence<'_>| match seq {
         Sequence::Literals { literals } => decoded.extend_from_slice(literals),

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -13,7 +13,6 @@
 
 use alloc::collections::VecDeque;
 use alloc::vec::Vec;
-use core::convert::TryInto;
 
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
@@ -43,6 +42,22 @@ const ROW_UPDATE_MAX_START: usize = 96;
 const ROW_UPDATE_MAX_END: usize = 32;
 /// Hash-cache sentinel for a position too close to the end to hash.
 const ROW_CACHE_NONE: u32 = u32::MAX;
+
+/// Row hash multiplier (upstream zstd `prime8bytes`, `zstd_compress_internal.h`):
+/// the key bytes are shifted to the top of a 64-bit word and multiplied; the
+/// row and tag are the product's top bits (`ZSTD_hashPtrSalted` shape).
+pub(crate) const ROW_HASH_PRIME: u64 = 0xCF1B_BCDC_B7A5_6463;
+
+/// Per-parse view of the live history: raw base pointer + length + absolute
+/// start, hoisted ONCE per block so the hot loops read no `Option` branch
+/// and no `Vec` header per access. Valid for the whole parse: the history
+/// buffer is never reallocated while a block is being scanned.
+#[derive(Clone, Copy)]
+struct RowScan {
+    base: *const u8,
+    len: usize,
+    hist_start: usize,
+}
 
 /// Upstream zstd `ZSTD_highbit32(offBase)` term of the lazy gain formula:
 /// `offBase` is `offset + 3` for a real offset and 1 for repcode 1
@@ -507,18 +522,23 @@ macro_rules! greedy_parse_body {
 /// means nothing found (upstream's `ml = 4-1`), `offset` is the distance.
 /// Leftover attempts fund the dictionary row (upstream `dictMatchState`).
 macro_rules! row_find_best_match {
-    ($m:expr, $abs_pos:expr, $row:expr, $tag:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
-        let concat = $m.live_history();
-        let hist_start = $m.history_abs_start;
+    ($m:expr, $ctx:ident, $abs_pos:expr, $row:expr, $tag:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        let hist_start = $ctx.hist_start;
         let cur_idx = $abs_pos - hist_start;
         // SAFETY: the parse searches only positions >= 16 bytes before the
-        // block end, so `cur_idx + 16 <= concat.len()`.
-        let cur_ptr = unsafe { concat.as_ptr().add(cur_idx) };
-        let limit = concat.len() - cur_idx;
+        // block end, so `cur_idx + 16 <= $ctx.len`.
+        let cur_ptr = unsafe { $ctx.base.add(cur_idx) };
+        let limit = $ctx.len - cur_idx;
         let row_entries = 1usize << $rl;
         let row_mask = row_entries - 1;
         let row_base = $row << $rl;
-        let head = $m.row_heads[$row] as usize;
+        // SAFETY (table indexing below): `$row < row_heads.len()` and
+        // `row_base + row_entries <= row_tags.len() == row_positions.len()`
+        // by the `ensure_tables` sizing (`row` is masked to `row_hash_log`
+        // bits, `row_log == $rl`), the same argument as `insert_at`.
+        debug_assert_eq!($rl, $m.row_log);
+        debug_assert!(row_base + row_entries <= $m.row_positions.len());
+        let head = unsafe { *$m.row_heads.get_unchecked($row) } as usize;
         let window_low = hist_start.max($abs_pos.saturating_sub($m.max_window_size));
         let budget = $m.search_depth.min(row_entries);
         let mut attempts = budget;
@@ -534,8 +554,11 @@ macro_rules! row_find_best_match {
         {
             #[allow(unused_mut)]
             let mut pending: u64 = if $use_mask {
-                let m =
-                    $maskmac!(&$m.row_tags[row_base..row_base + row_entries], $tag) & entries_bits;
+                // SAFETY: see the table-indexing note above.
+                let tags = unsafe {
+                    core::slice::from_raw_parts($m.row_tags.as_ptr().add(row_base), row_entries)
+                };
+                let m = $maskmac!(tags, $tag) & entries_bits;
                 if head == 0 {
                     m
                 } else {
@@ -568,7 +591,8 @@ macro_rules! row_find_best_match {
                     found
                 };
                 let Some(slot) = slot_opt else { break };
-                let raw = $m.row_positions[row_base + slot];
+                // SAFETY: `slot < row_entries`; see the table-indexing note.
+                let raw = unsafe { *$m.row_positions.get_unchecked(row_base + slot) };
                 // Newest-first order: the first empty / below-floor entry ends
                 // the walk (upstream `if (matchIndex < lowLimit) break`).
                 if raw == ROW_EMPTY_SLOT || (raw as usize) < window_low {
@@ -586,13 +610,11 @@ macro_rules! row_find_best_match {
                     // SAFETY: prefetch is a hint; the candidate lies in the live
                     // history.
                     unsafe {
-                        _mm_prefetch(
-                            concat.as_ptr().add(raw as usize - hist_start).cast(),
-                            _MM_HINT_T0,
-                        );
+                        _mm_prefetch($ctx.base.add(raw as usize - hist_start).cast(), _MM_HINT_T0);
                     }
                 }
-                buf[n] = raw;
+                // SAFETY: `n < attempts_at_entry <= row_entries <= 64`.
+                unsafe { *buf.get_unchecked_mut(n) = raw };
                 n += 1;
                 attempts -= 1;
             }
@@ -603,7 +625,7 @@ macro_rules! row_find_best_match {
             // `+ ml - 3` where `ml + 1 <= limit` (the count breaks out of the
             // loop at `ml == limit`), so both reads stay inside `concat`.
             unsafe {
-                let cand_ptr = concat.as_ptr().add(cand_idx);
+                let cand_ptr = $ctx.base.add(cand_idx);
                 if rd32(cand_ptr.add(ml - 3)) == rd32(cur_ptr.add(ml - 3)) {
                     let cml = $cpl(cand_ptr, cur_ptr, limit);
                     if cml > ml {
@@ -675,7 +697,7 @@ macro_rules! row_find_best_match {
                 }
                 // SAFETY: `dp + 4 <= dict_end <= cur_idx`, `cur_idx + 4 <= concat.len()`.
                 unsafe {
-                    let dptr = concat.as_ptr().add(dp);
+                    let dptr = $ctx.base.add(dp);
                     if rd32(dptr) == rd32(cur_ptr) {
                         let cml = $cpl(dptr, cur_ptr, limit);
                         if cml > ml {
@@ -698,25 +720,25 @@ macro_rules! row_find_best_match {
 /// its 96 head + 32 tail positions), search `$p`, then index `$p` itself.
 /// `$ntu` is the parse's `nextToUpdate` local, `$skip` its `lazySkipping`.
 macro_rules! lazy_search_at {
-    ($m:expr, $p:expr, $ntu:ident, $skip:ident, $cache:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+    ($m:expr, $ctx:ident, $p:expr, $ntu:ident, $skip:ident, $cache:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         let p = $p;
         let (row, tag) = if $skip {
             // Lazy skipping: the skipped-over gap is not indexed and the cache
             // is not maintained; the position is hashed directly.
-            row_cache_hash!($m, $rl, p)
+            row_cache_hash!($m, $ctx, $rl, p)
         } else {
             if p - $ntu > ROW_UPDATE_SKIP_THRESHOLD {
-                row_cache_insert_range!($m, $cache, $rl, $ntu, $ntu + ROW_UPDATE_MAX_START);
-                row_cache_fill!($m, $cache, $rl, p - ROW_UPDATE_MAX_END);
-                row_cache_insert_range!($m, $cache, $rl, p - ROW_UPDATE_MAX_END, p);
+                row_cache_insert_range!($m, $ctx, $cache, $rl, $ntu, $ntu + ROW_UPDATE_MAX_START);
+                row_cache_fill!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END);
+                row_cache_insert_range!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END, p);
             } else {
-                row_cache_insert_range!($m, $cache, $rl, $ntu, p);
+                row_cache_insert_range!($m, $ctx, $cache, $rl, $ntu, p);
             }
-            row_cache_next!($m, $cache, $rl, p)
+            row_cache_next!($m, $ctx, $cache, $rl, p)
         };
         let r = if row != ROW_CACHE_NONE {
             let row = row as usize;
-            let r = row_find_best_match!($m, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
+            let r = row_find_best_match!($m, $ctx, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
             $m.insert_at::<$rl>(p, row, tag);
             r
         } else {
@@ -731,8 +753,8 @@ macro_rules! lazy_search_at {
 /// `ZSTD_row_fillHashCache` / `ZSTD_row_nextCachedHash` body): `(row, tag)`
 /// with `row == ROW_CACHE_NONE` past the hashable end.
 macro_rules! row_cache_hash {
-    ($m:expr, $rl:expr, $pos:expr) => {{
-        match $m.hash_and_row($pos) {
+    ($m:expr, $ctx:ident, $rl:expr, $pos:expr) => {{
+        match $m.row_hash_at($ctx, $pos) {
             Some((row, tag)) => {
                 $m.prefetch_row::<$rl>(row);
                 (row as u32, tag)
@@ -745,10 +767,10 @@ macro_rules! row_cache_hash {
 /// Upstream zstd `ZSTD_row_fillHashCache`: (re)load the cache for the
 /// positions `$from .. $from + ROW_HASH_CACHE_SIZE`.
 macro_rules! row_cache_fill {
-    ($m:expr, $cache:ident, $rl:expr, $from:expr) => {{
+    ($m:expr, $ctx:ident, $cache:ident, $rl:expr, $from:expr) => {{
         let from = $from;
         for pos in from..from + ROW_HASH_CACHE_SIZE {
-            $cache[pos & (ROW_HASH_CACHE_SIZE - 1)] = row_cache_hash!($m, $rl, pos);
+            $cache[pos & (ROW_HASH_CACHE_SIZE - 1)] = row_cache_hash!($m, $ctx, $rl, pos);
         }
     }};
 }
@@ -758,11 +780,11 @@ macro_rules! row_cache_fill {
 /// that row). Valid only while positions are consumed in sequence from the
 /// last fill, exactly as upstream.
 macro_rules! row_cache_next {
-    ($m:expr, $cache:ident, $rl:expr, $pos:expr) => {{
+    ($m:expr, $ctx:ident, $cache:ident, $rl:expr, $pos:expr) => {{
         let pos = $pos;
         let slot = pos & (ROW_HASH_CACHE_SIZE - 1);
         let cur = $cache[slot];
-        $cache[slot] = row_cache_hash!($m, $rl, pos + ROW_HASH_CACHE_SIZE);
+        $cache[slot] = row_cache_hash!($m, $ctx, $rl, pos + ROW_HASH_CACHE_SIZE);
         cur
     }};
 }
@@ -770,9 +792,9 @@ macro_rules! row_cache_next {
 /// Upstream zstd `ZSTD_row_update_internalImpl` with the cache: index every
 /// position of `$from .. $to` through the hash cache.
 macro_rules! row_cache_insert_range {
-    ($m:expr, $cache:ident, $rl:expr, $from:expr, $to:expr) => {{
+    ($m:expr, $ctx:ident, $cache:ident, $rl:expr, $from:expr, $to:expr) => {{
         for pos in $from..$to {
-            let (row, tag) = row_cache_next!($m, $cache, $rl, pos);
+            let (row, tag) = row_cache_next!($m, $ctx, $cache, $rl, pos);
             if row != ROW_CACHE_NONE {
                 $m.insert_at::<$rl>(pos, row as usize, tag);
             }
@@ -804,7 +826,8 @@ macro_rules! lazy_parse_body {
                 $m.insert_positions::<$rl>(backfill_start, current_abs_start);
             }
 
-            let hist_start = $m.history_abs_start;
+            let scan = $m.scan_ctx();
+            let hist_start = scan.hist_start;
             let depth = $m.lazy_depth;
             let block_end = current_abs_start + current_len;
             let ilimit = block_end.saturating_sub(LAZY_ROW_ILIMIT_MARGIN);
@@ -815,7 +838,7 @@ macro_rules! lazy_parse_body {
             let mut lazy_skipping = false;
             // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
             let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
-            row_cache_fill!($m, hash_cache, $rl, next_to_update);
+            row_cache_fill!($m, scan, hash_cache, $rl, next_to_update);
             // Repcodes reaching below the window are disabled for the block
             // (upstream `maxRep`); the bound also keeps every rep read inside
             // the live history since `ip` only grows.
@@ -829,7 +852,7 @@ macro_rules! lazy_parse_body {
                 let mut off = 0usize;
                 let mut start = ip + 1;
                 {
-                    let base = $m.live_history().as_ptr();
+                    let base = scan.base;
                     // SAFETY: `ip + 1 + 4 <= block_end` (`ip < ilimit`), and
                     // `offset_1 <= max_rep` keeps the rep source in history.
                     unsafe {
@@ -845,6 +868,7 @@ macro_rules! lazy_parse_body {
                 if !(match_length >= 4 && depth == 0) {
                     let (ml2, off2) = lazy_search_at!(
                         $m,
+                        scan,
                         ip,
                         next_to_update,
                         lazy_skipping,
@@ -869,7 +893,7 @@ macro_rules! lazy_parse_body {
                         while ip < ilimit {
                             ip += 1;
                             {
-                                let base = $m.live_history().as_ptr();
+                                let base = scan.base;
                                 // SAFETY: `ip + 4 <= block_end`, `offset_1 <= max_rep`.
                                 unsafe {
                                     let cur = base.add(ip - hist_start);
@@ -892,6 +916,7 @@ macro_rules! lazy_parse_body {
                             }
                             let (ml2, off2) = lazy_search_at!(
                                 $m,
+                                scan,
                                 ip,
                                 next_to_update,
                                 lazy_skipping,
@@ -912,7 +937,7 @@ macro_rules! lazy_parse_body {
                             if depth == 2 && ip < ilimit {
                                 ip += 1;
                                 {
-                                    let base = $m.live_history().as_ptr();
+                                    let base = scan.base;
                                     // SAFETY: as above.
                                     unsafe {
                                         let cur = base.add(ip - hist_start);
@@ -936,6 +961,7 @@ macro_rules! lazy_parse_body {
                                 }
                                 let (ml2, off2) = lazy_search_at!(
                                     $m,
+                                    scan,
                                     ip,
                                     next_to_update,
                                     lazy_skipping,
@@ -990,14 +1016,14 @@ macro_rules! lazy_parse_body {
                 ip = anchor;
                 if lazy_skipping {
                     // A match ends lazy skipping; the cache is stale, refill it.
-                    row_cache_fill!($m, hash_cache, $rl, next_to_update);
+                    row_cache_fill!($m, scan, hash_cache, $rl, next_to_update);
                     lazy_skipping = false;
                 }
 
                 // Immediate repcode: `offset_2` right after the stored match,
                 // swapping the two reps on every hit.
                 while ip <= ilimit && offset_2 > 0 {
-                    let base = $m.live_history().as_ptr();
+                    let base = scan.base;
                     // SAFETY: `ip + 4 <= block_end`, `offset_2 <= max_rep`.
                     let rep_len = unsafe {
                         let cur = base.add(ip - hist_start);
@@ -1662,6 +1688,10 @@ pub(crate) struct RowMatchGenerator {
     /// a local in the parse loops so the per-position compare reads a
     /// register, not this field. Default `ROW_MIN_MATCH_LEN` (5).
     pub(crate) mls: usize,
+    /// `64 - 8 * key width`: left shift placing the hash key at the top of
+    /// the 64-bit word (upstream zstd `ZSTD_hashNPtr`, key width = `mls`
+    /// capped at 6). Kept in sync with `mls` by `configure`.
+    row_key_shift: u32,
     pub(crate) lazy_depth: u8,
     /// Cached fastpath kernel for `hash_mix_u64`; see Dfast for rationale.
     pub(crate) hash_kernel: crate::encoding::fastpath::FastpathKernel,
@@ -1722,6 +1752,7 @@ impl RowMatchGenerator {
             search_depth: ROW_SEARCH_DEPTH,
             target_len: ROW_TARGET_LEN,
             mls: ROW_MIN_MATCH_LEN,
+            row_key_shift: (64 - 8 * ROW_MIN_MATCH_LEN.min(6)) as u32,
             lazy_depth: 1,
             hash_kernel: crate::encoding::fastpath::select_kernel(),
             row_heads: Vec::new(),
@@ -1790,6 +1821,7 @@ impl RowMatchGenerator {
         // floor can't be satisfied: the hash only surfaces candidates
         // sharing the 4-byte key) and a sane upper bound.
         self.mls = config.mls.clamp(ROW_HASH_KEY_LEN, 7);
+        self.row_key_shift = (64 - 8 * self.mls.min(6)) as u32;
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
@@ -2213,38 +2245,57 @@ impl RowMatchGenerator {
     /// the probe's real-byte key there. Those few dict-tail entries stay
     /// unreachable, mirroring the upstream zstd, whose dictionary load also stops
     /// hashing short of the dictionary end.
+    /// Row hash of the key at `base[idx..]` (upstream zstd `ZSTD_hashPtrSalted`
+    /// shape): the `mls`-byte key (8-byte read shifted to the top of the
+    /// word; the last < 8 bytes of the window fall back to a 4-byte key)
+    /// times [`ROW_HASH_PRIME`]. A position hashes identically in the probe,
+    /// the cache and the dictionary fill, so every table agrees on its row.
+    ///
+    /// # Safety
+    /// `idx + ROW_HASH_KEY_LEN <= len` and `base` must point to `len` bytes.
     #[inline(always)]
-    fn row_key_value(concat: &[u8], idx: usize, key_len: usize) -> u64 {
-        if idx + 8 <= concat.len() {
-            let v = u64::from_le_bytes(concat[idx..idx + 8].try_into().unwrap());
-            v & ((1u64 << (key_len * 8)) - 1)
-        } else {
-            u32::from_le_bytes(concat[idx..idx + ROW_HASH_KEY_LEN].try_into().unwrap()) as u64
+    unsafe fn row_hash_raw(base: *const u8, len: usize, idx: usize, key_shift: u32) -> u64 {
+        let value = unsafe {
+            if idx + 8 <= len {
+                u64::from_le_bytes(base.add(idx).cast::<[u8; 8]>().read_unaligned())
+            } else {
+                u64::from(rd32(base.add(idx)))
+            }
+        };
+        (value << key_shift).wrapping_mul(ROW_HASH_PRIME)
+    }
+
+    /// The live history as a [`RowScan`] for one parse.
+    #[inline(always)]
+    fn scan_ctx(&self) -> RowScan {
+        let history = self.live_history();
+        RowScan {
+            base: history.as_ptr(),
+            len: history.len(),
+            hist_start: self.history_abs_start,
         }
     }
 
+    /// `(row, tag)` of `abs_pos` through a hoisted [`RowScan`]; `None` when
+    /// fewer than `ROW_HASH_KEY_LEN` bytes follow the position.
     #[inline(always)]
-    pub(crate) fn hash_and_row(&self, abs_pos: usize) -> Option<(usize, u8)> {
-        let idx = abs_pos - self.history_abs_start;
-        let concat = self.live_history();
-        if idx + ROW_HASH_KEY_LEN > concat.len() {
+    fn row_hash_at(&self, ctx: RowScan, abs_pos: usize) -> Option<(usize, u8)> {
+        let idx = abs_pos - ctx.hist_start;
+        if idx + ROW_HASH_KEY_LEN > ctx.len {
             return None;
         }
-        // Upstream zstd `ZSTD_hashPtrSalted` hashes `mls` bytes (5-6 on the row
-        // levels), not 4: a wider key cuts the false tag hits whose
-        // candidates then cost a data load + reject in the probe. Read 8
-        // bytes and mask to the key width when the tail allows; the last
-        // <8 bytes of the window keep the 4-byte key (a position hashes
-        // identically in the probe and the insert either way, so the
-        // mixed tail stays self-consistent).
-        let value = Self::row_key_value(concat, idx, self.mls.min(6));
-        let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(self.hash_kernel, value);
+        // SAFETY: `idx + ROW_HASH_KEY_LEN <= ctx.len`, `ctx` views the live history.
+        let hash = unsafe { Self::row_hash_raw(ctx.base, ctx.len, idx, self.row_key_shift) };
         let total_bits = self.row_hash_log + ROW_TAG_BITS;
         let combined = hash >> (u64::BITS as usize - total_bits);
         let row_mask = (1usize << self.row_hash_log) - 1;
         let row = ((combined >> ROW_TAG_BITS) as usize) & row_mask;
-        let tag = combined as u8;
-        Some((row, tag))
+        Some((row, combined as u8))
+    }
+
+    #[inline(always)]
+    pub(crate) fn hash_and_row(&self, abs_pos: usize) -> Option<(usize, u8)> {
+        self.row_hash_at(self.scan_ctx(), abs_pos)
     }
 
     fn backfill_start(&self, current_abs_start: usize) -> usize {
@@ -2841,8 +2892,7 @@ impl RowMatchGenerator {
         }
         let row_log = self.row_log;
         let row_hash_log = self.row_hash_log;
-        let hash_kernel = self.hash_kernel;
-        let key_len = self.mls.min(6);
+        let key_shift = self.row_key_shift;
         let history_start = self.history_start;
         let concat_len = self.history.len() - history_start;
         // Row hash needs `ROW_HASH_KEY_LEN` readable bytes of lookahead.
@@ -2875,15 +2925,11 @@ impl RowMatchGenerator {
         // is u32-bounded upstream).
         for concat in start_concat..safe_end {
             unsafe {
-                // Same key reader as the live `hash_and_row` (width and
-                // endianness): any divergence buckets dict rows differently
-                // and loses every attached-dict match.
-                let value = Self::row_key_value(
-                    core::slice::from_raw_parts(base.add(history_start), concat_len),
-                    concat,
-                    key_len,
-                );
-                let hash = crate::encoding::fastpath::hash_mix_u64_with_kernel(hash_kernel, value);
+                // Same hash as the live `row_hash_at` (key width, shift and
+                // prime): any divergence buckets dict rows differently and
+                // loses every attached-dict match.
+                let hash =
+                    Self::row_hash_raw(base.add(history_start), concat_len, concat, key_shift);
                 let combined = hash >> (u64::BITS as usize - total_bits);
                 let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;
                 let tag = combined as u8;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -871,12 +871,28 @@ macro_rules! lazy_parse_body {
             // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
             let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
             row_cache_fill!($m, scan, hash_cache, $rl, next_to_update);
+            // Upstream `rep[0..2]` entering the block: carried from the
+            // previous lazy block, else the frame / dictionary history.
             // Repcodes reaching below the window are disabled for the block
-            // (upstream `maxRep`); the bound also keeps every rep read inside
-            // the live history since `ip` only grows.
+            // (upstream `maxRep`, remembered in `offset_saved` so an unused
+            // one is handed back at the end); the bound also keeps every rep
+            // read inside the live history since `ip` only grows.
+            let [rep_in_1, rep_in_2] = $m
+                .lazy_reps
+                .unwrap_or([$m.offset_hist[0] as usize, $m.offset_hist[1] as usize]);
             let max_rep = ip - hist_start.max(ip.saturating_sub($m.max_window_size));
-            let mut offset_1 = ($m.offset_hist[0] as usize).min(max_rep + 1) % (max_rep + 1);
-            let mut offset_2 = ($m.offset_hist[1] as usize).min(max_rep + 1) % (max_rep + 1);
+            let mut offset_1 = rep_in_1;
+            let mut offset_2 = rep_in_2;
+            let mut offset_saved_1 = 0usize;
+            let mut offset_saved_2 = 0usize;
+            if offset_2 > max_rep {
+                offset_saved_2 = offset_2;
+                offset_2 = 0;
+            }
+            if offset_1 > max_rep {
+                offset_saved_1 = offset_1;
+                offset_1 = 0;
+            }
 
             while ip < ilimit {
                 let mut match_length = 0usize;
@@ -1083,6 +1099,26 @@ macro_rules! lazy_parse_body {
             // first search, which then reads full 8-byte keys across the
             // boundary) is carried in `lazy_next_to_update`.
             $m.lazy_next_to_update = next_to_update;
+            // Upstream's rep save: a disabled `offset_1` that became valid
+            // rotates the saved one into `rep[1]`; unused disabled reps are
+            // restored as they were.
+            let offset_saved_2 = if offset_saved_1 != 0 && offset_1 != 0 {
+                offset_saved_1
+            } else {
+                offset_saved_2
+            };
+            $m.lazy_reps = Some([
+                if offset_1 != 0 {
+                    offset_1
+                } else {
+                    offset_saved_1
+                },
+                if offset_2 != 0 {
+                    offset_2
+                } else {
+                    offset_saved_2
+                },
+            ]);
             if anchor < block_end {
                 let concat = $m.live_history();
                 $handle(Sequence::Literals {
@@ -1729,6 +1765,16 @@ pub(crate) struct RowMatchGenerator {
     /// the previous tail from here (with the block's data now readable
     /// past it, as upstream), instead of a per-block backfill.
     lazy_next_to_update: usize,
+    /// Upstream `rep[0..2]` as the lazy parse left them at the end of the
+    /// previous block (`ZSTD_compressBlock_lazy_generic` saves `offset_1` /
+    /// `offset_2`, restoring a window-disabled rep it never used). `None`
+    /// until the first lazy block of a frame: then the reps come from
+    /// `offset_hist` (frame start or dictionary). Kept apart from
+    /// `offset_hist` because the block encoder may encode a searched
+    /// offset that equals a rep as a repcode (no rotation) where upstream
+    /// stores it raw and rotates, so the encoder-side history and
+    /// upstream's parse-side reps legitimately differ.
+    lazy_reps: Option<[usize; 2]>,
     pub(crate) lazy_depth: u8,
     /// Cached fastpath kernel for `hash_mix_u64`; see Dfast for rationale.
     pub(crate) hash_kernel: crate::encoding::fastpath::FastpathKernel,
@@ -1791,6 +1837,7 @@ impl RowMatchGenerator {
             mls: ROW_MIN_MATCH_LEN,
             row_hash_mls: ROW_MIN_MATCH_LEN.clamp(4, 6) as u32,
             lazy_next_to_update: 0,
+            lazy_reps: None,
             lazy_depth: 1,
             hash_kernel: crate::encoding::fastpath::select_kernel(),
             row_heads: Vec::new(),
@@ -1863,6 +1910,13 @@ impl RowMatchGenerator {
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
+    /// Replace the repeat-offset history (dictionary priming): the lazy
+    /// parse's carried reps restart from it at the next block.
+    pub(crate) fn set_offset_hist(&mut self, offset_hist: [u32; 3]) {
+        self.offset_hist = offset_hist;
+        self.lazy_reps = None;
+    }
+
     pub(crate) fn reset(&mut self) {
         // Floor-advance reset (same shape as the dfast/HC backends): instead
         // of re-zeroing the row tables per frame (a multi-MiB memset that
@@ -1897,8 +1951,10 @@ impl RowMatchGenerator {
             self.row_positions.fill(ROW_EMPTY_SLOT);
             self.row_tags.fill(0);
         }
-        // Nothing of the previous frame is indexed for the new one.
+        // Nothing of the previous frame is indexed for the new one, and the
+        // lazy reps restart from the frame's initial history.
         self.lazy_next_to_update = self.history_abs_start;
+        self.lazy_reps = None;
         // Block buffers are returned to the caller's pool per block in
         // `add_data`, so there is nothing window-side to recycle here.
         self.chunk_lens.clear();

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -17,7 +17,7 @@ use alloc::vec::Vec;
 use super::Sequence;
 use super::blocks::encode_offset_with_history;
 use super::dict_attach::DictAttach;
-use super::levels::config::RowConfig;
+use super::levels::config::{RowConfig, RowDictPlan};
 use super::match_generator::{
     ROW_EMPTY_SLOT, ROW_HASH_BITS, ROW_HASH_KEY_LEN, ROW_LOG, ROW_MIN_MATCH_LEN, ROW_SEARCH_DEPTH,
     ROW_TAG_BITS, ROW_TARGET_LEN,
@@ -28,6 +28,7 @@ use super::match_generator::{
 /// by `(ip - anchor) >> kSearchStrength + 1`, and steps above
 /// `kLazySkippingStep` stop indexing the skipped-over positions.
 const LAZY_ROW_ILIMIT_MARGIN: usize = 16;
+const LAZY_HC_ILIMIT_MARGIN: usize = 8;
 const LAZY_SEARCH_STRENGTH: u32 = 8;
 const LAZY_SKIPPING_STEP: usize = 8;
 
@@ -112,6 +113,18 @@ pub(crate) struct RowDictTables {
     pub(crate) heads: Vec<u8>,
     pub(crate) positions: Vec<u32>,
     pub(crate) tags: Vec<u8>,
+    /// Hash-chain form of the same index (upstream CDict `hashTable` /
+    /// `chainTable`) when the dictionary's cParams resolve to the chain
+    /// finder; concat-indexed positions, `ROW_EMPTY_SLOT` = empty.
+    pub(crate) hc_hash: Vec<u32>,
+    pub(crate) hc_chain: Vec<u32>,
+    /// Geometry the index was built with (the CDict's cParams): `hash_log`
+    /// (`hashLog`), `chain_log`, `row_log` (`clamp(searchLog, 4, 6)`); the
+    /// row form uses `hash_log - row_log` row bits.
+    pub(crate) hash_log: usize,
+    pub(crate) chain_log: usize,
+    pub(crate) row_log: usize,
+    pub(crate) use_row: bool,
 }
 use super::match_table::helpers::{
     INCOMPRESSIBLE_SKIP_STEP, best_len_offset_candidate, extend_backwards_shared,
@@ -301,242 +314,6 @@ macro_rules! dispatch_tag_kernel {
     }};
 }
 
-/// Per-tier `#[target_feature]` umbrella over the greedy row kernel: with
-/// the umbrella's features a superset of the tier probe's, the
-/// `#[inline(always)]` loop body AND the tier's `row_probe_*` merge into ONE
-/// compiled function (upstream zstd `ZSTD_compressBlock_greedy_row` shape) instead
-/// of paying a non-inlinable `#[target_feature]` call per position.
-/// The greedy row parse BODY as a macro: expanded per tier with the tier's
-/// own SIMD pairing (`$maskmac` tag-match + `$cpl` prefix kernel), with the
-/// probe body expanded inline at the search site — the full upstream zstd
-/// `ZSTD_compressBlock_greedy_row` monolith, one compiled function per tier.
-macro_rules! greedy_parse_body {
-    ($m:expr, $handle:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
-        #[allow(unused_labels)]
-        'parse: {
-            debug_assert_eq!($rl, $m.row_log);
-            $m.ensure_tables();
-
-            let (current_abs_start, current_len) = $m.current_block_range();
-            if current_len == 0 {
-                break 'parse;
-            }
-            let backfill_start = $m.backfill_start(current_abs_start);
-            if backfill_start < current_abs_start {
-                $m.insert_positions::<$rl>(backfill_start, current_abs_start);
-            }
-
-            // Upstream zstd mls for repcode probes is 4 (`MEM_read32` compare on
-            // `ip+1` against `ip+1-offset_1`, length extended by
-            // `ZSTD_count + 4`). The row matcher's `ROW_MIN_MATCH_LEN = 5`
-            // gates the *regular* search via the row-table layout; rep
-            // probes are independent of the row table and benefit from
-            // the lower upstream zstd threshold (a 4-byte rep is cheap to
-            // encode and frequently outperforms emitting the bytes as
-            // literals).
-            const REP_MIN_MATCH_LEN: usize = 4;
-            // Outer-loop lookahead floor: at least `REP_MIN_MATCH_LEN + 1`
-            // bytes left so the `abs_pos + 1` repcode probe can succeed even
-            // in the block tail (the rep probe needs `REP_MIN_MATCH_LEN`
-            // bytes one position ahead). This keeps the tail 4-byte rep-only
-            // case from falling through as literals.
-            const GREEDY_MIN_LOOKAHEAD: usize = REP_MIN_MATCH_LEN + 1;
-
-            let mut pos = 0usize;
-            let mut literals_start = 0usize;
-            // Software pipeline over the dependent row load: on a miss the next
-            // position's (row, tag) is computed ahead and its tag/position rows
-            // prefetched, so the probe's row loads (the hottest instructions of
-            // this loop — a hash-dependent cache miss per position) overlap the
-            // current iteration's tail instead of stalling the next probe.
-            // Upstream zstd `ZSTD_RowFindBestMatch` gets the same overlap from its
-            // hash-cache + `ZSTD_row_prefetch` pipeline.
-            let mut carried: Option<(usize, (usize, u8))> = None;
-
-            while pos + GREEDY_MIN_LOOKAHEAD <= current_len {
-                let abs_pos = current_abs_start + pos;
-                let lit_len = pos - literals_start;
-
-                // (1) Default start = abs_pos + 1: probe the repcode bank
-                //     at the next byte, treating one byte as already
-                //     committed to the literal run. Upstream zstd probes only
-                //     rep1 here; `repcode_candidate_shared` probes all three
-                //     plus the `ll0` fallback because the upstream zstd "ll0" trick
-                //     is already baked into our shared helper. The extra
-                //     probes only add candidates that have repcode encoding
-                //     costs (cheap), so the ratio direction is positive vs
-                //     upstream zstd while still landing in the "greedy via repcode"
-                //     algorithmic shape.
-                let rep_probe_pos = abs_pos + 1;
-                let rep_probe_lit_len = lit_len + 1;
-                let rep_match = if rep_probe_pos + REP_MIN_MATCH_LEN <= $m.history_abs_end() {
-                    repcode_candidate_shared(
-                        $m.hash_kernel,
-                        $m.live_history(),
-                        $m.history_abs_start,
-                        $m.offset_hist,
-                        rep_probe_pos,
-                        rep_probe_lit_len,
-                        REP_MIN_MATCH_LEN,
-                    )
-                } else {
-                    None
-                };
-
-                // (2) Upstream zstd greedy (depth 0): a repcode hit commits
-                // immediately and SKIPS the regular row search
-                // (`zstd_lazy.c:2039`, `if (depth==0) goto _storeSequence`).
-                // The regular `row_candidate` (SIMD row scan + match
-                // extension) is the dominant per-position cost; running it on
-                // every rep hit made rep-dense inputs (repetitive logs) up to
-                // ~11x slower than upstream, which short-circuits. So only
-                // run the regular search when there is no rep to take.
-                // `row_candidate` is `&self` (a pure search, no table
-                // mutation), so skipping it drops no hash insert: the
-                // post-emit `insert_positions(abs_pos, ..)` still indexes the
-                // committed span.
-                let hash = match carried.take() {
-                    Some((carried_pos, rt)) if carried_pos == abs_pos => Some(rt),
-                    _ => None,
-                };
-                let chosen = match rep_match {
-                    Some(rep) => Some(rep),
-                    // Probe body expanded inline (tier SIMD pairing via the
-                    // enclosing monolith macro), not a function call.
-                    None => {
-                        // Greedy already short-circuited on a rep hit above,
-                        // so the probe starts from no candidate here.
-                        row_probe_body!(
-                            $m, abs_pos, lit_len, hash, None, $rl, $use_mask, $maskmac, $cpl
-                        )
-                    }
-                };
-
-                let Some(candidate) = chosen else {
-                    // Upstream zstd `kSearchStrength = 8` shifts hard on miss
-                    // (step grows by `lit_len >> 8`). Empirically on our
-                    // corpus that recovers ~30% speed but costs ratio by
-                    // dropping hash inserts on long literal runs that
-                    // would have served future matches. Shift right by
-                    // `SKIP_STRENGTH = 10` instead — same shape, ~4×
-                    // rarer growth, so the step stays at 1 byte until the
-                    // literal run hits ~1 KiB and only then begins
-                    // skipping. Lets us keep most of upstream zstd's speed
-                    // characteristic without re-introducing the ratio
-                    // drain.
-                    const SKIP_STRENGTH: u32 = 10;
-                    let step = ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
-                    // Reuse the probe's (row, tag) for the insert (the rep-hit
-                    // path never computed one, so fall back to the hashing
-                    // insert there — `hash` is `Some` exactly when the probe
-                    // ran on this position).
-                    match hash {
-                        Some((row, tag)) => $m.insert_at::<$rl>(abs_pos, row, tag),
-                        None => $m.insert_position::<$rl>(abs_pos),
-                    }
-                    if step == 1 {
-                        let next_abs = abs_pos + 1;
-                        if let Some((row, tag)) = $m.hash_and_row(next_abs) {
-                            $m.prefetch_row::<$rl>(row);
-                            carried = Some((next_abs, (row, tag)));
-                        }
-                    }
-                    pos += step;
-                    continue;
-                };
-
-                // Emit sequence.
-                let start = candidate.start - current_abs_start;
-                // Index `[abs_pos, candidate.start + match_len)`, NOT
-                // `[candidate.start, candidate.start + match_len)`.
-                // `extend_backwards_shared` can move `candidate.start`
-                // below `abs_pos` by absorbing literal bytes that the
-                // outer loop already indexed on earlier miss iterations
-                // via `insert_position(abs_pos)`. Re-indexing them here
-                // would write the same `abs_pos -> position` mapping
-                // into the row table a second time, evicting more recent
-                // / more useful slot tenants from the same row's chain.
-                // Measured on `decodecorpus-z000033`: the
-                // `candidate.start` lower bound regresses `rust_bytes` by
-                // ~+447 over `abs_pos` (537897 -> 538344), so the
-                // narrower range is intentional.
-                $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
-                // Trailing literals of the current block. Read via
-                // `live_history()` (borrowed-aware) sliced at the block's
-                // offset within the live region: owned →
-                // `live_history()[window_size - current_len..]` (byte-identical
-                // to the old `history[history.len()-current_len..]`); borrowed →
-                // `live_history()[block_start..]` (the in-place input, since the
-                // owned `history` mirror is empty under the no-copy path).
-                let current = &$m.live_history()[(current_abs_start - $m.history_abs_start)..];
-                let literals = &current[literals_start..start];
-                $handle(Sequence::Triple {
-                    literals,
-                    offset: candidate.offset,
-                    match_len: candidate.match_len,
-                });
-                let _ = encode_offset_with_history(
-                    candidate.offset as u32,
-                    literals.len() as u32,
-                    &mut $m.offset_hist,
-                );
-                pos = start + candidate.match_len;
-                literals_start = pos;
-                // Same hash + row prefetch carry as the miss path: the next
-                // probe position is known here (right past the emitted match),
-                // and its row is otherwise guaranteed cold after the match-span
-                // insert walked other rows. The rep probe at the next iteration
-                // may consume the position without a row probe — then the
-                // carried hash is only reused by the insert-side, never wasted.
-                if pos + GREEDY_MIN_LOOKAHEAD <= current_len {
-                    let next_abs = current_abs_start + pos;
-                    if let Some((row, tag)) = $m.hash_and_row(next_abs) {
-                        $m.prefetch_row::<$rl>(row);
-                        carried = Some((next_abs, (row, tag)));
-                    }
-                }
-
-                // Upstream zstd's `lazy_generic` has an immediate-repcode loop here
-                // (probing `offset_2` after each main emit and swapping
-                // `offset_1 ↔ offset_2` on hit). It was implemented and
-                // shipped in earlier iterations of this method but never
-                // fired on any test or benchmark workload — the
-                // `repcode_candidate_shared` probe at the top of the main
-                // loop already evaluates all three rep slots (rep1, rep2,
-                // rep3 + the `ll0` fallback), and the immediate-rep slot
-                // (`offset_hist[1]` at `lit_len = 0`) is subsumed by the
-                // next main-loop iteration's rep probe of the same slot.
-                // Upstream zstd's version is single-rep, so the inner loop catches
-                // hits its main-loop probe wouldn't; ours is three-rep, so
-                // the inner loop is dead by construction. Removed to free
-                // the per-iteration check and keep the parser body lean.
-            }
-
-            while pos + ROW_HASH_KEY_LEN <= current_len {
-                $m.insert_position::<$rl>(current_abs_start + pos);
-                pos += 1;
-            }
-            // Every position up to the block end is indexed; a following
-            // lazy block resumes its gap fill from there.
-            $m.lazy_next_to_update = current_abs_start + current_len;
-
-            if literals_start < current_len {
-                // Trailing literals of the current block. Read via
-                // `live_history()` (borrowed-aware) sliced at the block's
-                // offset within the live region: owned →
-                // `live_history()[window_size - current_len..]` (byte-identical
-                // to the old `history[history.len()-current_len..]`); borrowed →
-                // `live_history()[block_start..]` (the in-place input, since the
-                // owned `history` mirror is empty under the no-copy path).
-                let current = &$m.live_history()[(current_abs_start - $m.history_abs_start)..];
-                $handle(Sequence::Literals {
-                    literals: &current[literals_start..],
-                });
-            }
-        }
-    }};
-}
-
 /// Upstream zstd `ZSTD_RowFindBestMatch` (zstd_lazy.c:1141) at one position:
 /// the row is walked newest-first until the first entry below the window
 /// floor, the in-window candidates are buffered (and their data prefetched),
@@ -563,7 +340,7 @@ macro_rules! row_find_best_match {
         debug_assert_eq!($rl, $m.row_log);
         debug_assert!(row_base + row_entries <= $m.row_positions.len());
         let head = unsafe { *$m.row_heads.get_unchecked($row) } as usize;
-        let window_low = hist_start.max($abs_pos.saturating_sub($m.max_window_size));
+        let window_low = $m.window_floor($abs_pos);
         let budget = $m.search_depth.min(row_entries);
         let mut attempts = budget;
         let mut ml = 3usize;
@@ -649,6 +426,10 @@ macro_rules! row_find_best_match {
                 attempts -= 1;
             }
         }
+        // A copied dictionary is upstream's `extDict` segment: its candidates
+        // are gated at the match head (`MEM_read32(match) == MEM_read32(ip)`)
+        // instead of at the current best length.
+        let prefix_start = $m.dict_prefix_start();
         for &raw in &buf[..n] {
             let cand_idx = raw as usize - hist_start;
             // SAFETY: `cand_idx < cur_idx`; the gate reads 4 bytes at
@@ -656,7 +437,12 @@ macro_rules! row_find_best_match {
             // loop at `ml == limit`), so both reads stay inside `concat`.
             unsafe {
                 let cand_ptr = $ctx.base.add(cand_idx);
-                if rd32(cand_ptr.add(ml - 3)) == rd32(cur_ptr.add(ml - 3)) {
+                let gate = if (raw as usize) >= prefix_start {
+                    rd32(cand_ptr.add(ml - 3)) == rd32(cur_ptr.add(ml - 3))
+                } else {
+                    rd32(cand_ptr) == rd32(cur_ptr)
+                };
+                if gate {
                     let cml = $cpl(cand_ptr, cur_ptr, limit);
                     if cml > ml {
                         ml = cml;
@@ -668,22 +454,41 @@ macro_rules! row_find_best_match {
                 }
             }
         }
-        // Dictionary row: funded by the attempts the live row left (upstream
-        // shares one `nbAttempts`), floored at a full 16-entry row so the CDict
-        // search depth stays effective on small-level dictionaries.
-        let dict_budget = budget.max(16);
-        let used = budget - attempts;
+        // Attached dictionary (upstream `dictMatchState`): ONE bounded row of
+        // the CDict's own tables, addressed by the unsalted hash of the
+        // position at the dictionary's row width (`ZSTD_hashPtr(ip,
+        // dms->rowHashLog + 8, mls)`), walked with the attempts the live row
+        // left (`nbAttempts` is shared), each entry gated by a 4-byte compare
+        // at the match head. `dict.row_log == $rl` (the frame keeps the
+        // CDict's `searchLog`).
         if ml < limit
-            && used < dict_budget
+            && attempts > 0
             && let Some(dict) = $m.dict.table()
+            && dict.use_row
         {
-            let mut dattempts = dict_budget - used;
+            debug_assert_eq!(dict.row_log, $rl);
+            let mut dattempts = attempts;
             let dict_end = $m.dict.region_len();
-            let dhead = dict.heads[$row] as usize;
+            let dict_row_hash_log = dict.hash_log - $rl;
+            // SAFETY: `cur_idx + 16 <= $ctx.len`.
+            let dcombined = unsafe {
+                RowMatchGenerator::key_hash_raw(
+                    $ctx.base,
+                    $ctx.len,
+                    cur_idx,
+                    $m.row_hash_mls,
+                    dict_row_hash_log + ROW_TAG_BITS,
+                    0,
+                )
+            };
+            let drow = ((dcombined >> ROW_TAG_BITS) as usize) & ((1usize << dict_row_hash_log) - 1);
+            let dtag = dcombined as u8;
+            let drow_base = drow << $rl;
+            let dhead = dict.heads[drow] as usize;
             #[allow(unused_mut)]
             let mut dpending: u64 = if $use_mask {
                 let m =
-                    $maskmac!(&dict.tags[row_base..row_base + row_entries], $tag) & entries_bits;
+                    $maskmac!(&dict.tags[drow_base..drow_base + row_entries], dtag) & entries_bits;
                 if dhead == 0 {
                     m
                 } else {
@@ -708,7 +513,7 @@ macro_rules! row_find_best_match {
                     while dscan < row_entries {
                         let s = (dhead + dscan) & row_mask;
                         dscan += 1;
-                        if dict.tags[row_base + s] == $tag {
+                        if dict.tags[drow_base + s] == dtag {
                             found = Some(s);
                             break;
                         }
@@ -719,16 +524,14 @@ macro_rules! row_find_best_match {
                 if slot == 0 {
                     continue;
                 }
-                let dp = dict.positions[row_base + slot];
+                let dp = dict.positions[drow_base + slot];
                 if dp == ROW_EMPTY_SLOT {
                     break;
                 }
                 dattempts -= 1;
                 let dp = dp as usize;
-                if dp + 4 > dict_end {
-                    continue;
-                }
-                // SAFETY: `dp + 4 <= dict_end <= cur_idx`, `cur_idx + 4 <= concat.len()`.
+                debug_assert!(dp + 8 <= dict_end);
+                // SAFETY: `dp + 8 <= dict_end <= cur_idx`, `cur_idx + 4 <= $ctx.len`.
                 unsafe {
                     let dptr = $ctx.base.add(dp);
                     if rd32(dptr) == rd32(cur_ptr) {
@@ -755,30 +558,163 @@ macro_rules! row_find_best_match {
 macro_rules! lazy_search_at {
     ($m:expr, $ctx:ident, $p:expr, $ntu:ident, $skip:ident, $cache:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         let p = $p;
-        let (row, tag) = if $skip {
-            // Lazy skipping: the skipped-over gap is not indexed and the cache
-            // is not maintained; the position is hashed directly.
-            row_cache_hash!($m, $ctx, $rl, p)
+        if $m.use_chain {
+            hc_find_best_match!($m, $ctx, p, $ntu, $skip, $cpl)
         } else {
-            if p - $ntu > ROW_UPDATE_SKIP_THRESHOLD {
-                row_cache_insert_range!($m, $ctx, $cache, $rl, $ntu, $ntu + ROW_UPDATE_MAX_START);
-                row_cache_fill!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END);
-                row_cache_insert_range!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END, p);
+            let (row, tag) = if $skip {
+                // Lazy skipping: the skipped-over gap is not indexed and the cache
+                // is not maintained; the position is hashed directly.
+                row_cache_hash!($m, $ctx, $rl, p)
             } else {
-                row_cache_insert_range!($m, $ctx, $cache, $rl, $ntu, p);
-            }
-            row_cache_next!($m, $ctx, $cache, $rl, p)
-        };
-        let r = if row != ROW_CACHE_NONE {
-            let row = row as usize;
-            let r = row_find_best_match!($m, $ctx, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
-            $m.insert_at::<$rl>(p, row, tag);
+                if p - $ntu > ROW_UPDATE_SKIP_THRESHOLD {
+                    row_cache_insert_range!(
+                        $m,
+                        $ctx,
+                        $cache,
+                        $rl,
+                        $ntu,
+                        $ntu + ROW_UPDATE_MAX_START
+                    );
+                    row_cache_fill!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END);
+                    row_cache_insert_range!($m, $ctx, $cache, $rl, p - ROW_UPDATE_MAX_END, p);
+                } else {
+                    row_cache_insert_range!($m, $ctx, $cache, $rl, $ntu, p);
+                }
+                row_cache_next!($m, $ctx, $cache, $rl, p)
+            };
+            let r = if row != ROW_CACHE_NONE {
+                let row = row as usize;
+                let r = row_find_best_match!($m, $ctx, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
+                $m.insert_at::<$rl>(p, row, tag);
+                r
+            } else {
+                (3usize, 0usize)
+            };
+            $ntu = p + 1;
             r
-        } else {
-            (3usize, 0usize)
-        };
-        $ntu = p + 1;
-        r
+        }
+    }};
+}
+
+/// Upstream zstd `ZSTD_HcFindBestMatch` (zstd_lazy.c:667, noDict) with its
+/// `ZSTD_insertAndFindFirstIndex_internal` update: every position of the
+/// gap `[$ntu, p)` is chained (only the first one while lazy-skipping), then
+/// the chain of `p`'s bucket is walked newest-first, each link gated by the
+/// 4-byte compare at the current best length, at most `search_depth` links
+/// and never past `p - chainSize`. `p` itself is chained by the next
+/// search's gap, as upstream. Evaluates to `(ml, offset)` like
+/// `row_find_best_match!`.
+macro_rules! hc_find_best_match {
+    ($m:expr, $ctx:ident, $p:expr, $ntu:ident, $skip:ident, $cpl:path) => {{
+        let p = $p;
+        let hist_start = $ctx.hist_start;
+        let chain_mask = (1usize << $m.hc_chain_log) - 1;
+        let cur_idx = p - hist_start;
+        // SAFETY: the parse searches only positions >= 16 bytes before the
+        // block end.
+        let cur_ptr = unsafe { $ctx.base.add(cur_idx) };
+        let limit = $ctx.len - cur_idx;
+        {
+            let mut idx = $ntu;
+            while idx < p {
+                let h = $m.hc_hash_at($ctx, idx);
+                $m.hc_chain[idx & chain_mask] = $m.hc_hash[h];
+                $m.hc_hash[h] = idx as u32;
+                idx += 1;
+                if $skip {
+                    break;
+                }
+            }
+            $ntu = p;
+        }
+        let window_low = $m.window_floor(p);
+        let min_chain = p.saturating_sub(chain_mask + 1);
+        let mut attempts = $m.search_depth;
+        let mut ml = 3usize;
+        let mut best_off = 0usize;
+        // A copied dictionary is upstream's `extDict` segment: its candidates
+        // are gated at the match head instead of at the current best length.
+        let prefix_start = $m.dict_prefix_start();
+        let mut match_index = $m.hc_hash[$m.hc_hash_at($ctx, p)];
+        while match_index != ROW_EMPTY_SLOT && (match_index as usize) >= window_low && attempts > 0
+        {
+            let cand = match_index as usize;
+            // SAFETY: `cand < p`; the gate reads 4 bytes at `+ ml - 3` with
+            // `ml + 1 <= limit` (the count breaks out at `ml == limit`).
+            unsafe {
+                let cand_ptr = $ctx.base.add(cand - hist_start);
+                let gate = if cand >= prefix_start {
+                    rd32(cand_ptr.add(ml - 3)) == rd32(cur_ptr.add(ml - 3))
+                } else {
+                    rd32(cand_ptr) == rd32(cur_ptr)
+                };
+                if gate {
+                    let cml = $cpl(cand_ptr, cur_ptr, limit);
+                    if cml > ml {
+                        ml = cml;
+                        best_off = p - cand;
+                        if cml == limit {
+                            break;
+                        }
+                    }
+                }
+            }
+            if cand <= min_chain {
+                break;
+            }
+            match_index = $m.hc_chain[cand & chain_mask];
+            attempts -= 1;
+        }
+        // Attached dictionary (upstream `dictMatchState`): the CDict's own
+        // chain, entered through its hash table at its `hashLog` (unsalted,
+        // the frame's key width), walked with the remaining attempts, each
+        // link gated by a 4-byte compare at the match head and never past
+        // `dictSize - chainSize`.
+        if ml < limit
+            && attempts > 0
+            && let Some(dict) = $m.dict.table()
+            && !dict.use_row
+        {
+            let dict_end = $m.dict.region_len();
+            let dchain_mask = (1usize << dict.chain_log) - 1;
+            let dmin_chain = dict_end.saturating_sub(dchain_mask + 1);
+            // SAFETY: `cur_idx + 16 <= $ctx.len`.
+            let dh = unsafe {
+                RowMatchGenerator::key_hash_raw(
+                    $ctx.base,
+                    $ctx.len,
+                    cur_idx,
+                    $m.row_hash_mls,
+                    dict.hash_log,
+                    0,
+                )
+            } as usize;
+            let mut dmi = dict.hc_hash[dh];
+            while dmi != ROW_EMPTY_SLOT && attempts > 0 {
+                let dp = dmi as usize;
+                debug_assert!(dp + 8 <= dict_end);
+                // SAFETY: `dp + 8 <= dict_end <= cur_idx`, `cur_idx + 4 <= $ctx.len`.
+                unsafe {
+                    let dptr = $ctx.base.add(dp);
+                    if rd32(dptr) == rd32(cur_ptr) {
+                        let cml = $cpl(dptr, cur_ptr, limit);
+                        if cml > ml {
+                            ml = cml;
+                            best_off = p - (hist_start + dp);
+                            if cml == limit {
+                                break;
+                            }
+                        }
+                    }
+                }
+                if dp <= dmin_chain {
+                    break;
+                }
+                dmi = dict.hc_chain[dp & dchain_mask];
+                attempts -= 1;
+            }
+        }
+        (ml, best_off)
     }};
 }
 
@@ -858,10 +794,23 @@ macro_rules! lazy_parse_body {
             let hist_start = scan.hist_start;
             let depth = $m.lazy_depth;
             let block_end = current_abs_start + current_len;
-            let ilimit = block_end.saturating_sub(LAZY_ROW_ILIMIT_MARGIN);
+            // Upstream `ilimit`: `iend - 8 - ZSTD_ROW_HASH_CACHE_SIZE` for the
+            // row search, `iend - 8` for the hash chain.
+            let ilimit = block_end.saturating_sub(if $m.use_chain {
+                LAZY_HC_ILIMIT_MARGIN
+            } else {
+                LAZY_ROW_ILIMIT_MARGIN
+            });
             let mut anchor = current_abs_start;
-            // `ip += (dictAndPrefixLength == 0)`: nothing precedes the first byte.
-            let mut ip = current_abs_start + usize::from(current_abs_start == hist_start);
+            // Upstream skips the first byte of a frame: `ip += (dictAndPrefixLength
+            // == 0)` on a plain / attached-dictionary frame (nothing precedes it),
+            // `ip += (ip == prefixStart)` on a copied-dictionary frame (upstream
+            // `extDict`, the dictionary being the segment below the prefix).
+            let first_byte = match $m.dict_plan {
+                Some(plan) if !plan.attach => $m.dict_prefix_start(),
+                _ => hist_start,
+            };
+            let mut ip = current_abs_start + usize::from(current_abs_start == first_byte);
             // Upstream `nextToUpdate`: resume where the previous block
             // stopped indexing (a lazy block leaves its last <= 16 bytes,
             // now readable with the full 8-byte key; the other parses set
@@ -890,18 +839,44 @@ macro_rules! lazy_parse_body {
             let [rep_in_1, rep_in_2] = $m
                 .lazy_reps
                 .unwrap_or([$m.offset_hist[0] as usize, $m.offset_hist[1] as usize]);
-            let max_rep = ip - hist_start.max(ip.saturating_sub($m.max_window_size));
+            // Repcode validity. Plain frame (upstream `noDict`): reps reaching
+            // below the window are disabled for the whole block (`maxRep`,
+            // remembered in `offset_saved`). Dictionary frame (upstream
+            // `extDict` / `dictMatchState`): no block-start clamp; every rep
+            // probe checks the window floor at its own position and
+            // `ZSTD_index_overlap_check` (a source in the last 3 bytes below
+            // the frame's prefix, straddling the dictionary boundary, is not
+            // taken).
+            let dict_frame = $m.dict_plan.is_some();
+            let attached = $m.dict_plan.is_some_and(|p| p.attach);
+            let prefix_start = $m.dict_prefix_start();
+            let search_window = $m.search_window;
+            let rep_ok = |pos: usize, off: usize| -> bool {
+                if off == 0 || off > pos {
+                    return false;
+                }
+                let cand = pos - off;
+                let floor = if attached {
+                    hist_start
+                } else {
+                    hist_start.max(pos.saturating_sub(search_window))
+                };
+                cand >= floor && !(cand < prefix_start && cand + 3 >= prefix_start)
+            };
             let mut offset_1 = rep_in_1;
             let mut offset_2 = rep_in_2;
             let mut offset_saved_1 = 0usize;
             let mut offset_saved_2 = 0usize;
-            if offset_2 > max_rep {
-                offset_saved_2 = offset_2;
-                offset_2 = 0;
-            }
-            if offset_1 > max_rep {
-                offset_saved_1 = offset_1;
-                offset_1 = 0;
+            if !dict_frame {
+                let max_rep = ip - $m.window_floor(ip);
+                if offset_2 > max_rep {
+                    offset_saved_2 = offset_2;
+                    offset_2 = 0;
+                }
+                if offset_1 > max_rep {
+                    offset_saved_1 = offset_1;
+                    offset_1 = 0;
+                }
             }
 
             while ip < ilimit {
@@ -915,7 +890,7 @@ macro_rules! lazy_parse_body {
                     // `offset_1 <= max_rep` keeps the rep source in history.
                     unsafe {
                         let cur = base.add(ip + 1 - hist_start);
-                        if offset_1 > 0 && rd32(cur.sub(offset_1)) == rd32(cur) {
+                        if rep_ok(ip + 1, offset_1) && rd32(cur.sub(offset_1)) == rd32(cur) {
                             match_length =
                                 $cpl(cur.add(4).sub(offset_1), cur.add(4), block_end - (ip + 5))
                                     + 4;
@@ -942,9 +917,18 @@ macro_rules! lazy_parse_body {
                         off = off2;
                     }
                     if match_length < 4 {
-                        let step = ((ip - anchor) >> LAZY_SEARCH_STRENGTH) + 1;
-                        ip += step;
-                        lazy_skipping = step > LAZY_SKIPPING_STEP;
+                        // Upstream: `step = ((ip - anchor) >> kSearchStrength) + 1`
+                        // and lazy skipping past `step > 8` on a plain / attached
+                        // frame; the `extDict` body (copied dictionary) counts
+                        // the `+ 1` outside the skipping test, one 256-byte
+                        // stretch later.
+                        let gap = (ip - anchor) >> LAZY_SEARCH_STRENGTH;
+                        ip += gap + 1;
+                        lazy_skipping = if dict_frame && !attached {
+                            gap > LAZY_SKIPPING_STEP
+                        } else {
+                            gap + 1 > LAZY_SKIPPING_STEP
+                        };
                         continue;
                     }
                     if depth >= 1 {
@@ -955,7 +939,8 @@ macro_rules! lazy_parse_body {
                                 // SAFETY: `ip + 4 <= block_end`, `offset_1 <= max_rep`.
                                 unsafe {
                                     let cur = base.add(ip - hist_start);
-                                    if offset_1 > 0 && rd32(cur) == rd32(cur.sub(offset_1)) {
+                                    if rep_ok(ip, offset_1) && rd32(cur) == rd32(cur.sub(offset_1))
+                                    {
                                         let ml_rep = $cpl(
                                             cur.add(4).sub(offset_1),
                                             cur.add(4),
@@ -999,7 +984,9 @@ macro_rules! lazy_parse_body {
                                     // SAFETY: as above.
                                     unsafe {
                                         let cur = base.add(ip - hist_start);
-                                        if offset_1 > 0 && rd32(cur) == rd32(cur.sub(offset_1)) {
+                                        if rep_ok(ip, offset_1)
+                                            && rd32(cur) == rd32(cur.sub(offset_1))
+                                        {
                                             let ml_rep = $cpl(
                                                 cur.add(4).sub(offset_1),
                                                 cur.add(4),
@@ -1044,10 +1031,17 @@ macro_rules! lazy_parse_body {
                 }
                 if off != 0 {
                     // Catch-up: absorb preceding literal bytes that also match,
-                    // never past `anchor` nor below the prefix floor.
+                    // never past `anchor` nor below the match's segment start
+                    // (upstream `mStart`: the prefix start for a prefix match,
+                    // the dictionary start for a dictionary match).
                     let concat = $m.live_history();
+                    let m_start = if start - off >= prefix_start {
+                        prefix_start.max(hist_start)
+                    } else {
+                        hist_start
+                    };
                     while start > anchor
-                        && start - off > hist_start
+                        && start - off > m_start
                         && concat[start - 1 - hist_start] == concat[start - 1 - off - hist_start]
                     {
                         start -= 1;
@@ -1080,7 +1074,7 @@ macro_rules! lazy_parse_body {
 
                 // Immediate repcode: `offset_2` right after the stored match,
                 // swapping the two reps on every hit.
-                while ip <= ilimit && offset_2 > 0 {
+                while ip <= ilimit && rep_ok(ip, offset_2) {
                     let base = scan.base;
                     // SAFETY: `ip + 4 <= block_end`, `offset_2 <= max_rep`.
                     let rep_len = unsafe {
@@ -1160,33 +1154,6 @@ macro_rules! gen_lazy_monolith {
             mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
         ) {
             lazy_parse_body!(self, handle_sequence, ROW_LOG, $use_mask, $maskmac, $cpl)
-        }
-    };
-}
-
-/// Per-tier greedy kernels: the parse body AND its probe expand inline under
-/// the tier's `#[target_feature]` umbrella with the tier's own SIMD pairing
-/// (the `K` parameter is kept only so the dispatch site stays uniform).
-macro_rules! gen_greedy_monolith {
-    ($name:ident, $use_mask:literal, $maskmac:ident, $cpl:path $(, $tf:literal)?) => {
-        $(#[target_feature(enable = $tf)])?
-        // wasm32+simd128 resolves the dispatch at compile time to the
-        // simd128 kernel, leaving the scalar monolith uncalled there
-        // (same shape as the `ScalarTags` allowance).
-        #[cfg_attr(
-            all(
-                target_arch = "wasm32",
-                target_feature = "simd128",
-                feature = "kernel_simd128"
-            ),
-            allow(dead_code)
-        )]
-        #[allow(unused_unsafe)]
-        unsafe fn $name<K: RowTags, const ROW_LOG: usize>(
-            &mut self,
-            mut handle_sequence: impl for<'a> FnMut(Sequence<'a>),
-        ) {
-            greedy_parse_body!(self, handle_sequence, ROW_LOG, $use_mask, $maskmac, $cpl)
         }
     };
 }
@@ -1758,6 +1725,28 @@ pub(crate) struct RowMatchGenerator {
     pub(crate) history_start: usize,
     pub(crate) history_abs_start: usize,
     pub(crate) offset_hist: [u32; 3],
+    /// Upstream `ZSTD_resolveRowMatchFinderMode`: with a window of 2^14 or
+    /// less the greedy/lazy parse searches a hash chain (`ZSTD_HcFindBestMatch`)
+    /// instead of rows. Resolved in `configure` from `max_window_size`.
+    use_chain: bool,
+    /// Hash-chain tables (upstream `hashTable` / `chainTable`, `hashLog` /
+    /// `chainLog` wide) used when `use_chain`; absolute positions,
+    /// `ROW_EMPTY_SLOT` = empty.
+    hc_chain_log: usize,
+    hc_hash: Vec<u32>,
+    hc_chain: Vec<u32>,
+    /// Salt XORed into the live row hash: a fresh context's
+    /// [`ROW_HASH_SALT`], or 0 after a dictionary's tables were copied in
+    /// (upstream `ZSTD_resetCCtx_byCopyingCDict` inherits the CDict's salt,
+    /// which is always 0).
+    hash_salt: u64,
+    /// The dictionary plan of the current frame (upstream
+    /// `ZSTD_resetCCtx_usingCDict`), `None` without a dictionary.
+    dict_plan: Option<RowDictPlan>,
+    /// `1 << windowLog` of the frame: the match distance bound (upstream
+    /// `maxDistance`). `max_window_size` additionally grows by a primed
+    /// dictionary's length for eviction only.
+    search_window: usize,
     pub(crate) row_hash_log: usize,
     pub(crate) row_log: usize,
     pub(crate) search_depth: usize,
@@ -1840,6 +1829,13 @@ impl RowMatchGenerator {
             history_start: 0,
             history_abs_start: 0,
             offset_hist: [1, 4, 8],
+            use_chain: false,
+            hc_chain_log: ROW_HASH_BITS,
+            hc_hash: Vec::new(),
+            hc_chain: Vec::new(),
+            hash_salt: ROW_HASH_SALT,
+            dict_plan: None,
+            search_window: 0,
             row_hash_log: ROW_HASH_BITS - ROW_LOG,
             row_log: ROW_LOG,
             search_depth: ROW_SEARCH_DEPTH,
@@ -1883,6 +1879,45 @@ impl RowMatchGenerator {
         self.row_hash_log + self.row_log
     }
 
+    /// Whether the parse searches the hash chain (window <= 2^14, upstream
+    /// `ZSTD_resolveRowMatchFinderMode`) instead of rows.
+    #[cfg(test)]
+    pub(crate) fn uses_hash_chain(&self) -> bool {
+        self.use_chain
+    }
+
+    /// Hash-chain table width (`chainLog`) applied by `configure`.
+    #[cfg(test)]
+    pub(crate) fn hc_chain_log(&self) -> usize {
+        self.hc_chain_log
+    }
+
+    /// Lowest position a search at `abs_pos` may match (upstream
+    /// `lowLimit`): `curr - maxDistance` within the live history, or the
+    /// history floor itself with an attached dictionary (upstream
+    /// `isDictionary ? lowestValid : withinMaxDistance`).
+    #[inline(always)]
+    fn window_floor(&self, abs_pos: usize) -> usize {
+        if self.dict_plan.is_some_and(|p| p.attach) {
+            self.history_abs_start
+        } else {
+            self.history_abs_start
+                .max(abs_pos.saturating_sub(self.search_window))
+        }
+    }
+
+    /// Absolute start of the frame's own prefix on a dictionary frame
+    /// (upstream `prefixLowestIndex` / `dictLimit`; the dictionary lies
+    /// below it), else 0 so the boundary rules never fire.
+    #[inline(always)]
+    fn dict_prefix_start(&self) -> usize {
+        if self.dict_plan.is_some() {
+            self.history_abs_start + self.dict.region_len()
+        } else {
+            0
+        }
+    }
+
     pub(crate) fn set_hash_bits(&mut self, bits: usize) {
         // The level's (source-size-adjusted) hashLog as upstream applies it:
         // a narrower table changes row assignment and eviction, and with it
@@ -1915,6 +1950,22 @@ impl RowMatchGenerator {
         // sharing the 4-byte key) and a sane upper bound.
         self.mls = config.mls.clamp(ROW_HASH_KEY_LEN, 7);
         self.row_hash_mls = self.mls.clamp(4, 6) as u32;
+        // Upstream `ZSTD_resolveRowMatchFinderMode`: rows only above a 2^14
+        // window; the window is source-size-adjusted, so inputs of 16 KiB or
+        // less search the hash chain. A dictionary frame inherits the CDict's
+        // decision (`ZSTD_resetCCtx_usingCDict`: "cdict overrides"), and a
+        // copied dictionary brings the CDict's salt (0) with its tables.
+        self.use_chain = match self.dict_plan {
+            Some(plan) => !plan.use_row,
+            None => self.max_window_size <= (1usize << 14),
+        };
+        self.hash_salt = match self.dict_plan {
+            Some(plan) if !plan.attach => 0,
+            _ => ROW_HASH_SALT,
+        };
+        // Taken before dictionary priming inflates `max_window_size`.
+        self.search_window = self.max_window_size;
+        self.hc_chain_log = config.chain_log.max(1);
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
@@ -1923,6 +1974,17 @@ impl RowMatchGenerator {
     pub(crate) fn set_offset_hist(&mut self, offset_hist: [u32; 3]) {
         self.offset_hist = offset_hist;
         self.lazy_reps = None;
+    }
+
+    /// Install the frame's dictionary plan (upstream
+    /// `ZSTD_resetCCtx_usingCDict`) before [`Self::configure`], which reads
+    /// it for the match-finder and salt; `None` for a plain frame.
+    pub(crate) fn set_dict_plan(&mut self, plan: Option<RowDictPlan>) {
+        if self.dict_plan != plan {
+            // The prepared dictionary index was built for another plan.
+            self.dict.invalidate();
+        }
+        self.dict_plan = plan;
     }
 
     pub(crate) fn reset(&mut self) {
@@ -1958,6 +2020,8 @@ impl RowMatchGenerator {
             self.row_heads.fill(0);
             self.row_positions.fill(ROW_EMPTY_SLOT);
             self.row_tags.fill(0);
+            self.hc_hash.fill(ROW_EMPTY_SLOT);
+            self.hc_chain.fill(ROW_EMPTY_SLOT);
         }
         // Nothing of the previous frame is indexed for the new one, and the
         // lazy reps restart from the frame's initial history.
@@ -2065,7 +2129,12 @@ impl RowMatchGenerator {
         if delta == 0 {
             return;
         }
-        for slot in self.row_positions.iter_mut() {
+        for slot in self
+            .row_positions
+            .iter_mut()
+            .chain(self.hc_hash.iter_mut())
+            .chain(self.hc_chain.iter_mut())
+        {
             if *slot == ROW_EMPTY_SLOT {
                 continue;
             }
@@ -2241,6 +2310,20 @@ impl RowMatchGenerator {
             self.row_tags.clear();
             self.row_tags.resize(total, 0);
         }
+        if self.use_chain {
+            // Hash-chain mode: `hashTable` is `1 << hashLog` wide (the full
+            // row hash width, no tag bits), `chainTable` `1 << chainLog`.
+            let hash_len = 1usize << (self.row_hash_log + self.row_log);
+            let chain_len = 1usize << self.hc_chain_log;
+            if self.hc_hash.len() != hash_len {
+                self.hc_hash.clear();
+                self.hc_hash.resize(hash_len, ROW_EMPTY_SLOT);
+            }
+            if self.hc_chain.len() != chain_len {
+                self.hc_chain.clear();
+                self.hc_chain.resize(chain_len, ROW_EMPTY_SLOT);
+            }
+        }
     }
 
     fn compact_history(&mut self) {
@@ -2354,32 +2437,29 @@ impl RowMatchGenerator {
     /// the probe's real-byte key there. Those few dict-tail entries stay
     /// unreachable, mirroring the upstream zstd, whose dictionary load also stops
     /// hashing short of the dictionary end.
-    /// Upstream zstd `ZSTD_hashPtrSalted(p, hashLog + 8, mls, salt)` of the
-    /// key at `base[idx..]`: the `mls`-byte key hashed by `ZSTD_hash4` /
-    /// `ZSTD_hash5` / `ZSTD_hash6`, salted with [`ROW_HASH_SALT`], reduced to
-    /// its top `total_bits` (= row bits + tag bits). A position hashes
-    /// identically in the probe, the cache and the dictionary fill, so every
-    /// table agrees on its row. Only the last < 8 bytes of the window (never
-    /// reached by the lazy parse, which stops 16 bytes early) fall back to
-    /// the 4-byte key.
+    /// Upstream zstd `ZSTD_hash4/5/6` of the `mls`-byte key at `base[idx..]`
+    /// with `salt` XORed into the product, reduced to the top `bits`:
+    /// `ZSTD_hashPtrSalted` for the row tables, `ZSTD_hashPtr` (salt 0) for
+    /// the hash chain.
     ///
     /// # Safety
     /// `idx + ROW_HASH_KEY_LEN <= len` and `base` must point to `len` bytes.
     #[inline(always)]
-    pub(crate) unsafe fn row_hash_raw(
+    unsafe fn key_hash_raw(
         base: *const u8,
         len: usize,
         idx: usize,
         mls: u32,
-        total_bits: usize,
+        bits: usize,
+        salt: u64,
     ) -> u64 {
-        debug_assert!(total_bits <= 32);
+        debug_assert!(bits <= 32);
         // SAFETY: `idx + 4 <= len`; the 8-byte read is taken only when it fits.
         unsafe {
             let p = base.add(idx);
             if mls == 4 || idx + 8 > len {
-                let v = rd32(p).wrapping_mul(ROW_HASH_PRIME4) ^ (ROW_HASH_SALT as u32);
-                u64::from(v >> (32 - total_bits))
+                let v = rd32(p).wrapping_mul(ROW_HASH_PRIME4) ^ (salt as u32);
+                u64::from(v >> (32 - bits))
             } else {
                 let v = u64::from_le_bytes(p.cast::<[u8; 8]>().read_unaligned());
                 let h = if mls == 5 {
@@ -2387,9 +2467,20 @@ impl RowMatchGenerator {
                 } else {
                     (v << 16).wrapping_mul(ROW_HASH_PRIME6)
                 };
-                (h ^ ROW_HASH_SALT) >> (64 - total_bits)
+                (h ^ salt) >> (64 - bits)
             }
         }
+    }
+
+    /// Hash-chain bucket of `abs_pos` (upstream `ZSTD_hashPtr(p, hashLog, mls)`).
+    /// Callers pass positions at least `ROW_HASH_KEY_LEN` bytes before the end.
+    #[inline(always)]
+    fn hc_hash_at(&self, ctx: RowScan, abs_pos: usize) -> usize {
+        let idx = abs_pos - ctx.hist_start;
+        debug_assert!(idx + ROW_HASH_KEY_LEN <= ctx.len);
+        let bits = self.row_hash_log + self.row_log;
+        // SAFETY: caller contract, `ctx` views the live history.
+        unsafe { Self::key_hash_raw(ctx.base, ctx.len, idx, self.row_hash_mls, bits, 0) as usize }
     }
 
     /// The live history as a [`RowScan`] for one parse.
@@ -2413,8 +2504,16 @@ impl RowMatchGenerator {
         }
         let total_bits = self.row_hash_log + ROW_TAG_BITS;
         // SAFETY: `idx + ROW_HASH_KEY_LEN <= ctx.len`, `ctx` views the live history.
-        let combined =
-            unsafe { Self::row_hash_raw(ctx.base, ctx.len, idx, self.row_hash_mls, total_bits) };
+        let combined = unsafe {
+            Self::key_hash_raw(
+                ctx.base,
+                ctx.len,
+                idx,
+                self.row_hash_mls,
+                total_bits,
+                self.hash_salt,
+            )
+        };
         let row_mask = (1usize << self.row_hash_log) - 1;
         let row = ((combined >> ROW_TAG_BITS) as usize) & row_mask;
         Some((row, combined as u8))
@@ -2582,92 +2681,6 @@ impl RowMatchGenerator {
         crate::encoding::fastpath::scalar::common_prefix_len_ptr
     );
 
-    pub(crate) fn start_matching_greedy(
-        &mut self,
-        handle_sequence: impl for<'a> FnMut(Sequence<'a>),
-    ) {
-        // SAFETY: each `greedy_*` umbrella is entered only when its kernel
-        // was runtime-detected (`tag_kernel`), upholding the
-        // `#[target_feature]` contract; the wasm tier is compile-time.
-        #[cfg(all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        ))]
-        {
-            // SAFETY: simd128 is a compile-time feature here; no runtime gate.
-            unsafe { dispatch_row_log!(self.greedy_simd128::<Simd128Tags>(handle_sequence)) }
-        }
-        #[cfg(not(all(
-            target_arch = "wasm32",
-            target_feature = "simd128",
-            feature = "kernel_simd128"
-        )))]
-        {
-            match self.tag_kernel {
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-                FastpathKernel::Avx2Bmi2 => unsafe {
-                    dispatch_row_log!(self.greedy_avx2bmi2::<Avx2Bmi2Tags>(handle_sequence))
-                },
-                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-                FastpathKernel::Sse42 => unsafe {
-                    dispatch_row_log!(self.greedy_sse42::<Sse42Tags>(handle_sequence))
-                },
-                #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-                FastpathKernel::Neon => unsafe {
-                    dispatch_row_log!(self.greedy_neon::<NeonTags>(handle_sequence))
-                },
-                // SAFETY: the scalar kernel has no `#[target_feature]`; the
-                // fn is `unsafe` only for macro uniformity.
-                FastpathKernel::Scalar => unsafe {
-                    dispatch_row_log!(self.greedy_scalar::<ScalarTags>(handle_sequence))
-                },
-            }
-        }
-    }
-
-    gen_greedy_monolith!(
-        greedy_scalar,
-        false,
-        row_tag_mask_scalar,
-        crate::encoding::fastpath::scalar::common_prefix_len_ptr
-    );
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_greedy_monolith!(
-        greedy_sse42,
-        true,
-        row_tag_mask_sse2,
-        crate::encoding::fastpath::sse42::common_prefix_len_ptr,
-        "sse4.2"
-    );
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    gen_greedy_monolith!(
-        greedy_avx2bmi2,
-        true,
-        row_tag_mask_avx2,
-        crate::encoding::fastpath::avx2_bmi2::common_prefix_len_ptr,
-        "avx2,bmi2"
-    );
-    #[cfg(all(target_arch = "aarch64", target_endian = "little"))]
-    gen_greedy_monolith!(
-        greedy_neon,
-        true,
-        row_tag_mask_neon,
-        crate::encoding::fastpath::neon::common_prefix_len_ptr,
-        "neon"
-    );
-    #[cfg(all(
-        target_arch = "wasm32",
-        target_feature = "simd128",
-        feature = "kernel_simd128"
-    ))]
-    gen_greedy_monolith!(
-        greedy_simd128,
-        true,
-        row_tag_mask_simd128,
-        crate::encoding::fastpath::scalar::common_prefix_len_ptr
-    );
-
     pub(crate) fn skip_matching_with_hint(&mut self, incompressible_hint: Option<bool>) {
         match self.row_log {
             4 => self.skip_matching_with_hint_rl::<4>(incompressible_hint),
@@ -2693,11 +2706,9 @@ impl RowMatchGenerator {
         handle_sequence: impl for<'a> FnMut(Sequence<'a>),
     ) {
         self.stage_borrowed_block(block_start, block_end);
-        if greedy {
-            self.start_matching_greedy(handle_sequence);
-        } else {
-            self.start_matching(handle_sequence);
-        }
+        // Greedy runs the same lazy monolith at depth 0.
+        let _ = greedy;
+        self.start_matching(handle_sequence);
     }
 
     /// Borrowed equivalent of [`Self::skip_matching_with_hint`]: stage the
@@ -2836,25 +2847,6 @@ impl RowMatchGenerator {
         }
     }
 
-    /// Index a just-emitted match span, mirroring the upstream zstd
-    /// `ZSTD_row_update_internal` skip-threshold (`zstd_lazy.c:922-940`):
-    /// when the span exceeds `SKIP_THRESHOLD` positions, only the first
-    /// `MAX_START` and last `MAX_END` are indexed and the interior is
-    /// skipped. Indexing every interior byte of a long match is
-    /// O(matchlen) and dominates encode time on periodic inputs (e.g.
-    /// repeated log lines), where a single greedy/lazy match can span an
-    /// entire block: that O(matchlen) fill, not the search, is what left
-    /// the row backend ~11x slower than FFI on those streams. The upstream zstd
-    /// caps the fill at 96 + 32 positions regardless of match length.
-    fn insert_match_span<const ROW_LOG: usize>(&mut self, start: usize, end: usize) {
-        if end.saturating_sub(start) > ROW_UPDATE_SKIP_THRESHOLD {
-            self.insert_positions::<ROW_LOG>(start, start + ROW_UPDATE_MAX_START);
-            self.insert_positions::<ROW_LOG>(end - ROW_UPDATE_MAX_END, end);
-        } else {
-            self.insert_positions::<ROW_LOG>(start, end);
-        }
-    }
-
     fn insert_positions_with_step<const ROW_LOG: usize>(
         &mut self,
         start: usize,
@@ -2971,117 +2963,173 @@ impl RowMatchGenerator {
         self.dict.invalidate();
     }
 
-    /// Upstream zstd `ZSTD_RowFindBestMatch` `dictMatchState` attach: index the
-    /// just-committed dictionary block (current `chunk_lens` tail) into the
-    /// SEPARATE immutable dict row tables instead of the live ones, so the live
-    /// rows carry only input and the dict is never re-indexed per frame. The
-    /// dual-probe in `row_candidate_rl` searches live + dict (one bounded row
-    /// each).
-    pub(crate) fn prime_dict_attach_current_block(&mut self) {
+    /// Index the just-committed dictionary block (current `chunk_lens` tail)
+    /// per the frame's [`RowDictPlan`]: upstream `ZSTD_loadDictionaryContent`
+    /// for the lazy strategies indexes every dictionary position up to
+    /// `dictSize - 8` (`ZSTD_row_update` / `ZSTD_insertAndFindFirstIndex`)
+    /// with the CDict's cParams and no salt. ATTACH keeps that index in the
+    /// separate dictionary tables the search probes as `dictMatchState`;
+    /// COPY writes it into the live tables (whose geometry and salt are the
+    /// CDict's for such a frame) and leaves `nextToUpdate` at `dictSize - 8`,
+    /// as `ZSTD_resetCCtx_byCopyingCDict` inherits it. The dictionary arrives
+    /// in slices; the index cursor carries across them so a slice boundary is
+    /// no boundary for the 8-byte key reads.
+    pub(crate) fn prime_dictionary_current_block(&mut self) {
         self.ensure_tables();
-        let current_len = self.chunk_lens.back().copied().unwrap_or(0);
-        if current_len == 0 {
+        let Some(plan) = self.dict_plan else {
+            // A dictionary on a frame the plan does not cover stays plain
+            // history.
+            self.skip_matching_with_hint(Some(false));
             return;
+        };
+        let concat_len = self.history.len() - self.history_start;
+        let indexable_end = concat_len.saturating_sub(8);
+        if plan.attach {
+            self.prime_dict_tables(plan, concat_len, indexable_end);
+        } else {
+            // COPY: the dictionary is the frame's `extDict` segment
+            // (`prefixStart` = its end) even though it lives in the live
+            // tables.
+            self.dict.set_region_len(concat_len);
+            let hist_start = self.history_abs_start;
+            let from = self.lazy_next_to_update.max(hist_start) - hist_start;
+            if from < indexable_end {
+                let scan = self.scan_ctx();
+                if self.use_chain {
+                    let chain_mask = (1usize << self.hc_chain_log) - 1;
+                    for idx in from..indexable_end {
+                        let h = self.hc_hash_at(scan, hist_start + idx);
+                        self.hc_chain[idx & chain_mask] = self.hc_hash[h];
+                        self.hc_hash[h] = idx as u32;
+                    }
+                } else {
+                    match self.row_log {
+                        4 => self.copy_dict_rows::<4>(scan, from, indexable_end),
+                        5 => self.copy_dict_rows::<5>(scan, from, indexable_end),
+                        _ => self.copy_dict_rows::<6>(scan, from, indexable_end),
+                    }
+                }
+            }
+            self.lazy_next_to_update = hist_start + indexable_end.max(from);
         }
-        let current_abs_start = self.history_abs_start + self.window_size - current_len;
-        let current_abs_end = current_abs_start + current_len;
-        let start_concat = current_abs_start - self.history_abs_start;
-        let end_concat = current_abs_end - self.history_abs_start;
-        // Backfill the `ROW_HASH_KEY_LEN - 1` bytes immediately before the
-        // block, mirroring the live insert path's `backfill_start`: those
-        // starts only become hashable once this block supplies the
-        // trailing key bytes, so without the backfill seam-spanning row
-        // candidates are dropped from the dict index permanently.
-        let prime_start = start_concat.saturating_sub(ROW_HASH_KEY_LEN - 1);
-        self.prime_dict_rows(prime_start, end_concat);
     }
 
-    /// Build the immutable dictionary row index over the contiguous-history
-    /// concat range `[start_concat, end_concat)`. Mirrors [`Self::insert_position`]'s
-    /// row-hash + head-decrement slot write, but writes a CONCAT index (stable
-    /// across rebases) into the SEPARATE [`Self::dict`] tables. `ROW_EMPTY_SLOT`
-    /// marks empty. Skips the rehash when the CDict cache is already primed.
-    fn prime_dict_rows(&mut self, start_concat: usize, end_concat: usize) {
-        let row_count = 1usize << self.row_hash_log;
-        let row_entries = 1usize << self.row_log;
-        let total = row_count * row_entries;
-        // Drop a cached dict index built for a different table shape (a genuine
-        // level change resizes `row_hash_log`/`row_log`). `set_hash_bits`'s
-        // per-frame oscillation does NOT reach here — this runs after setup with
-        // the final shape — so a same-level reused frame keeps the cache.
-        // Key on the FULL shape, not just `heads.len()`: a level change that
-        // keeps `row_hash_log` but changes `row_log` leaves `heads.len()`
-        // equal while `positions`/`tags` are sized for the old `row_log`,
-        // and the probe path then indexes `row << row_log` slots that the
-        // cached table doesn't have (OOB / wrong slots).
+    /// COPY-mode row indexing of dictionary positions `[from, to)` (concat
+    /// indices) into the live rows.
+    fn copy_dict_rows<const ROW_LOG: usize>(&mut self, scan: RowScan, from: usize, to: usize) {
+        for idx in from..to {
+            let abs = scan.hist_start + idx;
+            if let Some((row, tag)) = self.row_hash_at(scan, abs) {
+                self.insert_at::<ROW_LOG>(abs, row, tag);
+            }
+        }
+    }
+
+    /// ATTACH-mode index: build the separate dictionary tables over the
+    /// concat range `[cursor, indexable_end)` with the CDict's geometry
+    /// (`hash_log`, `chain_log`, `row_log = clamp(searchLog, 4, 6)`), its key
+    /// width, and salt 0 (`ZSTD_reset_matchState` for a CDict). Row form when
+    /// the CDict resolved to rows, hash-chain form otherwise. Positions are
+    /// CONCAT indices (stable across rebases). Skipped when the cached index
+    /// for this dictionary is already primed.
+    fn prime_dict_tables(&mut self, plan: RowDictPlan, concat_len: usize, indexable_end: usize) {
+        let cd = plan.cdict;
+        let hash_log = cd.hash_log as usize;
+        let chain_log = cd.chain_log as usize;
+        let row_log = (cd.search_log as usize).clamp(4, 6);
+        let use_row = plan.use_row;
+        let mls = cd.min_match.clamp(4, 6);
         if self.dict.table().is_some_and(|d| {
-            d.heads.len() != row_count || d.positions.len() != total || d.tags.len() != total
+            d.hash_log != hash_log
+                || d.chain_log != chain_log
+                || d.row_log != row_log
+                || d.use_row != use_row
         }) {
             self.dict.invalidate();
         }
-        self.dict.set_region_len(end_concat);
+        self.dict.set_region_len(concat_len);
         if self.dict.is_primed() {
             return;
         }
-        let row_log = self.row_log;
-        let row_hash_log = self.row_hash_log;
-        let hash_mls = self.row_hash_mls;
-        let history_start = self.history_start;
-        let concat_len = self.history.len() - history_start;
-        // Row hash needs `ROW_HASH_KEY_LEN` readable bytes of lookahead.
-        let safe_end = concat_len
-            .saturating_sub(ROW_HASH_KEY_LEN - 1)
-            .min(end_concat);
-        if start_concat >= safe_end {
+        let from = self.dict.next_to_update();
+        if from >= indexable_end {
             return;
         }
-        // `row_count` / `row_entries` / `total` were computed above for the
-        // shape-mismatch check and carry the same values here.
-        let row_mask = row_entries - 1;
-        let row_count_mask = row_count - 1;
+        self.dict.set_next_to_update(indexable_end);
+        let history_start = self.history_start;
         // Raw history base taken before the mutable dict borrow (disjoint
         // fields; the raw ptr holds no borrow).
         let base = self.history.as_ptr();
-        let dict = self.dict.table_mut_or_init(|| RowDictTables {
-            heads: alloc::vec![0u8; row_count],
-            positions: alloc::vec![ROW_EMPTY_SLOT; total],
-            tags: alloc::vec![0u8; total],
+        let dict = self.dict.table_mut_or_init(|| {
+            let (row_count, total) = if use_row {
+                (1usize << (hash_log - row_log), 1usize << hash_log)
+            } else {
+                (0, 0)
+            };
+            RowDictTables {
+                heads: alloc::vec![0u8; row_count],
+                positions: alloc::vec![ROW_EMPTY_SLOT; total],
+                tags: alloc::vec![0u8; total],
+                hc_hash: if use_row {
+                    Vec::new()
+                } else {
+                    alloc::vec![ROW_EMPTY_SLOT; 1usize << hash_log]
+                },
+                hc_chain: if use_row {
+                    Vec::new()
+                } else {
+                    alloc::vec![ROW_EMPTY_SLOT; 1usize << chain_log]
+                },
+                hash_log,
+                chain_log,
+                row_log,
+                use_row,
+            }
         });
-        let heads = dict.heads.as_mut_ptr();
-        let positions = dict.positions.as_mut_ptr();
-        let tags = dict.tags.as_mut_ptr();
-        let total_bits = row_hash_log + ROW_TAG_BITS;
-        // SAFETY: `base.add(history_start + concat)` is in-bounds for
-        // `concat + ROW_HASH_KEY_LEN <= concat_len` (enforced by `safe_end`).
-        // `row <= row_count_mask < row_count` (= heads.len()); `row_base + next
-        // < total` (= positions.len() = tags.len()). `concat` fits u32 (history
-        // is u32-bounded upstream).
-        for concat in start_concat..safe_end {
-            unsafe {
-                // Same hash as the live `row_hash_at` (key width, prime and
-                // salt): any divergence buckets dict rows differently and
-                // loses every attached-dict match.
-                let combined = Self::row_hash_raw(
-                    base.add(history_start),
-                    concat_len,
-                    concat,
-                    hash_mls,
-                    total_bits,
-                );
-                let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;
-                let tag = combined as u8;
-                let row_base = row << row_log;
-                let head = *heads.add(row) as usize;
-                // Upstream `ZSTD_row_nextIndex`: slot 0 is never written (it
-                // holds the head byte in upstream's tag row), so the cursor
-                // cycles over `1..=row_mask`.
-                let next = match head.wrapping_sub(1) & row_mask {
-                    0 => row_mask,
-                    n => n,
-                };
-                *heads.add(row) = next as u8;
-                *tags.add(row_base + next) = tag;
-                *positions.add(row_base + next) = concat as u32;
+        // SAFETY: `concat + 8 <= concat_len` for every indexed position
+        // (`indexable_end = concat_len - 8`), so the key reads stay inside the
+        // history; every table index is masked to its table's width.
+        unsafe {
+            let content = base.add(history_start);
+            if use_row {
+                let row_hash_log = hash_log - row_log;
+                let row_mask = (1usize << row_log) - 1;
+                let row_count_mask = (1usize << row_hash_log) - 1;
+                let heads = dict.heads.as_mut_ptr();
+                let positions = dict.positions.as_mut_ptr();
+                let tags = dict.tags.as_mut_ptr();
+                for concat in from..indexable_end {
+                    let combined = Self::key_hash_raw(
+                        content,
+                        concat_len,
+                        concat,
+                        mls,
+                        row_hash_log + ROW_TAG_BITS,
+                        0,
+                    );
+                    let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;
+                    let tag = combined as u8;
+                    let row_base = row << row_log;
+                    let head = *heads.add(row) as usize;
+                    // Upstream `ZSTD_row_nextIndex`: slot 0 is never written.
+                    let next = match head.wrapping_sub(1) & row_mask {
+                        0 => row_mask,
+                        n => n,
+                    };
+                    *heads.add(row) = next as u8;
+                    *tags.add(row_base + next) = tag;
+                    *positions.add(row_base + next) = concat as u32;
+                }
+            } else {
+                let chain_mask = (1usize << chain_log) - 1;
+                let hash = dict.hc_hash.as_mut_ptr();
+                let chain = dict.hc_chain.as_mut_ptr();
+                for concat in from..indexable_end {
+                    let h =
+                        Self::key_hash_raw(content, concat_len, concat, mls, hash_log, 0) as usize;
+                    *chain.add(concat & chain_mask) = *hash.add(h);
+                    *hash.add(h) = concat as u32;
+                }
             }
         }
     }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -89,6 +89,8 @@ struct RowScan {
     prefix_start: usize,
     dict_frame: bool,
     attached: bool,
+    /// Search through the hash-chain finder instead of the row table.
+    use_chain: bool,
 }
 
 /// Upstream zstd `ZSTD_highbit32(offBase)` term of the lazy gain formula:
@@ -572,7 +574,7 @@ macro_rules! row_find_best_match {
 macro_rules! lazy_search_at {
     ($m:expr, $ctx:ident, $p:expr, $ntu:ident, $skip:ident, $cache:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         let p = $p;
-        if $m.use_chain {
+        if $ctx.use_chain {
             hc_find_best_match!($m, $ctx, p, $ntu, $skip, $cpl)
         } else {
             let (row, tag) = if $skip {
@@ -814,7 +816,7 @@ macro_rules! lazy_parse_body {
             let block_end = current_abs_start + current_len;
             // Upstream `ilimit`: `iend - 8 - ZSTD_ROW_HASH_CACHE_SIZE` for the
             // row search, `iend - 8` for the hash chain.
-            let ilimit = block_end.saturating_sub(if $m.use_chain {
+            let ilimit = block_end.saturating_sub(if scan.use_chain {
                 LAZY_HC_ILIMIT_MARGIN
             } else {
                 LAZY_ROW_ILIMIT_MARGIN
@@ -870,6 +872,13 @@ macro_rules! lazy_parse_body {
             let prefix_start = scan.prefix_start;
             let search_window = scan.search_window;
             let rep_ok = |pos: usize, off: usize| -> bool {
+                if !dict_frame {
+                    // The block-start clamp below keeps every carried rep
+                    // in-window for the whole block (the window floor never
+                    // advances faster than the position) and searched
+                    // offsets are in-window by construction.
+                    return off != 0;
+                }
                 if off == 0 || off > pos {
                     return false;
                 }
@@ -2500,6 +2509,7 @@ impl RowMatchGenerator {
             prefix_start: self.dict_prefix_start(),
             dict_frame: self.dict_plan.is_some(),
             attached: self.dict_plan.is_some_and(|p| p.attach),
+            use_chain: self.use_chain,
         }
     }
 

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -516,6 +516,9 @@ macro_rules! greedy_parse_body {
                 $m.insert_position::<$rl>(current_abs_start + pos);
                 pos += 1;
             }
+            // Every position up to the block end is indexed; a following
+            // lazy block resumes its gap fill from there.
+            $m.lazy_next_to_update = current_abs_start + current_len;
 
             if literals_start < current_len {
                 // Trailing literals of the current block. Read via
@@ -859,14 +862,13 @@ macro_rules! lazy_parse_body {
             let mut anchor = current_abs_start;
             // `ip += (dictAndPrefixLength == 0)`: nothing precedes the first byte.
             let mut ip = current_abs_start + usize::from(current_abs_start == hist_start);
-            // Upstream `nextToUpdate`: resume where the previous lazy block
-            // stopped indexing (its last <= 16 bytes, now readable with the
-            // full 8-byte key); a stale cursor (another parse ran in
-            // between, or the floor moved past it) restarts at the 3 bytes
-            // preceding the block, the widest key overlap that still hashes.
-            let mut next_to_update = $m
-                .lazy_next_to_update
-                .clamp($m.backfill_start(current_abs_start), current_abs_start);
+            // Upstream `nextToUpdate`: resume where the previous block
+            // stopped indexing (a lazy block leaves its last <= 16 bytes,
+            // now readable with the full 8-byte key; the other parses set
+            // it to their block end). Bounded to the live history: a
+            // cursor the floor moved past restarts at the floor, exactly
+            // upstream's `nextToUpdate < lowLimit` clamp.
+            let mut next_to_update = $m.lazy_next_to_update.clamp(hist_start, current_abs_start);
             let mut lazy_skipping = false;
             // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
             let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
@@ -2149,6 +2151,10 @@ impl RowMatchGenerator {
                 // per block × 800 = ~104M inserts.
             }
         }
+        // A following lazy block gap-fills from here: the skipped block's
+        // last `ROW_HASH_KEY_LEN - 1` bytes, the same tail the next call's
+        // `backfill_start` insert covers.
+        self.lazy_next_to_update = current_abs_end.saturating_sub(ROW_HASH_KEY_LEN - 1);
     }
     /// Upstream zstd-parity greedy parse for `lazy_depth == 0` (level 5).
     ///

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -869,6 +869,14 @@ macro_rules! lazy_parse_body {
             // cursor the floor moved past restarts at the floor, exactly
             // upstream's `nextToUpdate < lowLimit` clamp.
             let mut next_to_update = $m.lazy_next_to_update.clamp(hist_start, current_abs_start);
+            // Upstream `ZSTD_buildSeqStore` "limited update after a very long
+            // match" (zstd_compress.c:3296): a block starting more than 384
+            // positions past the cursor indexes at most the last 192 + 384 of
+            // the gap.
+            if current_abs_start > next_to_update + 384 {
+                next_to_update =
+                    current_abs_start - (current_abs_start - next_to_update - 384).min(192);
+            }
             let mut lazy_skipping = false;
             // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
             let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
@@ -1876,12 +1884,10 @@ impl RowMatchGenerator {
     }
 
     pub(crate) fn set_hash_bits(&mut self, bits: usize) {
-        // Deliberate deviation from upstream zstd hashLog 21-23 on L9-12: the
-        // 20-bit cap keeps the row table L2/L3-resident. Measured on the
-        // 1 MiB corpus at L10 (tight pair, flat control): the honest
-        // 21-bit table cost +26.8% wall for a 19-byte output delta — our
-        // lazy-band ratio already beats the upstream zstd with the capped width.
-        let clamped = bits.clamp(self.row_log + 1, ROW_HASH_BITS);
+        // The level's (source-size-adjusted) hashLog as upstream applies it:
+        // a narrower table changes row assignment and eviction, and with it
+        // the candidate set every search sees.
+        let clamped = bits.max(self.row_log + 1);
         let row_hash_log = clamped.saturating_sub(self.row_log);
         if self.row_hash_log != row_hash_log {
             self.row_hash_log = row_hash_log;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -24,6 +24,35 @@ use super::match_generator::{
     ROW_TAG_BITS, ROW_TARGET_LEN,
 };
 
+/// Upstream zstd lazy-parse bounds (`zstd_lazy.c`): the row parse stops
+/// `8 + ZSTD_ROW_HASH_CACHE_SIZE` bytes before the block end, a miss steps
+/// by `(ip - anchor) >> kSearchStrength + 1`, and steps above
+/// `kLazySkippingStep` stop indexing the skipped-over positions.
+const LAZY_ROW_ILIMIT_MARGIN: usize = 16;
+const LAZY_SEARCH_STRENGTH: u32 = 8;
+const LAZY_SKIPPING_STEP: usize = 8;
+
+/// Upstream zstd `ZSTD_highbit32(offBase)` term of the lazy gain formula:
+/// `offBase` is `offset + 3` for a real offset and 1 for repcode 1
+/// (`off == 0` here), whose highbit is 0.
+#[inline(always)]
+fn offbase_highbit(off: usize) -> i64 {
+    if off == 0 {
+        0
+    } else {
+        i64::from(31 - ((off + 3) as u32).leading_zeros())
+    }
+}
+
+/// Unaligned little-endian 4-byte read (upstream zstd `MEM_read32`).
+///
+/// # Safety
+/// `p..p + 4` must be readable.
+#[inline(always)]
+unsafe fn rd32(p: *const u8) -> u32 {
+    u32::from_le_bytes(unsafe { p.cast::<[u8; 4]>().read_unaligned() })
+}
+
 /// Immutable row-hash dictionary index (upstream zstd `ZSTD_RowFindBestMatch`'s
 /// `dictMatchState` probe). Built once over the dictionary region and probed as
 /// ONE fixed-width row (`<= row_entries` tag-matched candidates) AFTER the live
@@ -457,24 +486,232 @@ macro_rules! greedy_parse_body {
     }};
 }
 
-/// Rep + row best-of-two probe (the lazy search step) with the probe body
-/// expanded inline under the enclosing tier umbrella.
-macro_rules! row_best_match {
-    ($m:expr, $abs_pos:expr, $lit_len:expr, $hash:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
-        let rep = $m.repcode_candidate($abs_pos, $lit_len);
-        row_probe_body!(
-            $m, $abs_pos, $lit_len, $hash, rep, $rl, $use_mask, $maskmac, $cpl
-        )
+/// Upstream zstd `ZSTD_RowFindBestMatch` (zstd_lazy.c:1141) at one position:
+/// the row is walked newest-first until the first entry below the window
+/// floor, the in-window candidates are buffered (and their data prefetched),
+/// then each is gated by a 4-byte compare at the current best length
+/// (`match + ml - 3`) before the full count. Lengths are FORWARD only (the
+/// catch-up belongs to the parse). Evaluates to `(ml, offset)`: `ml == 3`
+/// means nothing found (upstream's `ml = 4-1`), `offset` is the distance.
+/// Leftover attempts fund the dictionary row (upstream `dictMatchState`).
+macro_rules! row_find_best_match {
+    ($m:expr, $abs_pos:expr, $row:expr, $tag:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        let concat = $m.live_history();
+        let hist_start = $m.history_abs_start;
+        let cur_idx = $abs_pos - hist_start;
+        // SAFETY: the parse searches only positions >= 16 bytes before the
+        // block end, so `cur_idx + 16 <= concat.len()`.
+        let cur_ptr = unsafe { concat.as_ptr().add(cur_idx) };
+        let limit = concat.len() - cur_idx;
+        let row_entries = 1usize << $rl;
+        let row_mask = row_entries - 1;
+        let row_base = $row << $rl;
+        let head = $m.row_heads[$row] as usize;
+        let window_low = hist_start.max($abs_pos.saturating_sub($m.max_window_size));
+        let budget = $m.search_depth.min(row_entries);
+        let mut attempts = budget;
+        let mut ml = 3usize;
+        let mut best_off = 0usize;
+        let entries_bits: u64 = if row_entries >= 64 {
+            u64::MAX
+        } else {
+            (1u64 << row_entries) - 1
+        };
+        let mut buf = [0u32; 64];
+        let mut n = 0usize;
+        {
+            #[allow(unused_mut)]
+            let mut pending: u64 = if $use_mask {
+                let m =
+                    $maskmac!(&$m.row_tags[row_base..row_base + row_entries], $tag) & entries_bits;
+                if head == 0 {
+                    m
+                } else {
+                    ((m >> head) | (m << (row_entries - head))) & entries_bits
+                }
+            } else {
+                0
+            };
+            #[allow(unused_mut)]
+            let mut scan = 0usize;
+            while attempts > 0 {
+                let slot_opt = if $use_mask {
+                    if pending == 0 {
+                        None
+                    } else {
+                        let i = pending.trailing_zeros() as usize;
+                        pending &= pending - 1;
+                        Some((head + i) & row_mask)
+                    }
+                } else {
+                    let mut found = None;
+                    while scan < row_entries {
+                        let s = (head + scan) & row_mask;
+                        scan += 1;
+                        if $m.row_tags[row_base + s] == $tag {
+                            found = Some(s);
+                            break;
+                        }
+                    }
+                    found
+                };
+                let Some(slot) = slot_opt else { break };
+                let raw = $m.row_positions[row_base + slot];
+                // Newest-first order: the first empty / below-floor entry ends
+                // the walk (upstream `if (matchIndex < lowLimit) break`).
+                if raw == ROW_EMPTY_SLOT || (raw as usize) < window_low {
+                    break;
+                }
+                if (raw as usize) >= $abs_pos {
+                    continue;
+                }
+                #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+                {
+                    #[cfg(target_arch = "x86")]
+                    use core::arch::x86::{_MM_HINT_T0, _mm_prefetch};
+                    #[cfg(target_arch = "x86_64")]
+                    use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+                    // SAFETY: prefetch is a hint; the candidate lies in the live
+                    // history.
+                    unsafe {
+                        _mm_prefetch(
+                            concat.as_ptr().add(raw as usize - hist_start).cast(),
+                            _MM_HINT_T0,
+                        );
+                    }
+                }
+                buf[n] = raw;
+                n += 1;
+                attempts -= 1;
+            }
+        }
+        for &raw in &buf[..n] {
+            let cand_idx = raw as usize - hist_start;
+            // SAFETY: `cand_idx < cur_idx`; the gate reads 4 bytes at
+            // `+ ml - 3` where `ml + 1 <= limit` (the count breaks out of the
+            // loop at `ml == limit`), so both reads stay inside `concat`.
+            unsafe {
+                let cand_ptr = concat.as_ptr().add(cand_idx);
+                if rd32(cand_ptr.add(ml - 3)) == rd32(cur_ptr.add(ml - 3)) {
+                    let cml = $cpl(cand_ptr, cur_ptr, limit);
+                    if cml > ml {
+                        ml = cml;
+                        best_off = $abs_pos - raw as usize;
+                        if cml == limit {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        // Dictionary row: funded by the attempts the live row left (upstream
+        // shares one `nbAttempts`), floored at a full 16-entry row so the CDict
+        // search depth stays effective on small-level dictionaries.
+        let dict_budget = budget.max(16);
+        let used = budget - attempts;
+        if ml < limit
+            && used < dict_budget
+            && let Some(dict) = $m.dict.table()
+        {
+            let mut dattempts = dict_budget - used;
+            let dict_end = $m.dict.region_len();
+            let dhead = dict.heads[$row] as usize;
+            #[allow(unused_mut)]
+            let mut dpending: u64 = if $use_mask {
+                let m =
+                    $maskmac!(&dict.tags[row_base..row_base + row_entries], $tag) & entries_bits;
+                if dhead == 0 {
+                    m
+                } else {
+                    ((m >> dhead) | (m << (row_entries - dhead))) & entries_bits
+                }
+            } else {
+                0
+            };
+            #[allow(unused_mut)]
+            let mut dscan = 0usize;
+            while dattempts > 0 {
+                let slot_opt = if $use_mask {
+                    if dpending == 0 {
+                        None
+                    } else {
+                        let i = dpending.trailing_zeros() as usize;
+                        dpending &= dpending - 1;
+                        Some((dhead + i) & row_mask)
+                    }
+                } else {
+                    let mut found = None;
+                    while dscan < row_entries {
+                        let s = (dhead + dscan) & row_mask;
+                        dscan += 1;
+                        if dict.tags[row_base + s] == $tag {
+                            found = Some(s);
+                            break;
+                        }
+                    }
+                    found
+                };
+                let Some(slot) = slot_opt else { break };
+                let dp = dict.positions[row_base + slot];
+                if dp == ROW_EMPTY_SLOT {
+                    break;
+                }
+                dattempts -= 1;
+                let dp = dp as usize;
+                if dp + 4 > dict_end {
+                    continue;
+                }
+                // SAFETY: `dp + 4 <= dict_end <= cur_idx`, `cur_idx + 4 <= concat.len()`.
+                unsafe {
+                    let dptr = concat.as_ptr().add(dp);
+                    if rd32(dptr) == rd32(cur_ptr) {
+                        let cml = $cpl(dptr, cur_ptr, limit);
+                        if cml > ml {
+                            ml = cml;
+                            best_off = $abs_pos - (hist_start + dp);
+                            if cml == limit {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (ml, best_off)
     }};
 }
 
-/// The lazy row parse BODY as a macro — same per-tier monolith shape as
-/// `greedy_parse_body!` for the lazy levels. Upstream zstd's `ZSTD_searchMax`
-/// is `FORCE_INLINE_TEMPLATE` into `ZSTD_compressBlock_lazy_generic`, so the
-/// search at every probe site (current position + the `lazy_decide!` lookahead)
-/// expands the rep + row-probe body inline via `row_best_match!` rather than
-/// calling an out-of-line per-tier `#[target_feature]` search method — keeping
-/// the whole per-position pipeline one monolith with no per-position call cost.
+/// Upstream zstd `ZSTD_searchMax` for the row lazy parse: index the not yet
+/// indexed gap up to `$p` (skipped while lazy-skipping; a long gap keeps only
+/// its 96 head + 32 tail positions), search `$p`, then index `$p` itself.
+/// `$ntu` is the parse's `nextToUpdate` local, `$skip` its `lazySkipping`.
+macro_rules! lazy_search_at {
+    ($m:expr, $p:expr, $ntu:ident, $skip:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+        let p = $p;
+        if !$skip && $ntu < p {
+            $m.insert_match_span::<$rl>($ntu, p);
+        }
+        let r = match $m.hash_and_row(p) {
+            Some((row, tag)) => {
+                let r = row_find_best_match!($m, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
+                $m.insert_at::<$rl>(p, row, tag);
+                r
+            }
+            None => (3usize, 0usize),
+        };
+        $ntu = p + 1;
+        r
+    }};
+}
+
+/// The lazy row parse BODY: upstream zstd `ZSTD_compressBlock_lazy_generic`
+/// (zstd_lazy.c:1516) for the row-hash search, expanded per SIMD tier so the
+/// search splices (`lazy_search_at!`, upstream's `FORCE_INLINE_TEMPLATE
+/// ZSTD_searchMax`) inline into the parse loop as ONE monolith. Same
+/// decisions as upstream: repcode 1 probed one byte ahead, gain-weighted
+/// depth-1/depth-2 lookahead (each position searched once), catch-up on the
+/// chosen match only, immediate-repcode loop after every stored sequence,
+/// `>> 8` miss acceleration with lazy skipping past step 8.
 macro_rules! lazy_parse_body {
     ($m:expr, $handle:expr, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         #[allow(unused_labels)]
@@ -491,153 +728,220 @@ macro_rules! lazy_parse_body {
                 $m.insert_positions::<$rl>(backfill_start, current_abs_start);
             }
 
-            let mls = $m.mls;
-            let mut pos = 0usize;
-            let mut literals_start = 0usize;
-            // Lookahead search result carried into the next iteration
-            // (upstream zstd's lazy chain, `zstd_lazy.c` lazy_generic: a
-            // deferred position's successor is never searched twice — the
-            // depth loop carries the better match forward). `Some(r)` means
-            // this iteration's position was already searched as the previous
-            // iteration's lookahead, with result `r`.
-            let mut carried: Option<Option<MatchCandidate>> = None;
-            while pos + mls <= current_len {
-                let abs_pos = current_abs_start + pos;
-                let lit_len = pos - literals_start;
-                // The previous iteration deferred (carried set) — including the
-                // depth-2 defer-WITHOUT-carry case (`Some(None)`, where
-                // `abs_pos + 1` was cold but `abs_pos + 2` won). `carried.take()`
-                // below clears that, so capture it now: if this position then
-                // misses, the skip must advance by one so it cannot hop over the
-                // proven `abs_pos + 2` winner.
-                let deferred_from_prev = carried.is_some();
+            let hist_start = $m.history_abs_start;
+            let depth = $m.lazy_depth;
+            let block_end = current_abs_start + current_len;
+            let ilimit = block_end.saturating_sub(LAZY_ROW_ILIMIT_MARGIN);
+            let mut anchor = current_abs_start;
+            // `ip += (dictAndPrefixLength == 0)`: nothing precedes the first byte.
+            let mut ip = current_abs_start + usize::from(current_abs_start == hist_start);
+            let mut next_to_update = current_abs_start;
+            let mut lazy_skipping = false;
+            // Repcodes reaching below the window are disabled for the block
+            // (upstream `maxRep`); the bound also keeps every rep read inside
+            // the live history since `ip` only grows.
+            let max_rep = ip - hist_start.max(ip.saturating_sub($m.max_window_size));
+            let mut offset_1 = ($m.offset_hist[0] as usize).min(max_rep + 1) % (max_rep + 1);
+            let mut offset_2 = ($m.offset_hist[1] as usize).min(max_rep + 1) % (max_rep + 1);
 
-                // Hash the position ONCE per iteration: the probe consumes it
-                // and the defer branch reuses it for the insert (upstream zstd
-                // hashes once per position — `ZSTD_RowFindBestMatch` updates
-                // the row as part of the search, `zstd_lazy.c`). A carried
-                // iteration skips both: the search already ran.
-                let (hash, best) = match carried.take() {
-                    Some(best) => (None, best),
-                    None => {
-                        let hash = $m.hash_and_row(abs_pos);
-                        // Search spliced INLINE (upstream zstd `ZSTD_searchMax`
-                        // is `FORCE_INLINE_TEMPLATE` into `lazy_generic`): expand
-                        // the rep + row-probe body here rather than calling an
-                        // out-of-line per-tier `#[target_feature]` `$find` method
-                        // (a `target_feature` fn cannot inline across the call
-                        // boundary, so the call cost + arg marshalling was paid
-                        // per position — the dominant instruction-count gap vs C).
-                        let best = row_best_match!(
-                            $m, abs_pos, lit_len, hash, $rl, $use_mask, $maskmac, $cpl
-                        );
-                        (hash, best)
+            while ip < ilimit {
+                let mut match_length = 0usize;
+                // `0` = repcode 1 (`offset_1`), else a real distance.
+                let mut off = 0usize;
+                let mut start = ip + 1;
+                {
+                    let base = $m.live_history().as_ptr();
+                    // SAFETY: `ip + 1 + 4 <= block_end` (`ip < ilimit`), and
+                    // `offset_1 <= max_rep` keeps the rep source in history.
+                    unsafe {
+                        let cur = base.add(ip + 1 - hist_start);
+                        if offset_1 > 0 && rd32(cur.sub(offset_1)) == rd32(cur) {
+                            match_length =
+                                $cpl(cur.add(4).sub(offset_1), cur.add(4), block_end - (ip + 5))
+                                    + 4;
+                        }
                     }
-                };
-                let picked = 'pick: {
-                    let Some(best) = best else { break 'pick None };
-                    // The decision is a MACRO (spliced inline); its lookahead
-                    // `search` splice expands the row-probe body inline too, so the
-                    // whole per-position pipeline stays one `target_feature`
-                    // monolith with no out-of-line search call at any probe site.
-                    // target_len = MAX: upstream lazy has no sufficient-length
-                    // early-out (that is the OPT parser's; one here collapses lazy
-                    // to greedy, -7% ratio vs C). The macro weighs candidates by
-                    // length (ties to the smaller offset) and returns the carry so
-                    // the deferred position is searched once.
-                    let lazy_depth = $m.lazy_depth;
-                    let history_end = $m.history_abs_end();
-                    let mls = $m.mls;
-                    let decision = $crate::encoding::lazy_parse::lazy_decide!(
-                        best_len = best.match_len,
-                        best_off = best.offset,
-                        target_len = usize::MAX,
-                        lazy_depth = lazy_depth,
-                        abs_pos = abs_pos,
-                        lit_len = lit_len,
-                        history_end = history_end,
-                        min_match = mls,
-                        // Lookahead search, also spliced inline (no out-of-line
-                        // call): the enclosing kernel runs only when its tier was
-                        // runtime-detected, upholding the row-probe's
-                        // target_feature contract.
-                        search =
-                            |p, l| row_best_match!($m, p, l, None, $rl, $use_mask, $maskmac, $cpl),
+                }
+                // Upstream: a depth-0 rep hit is stored without searching.
+                if !(match_length >= 4 && depth == 0) {
+                    let (ml2, off2) = lazy_search_at!(
+                        $m,
+                        ip,
+                        next_to_update,
+                        lazy_skipping,
+                        $rl,
+                        $use_mask,
+                        $maskmac,
+                        $cpl
                     );
-                    if let Some(carry) = decision {
-                        carried = Some(carry);
-                        None
-                    } else {
-                        Some(best)
+                    if ml2 > match_length {
+                        match_length = ml2;
+                        start = ip;
+                        off = off2;
                     }
-                };
-                if let Some(candidate) = picked {
-                    $m.insert_match_span::<$rl>(abs_pos, candidate.start + candidate.match_len);
-                    // Trailing literals of the current block. Read via
-                    // `live_history()` (borrowed-aware) sliced at the block's
-                    // offset within the live region: owned →
-                    // `live_history()[window_size - current_len..]` (byte-identical
-                    // to the old `history[history.len()-current_len..]`); borrowed →
-                    // `live_history()[block_start..]` (the in-place input, since the
-                    // owned `history` mirror is empty under the no-copy path).
-                    let current = &$m.live_history()[(current_abs_start - $m.history_abs_start)..];
-                    let start = candidate.start - current_abs_start;
-                    let literals = &current[literals_start..start];
+                    if match_length < 4 {
+                        let step = ((ip - anchor) >> LAZY_SEARCH_STRENGTH) + 1;
+                        ip += step;
+                        lazy_skipping = step > LAZY_SKIPPING_STEP;
+                        continue;
+                    }
+                    if depth >= 1 {
+                        while ip < ilimit {
+                            ip += 1;
+                            {
+                                let base = $m.live_history().as_ptr();
+                                // SAFETY: `ip + 4 <= block_end`, `offset_1 <= max_rep`.
+                                unsafe {
+                                    let cur = base.add(ip - hist_start);
+                                    if offset_1 > 0 && rd32(cur) == rd32(cur.sub(offset_1)) {
+                                        let ml_rep = $cpl(
+                                            cur.add(4).sub(offset_1),
+                                            cur.add(4),
+                                            block_end - (ip + 4),
+                                        ) + 4;
+                                        let gain2 = (ml_rep * 3) as i64;
+                                        let gain1 =
+                                            (match_length * 3) as i64 - offbase_highbit(off) + 1;
+                                        if ml_rep >= 4 && gain2 > gain1 {
+                                            match_length = ml_rep;
+                                            off = 0;
+                                            start = ip;
+                                        }
+                                    }
+                                }
+                            }
+                            let (ml2, off2) = lazy_search_at!(
+                                $m,
+                                ip,
+                                next_to_update,
+                                lazy_skipping,
+                                $rl,
+                                $use_mask,
+                                $maskmac,
+                                $cpl
+                            );
+                            let gain2 = (ml2 * 4) as i64 - offbase_highbit(off2);
+                            let gain1 = (match_length * 4) as i64 - offbase_highbit(off) + 4;
+                            if ml2 >= 4 && gain2 > gain1 {
+                                match_length = ml2;
+                                off = off2;
+                                start = ip;
+                                continue;
+                            }
+                            if depth == 2 && ip < ilimit {
+                                ip += 1;
+                                {
+                                    let base = $m.live_history().as_ptr();
+                                    // SAFETY: as above.
+                                    unsafe {
+                                        let cur = base.add(ip - hist_start);
+                                        if offset_1 > 0 && rd32(cur) == rd32(cur.sub(offset_1)) {
+                                            let ml_rep = $cpl(
+                                                cur.add(4).sub(offset_1),
+                                                cur.add(4),
+                                                block_end - (ip + 4),
+                                            ) + 4;
+                                            let gain2 = (ml_rep * 4) as i64;
+                                            let gain1 = (match_length * 4) as i64
+                                                - offbase_highbit(off)
+                                                + 1;
+                                            if ml_rep >= 4 && gain2 > gain1 {
+                                                match_length = ml_rep;
+                                                off = 0;
+                                                start = ip;
+                                            }
+                                        }
+                                    }
+                                }
+                                let (ml2, off2) = lazy_search_at!(
+                                    $m,
+                                    ip,
+                                    next_to_update,
+                                    lazy_skipping,
+                                    $rl,
+                                    $use_mask,
+                                    $maskmac,
+                                    $cpl
+                                );
+                                let gain2 = (ml2 * 4) as i64 - offbase_highbit(off2);
+                                let gain1 = (match_length * 4) as i64 - offbase_highbit(off) + 7;
+                                if ml2 >= 4 && gain2 > gain1 {
+                                    match_length = ml2;
+                                    off = off2;
+                                    start = ip;
+                                    continue;
+                                }
+                            }
+                            break;
+                        }
+                    }
+                }
+                if off != 0 {
+                    // Catch-up: absorb preceding literal bytes that also match,
+                    // never past `anchor` nor below the prefix floor.
+                    let concat = $m.live_history();
+                    while start > anchor
+                        && start - off > hist_start
+                        && concat[start - 1 - hist_start] == concat[start - 1 - off - hist_start]
+                    {
+                        start -= 1;
+                        match_length += 1;
+                    }
+                    offset_2 = offset_1;
+                    offset_1 = off;
+                }
+                {
+                    let concat = $m.live_history();
+                    let literals = &concat[anchor - hist_start..start - hist_start];
                     $handle(Sequence::Triple {
                         literals,
-                        offset: candidate.offset,
-                        match_len: candidate.match_len,
+                        offset: offset_1,
+                        match_len: match_length,
                     });
                     let _ = encode_offset_with_history(
-                        candidate.offset as u32,
-                        literals.len() as u32,
+                        offset_1 as u32,
+                        (start - anchor) as u32,
                         &mut $m.offset_hist,
                     );
-                    pos = start + candidate.match_len;
-                    literals_start = pos;
-                } else {
-                    // Reuse the iteration's hash for the defer-path insert
-                    // when available (a carried iteration never hashed and
-                    // falls back to the rehashing insert).
-                    match hash {
-                        Some((row, tag)) => $m.insert_at::<$rl>(abs_pos, row, tag),
-                        None => $m.insert_position::<$rl>(abs_pos),
+                }
+                anchor = start + match_length;
+                ip = anchor;
+                lazy_skipping = false;
+
+                // Immediate repcode: `offset_2` right after the stored match,
+                // swapping the two reps on every hit.
+                while ip <= ilimit && offset_2 > 0 {
+                    let base = $m.live_history().as_ptr();
+                    // SAFETY: `ip + 4 <= block_end`, `offset_2 <= max_rep`.
+                    let rep_len = unsafe {
+                        let cur = base.add(ip - hist_start);
+                        if rd32(cur) != rd32(cur.sub(offset_2)) {
+                            break;
+                        }
+                        $cpl(cur.add(4).sub(offset_2), cur.add(4), block_end - (ip + 4)) + 4
+                    };
+                    core::mem::swap(&mut offset_1, &mut offset_2);
+                    {
+                        let concat = $m.live_history();
+                        $handle(Sequence::Triple {
+                            literals: &concat[ip - hist_start..ip - hist_start],
+                            offset: offset_1,
+                            match_len: rep_len,
+                        });
+                        let _ = encode_offset_with_history(offset_1 as u32, 0, &mut $m.offset_hist);
                     }
-                    if carried.is_some() || deferred_from_prev {
-                        // Defer: the lookahead found a better match — step
-                        // exactly one to take it next iteration. `deferred_from_prev`
-                        // covers the depth-2 defer-without-carry miss so the skip
-                        // below can't hop over the proven `abs_pos + 2` winner.
-                        pos += 1;
-                    } else {
-                        // Complete miss: accelerate through weakly-matching
-                        // stretches (upstream zstd `ip += (ip - anchor) >>
-                        // kSearchStrength + 1`, zstd_lazy.c lazy_generic).
-                        // Same softened `SKIP_STRENGTH = 10` as the greedy
-                        // kernel above: the step stays 1 until the literal
-                        // run hits ~1 KiB, protecting ratio on short runs.
-                        const SKIP_STRENGTH: u32 = 10;
-                        pos += ((lit_len as u32) >> SKIP_STRENGTH) as usize + 1;
-                    }
+                    ip += rep_len;
+                    anchor = ip;
                 }
             }
 
-            while pos + ROW_HASH_KEY_LEN <= current_len {
-                $m.insert_position::<$rl>(current_abs_start + pos);
-                pos += 1;
+            if next_to_update < block_end {
+                $m.insert_match_span::<$rl>(next_to_update, block_end);
             }
-
-            if literals_start < current_len {
-                // Trailing literals of the current block. Read via
-                // `live_history()` (borrowed-aware) sliced at the block's
-                // offset within the live region: owned →
-                // `live_history()[window_size - current_len..]` (byte-identical
-                // to the old `history[history.len()-current_len..]`); borrowed →
-                // `live_history()[block_start..]` (the in-place input, since the
-                // owned `history` mirror is empty under the no-copy path).
-                let current = &$m.live_history()[(current_abs_start - $m.history_abs_start)..];
+            if anchor < block_end {
+                let concat = $m.live_history();
                 $handle(Sequence::Literals {
-                    literals: &current[literals_start..],
+                    literals: &concat[anchor - hist_start..],
                 });
             }
         }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -32,6 +32,18 @@ const LAZY_ROW_ILIMIT_MARGIN: usize = 16;
 const LAZY_SEARCH_STRENGTH: u32 = 8;
 const LAZY_SKIPPING_STEP: usize = 8;
 
+/// Upstream zstd `ZSTD_ROW_HASH_CACHE_SIZE`: the row hash cache runs this
+/// many positions ahead of the parse, prefetching each position's row.
+const ROW_HASH_CACHE_SIZE: usize = 8;
+/// Upstream zstd `ZSTD_row_update_internal` gap rule: a gap of more than
+/// `ROW_UPDATE_SKIP_THRESHOLD` un-indexed positions indexes only its first
+/// `ROW_UPDATE_MAX_START` and last `ROW_UPDATE_MAX_END`.
+const ROW_UPDATE_SKIP_THRESHOLD: usize = 384;
+const ROW_UPDATE_MAX_START: usize = 96;
+const ROW_UPDATE_MAX_END: usize = 32;
+/// Hash-cache sentinel for a position too close to the end to hash.
+const ROW_CACHE_NONE: u32 = u32::MAX;
+
 /// Upstream zstd `ZSTD_highbit32(offBase)` term of the lazy gain formula:
 /// `offBase` is `offset + 3` for a real offset and 1 for repcode 1
 /// (`off == 0` here), whose highbit is 0.
@@ -686,21 +698,85 @@ macro_rules! row_find_best_match {
 /// its 96 head + 32 tail positions), search `$p`, then index `$p` itself.
 /// `$ntu` is the parse's `nextToUpdate` local, `$skip` its `lazySkipping`.
 macro_rules! lazy_search_at {
-    ($m:expr, $p:expr, $ntu:ident, $skip:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
+    ($m:expr, $p:expr, $ntu:ident, $skip:ident, $cache:ident, $rl:expr, $use_mask:literal, $maskmac:ident, $cpl:path) => {{
         let p = $p;
-        if !$skip && $ntu < p {
-            $m.insert_match_span::<$rl>($ntu, p);
-        }
-        let r = match $m.hash_and_row(p) {
-            Some((row, tag)) => {
-                let r = row_find_best_match!($m, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
-                $m.insert_at::<$rl>(p, row, tag);
-                r
+        let (row, tag) = if $skip {
+            // Lazy skipping: the skipped-over gap is not indexed and the cache
+            // is not maintained; the position is hashed directly.
+            row_cache_hash!($m, $rl, p)
+        } else {
+            if p - $ntu > ROW_UPDATE_SKIP_THRESHOLD {
+                row_cache_insert_range!($m, $cache, $rl, $ntu, $ntu + ROW_UPDATE_MAX_START);
+                row_cache_fill!($m, $cache, $rl, p - ROW_UPDATE_MAX_END);
+                row_cache_insert_range!($m, $cache, $rl, p - ROW_UPDATE_MAX_END, p);
+            } else {
+                row_cache_insert_range!($m, $cache, $rl, $ntu, p);
             }
-            None => (3usize, 0usize),
+            row_cache_next!($m, $cache, $rl, p)
+        };
+        let r = if row != ROW_CACHE_NONE {
+            let row = row as usize;
+            let r = row_find_best_match!($m, p, row, tag, $rl, $use_mask, $maskmac, $cpl);
+            $m.insert_at::<$rl>(p, row, tag);
+            r
+        } else {
+            (3usize, 0usize)
         };
         $ntu = p + 1;
         r
+    }};
+}
+
+/// Hash one position for the row cache and prefetch its row (upstream zstd
+/// `ZSTD_row_fillHashCache` / `ZSTD_row_nextCachedHash` body): `(row, tag)`
+/// with `row == ROW_CACHE_NONE` past the hashable end.
+macro_rules! row_cache_hash {
+    ($m:expr, $rl:expr, $pos:expr) => {{
+        match $m.hash_and_row($pos) {
+            Some((row, tag)) => {
+                $m.prefetch_row::<$rl>(row);
+                (row as u32, tag)
+            }
+            None => (ROW_CACHE_NONE, 0u8),
+        }
+    }};
+}
+
+/// Upstream zstd `ZSTD_row_fillHashCache`: (re)load the cache for the
+/// positions `$from .. $from + ROW_HASH_CACHE_SIZE`.
+macro_rules! row_cache_fill {
+    ($m:expr, $cache:ident, $rl:expr, $from:expr) => {{
+        let from = $from;
+        for pos in from..from + ROW_HASH_CACHE_SIZE {
+            $cache[pos & (ROW_HASH_CACHE_SIZE - 1)] = row_cache_hash!($m, $rl, pos);
+        }
+    }};
+}
+
+/// Upstream zstd `ZSTD_row_nextCachedHash`: take `$pos`'s cached hash and
+/// replace it with the hash of `$pos + ROW_HASH_CACHE_SIZE` (prefetching
+/// that row). Valid only while positions are consumed in sequence from the
+/// last fill, exactly as upstream.
+macro_rules! row_cache_next {
+    ($m:expr, $cache:ident, $rl:expr, $pos:expr) => {{
+        let pos = $pos;
+        let slot = pos & (ROW_HASH_CACHE_SIZE - 1);
+        let cur = $cache[slot];
+        $cache[slot] = row_cache_hash!($m, $rl, pos + ROW_HASH_CACHE_SIZE);
+        cur
+    }};
+}
+
+/// Upstream zstd `ZSTD_row_update_internalImpl` with the cache: index every
+/// position of `$from .. $to` through the hash cache.
+macro_rules! row_cache_insert_range {
+    ($m:expr, $cache:ident, $rl:expr, $from:expr, $to:expr) => {{
+        for pos in $from..$to {
+            let (row, tag) = row_cache_next!($m, $cache, $rl, pos);
+            if row != ROW_CACHE_NONE {
+                $m.insert_at::<$rl>(pos, row as usize, tag);
+            }
+        }
     }};
 }
 
@@ -737,6 +813,9 @@ macro_rules! lazy_parse_body {
             let mut ip = current_abs_start + usize::from(current_abs_start == hist_start);
             let mut next_to_update = current_abs_start;
             let mut lazy_skipping = false;
+            // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
+            let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
+            row_cache_fill!($m, hash_cache, $rl, next_to_update);
             // Repcodes reaching below the window are disabled for the block
             // (upstream `maxRep`); the bound also keeps every rep read inside
             // the live history since `ip` only grows.
@@ -769,6 +848,7 @@ macro_rules! lazy_parse_body {
                         ip,
                         next_to_update,
                         lazy_skipping,
+                        hash_cache,
                         $rl,
                         $use_mask,
                         $maskmac,
@@ -815,6 +895,7 @@ macro_rules! lazy_parse_body {
                                 ip,
                                 next_to_update,
                                 lazy_skipping,
+                                hash_cache,
                                 $rl,
                                 $use_mask,
                                 $maskmac,
@@ -858,6 +939,7 @@ macro_rules! lazy_parse_body {
                                     ip,
                                     next_to_update,
                                     lazy_skipping,
+                                    hash_cache,
                                     $rl,
                                     $use_mask,
                                     $maskmac,
@@ -906,7 +988,11 @@ macro_rules! lazy_parse_body {
                 }
                 anchor = start + match_length;
                 ip = anchor;
-                lazy_skipping = false;
+                if lazy_skipping {
+                    // A match ends lazy skipping; the cache is stale, refill it.
+                    row_cache_fill!($m, hash_cache, $rl, next_to_update);
+                    lazy_skipping = false;
+                }
 
                 // Immediate repcode: `offset_2` right after the stored match,
                 // swapping the two reps on every hit.
@@ -2583,12 +2669,9 @@ impl RowMatchGenerator {
     /// the row backend ~11x slower than FFI on those streams. The upstream zstd
     /// caps the fill at 96 + 32 positions regardless of match length.
     fn insert_match_span<const ROW_LOG: usize>(&mut self, start: usize, end: usize) {
-        const SKIP_THRESHOLD: usize = 384;
-        const MAX_START: usize = 96;
-        const MAX_END: usize = 32;
-        if end.saturating_sub(start) > SKIP_THRESHOLD {
-            self.insert_positions::<ROW_LOG>(start, start + MAX_START);
-            self.insert_positions::<ROW_LOG>(end - MAX_END, end);
+        if end.saturating_sub(start) > ROW_UPDATE_SKIP_THRESHOLD {
+            self.insert_positions::<ROW_LOG>(start, start + ROW_UPDATE_MAX_START);
+            self.insert_positions::<ROW_LOG>(end - ROW_UPDATE_MAX_END, end);
         } else {
             self.insert_positions::<ROW_LOG>(start, end);
         }
@@ -2637,11 +2720,21 @@ impl RowMatchGenerator {
             // SAFETY: prefetch is a hint and never faults; the indexes are in
             // bounds by the same `ensure_tables` sizing as `insert_at`.
             unsafe {
+                _mm_prefetch(self.row_heads.as_ptr().add(row).cast(), _MM_HINT_T0);
                 _mm_prefetch(self.row_tags.as_ptr().add(row_base).cast(), _MM_HINT_T0);
                 _mm_prefetch(
                     self.row_positions.as_ptr().add(row_base).cast(),
                     _MM_HINT_T0,
                 );
+                // Upstream zstd `ZSTD_row_prefetch` (zstd_lazy.c:816): rows of
+                // >= 32 entries span several 64-byte lines of positions; the
+                // second line is fetched too.
+                if ROW_LOG >= 5 {
+                    _mm_prefetch(
+                        self.row_positions.as_ptr().add(row_base + 16).cast(),
+                        _MM_HINT_T0,
+                    );
+                }
             }
         }
         #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -43,10 +43,31 @@ const ROW_UPDATE_MAX_END: usize = 32;
 /// Hash-cache sentinel for a position too close to the end to hash.
 const ROW_CACHE_NONE: u32 = u32::MAX;
 
-/// Row hash multiplier (upstream zstd `prime8bytes`, `zstd_compress_internal.h`):
-/// the key bytes are shifted to the top of a 64-bit word and multiplied; the
-/// row and tag are the product's top bits (`ZSTD_hashPtrSalted` shape).
-pub(crate) const ROW_HASH_PRIME: u64 = 0xCF1B_BCDC_B7A5_6463;
+/// Upstream zstd hash multipliers per key width (`zstd_compress_internal.h`
+/// `prime4bytes` / `prime5bytes` / `prime6bytes`): `ZSTD_hash4` multiplies
+/// the 32-bit key, `ZSTD_hash5` / `ZSTD_hash6` shift the 8-byte read so the
+/// key occupies the top 40 / 48 bits and multiply; the salt is XORed into
+/// the product and the row + tag are its top `hashLog + 8` bits.
+pub(crate) const ROW_HASH_PRIME4: u32 = 2_654_435_761;
+pub(crate) const ROW_HASH_PRIME5: u64 = 889_523_592_379;
+pub(crate) const ROW_HASH_PRIME6: u64 = 227_718_039_650_203;
+
+/// Upstream zstd `ZSTD_bitmix` (zstd_compress.c:1971, XXH3 rrmxmx shape).
+const fn zstd_bitmix(mut val: u64, len: u64) -> u64 {
+    val ^= val.rotate_right(49) ^ val.rotate_right(24);
+    val = val.wrapping_mul(0x9FB2_1C65_1E98_DF25);
+    val ^= (val >> 35).wrapping_add(len);
+    val = val.wrapping_mul(0x9FB2_1C65_1E98_DF25);
+    val ^ (val >> 28)
+}
+
+/// Row hash salt of a freshly created upstream context:
+/// `ZSTD_advanceHashSalt` on `hashSalt = hashSaltEntropy = 0`
+/// (zstd_compress.c:1980, run by `ZSTD_reset_matchState` for a CCtx). A
+/// fixed salt keeps row assignment identical to a fresh `ZSTD_CCtx`; the
+/// per-reset re-salting upstream does on context reuse only serves to
+/// defeat stale tags, which the position floor rejects here anyway.
+pub(crate) const ROW_HASH_SALT: u64 = zstd_bitmix(0, 8) ^ zstd_bitmix(0, 4);
 
 /// Per-parse view of the live history: raw base pointer + length + absolute
 /// start, hoisted ONCE per block so the hot loops read no `Option` branch
@@ -591,6 +612,12 @@ macro_rules! row_find_best_match {
                     found
                 };
                 let Some(slot) = slot_opt else { break };
+                // Upstream `if (matchPos == 0) continue`: slot 0 is never an
+                // entry (the tag byte there is upstream's head), and the
+                // skip does not spend an attempt.
+                if slot == 0 {
+                    continue;
+                }
                 // SAFETY: `slot < row_entries`; see the table-indexing note.
                 let raw = unsafe { *$m.row_positions.get_unchecked(row_base + slot) };
                 // Newest-first order: the first empty / below-floor entry ends
@@ -686,6 +713,9 @@ macro_rules! row_find_best_match {
                     found
                 };
                 let Some(slot) = slot_opt else { break };
+                if slot == 0 {
+                    continue;
+                }
                 let dp = dict.positions[row_base + slot];
                 if dp == ROW_EMPTY_SLOT {
                     break;
@@ -821,11 +851,6 @@ macro_rules! lazy_parse_body {
             if current_len == 0 {
                 break 'parse;
             }
-            let backfill_start = $m.backfill_start(current_abs_start);
-            if backfill_start < current_abs_start {
-                $m.insert_positions::<$rl>(backfill_start, current_abs_start);
-            }
-
             let scan = $m.scan_ctx();
             let hist_start = scan.hist_start;
             let depth = $m.lazy_depth;
@@ -834,7 +859,14 @@ macro_rules! lazy_parse_body {
             let mut anchor = current_abs_start;
             // `ip += (dictAndPrefixLength == 0)`: nothing precedes the first byte.
             let mut ip = current_abs_start + usize::from(current_abs_start == hist_start);
-            let mut next_to_update = current_abs_start;
+            // Upstream `nextToUpdate`: resume where the previous lazy block
+            // stopped indexing (its last <= 16 bytes, now readable with the
+            // full 8-byte key); a stale cursor (another parse ran in
+            // between, or the floor moved past it) restarts at the 3 bytes
+            // preceding the block, the widest key overlap that still hashes.
+            let mut next_to_update = $m
+                .lazy_next_to_update
+                .clamp($m.backfill_start(current_abs_start), current_abs_start);
             let mut lazy_skipping = false;
             // Upstream `ZSTD_row_fillHashCache(ms, base, rowLog, mls, nextToUpdate, ilimit)`.
             let mut hash_cache = [(ROW_CACHE_NONE, 0u8); ROW_HASH_CACHE_SIZE];
@@ -1047,9 +1079,10 @@ macro_rules! lazy_parse_body {
                 }
             }
 
-            if next_to_update < block_end {
-                $m.insert_match_span::<$rl>(next_to_update, block_end);
-            }
+            // The un-indexed tail (upstream leaves it to the next block's
+            // first search, which then reads full 8-byte keys across the
+            // boundary) is carried in `lazy_next_to_update`.
+            $m.lazy_next_to_update = next_to_update;
             if anchor < block_end {
                 let concat = $m.live_history();
                 $handle(Sequence::Literals {
@@ -1688,10 +1721,14 @@ pub(crate) struct RowMatchGenerator {
     /// a local in the parse loops so the per-position compare reads a
     /// register, not this field. Default `ROW_MIN_MATCH_LEN` (5).
     pub(crate) mls: usize,
-    /// `64 - 8 * key width`: left shift placing the hash key at the top of
-    /// the 64-bit word (upstream zstd `ZSTD_hashNPtr`, key width = `mls`
-    /// capped at 6). Kept in sync with `mls` by `configure`.
-    row_key_shift: u32,
+    /// Hash key width in bytes, `mls` bounded to 4..=6 (upstream zstd
+    /// `ZSTD_hashPtrSalted`'s `mls` switch). Kept in sync by `configure`.
+    row_hash_mls: u32,
+    /// Upstream `nextToUpdate` carried across blocks by the lazy parse: the
+    /// first position not yet indexed. The block after a lazy block indexes
+    /// the previous tail from here (with the block's data now readable
+    /// past it, as upstream), instead of a per-block backfill.
+    lazy_next_to_update: usize,
     pub(crate) lazy_depth: u8,
     /// Cached fastpath kernel for `hash_mix_u64`; see Dfast for rationale.
     pub(crate) hash_kernel: crate::encoding::fastpath::FastpathKernel,
@@ -1752,7 +1789,8 @@ impl RowMatchGenerator {
             search_depth: ROW_SEARCH_DEPTH,
             target_len: ROW_TARGET_LEN,
             mls: ROW_MIN_MATCH_LEN,
-            row_key_shift: (64 - 8 * ROW_MIN_MATCH_LEN.min(6)) as u32,
+            row_hash_mls: ROW_MIN_MATCH_LEN.clamp(4, 6) as u32,
+            lazy_next_to_update: 0,
             lazy_depth: 1,
             hash_kernel: crate::encoding::fastpath::select_kernel(),
             row_heads: Vec::new(),
@@ -1821,7 +1859,7 @@ impl RowMatchGenerator {
         // floor can't be satisfied: the hash only surfaces candidates
         // sharing the 4-byte key) and a sane upper bound.
         self.mls = config.mls.clamp(ROW_HASH_KEY_LEN, 7);
-        self.row_key_shift = (64 - 8 * self.mls.min(6)) as u32;
+        self.row_hash_mls = self.mls.clamp(4, 6) as u32;
         self.set_hash_bits(config.hash_bits.max(self.row_log + 1));
     }
 
@@ -1859,6 +1897,8 @@ impl RowMatchGenerator {
             self.row_positions.fill(ROW_EMPTY_SLOT);
             self.row_tags.fill(0);
         }
+        // Nothing of the previous frame is indexed for the new one.
+        self.lazy_next_to_update = self.history_abs_start;
         // Block buffers are returned to the caller's pool per block in
         // `add_data`, so there is nothing window-side to recycle here.
         self.chunk_lens.clear();
@@ -1972,6 +2012,7 @@ impl RowMatchGenerator {
                 (abs - delta) as u32
             };
         }
+        self.lazy_next_to_update = self.lazy_next_to_update.saturating_sub(delta);
         self.history_abs_start -= delta;
     }
 
@@ -2245,24 +2286,42 @@ impl RowMatchGenerator {
     /// the probe's real-byte key there. Those few dict-tail entries stay
     /// unreachable, mirroring the upstream zstd, whose dictionary load also stops
     /// hashing short of the dictionary end.
-    /// Row hash of the key at `base[idx..]` (upstream zstd `ZSTD_hashPtrSalted`
-    /// shape): the `mls`-byte key (8-byte read shifted to the top of the
-    /// word; the last < 8 bytes of the window fall back to a 4-byte key)
-    /// times [`ROW_HASH_PRIME`]. A position hashes identically in the probe,
-    /// the cache and the dictionary fill, so every table agrees on its row.
+    /// Upstream zstd `ZSTD_hashPtrSalted(p, hashLog + 8, mls, salt)` of the
+    /// key at `base[idx..]`: the `mls`-byte key hashed by `ZSTD_hash4` /
+    /// `ZSTD_hash5` / `ZSTD_hash6`, salted with [`ROW_HASH_SALT`], reduced to
+    /// its top `total_bits` (= row bits + tag bits). A position hashes
+    /// identically in the probe, the cache and the dictionary fill, so every
+    /// table agrees on its row. Only the last < 8 bytes of the window (never
+    /// reached by the lazy parse, which stops 16 bytes early) fall back to
+    /// the 4-byte key.
     ///
     /// # Safety
     /// `idx + ROW_HASH_KEY_LEN <= len` and `base` must point to `len` bytes.
     #[inline(always)]
-    unsafe fn row_hash_raw(base: *const u8, len: usize, idx: usize, key_shift: u32) -> u64 {
-        let value = unsafe {
-            if idx + 8 <= len {
-                u64::from_le_bytes(base.add(idx).cast::<[u8; 8]>().read_unaligned())
+    pub(crate) unsafe fn row_hash_raw(
+        base: *const u8,
+        len: usize,
+        idx: usize,
+        mls: u32,
+        total_bits: usize,
+    ) -> u64 {
+        debug_assert!(total_bits <= 32);
+        // SAFETY: `idx + 4 <= len`; the 8-byte read is taken only when it fits.
+        unsafe {
+            let p = base.add(idx);
+            if mls == 4 || idx + 8 > len {
+                let v = rd32(p).wrapping_mul(ROW_HASH_PRIME4) ^ (ROW_HASH_SALT as u32);
+                u64::from(v >> (32 - total_bits))
             } else {
-                u64::from(rd32(base.add(idx)))
+                let v = u64::from_le_bytes(p.cast::<[u8; 8]>().read_unaligned());
+                let h = if mls == 5 {
+                    (v << 24).wrapping_mul(ROW_HASH_PRIME5)
+                } else {
+                    (v << 16).wrapping_mul(ROW_HASH_PRIME6)
+                };
+                (h ^ ROW_HASH_SALT) >> (64 - total_bits)
             }
-        };
-        (value << key_shift).wrapping_mul(ROW_HASH_PRIME)
+        }
     }
 
     /// The live history as a [`RowScan`] for one parse.
@@ -2284,10 +2343,10 @@ impl RowMatchGenerator {
         if idx + ROW_HASH_KEY_LEN > ctx.len {
             return None;
         }
-        // SAFETY: `idx + ROW_HASH_KEY_LEN <= ctx.len`, `ctx` views the live history.
-        let hash = unsafe { Self::row_hash_raw(ctx.base, ctx.len, idx, self.row_key_shift) };
         let total_bits = self.row_hash_log + ROW_TAG_BITS;
-        let combined = hash >> (u64::BITS as usize - total_bits);
+        // SAFETY: `idx + ROW_HASH_KEY_LEN <= ctx.len`, `ctx` views the live history.
+        let combined =
+            unsafe { Self::row_hash_raw(ctx.base, ctx.len, idx, self.row_hash_mls, total_bits) };
         let row_mask = (1usize << self.row_hash_log) - 1;
         let row = ((combined >> ROW_TAG_BITS) as usize) & row_mask;
         Some((row, combined as u8))
@@ -2817,7 +2876,13 @@ impl RowMatchGenerator {
         debug_assert!(row_base + row_entries <= self.row_positions.len());
         unsafe {
             let head = *self.row_heads.get_unchecked(row) as usize;
-            let next = head.wrapping_sub(1) & row_mask;
+            // Upstream `ZSTD_row_nextIndex`: slot 0 is never written (it
+            // holds the head byte in upstream's tag row), so the cursor
+            // cycles over `1..=row_mask`.
+            let next = match head.wrapping_sub(1) & row_mask {
+                0 => row_mask,
+                n => n,
+            };
             *self.row_heads.get_unchecked_mut(row) = next as u8;
             *self.row_tags.get_unchecked_mut(row_base + next) = tag;
             // `abs_pos < u32::MAX` holds: `add_data` caps a Row frame's
@@ -2892,7 +2957,7 @@ impl RowMatchGenerator {
         }
         let row_log = self.row_log;
         let row_hash_log = self.row_hash_log;
-        let key_shift = self.row_key_shift;
+        let hash_mls = self.row_hash_mls;
         let history_start = self.history_start;
         let concat_len = self.history.len() - history_start;
         // Row hash needs `ROW_HASH_KEY_LEN` readable bytes of lookahead.
@@ -2925,17 +2990,27 @@ impl RowMatchGenerator {
         // is u32-bounded upstream).
         for concat in start_concat..safe_end {
             unsafe {
-                // Same hash as the live `row_hash_at` (key width, shift and
-                // prime): any divergence buckets dict rows differently and
+                // Same hash as the live `row_hash_at` (key width, prime and
+                // salt): any divergence buckets dict rows differently and
                 // loses every attached-dict match.
-                let hash =
-                    Self::row_hash_raw(base.add(history_start), concat_len, concat, key_shift);
-                let combined = hash >> (u64::BITS as usize - total_bits);
+                let combined = Self::row_hash_raw(
+                    base.add(history_start),
+                    concat_len,
+                    concat,
+                    hash_mls,
+                    total_bits,
+                );
                 let row = ((combined >> ROW_TAG_BITS) as usize) & row_count_mask;
                 let tag = combined as u8;
                 let row_base = row << row_log;
                 let head = *heads.add(row) as usize;
-                let next = head.wrapping_sub(1) & row_mask;
+                // Upstream `ZSTD_row_nextIndex`: slot 0 is never written (it
+                // holds the head byte in upstream's tag row), so the cursor
+                // cycles over `1..=row_mask`.
+                let next = match head.wrapping_sub(1) & row_mask {
+                    0 => row_mask,
+                    n => n,
+                };
                 *heads.add(row) = next as u8;
                 *tags.add(row_base + next) = tag;
                 *positions.add(row_base + next) = concat as u32;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -79,6 +79,16 @@ struct RowScan {
     base: *const u8,
     len: usize,
     hist_start: usize,
+    /// Frame-constant search parameters hoisted with the view so the hot
+    /// loops never re-read them through `&mut self`: the salt of the live
+    /// row hash, the match-distance bound, the dictionary prefix start
+    /// (0 without a dictionary) and whether a dictionary is attached (no
+    /// distance bound, upstream `isDictionary`).
+    salt: u64,
+    search_window: usize,
+    prefix_start: usize,
+    dict_frame: bool,
+    attached: bool,
 }
 
 /// Upstream zstd `ZSTD_highbit32(offBase)` term of the lazy gain formula:
@@ -340,7 +350,11 @@ macro_rules! row_find_best_match {
         debug_assert_eq!($rl, $m.row_log);
         debug_assert!(row_base + row_entries <= $m.row_positions.len());
         let head = unsafe { *$m.row_heads.get_unchecked($row) } as usize;
-        let window_low = $m.window_floor($abs_pos);
+        let window_low = if $ctx.attached {
+            hist_start
+        } else {
+            hist_start.max($abs_pos.saturating_sub($ctx.search_window))
+        };
         let budget = $m.search_depth.min(row_entries);
         let mut attempts = budget;
         let mut ml = 3usize;
@@ -429,7 +443,7 @@ macro_rules! row_find_best_match {
         // A copied dictionary is upstream's `extDict` segment: its candidates
         // are gated at the match head (`MEM_read32(match) == MEM_read32(ip)`)
         // instead of at the current best length.
-        let prefix_start = $m.dict_prefix_start();
+        let prefix_start = $ctx.prefix_start;
         for &raw in &buf[..n] {
             let cand_idx = raw as usize - hist_start;
             // SAFETY: `cand_idx < cur_idx`; the gate reads 4 bytes at
@@ -627,14 +641,18 @@ macro_rules! hc_find_best_match {
             }
             $ntu = p;
         }
-        let window_low = $m.window_floor(p);
+        let window_low = if $ctx.attached {
+            hist_start
+        } else {
+            hist_start.max(p.saturating_sub($ctx.search_window))
+        };
         let min_chain = p.saturating_sub(chain_mask + 1);
         let mut attempts = $m.search_depth;
         let mut ml = 3usize;
         let mut best_off = 0usize;
         // A copied dictionary is upstream's `extDict` segment: its candidates
         // are gated at the match head instead of at the current best length.
-        let prefix_start = $m.dict_prefix_start();
+        let prefix_start = $ctx.prefix_start;
         let mut match_index = $m.hc_hash[$m.hc_hash_at($ctx, p)];
         while match_index != ROW_EMPTY_SLOT && (match_index as usize) >= window_low && attempts > 0
         {
@@ -807,7 +825,7 @@ macro_rules! lazy_parse_body {
             // `ip += (ip == prefixStart)` on a copied-dictionary frame (upstream
             // `extDict`, the dictionary being the segment below the prefix).
             let first_byte = match $m.dict_plan {
-                Some(plan) if !plan.attach => $m.dict_prefix_start(),
+                Some(plan) if !plan.attach => scan.prefix_start,
                 _ => hist_start,
             };
             let mut ip = current_abs_start + usize::from(current_abs_start == first_byte);
@@ -847,10 +865,10 @@ macro_rules! lazy_parse_body {
             // `ZSTD_index_overlap_check` (a source in the last 3 bytes below
             // the frame's prefix, straddling the dictionary boundary, is not
             // taken).
-            let dict_frame = $m.dict_plan.is_some();
-            let attached = $m.dict_plan.is_some_and(|p| p.attach);
-            let prefix_start = $m.dict_prefix_start();
-            let search_window = $m.search_window;
+            let dict_frame = scan.dict_frame;
+            let attached = scan.attached;
+            let prefix_start = scan.prefix_start;
+            let search_window = scan.search_window;
             let rep_ok = |pos: usize, off: usize| -> bool {
                 if off == 0 || off > pos {
                     return false;
@@ -868,7 +886,7 @@ macro_rules! lazy_parse_body {
             let mut offset_saved_1 = 0usize;
             let mut offset_saved_2 = 0usize;
             if !dict_frame {
-                let max_rep = ip - $m.window_floor(ip);
+                let max_rep = ip - hist_start.max(ip.saturating_sub(search_window));
                 if offset_2 > max_rep {
                     offset_saved_2 = offset_2;
                     offset_2 = 0;
@@ -1892,20 +1910,6 @@ impl RowMatchGenerator {
         self.hc_chain_log
     }
 
-    /// Lowest position a search at `abs_pos` may match (upstream
-    /// `lowLimit`): `curr - maxDistance` within the live history, or the
-    /// history floor itself with an attached dictionary (upstream
-    /// `isDictionary ? lowestValid : withinMaxDistance`).
-    #[inline(always)]
-    fn window_floor(&self, abs_pos: usize) -> usize {
-        if self.dict_plan.is_some_and(|p| p.attach) {
-            self.history_abs_start
-        } else {
-            self.history_abs_start
-                .max(abs_pos.saturating_sub(self.search_window))
-        }
-    }
-
     /// Absolute start of the frame's own prefix on a dictionary frame
     /// (upstream `prefixLowestIndex` / `dictLimit`; the dictionary lies
     /// below it), else 0 so the boundary rules never fire.
@@ -2491,6 +2495,11 @@ impl RowMatchGenerator {
             base: history.as_ptr(),
             len: history.len(),
             hist_start: self.history_abs_start,
+            salt: self.hash_salt,
+            search_window: self.search_window,
+            prefix_start: self.dict_prefix_start(),
+            dict_frame: self.dict_plan.is_some(),
+            attached: self.dict_plan.is_some_and(|p| p.attach),
         }
     }
 
@@ -2511,7 +2520,7 @@ impl RowMatchGenerator {
                 idx,
                 self.row_hash_mls,
                 total_bits,
-                self.hash_salt,
+                ctx.salt,
             )
         };
         let row_mask = (1usize << self.row_hash_log) - 1;

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -394,6 +394,13 @@ fn compress_and_collect_sequences_impl(
     // assumes streaming sizing, which would diverge from libzstd's
     // `ZSTD_generateSequences` (which receives `srcSize` directly).
     compressor.set_source_size_hint(input.len() as u64);
+    // Full blocks only: upstream's `ZSTD_generateSequences` runs
+    // `ZSTD_compress2` in sequence-collecting mode, where every block is
+    // written raw (`cSize = blockSize + 3`) so the `savings >= 3` gate of
+    // `ZSTD_optimalBlockSize` never opens and the pre-splitter never cuts.
+    // Matching that keeps both streams' block boundaries (and therefore
+    // block-entry parse state) aligned for the comparison.
+    compressor.set_pre_split_disabled(true);
     compressor.compress();
     // `Rc::try_unwrap` succeeds because the inner `CapturingMatcher`
     // is dropped when `compressor` goes out of scope at the end of the

--- a/zstd/src/encoding/sequence_capture.rs
+++ b/zstd/src/encoding/sequence_capture.rs
@@ -194,6 +194,12 @@ impl Matcher for CapturingMatcher {
         self.inner.set_source_size_hint(size);
     }
 
+    fn set_dictionary_size_hint(&mut self, size: usize) {
+        // Forwarded so the frame's cParams derive from the dictionary exactly
+        // as in production (`resolve_level_params_with_dict`).
+        self.inner.set_dictionary_size_hint(size);
+    }
+
     fn prime_with_dictionary(&mut self, dict_content: &[u8], offset_hist: [u32; 3]) {
         self.inner.prime_with_dictionary(dict_content, offset_hist);
     }

--- a/zstd/src/huff0/huff0_encoder.rs
+++ b/zstd/src/huff0/huff0_encoder.rs
@@ -383,11 +383,8 @@ impl<V: AsMut<Vec<u8>>> HuffmanEncoder<'_, '_, V> {
     ) {
         assert!(weights.len() <= 128);
         writer.write_bits(weights.len() as u8 + 127, 8);
-        let pairs = weights.chunks_exact(2);
-        let remainder = pairs.remainder();
-        for pair in pairs {
-            let weight1 = pair[0];
-            let weight2 = pair[1];
+        let (pairs, remainder) = weights.as_chunks::<2>();
+        for &[weight1, weight2] in pairs {
             assert!(weight1 < 16);
             assert!(weight2 < 16);
             writer.write_bits(weight2, 4);


### PR DESCRIPTION
## Summary

The lazy band (greedy / lazy / lazy2, levels 5-12) was 2.2x slower than libzstd on `decodecorpus-z000033` while producing a different, slightly smaller stream: the parse was not the upstream one (back-extension of every candidate, three rep probes per position, re-search after a rejected candidate, no `ml-3` gate), so it did more work per position. The Row backend now runs the upstream `ZSTD_compressBlock_lazy_generic` parse and produces the same sequence stream as `ZSTD_generateSequences` (100 % parity on z000033 at L5/6/8/11/12 without dictionary and at L5/6/8 with a raw-content dictionary; small fixtures with and without dictionary).

Stacked on #467.

### Parse (`encoding/row/mod.rs`)
- upstream `lazy_generic` parse as one monolith per SIMD tier: repcodes carried across blocks with `offsetSaved`, first-byte rule, gain formula at depth 1/2, catch-up of the match start, `lazySkipping`, immediate repcode loop, `nextToUpdate` carry with the `buildSeqStore` limited-update rule
- upstream row hash (prime4/5/6 + salt, reset salt), hash cache, slot-0 rule, `ilimit` margins, `hashLog` cap
- greedy now runs on the shared lazy parse (depth 0); the separate greedy code is deleted
- frame constants (search bound, prefix start, salt, attach flag, chain-vs-row choice) hoisted into the scan view; the plain-frame rep check folds into the block-start clamp

### Match finder
- hash-chain finder (`ZSTD_HcFindBestMatch`, insert gap + walk + dictMatchState walk) for the levels/window sizes where upstream does not use rows (`ZSTD_resolveRowMatchFinderMode`: rows only above windowLog 14)
- row table sized by the level's hashLog as upstream

### Input-length dependent parameters
- `get_cparams` / `adjustCParams` / row-size table by source size and dictionary size (`encoding/cparams.rs`), CDict cParams and `shouldAttachDict` cutoffs (attach vs copy), frame takes the CDict's parameters as upstream
- pre-split at upstream's default `splitLevels` tier per strategy
- dictionary plan for the Row backend: attach (no distance bound, `index_overlap_check`) or copy, dictMatchState row/chain probes

### Bench / tools
- `compare_ffi`: the FFI arm compresses one-shot with `ZSTD_compress2` (was `ZSTD_compressStream2` in 128 KB chunks), so both arms see the same input-length dependent parameters; dashboard baselines move accordingly
- `compare_ffi_sequences`: captures with the pre-splitter off (upstream's collector never pre-splits), forwards the dictionary size hint, prints the absolute input position of every diverging row

## Numbers (i9, ours / c_ffi, one-shot)

| cell | before | after |
|---|---|---|
| compress/level_5_greedy/z000033 | ~2.2x | 14.59 / 9.40 ms = 1.55x |
| compress/level_6_lazy/z000033 | ~2.2x | 17.16 / 11.75 ms = 1.46x |
| compress/level_11_lazy/z000033 | ~2.2x | 27.25 / 18.48 ms = 1.47x |
| compress-dict/level_6_lazy/z000033 | | 19.38 / 13.05 ms = 1.49x |
| compress-dict/level_8_lazy/small-10k-random | | 159.3 / 141.7 us = 1.12x |

Compressed sizes now equal libzstd's on the lazy band. The residual 1.45-1.55x is instruction density in the search loop and the per-sequence store path, not extra work.

## Known gaps (out of this PR)

- dictionary frames whose CDict parameters resolve to the BT strategies (e.g. L11 with a 4 KB dictionary) keep the plain parameters
- the btlazy2 band for inputs <= 16 KB (e.g. z000002 L11) still emits 3-byte matches where upstream uses minMatch 4

## Testing

- `cargo nextest run -p structured-zstd -F hash,std,dict_builder` (839 passed), `-p ffi-bench -F bench_internals,dict_builder` (60 passed)
- clippy `-D warnings` with the CI feature set on stable 1.98 (includes fixes for the new 1.98 lints), `cargo fmt --check`
- sequence parity via `compare_ffi_sequences` as listed above

Part of #178
Part of #28