### PR TITLE
perf(encoder): hold each backend's index tables in one buffer

### DIFF
--- a/zstd/src/encoding/hc/generator.rs
+++ b/zstd/src/encoding/hc/generator.rs
@@ -131,7 +131,7 @@ macro_rules! bt_insert_step_no_rebase_body {
             // SAFETY: prefetch is a hint that never faults; `hash` indexes
             // `hash_table` directly below, so it is in bounds.
             unsafe {
-                _mm_prefetch($table.hash_table.as_ptr().add(hash).cast(), _MM_HINT_T0);
+                _mm_prefetch($table.hash_table().as_ptr().add(hash).cast(), _MM_HINT_T0);
             }
             // Prefetch the NEXT position's bucket too. The optimal-parser DP
             // advances one position per iteration, so this miss is issued a
@@ -150,7 +150,7 @@ macro_rules! bt_insert_step_no_rebase_body {
                 // harmless no-op hint.
                 unsafe {
                     _mm_prefetch(
-                        $table.hash_table.as_ptr().add(hash_next).cast(),
+                        $table.hash_table().as_ptr().add(hash_next).cast(),
                         _MM_HINT_T0,
                     );
                 }
@@ -170,8 +170,8 @@ macro_rules! bt_insert_step_no_rebase_body {
         // Hoist the BT pointer-pair base out of `self` once — see the
         // collect-matches body for the full rationale (per-step Vec reload +
         // bounds check through `&mut self` vs the upstream zstd's raw `U32*` walk).
-        let chain_ptr = $table.chain_table.as_mut_ptr();
-        debug_assert_eq!($table.chain_table.len(), 2 << $table.bt_log());
+        let chain_ptr = $table.chain_table_mut().as_mut_ptr();
+        debug_assert_eq!($table.chain_table().len(), 2 << $table.bt_log());
         let window_low = $table.window_low_abs_for_target($target_abs);
         // `abs_pos + 9` is safe in raw form: `MatchTable::add_data` caps
         // total input at `usize::MAX - STREAM_ABS_HEADROOM` (where
@@ -189,8 +189,8 @@ macro_rules! bt_insert_step_no_rebase_body {
         let pair_idx = $table.bt_pair_index_for_abs($abs_pos);
         let mut smaller_slot = pair_idx;
         let mut larger_slot = pair_idx + 1;
-        let mut match_stored = $table.hash_table[hash];
-        $table.hash_table[hash] = stored;
+        let mut match_stored = $table.hash_table()[hash];
+        $table.hash_table_mut()[hash] = stored;
 
         while compares_left > 0 {
             if match_stored == $crate::encoding::match_table::storage::HC_EMPTY {
@@ -335,7 +335,7 @@ macro_rules! hash3_candidate_body {
             3,
         );
         let entry = $table
-            .hash3_table
+            .hash3_table()
             .get(hash3)
             .copied()
             .unwrap_or($crate::encoding::match_table::storage::HC_EMPTY);
@@ -590,7 +590,7 @@ macro_rules! bt_insert_and_collect_matches_body {
                                 3,
                             );
                         let entry = $table
-                            .hash3_table
+                            .hash3_table()
                             .get(hh)
                             .copied()
                             .unwrap_or($crate::encoding::match_table::storage::HC_EMPTY);
@@ -670,7 +670,7 @@ macro_rules! bt_insert_and_collect_matches_body {
             // SAFETY: prefetch is a hint that never faults; `hash` indexes
             // `hash_table` directly below, so it is in bounds.
             unsafe {
-                _mm_prefetch($table.hash_table.as_ptr().add(hash).cast(), _MM_HINT_T0);
+                _mm_prefetch($table.hash_table().as_ptr().add(hash).cast(), _MM_HINT_T0);
             }
             // Prefetch the NEXT position's bucket too. The optimal-parser DP
             // advances one position per iteration, so this miss is issued a
@@ -689,7 +689,7 @@ macro_rules! bt_insert_and_collect_matches_body {
                 // harmless no-op hint.
                 unsafe {
                     _mm_prefetch(
-                        $table.hash_table.as_ptr().add(hash_next).cast(),
+                        $table.hash_table().as_ptr().add(hash_next).cast(),
                         _MM_HINT_T0,
                     );
                 }
@@ -711,8 +711,8 @@ macro_rules! bt_insert_and_collect_matches_body {
         // `chain_table`. Indices are in bounds by the BT invariants:
         // `bt_pair_index_for_abs` returns `2*(abs & bt_mask) (+1)` ≤
         // `chain_table.len()-1`, and the slots only ever hold those values.
-        let chain_ptr = $table.chain_table.as_mut_ptr();
-        debug_assert_eq!($table.chain_table.len(), 2 << $table.bt_log());
+        let chain_ptr = $table.chain_table_mut().as_mut_ptr();
+        debug_assert_eq!($table.chain_table().len(), 2 << $table.bt_log());
         // See `bt_insert_step_no_rebase_body!`: saturating is needed for the
         // first BT walk of a fresh frame where `abs_pos < bt_mask`.
         let bt_low = $abs_pos.saturating_sub(bt_mask);
@@ -761,8 +761,8 @@ macro_rules! bt_insert_and_collect_matches_body {
         let pair_idx = $table.bt_pair_index_for_abs($abs_pos);
         let mut smaller_slot = pair_idx;
         let mut larger_slot = pair_idx + 1;
-        let mut match_stored = $table.hash_table[hash];
-        $table.hash_table[hash] = stored;
+        let mut match_stored = $table.hash_table()[hash];
+        $table.hash_table_mut()[hash] = stored;
         // Upstream zstd semantics: `bestLength` starts at `lengthToBeat - 1`; rep/hash3
         // probing may raise it; BT then only reports strictly longer matches.
         // `min_match_len >= HC_FORMAT_MINMATCH (3)` by configure invariant,
@@ -1111,11 +1111,12 @@ impl HcMatchGenerator {
             }
             _ => {}
         }
-        if resize && !self.table.hash_table.is_empty() {
-            // Force reallocation on next ensure_tables() call.
-            self.table.hash_table.clear();
-            self.table.hash3_table.clear();
-            self.table.chain_table.clear();
+        if resize && !self.table.tables.is_empty() {
+            // Force reallocation on next ensure_tables() call. The seams go
+            // with the buffer, so `ensure_tables` sees a fresh layout.
+            self.table.tables.clear();
+            self.table.chain_off = 0;
+            self.table.hash3_off = 0;
         }
     }
 

--- a/zstd/src/encoding/hc/hc_tests.rs
+++ b/zstd/src/encoding/hc/hc_tests.rs
@@ -129,10 +129,10 @@ fn hash_chain_candidate_forward_ties_keep_first_visited() {
     let probe_hash = t.hash_position(&concat[abs_pos..]);
     // Hand-wire the chain head + link so the walk surfaces pos 9 first
     // (offset 18) then pos 18 (offset 9). `stored = pos + 1`.
-    t.hash_table[probe_hash] = 9 + 1;
+    t.hash_table_mut()[probe_hash] = 9 + 1;
     let chain_mask = (1usize << t.chain_log) - 1;
-    t.chain_table[9 & chain_mask] = 18 + 1;
-    t.chain_table[18 & chain_mask] = HC_EMPTY;
+    t.chain_table_mut()[9 & chain_mask] = 18 + 1;
+    t.chain_table_mut()[18 & chain_mask] = HC_EMPTY;
 
     let hc = HcMatcher::new(2, 16, 64);
     let cand = hc.hash_chain_candidate::<false>(t.live_history(), false, &t, abs_pos);

--- a/zstd/src/encoding/hc/mod.rs
+++ b/zstd/src/encoding/hc/mod.rs
@@ -239,7 +239,7 @@ impl HcMatcher {
         // lazy hot path.
         let hash = table.hash_position(&concat[current_idx..]);
         let chain_mask = (1usize << table.chain_log) - 1;
-        let mut cur = table.hash_table[hash];
+        let mut cur = table.hash_table()[hash];
         // Cap loop at MAX_HC_SEARCH_DEPTH so a misconfigured
         // `search_depth > MAX_HC_SEARCH_DEPTH` (BT modes set it from the
         // upstream zstd config, which can exceed our cap) cannot run forever.
@@ -296,7 +296,7 @@ impl HcMatcher {
         // per-find load count. `candidate_rel & chain_mask` is always
         // `< chain_table.len()` (the table is `1 << chain_log` and
         // `chain_mask == len - 1`), so the raw read is in-bounds.
-        let chain_ptr: *const u32 = table.chain_table.as_ptr();
+        let chain_ptr: *const u32 = table.chain_table().as_ptr();
         while steps < max_chain_steps {
             if cur == HC_EMPTY {
                 break;

--- a/zstd/src/encoding/hc/optimal.rs
+++ b/zstd/src/encoding/hc/optimal.rs
@@ -893,13 +893,13 @@ macro_rules! collect_optimal_candidates_initialized_body {
         // a future caller may pre-allocate hash3 storage without
         // wiring the BtUltra2 path through.
         let use_hash3: bool = <$strategy_ty as crate::encoding::strategy::Strategy>::USE_HASH3;
-        debug_assert!(!$self.table.hash_table.is_empty());
-        debug_assert!($self.table.hash3_log == 0 || !$self.table.hash3_table.is_empty());
+        debug_assert!(!$self.table.hash_table().is_empty());
+        debug_assert!($self.table.hash3_log == 0 || !$self.table.hash3_table().is_empty());
         debug_assert!(
             !use_hash3 || $self.table.hash3_log != 0,
             "Strategy::USE_HASH3 = true but runtime hash3_log is 0 — call configure() first",
         );
-        debug_assert!(!$self.table.chain_table.is_empty());
+        debug_assert!(!$self.table.chain_table().is_empty());
         let min_match_len = HC_OPT_MIN_MATCH_LEN;
         let reps = $query.reps;
         let lit_len = $query.lit_len;

--- a/zstd/src/encoding/match_generator/dict_prime.rs
+++ b/zstd/src/encoding/match_generator/dict_prime.rs
@@ -440,9 +440,12 @@ impl MatchGeneratorDriver {
             let MatcherStorage::HashChain(hc) = &mut self.storage else {
                 unreachable!("bt_decoupled implies HashChain storage");
             };
-            let hash_table = core::mem::take(&mut hc.table.hash_table);
-            let chain_table = core::mem::take(&mut hc.table.chain_table);
-            let hash3_table = core::mem::take(&mut hc.table.hash3_table);
+            // One buffer holds all three regions now; its seams describe it,
+            // so they are taken with it — a snapshot left holding non-zero
+            // seams over an empty buffer would index out of bounds.
+            let tables = core::mem::take(&mut hc.table.tables);
+            let chain_off = core::mem::take(&mut hc.table.chain_off);
+            let hash3_off = core::mem::take(&mut hc.table.hash3_off);
             // The LDM producer carries no dictionary state (LDM is not
             // dict-primed; its hash table is empty at capture), so it is not
             // retained either — `restore` reinstates the frame's freshly-reset
@@ -456,9 +459,9 @@ impl MatchGeneratorDriver {
             let MatcherStorage::HashChain(hc) = &mut self.storage else {
                 unreachable!("storage variant is stable across the take/put");
             };
-            hc.table.hash_table = hash_table;
-            hc.table.chain_table = chain_table;
-            hc.table.hash3_table = hash3_table;
+            hc.table.tables = tables;
+            hc.table.chain_off = chain_off;
+            hc.table.hash3_off = hash3_off;
             #[cfg(feature = "ldm")]
             hc.set_ldm_producer(ldm_producer);
             self.primed = Some((snapshot, self.dictionary_retained_budget, key));

--- a/zstd/src/encoding/match_generator/mod.rs
+++ b/zstd/src/encoding/match_generator/mod.rs
@@ -1145,8 +1145,8 @@ impl Matcher for MatchGeneratorDriver {
                 }
                 MatcherStorage::Row(m) => {
                     m.row_heads = Vec::new();
-                    m.row_positions = Vec::new();
                     m.row_tags = Vec::new();
+                    m.release_tables();
                     m.reset();
                 }
                 MatcherStorage::HashChain(m) => {

--- a/zstd/src/encoding/match_generator/mod.rs
+++ b/zstd/src/encoding/match_generator/mod.rs
@@ -1157,9 +1157,9 @@ impl Matcher for MatchGeneratorDriver {
                     // otherwise stay pinned across the backend switch,
                     // even though no future caller of this backend will
                     // touch them.
-                    m.table.hash_table = Vec::new();
-                    m.table.chain_table = Vec::new();
-                    m.table.hash3_table = Vec::new();
+                    m.table.tables = Vec::new();
+                    m.table.chain_off = 0;
+                    m.table.hash3_off = 0;
                     let vec_pool = &mut self.vec_pool;
                     m.reset(|mut data| {
                         data.resize(data.capacity(), 0);

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -2654,8 +2654,8 @@ fn driver_better_to_best_resizes_hc_tables() {
     driver.skip_matching_with_hint(None);
 
     let hc = driver.hc_matcher();
-    let better_hash_len = hc.table.hash_table.len();
-    let better_chain_len = hc.table.chain_table.len();
+    let better_hash_len = hc.table.hash_table().len();
+    let better_chain_len = hc.table.chain_table().len();
 
     // Switch to L20 — must resize to larger tables.
     driver.reset(CompressionLevel::Level(20));
@@ -2670,15 +2670,15 @@ fn driver_better_to_best_resizes_hc_tables() {
 
     let hc = driver.hc_matcher();
     assert!(
-        hc.table.hash_table.len() > better_hash_len,
+        hc.table.hash_table().len() > better_hash_len,
         "L20 hash_table ({}) should be larger than L16 ({})",
-        hc.table.hash_table.len(),
+        hc.table.hash_table().len(),
         better_hash_len
     );
     assert!(
-        hc.table.chain_table.len() > better_chain_len,
+        hc.table.chain_table().len() > better_chain_len,
         "L20 chain_table ({}) should be larger than L16 ({})",
-        hc.table.chain_table.len(),
+        hc.table.chain_table().len(),
         better_chain_len
     );
 }
@@ -3664,7 +3664,7 @@ fn hc_reset_advances_floor_past_prior_frame_entries() {
     hc.table.insert_positions(0, 6);
     let prev_end = hc.table.history_abs_end();
     assert_eq!(prev_end, 10);
-    assert!(hc.table.hash_table.iter().any(|&v| v != HC_EMPTY));
+    assert!(hc.table.hash_table().iter().any(|&v| v != HC_EMPTY));
 
     hc.reset(|_| {});
 
@@ -3674,7 +3674,7 @@ fn hc_reset_advances_floor_past_prior_frame_entries() {
     // to an absolute position strictly below `history_abs_start` and is
     // rejected by the `window_low` guard before any byte is read.
     assert_eq!(hc.table.history_abs_start, prev_end);
-    for &slot in hc.table.hash_table.iter() {
+    for &slot in hc.table.hash_table().iter() {
         if let Some(candidate_abs) =
             MatchTable::stored_abs_position_fast(slot, hc.table.position_base, hc.table.index_shift)
         {
@@ -3692,8 +3692,8 @@ fn hc_reset_full_zeroes_when_floor_would_cross_ceiling() {
     let mut hc = HcMatchGenerator::new(32);
     hc.table.add_data(b"abcdeabcde".to_vec(), |_| {});
     hc.table.ensure_tables();
-    hc.table.hash_table.fill(123);
-    hc.table.chain_table.fill(456);
+    hc.table.hash_table_mut().fill(123);
+    hc.table.chain_table_mut().fill(456);
     // Push the would-be floor (`history_abs_end`) past the ceiling so
     // `reset` takes the bounded fallback: rewind to the origin and zero
     // the tables, keeping the absolute cursor from climbing toward
@@ -3704,8 +3704,8 @@ fn hc_reset_full_zeroes_when_floor_would_cross_ceiling() {
 
     assert_eq!(hc.table.history_abs_start, 0);
     assert_eq!(hc.table.position_base, 0);
-    assert!(hc.table.hash_table.iter().all(|&v| v == HC_EMPTY));
-    assert!(hc.table.chain_table.iter().all(|&v| v == HC_EMPTY));
+    assert!(hc.table.hash_table().iter().all(|&v| v == HC_EMPTY));
+    assert!(hc.table.chain_table().iter().all(|&v| v == HC_EMPTY));
 }
 
 #[test]
@@ -3854,7 +3854,7 @@ fn hc_sparse_skip_matching_does_not_reinsert_sparse_tail_positions() {
         .expect("overlap position should be representable as relative position");
     let chain_idx = rel as usize & ((1 << matcher.table.chain_log) - 1);
     assert_ne!(
-        matcher.table.chain_table[chain_idx],
+        matcher.table.chain_table()[chain_idx],
         rel + 1,
         "sparse-grid tail positions must not be reinserted (self-loop chain entry)"
     );
@@ -3877,13 +3877,13 @@ fn hc_insert_position_no_rebase_returns_when_relative_pos_unavailable() {
     hc.table.history_abs_start = 0;
     hc.table.position_base = 1;
     hc.table.ensure_tables();
-    let before_hash = hc.table.hash_table.clone();
-    let before_chain = hc.table.chain_table.clone();
+    let before_hash = hc.table.hash_table().to_vec();
+    let before_chain = hc.table.chain_table().to_vec();
 
     hc.table.insert_position_no_rebase(0);
 
-    assert_eq!(hc.table.hash_table, before_hash);
-    assert_eq!(hc.table.chain_table, before_chain);
+    assert_eq!(hc.table.hash_table(), before_hash);
+    assert_eq!(hc.table.chain_table(), before_chain);
 }
 
 #[test]
@@ -4194,7 +4194,7 @@ fn hc_rebases_positions_after_u32_boundary() {
     assert!(
         matcher
             .table
-            .hash_table
+            .hash_table()
             .iter()
             .any(|entry| *entry != HC_EMPTY),
         "HC hash table should still be populated after crossing u32 boundary"
@@ -4257,8 +4257,7 @@ fn hc_rebase_rebuilds_only_inserted_prefix() {
     expected.table.ensure_tables();
     expected.table.history_abs_start = history_abs_start;
     expected.table.position_base = expected.table.history_abs_start;
-    expected.table.hash_table.fill(HC_EMPTY);
-    expected.table.chain_table.fill(HC_EMPTY);
+    expected.table.tables.fill(HC_EMPTY);
     for pos in expected.table.history_abs_start..abs_pos {
         expected.table.insert_position_no_rebase(pos);
     }
@@ -4270,11 +4269,13 @@ fn hc_rebase_rebuilds_only_inserted_prefix() {
         "rebase should still anchor to the oldest live absolute position"
     );
     assert_eq!(
-        matcher.table.hash_table, expected.table.hash_table,
+        matcher.table.hash_table(),
+        expected.table.hash_table(),
         "rebase must rebuild only positions already inserted before abs_pos"
     );
     assert_eq!(
-        matcher.table.chain_table, expected.table.chain_table,
+        matcher.table.chain_table(),
+        expected.table.chain_table(),
         "future positions must not be pre-seeded into HC chains during rebase"
     );
 }

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -2425,7 +2425,7 @@ fn row_skip_matching_with_incompressible_hint_uses_sparse_prefix() {
     dense.add_data(data.clone(), |_| {});
     dense.skip_matching_with_hint(Some(false));
     let dense_slots = dense
-        .row_positions
+        .row_positions()
         .iter()
         .filter(|&&pos| pos != ROW_EMPTY_SLOT)
         .count();
@@ -2435,7 +2435,7 @@ fn row_skip_matching_with_incompressible_hint_uses_sparse_prefix() {
     sparse.add_data(data, |_| {});
     sparse.skip_matching_with_hint(Some(true));
     let sparse_slots = sparse
-        .row_positions
+        .row_positions()
         .iter()
         .filter(|&&pos| pos != ROW_EMPTY_SLOT)
         .count();
@@ -2468,7 +2468,7 @@ fn row_skip_matching_with_none_hint_leaves_interior_empty() {
     none_hint.add_data(data.clone(), |_| {});
     none_hint.skip_matching_with_hint(None);
     let none_slots = none_hint
-        .row_positions
+        .row_positions()
         .iter()
         .filter(|&&pos| pos != ROW_EMPTY_SLOT)
         .count();
@@ -2480,7 +2480,7 @@ fn row_skip_matching_with_none_hint_leaves_interior_empty() {
     dense.add_data(data, |_| {});
     dense.skip_matching_with_hint(Some(false));
     let dense_slots = dense
-        .row_positions
+        .row_positions()
         .iter()
         .filter(|&&pos| pos != ROW_EMPTY_SLOT)
         .count();

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -2020,6 +2020,39 @@ fn driver_no_dictionary_reset_drops_the_attached_tables() {
 /// the chain / tree tables — they are tens of MiB at the btlazy2 levels and
 /// the rows finder never reads them.
 #[test]
+fn driver_rows_frame_releases_the_tree_buffer_capacity() {
+    // Coming back from a btlazy2 level, the row frame must not keep the tree
+    // tables' allocation resident: reporting a zero length while holding tens
+    // of MiB of capacity is the same leak in a different accounting column.
+    let mut driver = MatchGeneratorDriver::new(32, 2);
+    driver.set_source_size_hint(1 << 20);
+    driver.reset(CompressionLevel::Level(15));
+    let mut space = driver.get_next_space();
+    space[..12].copy_from_slice(b"abcabcabcabc");
+    space.truncate(12);
+    driver.commit_space(space);
+    driver.skip_matching_with_hint(None);
+    let tree_capacity = driver.row_matcher().tables_capacity();
+    assert!(
+        tree_capacity > 0,
+        "fixture precondition: the tree tables are allocated at L15"
+    );
+
+    driver.set_source_size_hint(1 << 20);
+    driver.reset(CompressionLevel::Level(5));
+    let mut space = driver.get_next_space();
+    space[..12].copy_from_slice(b"abcabcabcabc");
+    space.truncate(12);
+    driver.commit_space(space);
+    driver.skip_matching_with_hint(None);
+    assert!(
+        driver.row_matcher().tables_capacity() < tree_capacity,
+        "a rows frame must hand back the oversized tree buffer, kept {} of {tree_capacity}",
+        driver.row_matcher().tables_capacity()
+    );
+}
+
+#[test]
 fn driver_rows_reset_releases_the_tree_tables() {
     let mut driver = MatchGeneratorDriver::new(32, 2);
     driver.set_source_size_hint(1 << 20);

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -72,8 +72,8 @@ pub(crate) const MAX_PRIMED_WINDOW_SIZE: usize =
 /// lets every downstream `abs_pos + N` site stay raw and keeps i686
 /// streams correct. New match-finder backends with their own
 /// `add_data` path must route through this helper.
-/// Capacity above which a table buffer counts as oversized for a layout of
-/// `wanted` slots and is handed back rather than re-used.
+/// Whether a table buffer of `capacity` slots is too big to keep for a layout
+/// of `wanted` slots, and should be handed back rather than re-used.
 ///
 /// Re-using the allocation is the whole point of holding the tables in one
 /// buffer, so a small overshoot is kept: levels within a factor of two of each
@@ -81,12 +81,13 @@ pub(crate) const MAX_PRIMED_WINDOW_SIZE: usize =
 /// that, a compressor that once ran a large level would pin its biggest
 /// allocation for the rest of its life. Upstream applies the same hysteresis
 /// to its workspace (`workspaceOversizedDuration`).
-/// `saturating_mul`: a table wider than half the address space cannot exist,
-/// and clamping the threshold at the maximum is the meaningful answer for one
-/// that somehow did — every capacity compares below it.
+///
+/// Phrased as a halving rather than `wanted * 2` so no arithmetic can leave
+/// the type: a doubling would need a clamp, and a clamp here fails open —
+/// `usize::MAX` compares above every capacity, silently disabling the release.
 #[inline]
-pub(crate) fn oversized_capacity(wanted: usize) -> usize {
-    wanted.saturating_mul(2)
+pub(crate) fn capacity_is_oversized(capacity: usize, wanted: usize) -> bool {
+    capacity / 2 > wanted
 }
 
 #[inline]
@@ -658,7 +659,7 @@ impl MatchTable {
         // re-lays out all three. That costs the same fill the separate vectors
         // paid for the region that changed, and saves two allocations.
         if self.chain_off != hash_size || self.hash3_off != hash_size + chain_size {
-            if self.tables.capacity() > oversized_capacity(total) {
+            if capacity_is_oversized(self.tables.capacity(), total) {
                 // Levelling down: `clear` + `resize` would keep the largest
                 // allocation this compressor ever made resident for every
                 // later frame, so hand the buffer back instead.

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -209,9 +209,19 @@ pub(crate) struct MatchTable {
     pub(crate) position_base: usize,
     pub(crate) index_shift: usize,
     pub(crate) offset_hist: [u32; 3],
-    pub(crate) hash_table: Vec<u32>,
-    pub(crate) hash3_table: Vec<u32>,
-    pub(crate) chain_table: Vec<u32>,
+    /// Single backing allocation for all three `u32` index tables (the cwksp
+    /// analog the dfast backend already uses for its long / short pair, and
+    /// the Row backend for its finder tables). Laid out as
+    /// `[hash | chain | hash3]`; the two offsets below mark the seams. One
+    /// allocation per compressor instead of three keeps the allocator seeing a
+    /// single size class, which is what decides whether the tables keep their
+    /// pages between frames rather than being handed back and faulted in again.
+    pub(crate) tables: Vec<u32>,
+    /// Start of the chain table inside [`Self::tables`] (== hash table length).
+    pub(crate) chain_off: usize,
+    /// Start of the hash3 table inside [`Self::tables`]; equals the buffer
+    /// length when hash3 is disabled.
+    pub(crate) hash3_off: usize,
     pub(crate) hash_log: usize,
     pub(crate) chain_log: usize,
     pub(crate) hash3_log: usize,
@@ -297,9 +307,9 @@ impl Clone for MatchTable {
             position_base: self.position_base,
             index_shift: self.index_shift,
             offset_hist: self.offset_hist,
-            hash_table: self.hash_table.clone(),
-            hash3_table: self.hash3_table.clone(),
-            chain_table: self.chain_table.clone(),
+            tables: self.tables.clone(),
+            chain_off: self.chain_off,
+            hash3_off: self.hash3_off,
             hash_log: self.hash_log,
             chain_log: self.chain_log,
             hash3_log: self.hash3_log,
@@ -326,9 +336,7 @@ impl Clone for MatchTable {
         // `clone_from` keep capacity and overwrite in place).
         self.chunk_lens.clone_from(&source.chunk_lens);
         self.history.clone_from(&source.history);
-        self.hash_table.clone_from(&source.hash_table);
-        self.hash3_table.clone_from(&source.hash3_table);
-        self.chain_table.clone_from(&source.chain_table);
+        self.tables.clone_from(&source.tables);
         self.dms.clone_from(&source.dms);
         // Scalars / Copy fields.
         self.max_window_size = source.max_window_size;
@@ -341,6 +349,10 @@ impl Clone for MatchTable {
         self.position_base = source.position_base;
         self.index_shift = source.index_shift;
         self.offset_hist = source.offset_hist;
+        // Seams of the table buffer copied just above; they describe it, so
+        // they travel with it exactly like the uncommitted count does.
+        self.chain_off = source.chain_off;
+        self.hash3_off = source.hash3_off;
         self.hash_log = source.hash_log;
         self.chain_log = source.chain_log;
         self.hash3_log = source.hash3_log;
@@ -464,9 +476,9 @@ impl MatchTable {
             position_base: 0,
             index_shift: 0,
             offset_hist: [1, 4, 8],
-            hash_table: Vec::new(),
-            hash3_table: Vec::new(),
-            chain_table: Vec::new(),
+            tables: Vec::new(),
+            chain_off: 0,
+            hash3_off: 0,
             hash_log: HC_HASH_LOG,
             chain_log: HC_CHAIN_LOG,
             hash3_log: HC3_HASH_LOG,
@@ -559,7 +571,7 @@ impl MatchTable {
         let Some(relative_pos) = self.relative_position(abs_pos) else {
             return;
         };
-        self.hash3_table[hash3] = relative_pos + 1;
+        self.hash3_table_mut()[hash3] = relative_pos + 1;
     }
 
     /// Insert a position into the main hash / chain table without
@@ -597,12 +609,16 @@ impl MatchTable {
         // `< chain_table.len() == 1 << chain_log`. Both indices are
         // provably in bounds, so the elided bounds checks save ~4
         // instructions per call on this per-byte-of-input hot path.
-        debug_assert!(hash < self.hash_table.len());
-        debug_assert!(chain_idx < self.chain_table.len());
+        debug_assert!(hash < self.chain_off);
+        debug_assert!(chain_idx < self.hash3_off - self.chain_off);
+        // Both regions come from the one buffer; the split ends with this
+        // statement, so it costs the same two base pointers the separate
+        // vectors did.
+        let (hash_tbl, chain_tbl) = self.hash_and_chain_mut();
         unsafe {
-            let prev = *self.hash_table.get_unchecked(hash);
-            *self.chain_table.get_unchecked_mut(chain_idx) = prev;
-            *self.hash_table.get_unchecked_mut(hash) = stored;
+            let prev = *hash_tbl.get_unchecked(hash);
+            *chain_tbl.get_unchecked_mut(chain_idx) = prev;
+            *hash_tbl.get_unchecked_mut(hash) = stored;
         }
     }
 
@@ -614,23 +630,69 @@ impl MatchTable {
     /// level change would index out of bounds (UB) on the next encode.
     pub(crate) fn ensure_tables(&mut self) {
         let hash_size = 1 << self.hash_log;
-        if self.hash_table.len() != hash_size {
-            self.hash_table = alloc::vec![HC_EMPTY; hash_size];
-        }
-
         let chain_size = 1 << self.chain_log;
-        if self.chain_table.len() != chain_size {
-            self.chain_table = alloc::vec![HC_EMPTY; chain_size];
-        }
-
         let hash3_size = if self.hash3_log == 0 {
             0
         } else {
             1 << self.hash3_log
         };
-        if self.hash3_table.len() != hash3_size {
-            self.hash3_table = alloc::vec![HC_EMPTY; hash3_size];
+        let total = hash_size + chain_size + hash3_size;
+        // The three regions share one buffer, so a width change on any of them
+        // re-lays out all three. That costs the same fill the separate vectors
+        // paid for the region that changed, and saves two allocations.
+        if self.chain_off != hash_size || self.hash3_off != hash_size + chain_size {
+            self.tables.clear();
+            self.tables.resize(total, HC_EMPTY);
+            self.chain_off = hash_size;
+            self.hash3_off = hash_size + chain_size;
+        } else if self.tables.len() != total {
+            self.tables.resize(total, HC_EMPTY);
         }
+    }
+
+    /// Hash table: the first region of the shared buffer.
+    #[inline(always)]
+    pub(crate) fn hash_table(&self) -> &[u32] {
+        &self.tables[..self.chain_off]
+    }
+
+    /// Mutable hash table; see [`Self::hash_table`].
+    #[inline(always)]
+    pub(crate) fn hash_table_mut(&mut self) -> &mut [u32] {
+        &mut self.tables[..self.chain_off]
+    }
+
+    /// Chain table: the region between the hash and hash3 seams.
+    #[inline(always)]
+    pub(crate) fn chain_table(&self) -> &[u32] {
+        &self.tables[self.chain_off..self.hash3_off]
+    }
+
+    /// Mutable chain table; see [`Self::chain_table`].
+    #[inline(always)]
+    pub(crate) fn chain_table_mut(&mut self) -> &mut [u32] {
+        &mut self.tables[self.chain_off..self.hash3_off]
+    }
+
+    /// HC3 side table: the tail region, empty when hash3 is disabled.
+    #[inline(always)]
+    pub(crate) fn hash3_table(&self) -> &[u32] {
+        &self.tables[self.hash3_off..]
+    }
+
+    /// Mutable HC3 side table; see [`Self::hash3_table`].
+    #[inline(always)]
+    pub(crate) fn hash3_table_mut(&mut self) -> &mut [u32] {
+        &mut self.tables[self.hash3_off..]
+    }
+
+    /// Hash and chain tables at once, for the walkers that read a head and
+    /// write a link in the same step.
+    #[inline(always)]
+    pub(crate) fn hash_and_chain_mut(&mut self) -> (&mut [u32], &mut [u32]) {
+        let (hash, rest) = self.tables.split_at_mut(self.chain_off);
+        let chain_len = self.hash3_off - self.chain_off;
+        (hash, &mut rest[..chain_len])
     }
 
     /// Unaligned little-endian `u32` load. Hot helper for every
@@ -897,9 +959,8 @@ impl MatchTable {
         let usize_sz = core::mem::size_of::<usize>();
         self.chunk_lens.capacity() * usize_sz
             + self.history.capacity()
-            + (self.hash_table.capacity()
-                + self.hash3_table.capacity()
-                + self.chain_table.capacity())
+            // One buffer for the hash, chain and hash3 regions together.
+            + (self.tables.capacity())
                 * u32_sz
             + self.dms.table().map_or(0, |t| {
                 (t.hash_table.capacity() + t.chain_table.capacity()) * u32_sz
@@ -1408,9 +1469,7 @@ impl MatchTable {
                 self.history_abs_start = 0;
                 self.position_base = 0;
                 self.index_shift = 0;
-                self.hash_table.fill(HC_EMPTY);
-                self.hash3_table.fill(HC_EMPTY);
-                self.chain_table.fill(HC_EMPTY);
+                self.tables.fill(HC_EMPTY);
                 self.skip_insert_until_abs = region;
                 self.next_to_update3 = region;
                 self.dictionary_limit_abs = Some(region);
@@ -1471,9 +1530,7 @@ impl MatchTable {
             self.position_base = 0;
             self.index_shift = 0;
             self.next_to_update3 = 0;
-            self.hash_table.fill(HC_EMPTY);
-            self.hash3_table.fill(HC_EMPTY);
-            self.chain_table.fill(HC_EMPTY);
+            self.tables.fill(HC_EMPTY);
         }
     }
 
@@ -1484,9 +1541,8 @@ impl MatchTable {
     /// dominated tiny dict frames. `Vec::fill` on an unallocated (empty) table
     /// is a no-op, so the unconditional fills are safe before `ensure_tables`.
     pub(crate) fn clear_chain_hash_tables(&mut self) {
-        self.hash_table.fill(HC_EMPTY);
-        self.hash3_table.fill(HC_EMPTY);
-        self.chain_table.fill(HC_EMPTY);
+        // One buffer holds all three regions, so one fill clears them.
+        self.tables.fill(HC_EMPTY);
     }
 
     /// Upstream zstd parity: `ZSTD_compressBlock_btopt_generic` starts its main
@@ -2456,10 +2512,13 @@ impl MatchTable {
             let live = self.live_history();
             (live.as_ptr(), live.len())
         };
-        let hash_ptr = self.hash_table.as_mut_ptr();
-        let chain_ptr = self.chain_table.as_mut_ptr();
-        debug_assert!(self.hash_table.len() == 1usize << hash_log);
-        debug_assert!(self.chain_table.len() == 1usize << self.chain_log);
+        debug_assert!(self.chain_off == 1usize << hash_log);
+        debug_assert!(self.hash3_off - self.chain_off == 1usize << self.chain_log);
+        // Base pointers into the one buffer, hoisted before the loop below.
+        // SAFETY: `chain_off` is in bounds (one past the hash region is the
+        // first chain slot), asserted just above.
+        let hash_ptr = self.tables.as_mut_ptr();
+        let chain_ptr = unsafe { hash_ptr.add(self.chain_off) };
         // The last `< 4` bytes of the live window can't be hashed. Compute
         // the hashable upper bound once instead of branching per position: a
         // position `pos` is hashable iff `pos - history_abs_start + 4 <=
@@ -2832,9 +2891,8 @@ impl MatchTable {
         self.position_base = self.history_abs_start;
         self.index_shift = 0;
         self.allow_zero_relative_position = true;
-        self.hash_table.fill(HC_EMPTY);
-        self.hash3_table.fill(HC_EMPTY);
-        self.chain_table.fill(HC_EMPTY);
+        // One buffer holds all three regions, so one fill clears them.
+        self.tables.fill(HC_EMPTY);
     }
 
     /// HC-side history replay after [`begin_rebase`]. Re-inserts every

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -72,6 +72,23 @@ pub(crate) const MAX_PRIMED_WINDOW_SIZE: usize =
 /// lets every downstream `abs_pos + N` site stay raw and keeps i686
 /// streams correct. New match-finder backends with their own
 /// `add_data` path must route through this helper.
+/// Capacity above which a table buffer counts as oversized for a layout of
+/// `wanted` slots and is handed back rather than re-used.
+///
+/// Re-using the allocation is the whole point of holding the tables in one
+/// buffer, so a small overshoot is kept: levels within a factor of two of each
+/// other trade the same buffer back and forth instead of churning it. Past
+/// that, a compressor that once ran a large level would pin its biggest
+/// allocation for the rest of its life. Upstream applies the same hysteresis
+/// to its workspace (`workspaceOversizedDuration`).
+/// `saturating_mul`: a table wider than half the address space cannot exist,
+/// and clamping the threshold at the maximum is the meaningful answer for one
+/// that somehow did — every capacity compares below it.
+#[inline]
+pub(crate) fn oversized_capacity(wanted: usize) -> usize {
+    wanted.saturating_mul(2)
+}
+
 #[inline]
 pub(crate) fn check_stream_abs_headroom(
     history_abs_start: usize,
@@ -641,8 +658,15 @@ impl MatchTable {
         // re-lays out all three. That costs the same fill the separate vectors
         // paid for the region that changed, and saves two allocations.
         if self.chain_off != hash_size || self.hash3_off != hash_size + chain_size {
-            self.tables.clear();
-            self.tables.resize(total, HC_EMPTY);
+            if self.tables.capacity() > oversized_capacity(total) {
+                // Levelling down: `clear` + `resize` would keep the largest
+                // allocation this compressor ever made resident for every
+                // later frame, so hand the buffer back instead.
+                self.tables = alloc::vec![HC_EMPTY; total];
+            } else {
+                self.tables.clear();
+                self.tables.resize(total, HC_EMPTY);
+            }
             self.chain_off = hash_size;
             self.hash3_off = hash_size + chain_size;
         } else if self.tables.len() != total {

--- a/zstd/src/encoding/match_table/storage/storage_tests.rs
+++ b/zstd/src/encoding/match_table/storage/storage_tests.rs
@@ -125,10 +125,10 @@ fn replay_history_for_rebase_bt_walks_inserted_prefix() {
     // into the hash table (via `hash_table[hash] = stored`) so the
     // ground-truth observation is "some hash slots are no longer
     // HC_EMPTY".
-    assert!(t.hash_table.iter().all(|&v| v == HC_EMPTY));
+    assert!(t.hash_table().iter().all(|&v| v == HC_EMPTY));
     t.replay_history_for_rebase_bt(0, 32);
     assert!(
-        t.hash_table.iter().any(|&v| v != HC_EMPTY),
+        t.hash_table().iter().any(|&v| v != HC_EMPTY),
         "BT replay must populate hash table"
     );
 }
@@ -136,9 +136,13 @@ fn replay_history_for_rebase_bt_walks_inserted_prefix() {
 #[test]
 fn begin_rebase_clears_index_tables_and_resets_base() {
     let mut t = new_table(32);
-    t.hash_table = vec![7; 16];
-    t.chain_table = vec![9; 16];
-    t.hash3_table = vec![5; 16];
+    // The three regions share one buffer; seed it through the seams so each
+    // region carries a distinct non-empty marker.
+    t.tables = vec![7; 48];
+    t.chain_off = 16;
+    t.hash3_off = 32;
+    t.chain_table_mut().fill(9);
+    t.hash3_table_mut().fill(5);
     t.history_abs_start = 50;
     t.position_base = 0;
     t.index_shift = 4;
@@ -149,9 +153,9 @@ fn begin_rebase_clears_index_tables_and_resets_base() {
     assert_eq!(t.position_base, 50);
     assert_eq!(t.index_shift, 0);
     assert!(t.allow_zero_relative_position);
-    assert!(t.hash_table.iter().all(|&v| v == HC_EMPTY));
-    assert!(t.chain_table.iter().all(|&v| v == HC_EMPTY));
-    assert!(t.hash3_table.iter().all(|&v| v == HC_EMPTY));
+    assert!(t.hash_table().iter().all(|&v| v == HC_EMPTY));
+    assert!(t.chain_table().iter().all(|&v| v == HC_EMPTY));
+    assert!(t.hash3_table().iter().all(|&v| v == HC_EMPTY));
 }
 
 /// Regression: `rebase_positions_cold` must replay the HC3 side
@@ -182,14 +186,14 @@ fn rebase_positions_cold_rebuilds_hash3_for_btultra2() {
     // positions up to the would-be rebase point.
     t.update_hash3_until(20);
     assert!(
-        t.hash3_table.iter().any(|&v| v != HC_EMPTY),
+        t.hash3_table().iter().any(|&v| v != HC_EMPTY),
         "fixture precondition: hash3 must be non-empty before rebase"
     );
 
     t.rebase_positions_cold(20);
 
     assert!(
-        t.hash3_table.iter().any(|&v| v != HC_EMPTY),
+        t.hash3_table().iter().any(|&v| v != HC_EMPTY),
         "rebase must repopulate the HC3 side table — \
              btultra2 short-match selection depends on it"
     );
@@ -204,7 +208,7 @@ fn insert_positions_with_step_zero_step_is_noop() {
     let next_to_update3_before = t.next_to_update3;
     // step=0 must early-return without touching anything.
     t.insert_positions_with_step(0, 16, 0);
-    assert!(t.hash_table.iter().all(|&v| v == HC_EMPTY));
+    assert!(t.hash_table().iter().all(|&v| v == HC_EMPTY));
     assert_eq!(t.next_to_update3, next_to_update3_before);
 }
 
@@ -220,7 +224,7 @@ fn insert_positions_with_step_saturating_step_breaks_loop() {
     t.insert_positions_with_step(0, 16, usize::MAX);
     // Exactly one position should have been inserted before the
     // loop terminated — observe that only one slot is non-empty.
-    let non_empty = t.hash_table.iter().filter(|&&v| v != HC_EMPTY).count();
+    let non_empty = t.hash_table().iter().filter(|&&v| v != HC_EMPTY).count();
     assert!(
         non_empty <= 1,
         "step=usize::MAX must break after the first insert"

--- a/zstd/src/encoding/match_table/storage/storage_tests.rs
+++ b/zstd/src/encoding/match_table/storage/storage_tests.rs
@@ -340,6 +340,30 @@ fn reserve_for_frame_takes_the_request_as_given() {
 }
 
 #[test]
+fn ensure_tables_releases_the_buffer_when_the_layout_shrinks() {
+    // A reused compressor moving from a large-log level to a small one must
+    // not keep the biggest allocation it ever used: `clear` + `resize` alone
+    // would shrink the length and leave the capacity resident for every later
+    // frame.
+    let mut t = new_table(1 << 20);
+    t.hash_log = 20;
+    t.chain_log = 20;
+    t.hash3_log = 0;
+    t.ensure_tables();
+    let large = t.tables.capacity();
+    assert!(large >= 2 << 20, "fixture precondition: a large layout");
+
+    t.hash_log = 10;
+    t.chain_log = 10;
+    t.ensure_tables();
+    assert!(
+        t.tables.capacity() < large / 2,
+        "a smaller layout must release the oversized buffer, kept {} of {large}",
+        t.tables.capacity()
+    );
+}
+
+#[test]
 fn clone_from_replaces_the_uncommitted_count_with_the_sources() {
     // `clone_from` is the primed-dictionary restore path: it overwrites the
     // history buffer wholesale, so a count describing the OLD buffer must not

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -3850,7 +3850,7 @@ impl RowMatchGenerator {
                 _mm_prefetch(self.row_heads.as_ptr().add(row).cast(), _MM_HINT_T0);
                 _mm_prefetch(self.row_tags.as_ptr().add(row_base).cast(), _MM_HINT_T0);
                 _mm_prefetch(
-                    self.row_positions.as_ptr().add(row_base).cast(),
+                    self.row_positions().as_ptr().add(row_base).cast(),
                     _MM_HINT_T0,
                 );
                 // Upstream zstd `ZSTD_row_prefetch` (zstd_lazy.c:816): rows of
@@ -3858,7 +3858,7 @@ impl RowMatchGenerator {
                 // second line is fetched too.
                 if ROW_LOG >= 5 {
                     _mm_prefetch(
-                        self.row_positions.as_ptr().add(row_base + 16).cast(),
+                        self.row_positions().as_ptr().add(row_base + 16).cast(),
                         _MM_HINT_T0,
                     );
                 }

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -3152,8 +3152,16 @@ impl RowMatchGenerator {
             // targets (musl) amplified into the dominant per-frame cost.
             self.row_heads.clear();
             self.row_heads.resize(row_count, 0);
-            self.tables.clear();
-            self.tables.resize(total, ROW_EMPTY_SLOT);
+            if self.tables.capacity() > super::match_table::storage::oversized_capacity(total) {
+                // Coming down from the chain / tree finder (or a wider row
+                // layout): `clear` + `resize` would keep that allocation —
+                // tens of MiB at the btlazy2 levels — resident for every later
+                // row frame, which is what the separate vectors released.
+                self.tables = alloc::vec![ROW_EMPTY_SLOT; total];
+            } else {
+                self.tables.clear();
+                self.tables.resize(total, ROW_EMPTY_SLOT);
+            }
             self.hc_split = 0;
             self.row_tags.clear();
             self.row_tags.resize(total, 0);
@@ -3173,8 +3181,16 @@ impl RowMatchGenerator {
             // width change on either therefore rewrites both, which costs the
             // same fill the separate vectors paid and saves an allocation.
             if self.hc_split != hash_len || self.tables.len() != hash_len + chain_len || relayout {
-                self.tables.clear();
-                self.tables.resize(hash_len + chain_len, empty);
+                let total = hash_len + chain_len;
+                if self.tables.capacity() > super::match_table::storage::oversized_capacity(total) {
+                    // Same release rule as the row branch: a level downgrade
+                    // must not pin the widest tables this compressor ever
+                    // used.
+                    self.tables = alloc::vec![empty; total];
+                } else {
+                    self.tables.clear();
+                    self.tables.resize(total, empty);
+                }
                 self.hc_split = hash_len;
             }
             self.hc_layout = self.finder;
@@ -3186,6 +3202,13 @@ impl RowMatchGenerator {
             // buffer, so nothing to release here beyond the split marker.
             self.hc_split = 0;
         }
+    }
+
+    /// Capacity of the shared table buffer, to check that a level downgrade
+    /// hands the oversized allocation back. Test-only.
+    #[cfg(test)]
+    pub(crate) fn tables_capacity(&self) -> usize {
+        self.tables.capacity()
     }
 
     /// Combined length of the chain / tree tables. Test-only.

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -3152,7 +3152,7 @@ impl RowMatchGenerator {
             // targets (musl) amplified into the dominant per-frame cost.
             self.row_heads.clear();
             self.row_heads.resize(row_count, 0);
-            if self.tables.capacity() > super::match_table::storage::oversized_capacity(total) {
+            if super::match_table::storage::capacity_is_oversized(self.tables.capacity(), total) {
                 // Coming down from the chain / tree finder (or a wider row
                 // layout): `clear` + `resize` would keep that allocation —
                 // tens of MiB at the btlazy2 levels — resident for every later
@@ -3182,7 +3182,8 @@ impl RowMatchGenerator {
             // same fill the separate vectors paid and saves an allocation.
             if self.hc_split != hash_len || self.tables.len() != hash_len + chain_len || relayout {
                 let total = hash_len + chain_len;
-                if self.tables.capacity() > super::match_table::storage::oversized_capacity(total) {
+                if super::match_table::storage::capacity_is_oversized(self.tables.capacity(), total)
+                {
                     // Same release rule as the row branch: a level downgrade
                     // must not pin the widest tables this compressor ever
                     // used.

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -450,7 +450,7 @@ macro_rules! row_find_best_match {
         // by the `ensure_tables` sizing (`row` is masked to `row_hash_log`
         // bits, `row_log == $rl`), the same argument as `insert_at`.
         debug_assert_eq!($rl, $m.row_log);
-        debug_assert!(row_base + row_entries <= $m.row_positions.len());
+        debug_assert!(row_base + row_entries <= $m.row_positions().len());
         let head = unsafe { *$m.row_heads.get_unchecked($row) } as usize;
         let window_low = $ctx.window_low($abs_pos);
         let budget = $m.search_depth.min(row_entries);
@@ -511,7 +511,7 @@ macro_rules! row_find_best_match {
                     continue;
                 }
                 // SAFETY: `slot < row_entries`; see the table-indexing note.
-                let raw = unsafe { *$m.row_positions.get_unchecked(row_base + slot) };
+                let raw = unsafe { *$m.row_positions().get_unchecked(row_base + slot) };
                 // Newest-first order: the first empty / below-floor entry ends
                 // the walk (upstream `if (matchIndex < lowLimit) break`).
                 if raw == ROW_EMPTY_SLOT || (raw as usize) < window_low {
@@ -733,8 +733,11 @@ macro_rules! hc_find_best_match {
             let mut idx = $ntu;
             while idx < p {
                 let h = $m.hc_hash_at($ctx, idx);
-                $m.hc_chain[idx & chain_mask] = $m.hc_hash[h];
-                $m.hc_hash[h] = idx as u32;
+                // Split per iteration so the hash helper can borrow again on
+                // the next one; the two halves come from one buffer.
+                let (hash, chain) = $m.hc_tables_mut();
+                chain[idx & chain_mask] = hash[h];
+                hash[h] = idx as u32;
                 idx += 1;
                 if $skip {
                     break;
@@ -750,7 +753,11 @@ macro_rules! hc_find_best_match {
         // A copied dictionary is upstream's `extDict` segment: its candidates
         // are gated at the match head instead of at the current best length.
         let prefix_start = $ctx.prefix_start;
-        let mut match_index = $m.hc_hash[$m.hc_hash_at($ctx, p)];
+        // Shared views of the two halves for the walk below, which only reads
+        // them; taken once so the chain hop is a plain index.
+        let hc_hash = $m.hc_hash();
+        let hc_chain = $m.hc_chain();
+        let mut match_index = hc_hash[$m.hc_hash_at($ctx, p)];
         while match_index != ROW_EMPTY_SLOT && (match_index as usize) >= window_low && attempts > 0
         {
             let cand = match_index as usize;
@@ -780,7 +787,7 @@ macro_rules! hc_find_best_match {
             if cand <= min_chain {
                 break;
             }
-            match_index = $m.hc_chain[cand & chain_mask];
+            match_index = hc_chain[cand & chain_mask];
             attempts -= 1;
         }
         // Attached dictionary (upstream `dictMatchState`): the CDict's own
@@ -850,9 +857,13 @@ macro_rules! dubt_update {
             let h = $m.hc_hash_at($ctx, idx);
             let ci = idx + BT_IDX_BASE;
             let node = 2 * (ci & bt_mask);
-            $m.hc_chain[node] = $m.hc_hash[h];
-            $m.hc_chain[node + 1] = BT_UNSORTED_MARK;
-            $m.hc_hash[h] = ci as u32;
+            // Both tables live in one buffer, so take the two halves together;
+            // the split ends with the iteration, leaving `hc_hash_at` free to
+            // borrow again on the next one.
+            let (hash, chain) = $m.hc_tables_mut();
+            chain[node] = hash[h];
+            chain[node + 1] = BT_UNSORTED_MARK;
+            hash[h] = ci as u32;
             idx += 1;
         }
     }};
@@ -865,8 +876,12 @@ macro_rules! dubt_update {
 /// not the dictionary rule). A node whose match runs to the block end is
 /// dropped from the tree (upstream: "no way to know if inf or sup").
 macro_rules! dubt_insert1 {
-    ($m:expr, $ctx:ident, $curr:expr, $nb_compares:expr, $bt_low:expr, $cpl:path) => {{
-        let bt_mask = (1usize << ($m.hc_chain_log - 1)) - 1;
+    // Takes the mask and the link table from the caller rather than the
+    // matcher: the caller already holds a mutable borrow of the shared table
+    // buffer, so reaching back through `$m` here would not borrow-check.
+    ($bt_mask:expr, $hc_chain:ident, $ctx:ident, $curr:expr, $nb_compares:expr, $bt_low:expr, $cpl:path) => {{
+        let bt_mask = $bt_mask;
+        let hc_chain = &mut *$hc_chain;
         let hist_start = $ctx.hist_start;
         let curr: usize = $curr;
         let cur_abs = curr - BT_IDX_BASE;
@@ -890,7 +905,7 @@ macro_rules! dubt_insert1 {
             + BT_IDX_BASE;
         let mut smaller_ptr = 2 * (curr & bt_mask);
         let mut larger_ptr = smaller_ptr + 1;
-        let mut match_index = $m.hc_chain[smaller_ptr] as usize;
+        let mut match_index = hc_chain[smaller_ptr] as usize;
         let mut common_smaller = 0usize;
         let mut common_larger = 0usize;
         let mut nb = $nb_compares;
@@ -915,31 +930,31 @@ macro_rules! dubt_insert1 {
                 break;
             }
             if smaller {
-                $m.hc_chain[smaller_ptr] = match_index as u32;
+                hc_chain[smaller_ptr] = match_index as u32;
                 common_smaller = ml;
                 if match_index <= $bt_low {
                     smaller_ptr = BT_DISCARD;
                     break;
                 }
                 smaller_ptr = next_ptr + 1;
-                match_index = $m.hc_chain[next_ptr + 1] as usize;
+                match_index = hc_chain[next_ptr + 1] as usize;
             } else {
-                $m.hc_chain[larger_ptr] = match_index as u32;
+                hc_chain[larger_ptr] = match_index as u32;
                 common_larger = ml;
                 if match_index <= $bt_low {
                     larger_ptr = BT_DISCARD;
                     break;
                 }
                 larger_ptr = next_ptr;
-                match_index = $m.hc_chain[next_ptr] as usize;
+                match_index = hc_chain[next_ptr] as usize;
             }
             nb -= 1;
         }
         if smaller_ptr != BT_DISCARD {
-            $m.hc_chain[smaller_ptr] = 0;
+            hc_chain[smaller_ptr] = 0;
         }
         if larger_ptr != BT_DISCARD {
-            $m.hc_chain[larger_ptr] = 0;
+            hc_chain[larger_ptr] = 0;
         }
     }};
 }
@@ -972,36 +987,49 @@ macro_rules! dubt_find_best_match {
             let window_low = $ctx.window_low(p) + BT_IDX_BASE;
             let bt_low = curr.saturating_sub(bt_mask);
             let unsort_limit = bt_low.max(window_low);
-            let mut match_index = $m.hc_hash[h] as usize;
+            // Take the two halves of the shared buffer once for the whole
+            // walk: every access below is an index into them, and re-deriving
+            // the split per access would put a load in the hot tree loop.
+            let search_depth = $m.search_depth;
+            let (hc_hash, hc_chain) = $m.hc_tables_mut();
+            let mut match_index = hc_hash[h] as usize;
             let mut next_candidate = 2 * (match_index & bt_mask);
             let mut unsorted_mark = next_candidate + 1;
-            let mut nb_compares = $m.search_depth;
+            let mut nb_compares = search_depth;
             let mut nb_candidates = nb_compares;
             let mut previous_candidate = 0usize;
             // Reach the end of the unsorted candidate list, reversing it
             // through the sort-mark slots.
             while match_index > unsort_limit
-                && $m.hc_chain[unsorted_mark] == BT_UNSORTED_MARK
+                && hc_chain[unsorted_mark] == BT_UNSORTED_MARK
                 && nb_candidates > 1
             {
-                $m.hc_chain[unsorted_mark] = previous_candidate as u32;
+                hc_chain[unsorted_mark] = previous_candidate as u32;
                 previous_candidate = match_index;
-                match_index = $m.hc_chain[next_candidate] as usize;
+                match_index = hc_chain[next_candidate] as usize;
                 next_candidate = 2 * (match_index & bt_mask);
                 unsorted_mark = next_candidate + 1;
                 nb_candidates -= 1;
             }
             // Nullify the last candidate if it is still unsorted (upstream:
             // costs a little ratio, buys speed).
-            if match_index > unsort_limit && $m.hc_chain[unsorted_mark] == BT_UNSORTED_MARK {
-                $m.hc_chain[next_candidate] = 0;
-                $m.hc_chain[unsorted_mark] = 0;
+            if match_index > unsort_limit && hc_chain[unsorted_mark] == BT_UNSORTED_MARK {
+                hc_chain[next_candidate] = 0;
+                hc_chain[unsorted_mark] = 0;
             }
             // Batch-sort the stacked candidates, oldest first.
             match_index = previous_candidate;
             while match_index != 0 {
-                let next_idx = $m.hc_chain[2 * (match_index & bt_mask) + 1] as usize;
-                dubt_insert1!($m, $ctx, match_index, nb_candidates, unsort_limit, $cpl);
+                let next_idx = hc_chain[2 * (match_index & bt_mask) + 1] as usize;
+                dubt_insert1!(
+                    bt_mask,
+                    hc_chain,
+                    $ctx,
+                    match_index,
+                    nb_candidates,
+                    unsort_limit,
+                    $cpl
+                );
                 match_index = next_idx;
                 nb_candidates += 1;
             }
@@ -1013,8 +1041,8 @@ macro_rules! dubt_find_best_match {
             let mut match_end_idx = curr + 8 + 1;
             let mut best_len = 0usize;
             let mut best_off = 0usize;
-            match_index = $m.hc_hash[h] as usize;
-            $m.hc_hash[h] = curr as u32;
+            match_index = hc_hash[h] as usize;
+            hc_hash[h] = curr as u32;
             while nb_compares > 0 && match_index > window_low {
                 // Tree nodes hold only earlier positions.
                 debug_assert!(match_index < curr, "tree walk reached a future node");
@@ -1054,31 +1082,31 @@ macro_rules! dubt_find_best_match {
                     break;
                 }
                 if smaller {
-                    $m.hc_chain[smaller_ptr] = match_index as u32;
+                    hc_chain[smaller_ptr] = match_index as u32;
                     common_smaller = ml;
                     if match_index <= bt_low {
                         smaller_ptr = BT_DISCARD;
                         break;
                     }
                     smaller_ptr = next_ptr + 1;
-                    match_index = $m.hc_chain[next_ptr + 1] as usize;
+                    match_index = hc_chain[next_ptr + 1] as usize;
                 } else {
-                    $m.hc_chain[larger_ptr] = match_index as u32;
+                    hc_chain[larger_ptr] = match_index as u32;
                     common_larger = ml;
                     if match_index <= bt_low {
                         larger_ptr = BT_DISCARD;
                         break;
                     }
                     larger_ptr = next_ptr;
-                    match_index = $m.hc_chain[next_ptr] as usize;
+                    match_index = hc_chain[next_ptr] as usize;
                 }
                 nb_compares -= 1;
             }
             if smaller_ptr != BT_DISCARD {
-                $m.hc_chain[smaller_ptr] = 0;
+                hc_chain[smaller_ptr] = 0;
             }
             if larger_ptr != BT_DISCARD {
-                $m.hc_chain[larger_ptr] = 0;
+                hc_chain[larger_ptr] = 0;
             }
             // Attached dictionary (upstream `dictMatchState`): walk the
             // CDict's sorted tree with the compares left, entered through
@@ -1956,7 +1984,7 @@ macro_rules! row_probe_body {
                 let Some(slot) = slot_opt else { break };
                 attempts += 1;
                 let idx = row_base + slot;
-                let raw_pos = $m.row_positions[idx];
+                let raw_pos = $m.row_positions()[idx];
                 if raw_pos == ROW_EMPTY_SLOT {
                     continue;
                 }
@@ -2260,8 +2288,6 @@ pub(crate) struct RowMatchGenerator {
     /// chain holds absolute positions with `ROW_EMPTY_SLOT` = empty; the tree
     /// holds `abs + BT_IDX_BASE` with 0 = none (`hc_layout` records which).
     hc_chain_log: usize,
-    hc_hash: Vec<u32>,
-    hc_chain: Vec<u32>,
     hc_layout: LazyFinder,
     /// Upstream `ms->loadedDictEnd` (absolute): the dictionary end while the
     /// dictionary is still valid for the block being parsed (its whole
@@ -2319,6 +2345,19 @@ pub(crate) struct RowMatchGenerator {
     /// compare, resolved once per matcher so the rep probe skips the
     /// `select_kernel()` atomic on every input byte.
     pub(crate) cpl_kernel: crate::encoding::fastpath::FastpathKernel,
+    /// Single backing allocation for every `u32` index table this matcher
+    /// owns (the cwksp analog the dfast backend already uses for its long /
+    /// short pair). The row finder and the chain / tree finder are mutually
+    /// exclusive, so one buffer serves both: in row mode it holds the row
+    /// positions, in chain / tree mode the hash table followed by the chain
+    /// table at `hc_split`. One allocation per compressor instead of three
+    /// keeps the allocator seeing a single size class, which is what decides
+    /// whether the tables keep their pages between frames.
+    pub(crate) tables: Vec<u32>,
+    /// Start of the chain / tree table inside [`Self::tables`]; the hash table
+    /// occupies everything before it. Zero in row mode, where the whole buffer
+    /// is row positions.
+    hc_split: usize,
     pub(crate) row_heads: Vec<u8>,
     // Absolute match positions, one per row slot. Stored as `u32` (not
     // `usize`): this is the largest match-finder array, and `u32` halves its
@@ -2329,7 +2368,6 @@ pub(crate) struct RowMatchGenerator {
     // origin down to the oldest live byte before that happens (see
     // [`Self::rebase_positions`]), keeping positions representable without
     // capping frame length.
-    pub(crate) row_positions: Vec<u32>,
     pub(crate) row_tags: Vec<u8>,
     /// Cached tag-match SIMD kernel; CPU features are fixed per process, so
     /// resolve once instead of querying per `row_candidate` call. On
@@ -2379,8 +2417,8 @@ impl RowMatchGenerator {
             offset_hist: [1, 4, 8],
             finder: LazyFinder::Rows,
             hc_chain_log: ROW_HASH_BITS,
-            hc_hash: Vec::new(),
-            hc_chain: Vec::new(),
+            tables: Vec::new(),
+            hc_split: 0,
             hc_layout: LazyFinder::Chain,
             loaded_dict_end: 0,
             low_limit: 0,
@@ -2399,7 +2437,6 @@ impl RowMatchGenerator {
             lazy_depth: 1,
             cpl_kernel: crate::encoding::fastpath::select_kernel(),
             row_heads: Vec::new(),
-            row_positions: Vec::new(),
             row_tags: Vec::new(),
             tag_kernel: crate::encoding::fastpath::select_kernel(),
             dict: DictAttach::new(),
@@ -2416,9 +2453,10 @@ impl RowMatchGenerator {
         self.chunk_lens.capacity() * core::mem::size_of::<usize>()
             + self.history.capacity()
             + self.row_heads.capacity()
-            + self.row_positions.capacity() * u32_sz
             + self.row_tags.capacity()
-            + (self.hc_hash.capacity() + self.hc_chain.capacity()) * u32_sz
+            // One buffer for whichever finder is live: row positions, or the
+            // chain / tree hash and link tables.
+            + self.tables.capacity() * u32_sz
             + self.dict.table().map_or(0, |t| {
                 t.heads.capacity()
                     + t.positions.capacity() * u32_sz
@@ -2488,7 +2526,8 @@ impl RowMatchGenerator {
         if self.row_hash_log != row_hash_log {
             self.row_hash_log = row_hash_log;
             self.row_heads.clear();
-            self.row_positions.clear();
+            self.tables.clear();
+            self.hc_split = 0;
             self.row_tags.clear();
             // NOTE: do NOT invalidate the dict here. `set_hash_bits` is called
             // twice per frame during level setup (once from `configure` with
@@ -2592,7 +2631,7 @@ impl RowMatchGenerator {
         // `set_borrowed_window` after this reset.
         self.borrowed_input = None;
         self.borrowed_block = None;
-        let tables_allocated = !self.row_positions.is_empty() || !self.hc_hash.is_empty();
+        let tables_allocated = !self.tables.is_empty();
         if next_floor <= REBASE_RESET_FLOOR_CEILING && tables_allocated {
             self.history_abs_start = next_floor;
         } else {
@@ -2602,11 +2641,15 @@ impl RowMatchGenerator {
             // by `rebase_positions` in `add_data`).
             self.history_abs_start = 0;
             self.row_heads.fill(0);
-            self.row_positions.fill(ROW_EMPTY_SLOT);
             self.row_tags.fill(0);
-            let empty = self.hc_empty_slot();
-            self.hc_hash.fill(empty);
-            self.hc_chain.fill(empty);
+            // The shared buffer holds whichever finder's tables are live, so
+            // it takes that finder's empty sentinel.
+            let empty = if self.hc_split == 0 {
+                ROW_EMPTY_SLOT
+            } else {
+                self.hc_empty_slot()
+            };
+            self.tables.fill(empty);
         }
         // Nothing of the previous frame is indexed for the new one, and the
         // lazy reps restart from the frame's initial history. The window
@@ -2863,27 +2906,26 @@ impl RowMatchGenerator {
                 (abs - delta) as u32
             };
         };
-        self.row_positions.iter_mut().for_each(rebase_abs);
-        if self.hc_layout == LazyFinder::Tree {
-            // Tree indices are `abs + BT_IDX_BASE`; 0 (none) and the unsorted
-            // mark are kept (upstream `ZSTD_reduceTable_btlazy2`).
-            let rebase_tree = |slot: &mut u32| {
-                let v = *slot as usize;
-                if v < BT_IDX_BASE {
-                    return;
-                }
-                let abs = v - BT_IDX_BASE;
-                *slot = if abs < delta {
-                    0
-                } else {
-                    (abs - delta + BT_IDX_BASE) as u32
-                };
+        // Tree indices are `abs + BT_IDX_BASE`; 0 (none) and the unsorted
+        // mark are kept (upstream `ZSTD_reduceTable_btlazy2`).
+        let rebase_tree = |slot: &mut u32| {
+            let v = *slot as usize;
+            if v < BT_IDX_BASE {
+                return;
+            }
+            let abs = v - BT_IDX_BASE;
+            *slot = if abs < delta {
+                0
+            } else {
+                (abs - delta + BT_IDX_BASE) as u32
             };
-            self.hc_hash.iter_mut().for_each(rebase_tree);
-            self.hc_chain.iter_mut().for_each(rebase_tree);
+        };
+        // One buffer, one pass: it holds row positions, or the chain / tree
+        // pair, and only the tree encodes its slots differently.
+        if self.hc_split != 0 && self.hc_layout == LazyFinder::Tree {
+            self.tables.iter_mut().for_each(rebase_tree);
         } else {
-            self.hc_hash.iter_mut().for_each(rebase_abs);
-            self.hc_chain.iter_mut().for_each(rebase_abs);
+            self.tables.iter_mut().for_each(rebase_abs);
         }
         self.lazy_next_to_update = self.lazy_next_to_update.saturating_sub(delta);
         self.low_limit = self.low_limit.saturating_sub(delta);
@@ -3043,6 +3085,51 @@ impl RowMatchGenerator {
     ///
     /// `pick_lazy_match` is intentionally not called here — depth == 0
     /// means "no lookahead", emit the first viable hit.
+    /// Drop the shared table allocation, for the backend switch that wants the
+    /// footprint gone before building the replacement variant.
+    pub(crate) fn release_tables(&mut self) {
+        self.tables = Vec::new();
+        self.hc_split = 0;
+    }
+
+    /// Row positions: in row mode the whole `u32` buffer is the position table.
+    #[inline(always)]
+    pub(crate) fn row_positions(&self) -> &[u32] {
+        &self.tables
+    }
+
+    /// Mutable row positions; see [`Self::row_positions`].
+    #[inline(always)]
+    pub(crate) fn row_positions_mut(&mut self) -> &mut [u32] {
+        &mut self.tables
+    }
+
+    /// Chain / tree hash table: the region before [`Self::hc_split`].
+    #[inline(always)]
+    pub(crate) fn hc_hash(&self) -> &[u32] {
+        &self.tables[..self.hc_split]
+    }
+
+    /// Chain / tree link table: the region from [`Self::hc_split`] on, and
+    /// empty in row mode — a zero split means the buffer holds row positions,
+    /// not a hash table of length zero (the hash is never smaller than two
+    /// slots), so the tail must not be reported as chain links.
+    #[inline(always)]
+    pub(crate) fn hc_chain(&self) -> &[u32] {
+        if self.hc_split == 0 {
+            &[]
+        } else {
+            &self.tables[self.hc_split..]
+        }
+    }
+
+    /// Both chain / tree tables at once, for the walkers that read the hash
+    /// head and write links in the same step.
+    #[inline(always)]
+    pub(crate) fn hc_tables_mut(&mut self) -> (&mut [u32], &mut [u32]) {
+        self.tables.split_at_mut(self.hc_split)
+    }
+
     pub(crate) fn ensure_tables(&mut self) {
         let row_count = 1usize << self.row_hash_log;
         let row_entries = 1usize << self.row_log;
@@ -3055,9 +3142,8 @@ impl RowMatchGenerator {
         };
         if total == 0 {
             self.row_heads = Vec::new();
-            self.row_positions = Vec::new();
             self.row_tags = Vec::new();
-        } else if self.row_positions.len() != total {
+        } else if self.tables.len() != total || self.hc_split != 0 {
             // Resize in place: `set_hash_bits` width changes `clear()` the
             // vecs but keep their capacity. The previous `vec![..]` form
             // re-allocated all three tables on every width change — three
@@ -3066,8 +3152,9 @@ impl RowMatchGenerator {
             // targets (musl) amplified into the dominant per-frame cost.
             self.row_heads.clear();
             self.row_heads.resize(row_count, 0);
-            self.row_positions.clear();
-            self.row_positions.resize(total, ROW_EMPTY_SLOT);
+            self.tables.clear();
+            self.tables.resize(total, ROW_EMPTY_SLOT);
+            self.hc_split = 0;
             self.row_tags.clear();
             self.row_tags.resize(total, 0);
         }
@@ -3081,29 +3168,30 @@ impl RowMatchGenerator {
             let chain_len = 1usize << self.hc_chain_log;
             let empty = self.hc_empty_slot();
             let relayout = self.hc_layout != self.finder;
-            if self.hc_hash.len() != hash_len || relayout {
-                self.hc_hash.clear();
-                self.hc_hash.resize(hash_len, empty);
-            }
-            if self.hc_chain.len() != chain_len || relayout {
-                self.hc_chain.clear();
-                self.hc_chain.resize(chain_len, empty);
+            // Both tables share the one buffer, so they are sized together:
+            // the hash occupies `[0, hash_len)` and the chain the rest. A
+            // width change on either therefore rewrites both, which costs the
+            // same fill the separate vectors paid and saves an allocation.
+            if self.hc_split != hash_len || self.tables.len() != hash_len + chain_len || relayout {
+                self.tables.clear();
+                self.tables.resize(hash_len + chain_len, empty);
+                self.hc_split = hash_len;
             }
             self.hc_layout = self.finder;
         } else {
             // Rows mode never reads the chain / tree tables; a reused
             // compressor coming back from a btlazy2 level (same Row storage,
             // no backend swap) must not retain them (tens of MiB) alongside
-            // the live row tables.
-            self.hc_hash = Vec::new();
-            self.hc_chain = Vec::new();
+            // the live row tables. The row branch above re-sizes the shared
+            // buffer, so nothing to release here beyond the split marker.
+            self.hc_split = 0;
         }
     }
 
     /// Combined length of the chain / tree tables. Test-only.
     #[cfg(test)]
     pub(crate) fn hc_tables_len(&self) -> usize {
-        self.hc_hash.len() + self.hc_chain.len()
+        self.hc_hash().len() + self.hc_chain().len()
     }
 
     /// The absolute coordinate floor. Test-only.
@@ -3802,7 +3890,7 @@ impl RowMatchGenerator {
         // index pairs are provably in bounds; per-byte hot path on
         // fast/dfast/row levels saves ~6 instructions and 3 branches.
         debug_assert!(row < self.row_heads.len());
-        debug_assert!(row_base + row_entries <= self.row_positions.len());
+        debug_assert!(row_base + row_entries <= self.row_positions().len());
         unsafe {
             let head = *self.row_heads.get_unchecked(row) as usize;
             // Upstream `ZSTD_row_nextIndex`: slot 0 is never written (it
@@ -3817,7 +3905,7 @@ impl RowMatchGenerator {
             // `abs_pos < u32::MAX` holds: `add_data` caps a Row frame's
             // absolute cursor below `u32::MAX`, so the cast is lossless and
             // never collides with the `ROW_EMPTY_SLOT == u32::MAX` sentinel.
-            *self.row_positions.get_unchecked_mut(row_base + next) = abs_pos as u32;
+            *self.row_positions_mut().get_unchecked_mut(row_base + next) = abs_pos as u32;
         }
     }
 
@@ -4011,9 +4099,10 @@ impl RowMatchGenerator {
         // the live tables were just sized to the logs and hold nothing of
         // this frame yet (the tree convention's 0 = none).
         unsafe {
+            let (hc_hash, hc_chain) = self.tables.split_at_mut(self.hc_split);
             Self::update_dict_tree(
-                &mut self.hc_hash,
-                &mut self.hc_chain,
+                hc_hash,
+                hc_chain,
                 base.add(history_start),
                 concat_len,
                 index_base,
@@ -4144,8 +4233,10 @@ impl RowMatchGenerator {
                     for idx in from..indexable_end {
                         let abs = hist_start + idx;
                         let h = self.hc_hash_at(scan, abs);
-                        self.hc_chain[abs & chain_mask] = self.hc_hash[h];
-                        self.hc_hash[h] = abs as u32;
+                        // One buffer: take both halves for this link write.
+                        let (hash, chain) = self.hc_tables_mut();
+                        chain[abs & chain_mask] = hash[h];
+                        hash[h] = abs as u32;
                     }
                 } else {
                     match self.row_log {


### PR DESCRIPTION
## Summary

Every matcher table was its own `Vec`, so a fresh compressor per frame issued
several independent allocations of very different sizes, and whether the
tables kept their pages between frames came down to how the allocator happened
to lay them out. The dfast backend already avoided this by holding its long
and short tables in one buffer; this extends the same shape to the other two.

- **Row** keeps its `u32` tables in one buffer. The row finder and the chain /
  tree finder are mutually exclusive, so one allocation serves both: row
  positions in row mode, hash followed by chain at `hc_split` in chain / tree
  mode.
- **HashChain** keeps hash, chain and hash3 in one buffer laid out
  `[hash | chain | hash3]`, with the two seams recorded alongside it.

A shrinking layout hands the allocation back rather than merely resizing into
it, once the existing capacity exceeds twice what is being built. `clear` +
`resize` alone keeps the capacity, so a compressor coming down from a wide
level would pin the largest buffer it ever made — the separate vectors
released it. The factor of two is hysteresis: re-using the buffer is the point
of consolidating it, so neighbouring levels trade the same allocation instead
of churning it.

Both are reached through accessors, and the walkers that read a head while
writing a link take the halves together with `split_at_mut`. The hot loops
take their slices once, above the loop, so no access re-derives a seam.

The seams travel with the buffer everywhere it is copied or moved: `clone`,
`clone_from`, and the dictionary-priming take / put. A snapshot left holding
non-zero seams over an emptied buffer would index out of bounds.

## Results

i9, `encode_loop_z000033` (1 MB corpus), fresh compressor per frame, 10
frames. All figures measured in one session against `main` and the C
reference:

| Level | faults (main -> ours, C) | cycles (main -> ours) |
|-------|--------------------------|------------------------|
| 13 | 47,366 -> 9,841 (C 8,725) | 1.754G -> 1.433G (**-18.3%**) |
| 22 | 69,073 -> 10,405 (C 9,027) | 8.841G -> 8.461G (**-4.3%**) |
| 16 | 19,213 -> 9,996 (C 8,739) | 4.046G -> 4.074G (+0.7%, noise) |
| 3  | 25,228 -> 25,230 (C 924) | 2.150G -> 2.16G (untouched) |

Levels 13, 16 and 22 now fault within the C reference's range, which was the
acceptance criterion. Level 13 was the regression this issue was opened for;
it is not just gone but 6% below where the staged path stood before #477.

## What is left, and why it is not this change

Level 3 still faults ~8x the C reference, and its tables were already in one
buffer, so nothing here moves it. Profiling the faults puts 48% in `memmove`
and 30% in `memset` — first-touch of freshly sized buffers (history, the
per-frame table fill, output), not table allocation. That is a different
mechanism: the C reference re-uses one workspace across frames without
re-clearing tables it knows are bounded, whereas we re-size and re-fill.
Worth its own issue rather than stretching this one.

## Correctness

Encoder output byte-identical across all levels 1-22 on the corpus fixture,
against the pre-change build.

## Testing

- 878 library tests, 62 FFI parity tests (including the full level ladder
  through the C codec both ways), 23 doctests
- `cargo clippy --workspace --all-targets` and the embedded
  (no-default-features) clippy job
- `cargo fmt --all --check`

Part of #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal match-finding tables into shared storage for hash-chain and row-based compression paths.
  * Updated table access, resizing, resetting, dictionary priming, and rebase handling to use the unified layout.
  * Preserved existing matching, candidate selection, chain-walk, and compression behavior.

* **Tests**
  * Updated coverage and validation to reflect the revised table storage while maintaining existing assertions and expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
