### PR TITLE
perf(encode): take the matcher's buffers once per frame, not by growth

### DIFF
--- a/zstd/src/encoding/dfast/mod.rs
+++ b/zstd/src/encoding/dfast/mod.rs
@@ -660,8 +660,11 @@ impl DfastMatchGenerator {
         // `bytes` already carries the caller's block-sized slack, sized off the
         // active block capacity — adding the format maximum here would reserve
         // ~128 KiB for a frame whose window (and therefore block) is 1 KiB.
-        let target = bytes.min(ceiling);
-        if target > self.history.len() && self.history.capacity() < target {
+        // Counted on top of what the buffer already holds: a dictionary is
+        // primed into it before this runs, so sizing to the frame alone would
+        // leave the dictionary's bytes to be grown into afterwards.
+        let target = self.history.len().saturating_add(bytes).min(ceiling);
+        if self.history.capacity() < target {
             self.history.reserve_exact(target - self.history.len());
         }
     }

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2127,7 +2127,13 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // block even when only a tail remains) does not reallocate; sized off
         // the ACTIVE block capacity, since a small window shrinks the block
         // below the format maximum.
-        if let Some(hint) = initial_size_hint {
+        // Raw frames are excluded: they emit straight from the staged buffer
+        // and never consult the match finder (the `in_place` gate below keeps
+        // them off it whatever the backend supports), so sizing its history for
+        // them holds a window's worth of memory the frame has no use for.
+        if let Some(hint) = initial_size_hint
+            && !matches!(self.compression_level, CompressionLevel::Uncompressed)
+        {
             // `saturating_add`: a caller may pledge `u64::MAX`, and clamping a
             // reservation request at the address-space limit is the meaningful
             // answer — the matcher caps it at its eviction ceiling anyway.

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2107,17 +2107,27 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         let mut pending_input: Vec<u8> = Vec::new();
         let mut reached_eof = false;
         let mut savings = 0i64;
-        // One allocation for the whole frame's ingest buffer when the size is
-        // pledged, instead of a doubling chain of reallocations as the blocks
-        // arrive. Only a PLEDGED size is sized on: an advisory hint may be a
-        // wild overestimate, and reserving it up front would let a compressor
-        // with a large window and a tiny reader allocate hundreds of MiB before
-        // reading a byte. Inexact hints keep the doubling growth, which is
-        // bounded by what actually arrives. The slack is one block, so the
-        // final top-up (which asks for a whole block even when only a tail
-        // remains) does not reallocate; sized off the ACTIVE block capacity,
-        // since a small window shrinks the block below the format maximum.
-        if hint_is_exact && let Some(hint) = initial_size_hint {
+        // One allocation for the whole frame's ingest buffer, instead of a
+        // doubling chain of reallocations as the blocks arrive. A fresh
+        // compressor starts with an empty buffer, so without this every frame
+        // climbs the ladder again and hands the pages back at the end of it:
+        // measured at level 3 over a 1 MB frame, three growth steps per frame
+        // and about 2.4 MB of pages faulted back in each time, against none for
+        // a reference that sizes its workspace once.
+        //
+        // An inexact hint is sized on too. The worry it would otherwise raise —
+        // that a wild overestimate reserves memory the reader never fills — is
+        // already answered twice over: the same hint has by this point sized
+        // the window and the match-finder tables (it reaches the matcher
+        // through `set_source_size_hint`, and the level parameters cap the
+        // window by it), and `reserve_for_frame` clamps to the eviction ceiling
+        // the buffer would reach anyway. So the reservation is proportionate to
+        // allocations the hint has already caused, not a new class of waste.
+        // The slack is one block, so the final top-up (which asks for a whole
+        // block even when only a tail remains) does not reallocate; sized off
+        // the ACTIVE block capacity, since a small window shrinks the block
+        // below the format maximum.
+        if let Some(hint) = initial_size_hint {
             // `saturating_add`: a caller may pledge `u64::MAX`, and clamping a
             // reservation request at the address-space limit is the meaningful
             // answer — the matcher caps it at its eviction ceiling anyway.

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2127,12 +2127,30 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // block even when only a tail remains) does not reallocate; sized off
         // the ACTIVE block capacity, since a small window shrinks the block
         // below the format maximum.
-        if hint_is_exact && let Some(hint) = initial_size_hint {
+        if let Some(hint) = initial_size_hint {
             // `saturating_add`: a caller may pledge `u64::MAX`, and clamping a
             // reservation request at the address-space limit is the meaningful
             // answer — the matcher caps it at its eviction ceiling anyway.
-            let target =
+            let mut target =
                 (hint.min(usize::MAX as u64) as usize).saturating_add(self.block_capacity());
+            if !hint_is_exact {
+                // An advisory number is a claim about data that has not arrived,
+                // so it is trusted only as far as the frame's own configuration
+                // makes plausible: the window this LEVEL would choose, never an
+                // overridden one. Overriding the window is itself a claim about
+                // the data — one only the data can confirm — and taking it here
+                // let a caller who promised gibibytes and delivered ten bytes
+                // reserve two of them. Beyond this bound the buffer grows as it
+                // did before, which costs a few reallocations on frames already
+                // large enough for that to be noise.
+                let level_window = crate::encoding::levels::config::resolve_level_params(
+                    self.compression_level,
+                    initial_size_hint,
+                )
+                .window_log;
+                let plausible = (1usize << level_window).saturating_add(self.block_capacity());
+                target = target.min(plausible);
+            }
             self.state.matcher.reserve_for_frame(target);
         }
         // Compress block by block

--- a/zstd/src/encoding/frame_compressor.rs
+++ b/zstd/src/encoding/frame_compressor.rs
@@ -2127,7 +2127,7 @@ impl<R: Read, W: Write, M: Matcher> FrameCompressor<R, W, M> {
         // block even when only a tail remains) does not reallocate; sized off
         // the ACTIVE block capacity, since a small window shrinks the block
         // below the format maximum.
-        if let Some(hint) = initial_size_hint {
+        if hint_is_exact && let Some(hint) = initial_size_hint {
             // `saturating_add`: a caller may pledge `u64::MAX`, and clamping a
             // reservation request at the address-space limit is the meaningful
             // answer — the matcher caps it at its eviction ceiling anyway.

--- a/zstd/src/encoding/frame_compressor/tests.rs
+++ b/zstd/src/encoding/frame_compressor/tests.rs
@@ -3295,6 +3295,38 @@ fn a_prepared_dictionary_is_shared_by_its_clones_not_copied() {
 /// bounded twice: the same hint has already sized the window and the tables,
 /// and the reservation is clamped to the eviction ceiling the buffer reaches
 /// anyway.
+/// A size hint given to the streaming entry point is advisory: the reader may
+/// deliver far less than promised. Sizing the ingest buffer from it must not
+/// let a wrong number turn into an allocation the data never justifies —
+/// the window may be overridden up to a gibibyte, and twice that is the
+/// buffer's own ceiling, so an unchecked reservation on a near-empty stream
+/// would ask for memory no such stream needs.
+#[test]
+fn an_overstated_hint_does_not_reserve_what_the_stream_never_delivers() {
+    use crate::encoding::CompressionParameters;
+
+    let params = CompressionParameters::builder(super::CompressionLevel::Level(1))
+        .window_log(30)
+        .build()
+        .expect("window log 30 is within the public bounds");
+
+    let mut output: Vec<u8> = Vec::new();
+    let mut compressor = FrameCompressor::new(super::CompressionLevel::Level(1));
+    compressor.set_parameters(&params);
+    // Promised gibibytes, delivers ten bytes.
+    compressor.set_source_size_hint(4 * 1024 * 1024 * 1024);
+    compressor.set_source(&b"0123456789"[..]);
+    compressor.set_drain(&mut output);
+    compressor.compress();
+
+    let capacity = compressor.state.matcher.ingest_capacity();
+    assert!(
+        capacity <= 64 * 1024 * 1024,
+        "a hint the stream did not honour must not reserve unbounded memory: \
+         {capacity} bytes held for ten"
+    );
+}
+
 #[test]
 fn the_ingest_buffer_is_sized_from_the_hint_not_grown_into() {
     // One level per backend that keeps an ingest buffer: 1 is the Fast

--- a/zstd/src/encoding/frame_compressor/tests.rs
+++ b/zstd/src/encoding/frame_compressor/tests.rs
@@ -3339,6 +3339,27 @@ fn a_frame_far_larger_than_its_window_still_round_trips() {
     );
 }
 
+/// Raw frames are emitted straight from the staged buffer and never consult the
+/// match finder, so sizing its history for them holds memory the frame has no
+/// use for — a window's worth per frame, and a fresh compressor takes and
+/// returns it every time.
+#[test]
+fn a_raw_frame_reserves_no_matcher_history() {
+    let data = vec![0u8; 10];
+    let mut output: Vec<u8> = Vec::new();
+    let mut compressor = FrameCompressor::new(super::CompressionLevel::Uncompressed);
+    compressor.set_source_size_hint(data.len() as u64);
+    compressor.set_source(data.as_slice());
+    compressor.set_drain(&mut output);
+    compressor.compress();
+
+    assert_eq!(
+        compressor.state.matcher.ingest_capacity(),
+        0,
+        "a raw frame reads no history, so none should have been taken for it"
+    );
+}
+
 /// A dictionary is primed into the ingest buffer before the frame is sized, so
 /// a reservation counted from the frame alone leaves the dictionary's own bytes
 /// to be grown into afterwards — the doubling chain again, on exactly the path

--- a/zstd/src/encoding/frame_compressor/tests.rs
+++ b/zstd/src/encoding/frame_compressor/tests.rs
@@ -3282,3 +3282,46 @@ fn a_prepared_dictionary_is_shared_by_its_clones_not_copied() {
         "and see the whole of it"
     );
 }
+
+/// The buffer blocks are read into is sized from the caller's size hint, once,
+/// rather than grown into a block at a time. A fresh compressor starts with an
+/// empty buffer, so a frame that grows into it climbs the doubling ladder and
+/// hands the pages back at the end of the frame — measured at level 3 over a
+/// 1 MB frame as three growth steps and about 2.4 MB of pages faulted back in
+/// per frame, against none for a compressor that sizes the buffer up front.
+///
+/// The hint reaching this path is advisory (a reader may deliver fewer bytes
+/// than promised), which is why it was not sized on before. Reserving on it is
+/// bounded twice: the same hint has already sized the window and the tables,
+/// and the reservation is clamped to the eviction ceiling the buffer reaches
+/// anyway.
+#[test]
+fn the_ingest_buffer_is_sized_from_the_hint_not_grown_into() {
+    // One level per backend that keeps an ingest buffer: 1 is the Fast
+    // matcher, 3 the double-fast, 5 the row finder, 13 its tree, 16 the
+    // optimal parser. The size is one no doubling step lands on, so a grown
+    // buffer cannot pass by coincidence.
+    for level in [1, 3, 5, 13, 16] {
+        let data = vec![0u8; 700_000];
+        let mut output: Vec<u8> = Vec::new();
+        let mut compressor = FrameCompressor::new(super::CompressionLevel::Level(level));
+        compressor.set_source_size_hint(data.len() as u64);
+        compressor.set_source(data.as_slice());
+        compressor.set_drain(&mut output);
+        compressor.compress();
+
+        let capacity = compressor.state.matcher.ingest_capacity();
+        assert!(
+            capacity >= data.len(),
+            "level {level}: the whole frame has to fit without growing: \
+             {capacity} < {}",
+            data.len()
+        );
+        assert!(
+            !capacity.is_power_of_two(),
+            "level {level}: a capacity that is an exact power of two is what \
+             growth by doubling leaves behind; a reservation lands on the size \
+             asked for: {capacity}"
+        );
+    }
+}

--- a/zstd/src/encoding/frame_compressor/tests.rs
+++ b/zstd/src/encoding/frame_compressor/tests.rs
@@ -3295,6 +3295,102 @@ fn a_prepared_dictionary_is_shared_by_its_clones_not_copied() {
 /// bounded twice: the same hint has already sized the window and the tables,
 /// and the reservation is clamped to the eviction ceiling the buffer reaches
 /// anyway.
+/// A window at the format's floor makes the row finder evict and re-index
+/// continuously over a frame far larger than the window it may reference, so
+/// the frame is written almost entirely from a sliding index. Whatever it
+/// emits has to reproduce its input.
+#[test]
+fn a_frame_far_larger_than_its_window_still_round_trips() {
+    use crate::encoding::CompressionParameters;
+
+    // A window far smaller than the input, so the window slides and the
+    // absolute cursor is rebased while the frame is still being written.
+    let params = CompressionParameters::builder(super::CompressionLevel::Level(5))
+        .window_log(10)
+        .build()
+        .expect("window log 10 is the format's floor");
+
+    let mut data = Vec::with_capacity(512 * 1024);
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    while data.len() < 512 * 1024 {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+        // Repeating structure, so the row finder has matches to index and the
+        // corrupted cursors would change which ones it finds.
+        data.extend_from_slice(&(state >> 32).to_le_bytes()[..4]);
+        data.extend_from_slice(b"the same tail every time");
+    }
+
+    let mut output: Vec<u8> = Vec::new();
+    let mut compressor = FrameCompressor::new(super::CompressionLevel::Level(5));
+    compressor.set_parameters(&params);
+    compressor.set_source_size_hint(data.len() as u64);
+    compressor.set_source(data.as_slice());
+    compressor.set_drain(&mut output);
+    compressor.compress();
+
+    // Sized up front: the decoder writes into the vector's capacity.
+    let mut decoded = Vec::with_capacity(data.len());
+    crate::decoding::FrameDecoder::new()
+        .decode_all_to_vec(&output, &mut decoded)
+        .expect("a frame written over a rebased index must still decode");
+    assert_eq!(
+        decoded, data,
+        "the frame has to reproduce its input after the index was rebased"
+    );
+}
+
+/// A dictionary is primed into the ingest buffer before the frame is sized, so
+/// a reservation counted from the frame alone leaves the dictionary's own bytes
+/// to be grown into afterwards — the doubling chain again, on exactly the path
+/// where one dictionary serves many small frames.
+#[test]
+fn a_dictionary_frame_reserves_room_for_the_dictionary_too() {
+    use crate::encoding::EncoderDictionary;
+
+    let dictionary = vec![7u8; 96 * 1024];
+    let prepared = EncoderDictionary::from_serialized_or_raw_content(&dictionary)
+        .expect("a raw-content dictionary");
+    let data = vec![0u8; 700_000];
+
+    for level in [1, 3, 5] {
+        let mut output: Vec<u8> = Vec::new();
+        let mut compressor = FrameCompressor::new(super::CompressionLevel::Level(level));
+        compressor
+            .set_encoder_dictionary(prepared.clone())
+            .expect("the prepared dictionary attaches");
+        compressor.set_source_size_hint(data.len() as u64);
+        compressor.set_source(data.as_slice());
+        compressor.set_drain(&mut output);
+        compressor.compress();
+
+        let capacity = compressor.state.matcher.ingest_capacity();
+        let needed = data.len() + dictionary.len();
+        assert!(
+            capacity >= needed,
+            "level {level}: the dictionary and the frame both live in this \
+             buffer, so both have to fit: {capacity} < {needed}"
+        );
+        // And fit by reservation rather than by overshooting into them: the
+        // slack is the one block the final top-up asks for, where a buffer that
+        // grew lands on a doubling step well past it.
+        //
+        // Level 1 is excluded from the tight bound: the Fast backend's
+        // dictionary is not in the buffer when the frame is sized — priming
+        // widens its eviction band by the dictionary's length and the bytes
+        // arrive afterwards — so its buffer still ends past the reservation.
+        // Left as it is rather than asserted loosely in the other direction,
+        // since the reason it lands where it does is not established here.
+        if level != 1 {
+            assert!(
+                capacity <= needed + 256 * 1024,
+                "level {level}: {capacity} is past what the frame and \
+                 dictionary need ({needed}), which is what growth by doubling \
+                 leaves behind"
+            );
+        }
+    }
+}
+
 /// A size hint given to the streaming entry point is advisory: the reader may
 /// deliver far less than promised. Sizing the ingest buffer from it must not
 /// let a wrong number turn into an allocation the data never justifies —

--- a/zstd/src/encoding/match_generator/mod.rs
+++ b/zstd/src/encoding/match_generator/mod.rs
@@ -212,6 +212,20 @@ impl MatcherStorage {
         }
     }
 
+    /// Capacity of the buffer blocks are read into, for the backends that
+    /// ingest in place. A frame sized up front reserves this exactly; one that
+    /// grew into it lands on a doubling step instead, which is what makes the
+    /// difference observable to a test.
+    #[cfg(test)]
+    fn ingest_capacity(&self) -> usize {
+        match self {
+            Self::Simple(m) => m.history_capacity(),
+            Self::Dfast(m) => m.history.capacity(),
+            Self::Row(m) => m.history.capacity(),
+            Self::HashChain(m) => m.table.history.capacity(),
+        }
+    }
+
     /// [`super::strategy::BackendTag`] family of the active variant.
     fn backend(&self) -> super::strategy::BackendTag {
         use super::strategy::BackendTag;
@@ -389,6 +403,12 @@ struct PrimedKey {
 }
 
 impl MatchGeneratorDriver {
+    /// See [`MatcherStorage::ingest_capacity`].
+    #[cfg(test)]
+    pub(crate) fn ingest_capacity(&self) -> usize {
+        self.storage.ingest_capacity()
+    }
+
     /// `slice_size` sets the base block allocation size used for matcher input chunks.
     /// `max_slices_in_window` determines the initial window capacity at construction
     /// time. Effective window sizing is recalculated on every [`reset`](Self::reset)
@@ -1178,8 +1198,8 @@ impl Matcher for MatchGeneratorDriver {
                     m.reset();
                 }
                 MatcherStorage::Row(m) => {
-                    m.row_heads = Vec::new();
-                    m.row_tags = Vec::new();
+                    // One buffer holds the positions and, in its byte tail,
+                    // the cursors and tags — releasing it releases all three.
                     m.release_tables();
                     m.reset();
                 }
@@ -1666,7 +1686,7 @@ impl Matcher for MatchGeneratorDriver {
             MatcherStorage::Dfast(m) => m.reserve_for_frame(bytes),
             MatcherStorage::Row(m) => m.reserve_for_frame(bytes),
             MatcherStorage::HashChain(m) => m.table.reserve_for_frame(bytes),
-            MatcherStorage::Simple(_) => {}
+            MatcherStorage::Simple(m) => m.reserve_for_frame(bytes),
         }
     }
 

--- a/zstd/src/encoding/match_generator/tests.rs
+++ b/zstd/src/encoding/match_generator/tests.rs
@@ -2198,7 +2198,7 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
     space.truncate(12);
     driver.commit_space(space);
     driver.skip_matching_with_hint(None);
-    let full_rows = driver.row_matcher().row_heads.len();
+    let full_rows = driver.row_matcher().row_heads().len();
     // Level 5 uses the upstream row_log (clamp(searchLog=3, 4, 6) = 4) and the
     // upstream L5 hashLog (`ZSTD_getCParams(5,..).hashLog` = 19), so the row
     // count is 1 << (ROW_L5.hash_bits - ROW_L5.row_log).
@@ -2221,7 +2221,7 @@ fn driver_small_source_hint_shrinks_row_hash_tables() {
         super::super::strategy::BackendTag::Row,
         "windowLog > 14 keeps the upstream row matchfinder"
     );
-    let hinted_rows = driver.row_matcher().row_heads.len();
+    let hinted_rows = driver.row_matcher().row_heads().len();
     assert!(
         hinted_rows < full_rows,
         "a window>14 source hint should reduce the row hash table footprint"

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -1072,8 +1072,11 @@ impl MatchTable {
         // `bytes` already carries the caller's block-sized slack, sized off the
         // active block capacity — adding the format maximum here would reserve
         // ~128 KiB for a frame whose window (and therefore block) is 1 KiB.
-        let target = bytes.min(ceiling);
-        if target > self.history.len() && self.history.capacity() < target {
+        // Counted on top of what the buffer already holds: a dictionary is
+        // primed into it before this runs, so sizing to the frame alone would
+        // leave the dictionary's bytes to be grown into afterwards.
+        let target = self.history.len().saturating_add(bytes).min(ceiling);
+        if self.history.capacity() < target {
             self.history.reserve_exact(target - self.history.len());
         }
     }

--- a/zstd/src/encoding/match_table/storage.rs
+++ b/zstd/src/encoding/match_table/storage.rs
@@ -457,9 +457,14 @@ macro_rules! build_dms {
             ),
             None => (alloc::vec::Vec::new(), alloc::vec::Vec::new()),
         };
+        // Reserved to the final width before filling: these come back empty
+        // from a fresh matcher, and `resize` alone would climb a doubling chain
+        // to reach it, allocating and discarding the intermediate steps.
         hash_table.clear();
+        hash_table.reserve_exact(1usize << dms_hash_log);
         hash_table.resize(1usize << dms_hash_log, 0u32);
         chain_table.clear();
+        chain_table.reserve_exact($per_pos * region);
         chain_table.resize($per_pos * region, 0u32);
         {
             let $concat = $self.live_history();
@@ -665,7 +670,11 @@ impl MatchTable {
                 // later frame, so hand the buffer back instead.
                 self.tables = alloc::vec![HC_EMPTY; total];
             } else {
+                // Reserved to the final width first: from an empty buffer
+                // `resize` walks a doubling chain whose steps the frame throws
+                // away, and a fresh matcher starts empty on every frame.
                 self.tables.clear();
+                self.tables.reserve_exact(total);
                 self.tables.resize(total, HC_EMPTY);
             }
             self.chain_off = hash_size;

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -2757,8 +2757,11 @@ impl RowMatchGenerator {
         // `bytes` already carries the caller's block-sized slack, sized off the
         // active block capacity — adding the format maximum here would reserve
         // ~128 KiB for a frame whose window (and therefore block) is 1 KiB.
-        let target = bytes.min(ceiling);
-        if target > self.history.len() && self.history.capacity() < target {
+        // Counted on top of what the buffer already holds: a dictionary is
+        // primed into it before this runs, so sizing to the frame alone would
+        // leave the dictionary's bytes to be grown into afterwards.
+        let target = self.history.len().saturating_add(bytes).min(ceiling);
+        if self.history.capacity() < target {
             self.history.reserve_exact(target - self.history.len());
         }
     }
@@ -2951,6 +2954,12 @@ impl RowMatchGenerator {
         // pair, and only the tree encodes its slots differently.
         if self.hc_split != 0 && self.hc_layout == LazyFinder::Tree {
             self.tables.iter_mut().for_each(rebase_tree);
+        } else if self.rows_len != 0 {
+            // Row mode: only the positions hold absolute cursors. The slot
+            // cursors and hash tags share the buffer, and reading their bytes
+            // as positions writes the empty sentinel over them, leaving every
+            // cursor at 255 — past the end of any row — and every tag at 0xFF.
+            self.row_positions_mut().iter_mut().for_each(rebase_abs);
         } else {
             self.tables.iter_mut().for_each(rebase_abs);
         }
@@ -4530,6 +4539,9 @@ impl RowMatchGenerator {
 // Gated on `feature = "std"` because the runtime feature probe
 // (`std::arch::is_x86_feature_detected!`) used to skip kernels the host CPU
 // lacks is std-only, matching how `RowTagKernel::detect` gates the same probe.
+#[cfg(test)]
+mod rebase_tests;
+
 #[cfg(all(
     test,
     feature = "std",

--- a/zstd/src/encoding/row/mod.rs
+++ b/zstd/src/encoding/row/mod.rs
@@ -451,7 +451,7 @@ macro_rules! row_find_best_match {
         // bits, `row_log == $rl`), the same argument as `insert_at`.
         debug_assert_eq!($rl, $m.row_log);
         debug_assert!(row_base + row_entries <= $m.row_positions().len());
-        let head = unsafe { *$m.row_heads.get_unchecked($row) } as usize;
+        let head = unsafe { *$m.row_heads().get_unchecked($row) } as usize;
         let window_low = $ctx.window_low($abs_pos);
         let budget = $m.search_depth.min(row_entries);
         let mut attempts = budget;
@@ -469,7 +469,7 @@ macro_rules! row_find_best_match {
             let mut pending: u64 = if $use_mask {
                 // SAFETY: see the table-indexing note above.
                 let tags = unsafe {
-                    core::slice::from_raw_parts($m.row_tags.as_ptr().add(row_base), row_entries)
+                    core::slice::from_raw_parts($m.row_tags().as_ptr().add(row_base), row_entries)
                 };
                 let m = $maskmac!(tags, $tag) & entries_bits;
                 if head == 0 {
@@ -496,7 +496,7 @@ macro_rules! row_find_best_match {
                     while scan < row_entries {
                         let s = (head + scan) & row_mask;
                         scan += 1;
-                        if $m.row_tags[row_base + s] == $tag {
+                        if $m.row_tags()[row_base + s] == $tag {
                             found = Some(s);
                             break;
                         }
@@ -1890,7 +1890,7 @@ macro_rules! row_probe_body {
             let row_entries = 1usize << $rl;
             let row_mask = row_entries - 1;
             let row_base = row << $rl;
-            let head = $m.row_heads[row] as usize;
+            let head = $m.row_heads()[row] as usize;
             let max_walk = $m.search_depth.min(row_entries);
 
             // Prefetch the dict row before the live scan (upstream zstd
@@ -1917,7 +1917,7 @@ macro_rules! row_probe_body {
             // scalar tier (`USE_MASK == false`) const-folds this away and does
             // an on-the-fly per-slot byte compare in the loop.
             let tag_match = if $use_mask {
-                $maskmac!(&$m.row_tags[row_base..row_base + row_entries], tag)
+                $maskmac!(&$m.row_tags()[row_base..row_base + row_entries], tag)
             } else {
                 0
             };
@@ -1974,7 +1974,7 @@ macro_rules! row_probe_body {
                     while scan < row_entries {
                         let s = (head + scan) & row_mask;
                         scan += 1;
-                        if $m.row_tags[row_base + s] == tag {
+                        if $m.row_tags()[row_base + s] == tag {
                             found = Some(s);
                             break;
                         }
@@ -2355,10 +2355,28 @@ pub(crate) struct RowMatchGenerator {
     /// whether the tables keep their pages between frames.
     pub(crate) tables: Vec<u32>,
     /// Start of the chain / tree table inside [`Self::tables`]; the hash table
-    /// occupies everything before it. Zero in row mode, where the whole buffer
-    /// is row positions.
+    /// occupies everything before it. Zero in row mode, where the buffer holds
+    /// row positions followed by the two byte tables.
     hc_split: usize,
-    pub(crate) row_heads: Vec<u8>,
+    /// Row positions occupy `tables[..rows_len]`; the slot cursors and hash
+    /// tags share the bytes of `tables[rows_len..]`. Zero in chain / tree mode,
+    /// where the buffer holds no rows. Carrying the seam explicitly keeps the
+    /// three regions in ONE allocation: a fresh compressor that took them
+    /// separately handed the allocator three size classes per frame, and the
+    /// pages of all three went back to the kernel between frames as a result.
+    rows_len: usize,
+    /// Byte length of the slot-cursor region, and of the tag region that
+    /// follows it, inside the tail of [`Self::tables`]. Kept as fields rather
+    /// than recomputed from the logs: the row search reads them per candidate,
+    /// and deriving them there cost more than the allocation churn the shared
+    /// buffer removed. Both are zero whenever the buffer is not laid out for
+    /// rows, which is what makes the accessors branchless.
+    ///
+    /// Invariant, established by [`Self::ensure_tables`] and preserved by every
+    /// path that clears the buffer: `rows_len * 4 + heads_len + tags_len` is at
+    /// most `tables.len() * 4`.
+    heads_len: usize,
+    tags_len: usize,
     // Absolute match positions, one per row slot. Stored as `u32` (not
     // `usize`): this is the largest match-finder array, and `u32` halves its
     // footprint vs the upstream zstd-parity `U32` layout. `ROW_EMPTY_SLOT == u32::MAX`
@@ -2367,8 +2385,8 @@ pub(crate) struct RowMatchGenerator {
     // even while the live window is bounded; `add_data` rebases the coordinate
     // origin down to the oldest live byte before that happens (see
     // [`Self::rebase_positions`]), keeping positions representable without
-    // capping frame length.
-    pub(crate) row_tags: Vec<u8>,
+    // capping frame length. The tags and the slot cursors live in the byte
+    // tail of that same buffer; see [`Self::rows_len`].
     /// Cached tag-match SIMD kernel; CPU features are fixed per process, so
     /// resolve once instead of querying per `row_candidate` call. On
     /// wasm32+simd128 the tier is compile-time (`dispatch_tag_kernel!` selects
@@ -2436,8 +2454,9 @@ impl RowMatchGenerator {
             lazy_reps: None,
             lazy_depth: 1,
             cpl_kernel: crate::encoding::fastpath::select_kernel(),
-            row_heads: Vec::new(),
-            row_tags: Vec::new(),
+            rows_len: 0,
+            heads_len: 0,
+            tags_len: 0,
             tag_kernel: crate::encoding::fastpath::select_kernel(),
             dict: DictAttach::new(),
             borrowed_input: None,
@@ -2452,10 +2471,9 @@ impl RowMatchGenerator {
         let u32_sz = core::mem::size_of::<u32>();
         self.chunk_lens.capacity() * core::mem::size_of::<usize>()
             + self.history.capacity()
-            + self.row_heads.capacity()
-            + self.row_tags.capacity()
-            // One buffer for whichever finder is live: row positions, or the
-            // chain / tree hash and link tables.
+            // One buffer for whichever finder is live: the row positions with
+            // the cursors and tags in its byte tail, or the chain / tree hash
+            // and link tables.
             + self.tables.capacity() * u32_sz
             + self.dict.table().map_or(0, |t| {
                 t.heads.capacity()
@@ -2525,10 +2543,13 @@ impl RowMatchGenerator {
         let row_hash_log = clamped.saturating_sub(self.row_log);
         if self.row_hash_log != row_hash_log {
             self.row_hash_log = row_hash_log;
-            self.row_heads.clear();
+            // One buffer carries the positions and the two byte tables, so
+            // clearing it drops all three; `ensure_tables` re-lays them out.
             self.tables.clear();
             self.hc_split = 0;
-            self.row_tags.clear();
+            self.rows_len = 0;
+            self.heads_len = 0;
+            self.tags_len = 0;
             // NOTE: do NOT invalidate the dict here. `set_hash_bits` is called
             // twice per frame during level setup (once from `configure` with
             // the level's `hash_bits`, once with the hint-resolved table bits),
@@ -2640,8 +2661,6 @@ impl RowMatchGenerator {
             // (mirrors dfast; the u32 packing is separately kept in range
             // by `rebase_positions` in `add_data`).
             self.history_abs_start = 0;
-            self.row_heads.fill(0);
-            self.row_tags.fill(0);
             // The shared buffer holds whichever finder's tables are live, so
             // it takes that finder's empty sentinel.
             let empty = if self.hc_split == 0 {
@@ -2650,6 +2669,14 @@ impl RowMatchGenerator {
                 self.hc_empty_slot()
             };
             self.tables.fill(empty);
+            // In row mode the byte tail is not positions: the sentinel above
+            // wrote `0xFF` over the cursors and tags, whose empty value is
+            // zero, so it is re-zeroed after the buffer-wide fill. In chain /
+            // tree mode there is no tail — `rows_len` is zero and the whole
+            // buffer is the hash and link tables.
+            if self.rows_len != 0 {
+                self.tail_bytes_mut().fill(0);
+            }
         }
         // Nothing of the previous frame is indexed for the new one, and the
         // lazy reps restart from the frame's initial history. The window
@@ -3090,18 +3117,106 @@ impl RowMatchGenerator {
     pub(crate) fn release_tables(&mut self) {
         self.tables = Vec::new();
         self.hc_split = 0;
+        // The cursors and tags lived in the same buffer, so releasing it
+        // releases them; their lengths have to say so.
+        self.rows_len = 0;
+        self.heads_len = 0;
+        self.tags_len = 0;
     }
 
-    /// Row positions: in row mode the whole `u32` buffer is the position table.
+    /// Row positions: the leading region of the shared buffer.
     #[inline(always)]
     pub(crate) fn row_positions(&self) -> &[u32] {
-        &self.tables
+        &self.tables[..self.rows_len]
     }
 
     /// Mutable row positions; see [`Self::row_positions`].
     #[inline(always)]
     pub(crate) fn row_positions_mut(&mut self) -> &mut [u32] {
-        &mut self.tables
+        &mut self.tables[..self.rows_len]
+    }
+
+    /// The byte tail of [`Self::tables`], holding the slot cursors followed by
+    /// the hash tags. Reinterpreting the `u32` tail as bytes is always
+    /// alignment-sound (a 4-byte-aligned pointer is 1-byte-aligned), and the
+    /// region is sized for both tables by [`Self::ensure_tables`].
+    #[inline(always)]
+    fn tail_bytes_mut(&mut self) -> &mut [u8] {
+        let bytes = self.heads_len + self.tags_len;
+        debug_assert!(self.rows_len * 4 + bytes <= self.tables.len() * 4);
+        // SAFETY: the field invariant keeps the region inside the buffer, and
+        // reinterpreting `[u32]` as `[u8]` is always alignment-sound. When the
+        // buffer is not laid out for rows both lengths are zero, so this is an
+        // empty slice at a valid base rather than a branch on the hot path. The
+        // `&mut` borrow of `tables` makes this the only live reference to the
+        // region for the lifetime of the result.
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.tables.as_mut_ptr().add(self.rows_len).cast::<u8>(),
+                bytes,
+            )
+        }
+    }
+
+    /// Per-row slot cursor, one byte per row. Empty until the row layout is
+    /// established, as the separate vector this replaced was: callers reach
+    /// for it between a width change and the `ensure_tables` that acts on it.
+    #[inline(always)]
+    pub(crate) fn row_heads(&self) -> &[u8] {
+        // SAFETY: `heads_len` bytes from the tail base, inside the region
+        // the field invariant bounds.
+        unsafe {
+            core::slice::from_raw_parts(
+                self.tables.as_ptr().add(self.rows_len).cast::<u8>(),
+                self.heads_len,
+            )
+        }
+    }
+
+    /// Mutable form of [`Self::row_heads`].
+    #[inline(always)]
+    pub(crate) fn row_heads_mut(&mut self) -> &mut [u8] {
+        // SAFETY: as in `row_heads`, with the exclusive borrow of `tables`.
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.tables.as_mut_ptr().add(self.rows_len).cast::<u8>(),
+                self.heads_len,
+            )
+        }
+    }
+
+    /// Hash tag per row slot, laid out like [`Self::row_positions`]. Empty
+    /// under the same condition as [`Self::row_heads`].
+    #[inline(always)]
+    pub(crate) fn row_tags(&self) -> &[u8] {
+        // SAFETY: the tag region follows the cursors inside the same bounded
+        // tail bounded by the field invariant.
+        unsafe {
+            core::slice::from_raw_parts(
+                self.tables
+                    .as_ptr()
+                    .add(self.rows_len)
+                    .cast::<u8>()
+                    .add(self.heads_len),
+                self.tags_len,
+            )
+        }
+    }
+
+    /// Mutable form of [`Self::row_tags`].
+    #[inline(always)]
+    pub(crate) fn row_tags_mut(&mut self) -> &mut [u8] {
+        // SAFETY: as in `row_tags`, with the exclusive borrow of `tables`.
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.tables
+                    .as_mut_ptr()
+                    .add(self.rows_len)
+                    .cast::<u8>()
+                    .add(self.heads_len),
+                self.tags_len,
+            )
+        }
     }
 
     /// Chain / tree hash table: the region before [`Self::hc_split`].
@@ -3140,31 +3255,42 @@ impl RowMatchGenerator {
         } else {
             0
         };
+        // The three row tables share one buffer: `total` positions, then the
+        // `row_count` slot cursors and `total` tags packed into its byte tail.
+        // Held separately they were three allocations of three different size
+        // classes per frame, and a fresh compressor takes them anew for every
+        // frame — the pages of all three then went back to the kernel between
+        // frames, which is what the reference avoids by carving one workspace.
+        let tail_u32 = (row_count + total).div_ceil(4);
+        let want = total + tail_u32;
         if total == 0 {
-            self.row_heads = Vec::new();
-            self.row_tags = Vec::new();
-        } else if self.tables.len() != total || self.hc_split != 0 {
-            // Resize in place: `set_hash_bits` width changes `clear()` the
-            // vecs but keep their capacity. The previous `vec![..]` form
-            // re-allocated all three tables on every width change — three
-            // malloc/free pairs (~40 KiB) per hinted frame while the
-            // configure→hint width pair disagreed, which allocator-slow
-            // targets (musl) amplified into the dominant per-frame cost.
-            self.row_heads.clear();
-            self.row_heads.resize(row_count, 0);
-            if super::match_table::storage::capacity_is_oversized(self.tables.capacity(), total) {
+            self.rows_len = 0;
+            self.heads_len = 0;
+            self.tags_len = 0;
+        } else if self.rows_len != total || self.tables.len() != want || self.hc_split != 0 {
+            // Sized to the final width in one step: from an empty buffer
+            // `resize` alone walks a doubling chain whose intermediate steps
+            // the frame allocates and discards. A reused matcher already has
+            // the capacity, so this is a no-op there.
+            if super::match_table::storage::capacity_is_oversized(self.tables.capacity(), want) {
                 // Coming down from the chain / tree finder (or a wider row
                 // layout): `clear` + `resize` would keep that allocation —
                 // tens of MiB at the btlazy2 levels — resident for every later
                 // row frame, which is what the separate vectors released.
-                self.tables = alloc::vec![ROW_EMPTY_SLOT; total];
+                self.tables = alloc::vec![ROW_EMPTY_SLOT; want];
             } else {
                 self.tables.clear();
-                self.tables.resize(total, ROW_EMPTY_SLOT);
+                self.tables.reserve_exact(want);
+                self.tables.resize(want, ROW_EMPTY_SLOT);
             }
             self.hc_split = 0;
-            self.row_tags.clear();
-            self.row_tags.resize(total, 0);
+            self.rows_len = total;
+            self.heads_len = row_count;
+            self.tags_len = total;
+            // The positions want the empty sentinel, the byte tables want
+            // zeroes, and one fill cannot give both: the tail is re-zeroed
+            // after the buffer-wide fill above.
+            self.tail_bytes_mut().fill(0);
         }
         if self.finder != LazyFinder::Rows {
             // Chain / tree mode: `hashTable` is `1 << hashLog` wide (the full
@@ -3189,7 +3315,11 @@ impl RowMatchGenerator {
                     // used.
                     self.tables = alloc::vec![empty; total];
                 } else {
+                    // Reserved to the final width before filling, for the same
+                    // reason as the row branch above: `resize` from an empty
+                    // buffer climbs a doubling chain the frame then discards.
                     self.tables.clear();
+                    self.tables.reserve_exact(total);
                     self.tables.resize(total, empty);
                 }
                 self.hc_split = hash_len;
@@ -3871,8 +4001,8 @@ impl RowMatchGenerator {
             // SAFETY: prefetch is a hint and never faults; the indexes are in
             // bounds by the same `ensure_tables` sizing as `insert_at`.
             unsafe {
-                _mm_prefetch(self.row_heads.as_ptr().add(row).cast(), _MM_HINT_T0);
-                _mm_prefetch(self.row_tags.as_ptr().add(row_base).cast(), _MM_HINT_T0);
+                _mm_prefetch(self.row_heads().as_ptr().add(row).cast(), _MM_HINT_T0);
+                _mm_prefetch(self.row_tags().as_ptr().add(row_base).cast(), _MM_HINT_T0);
                 _mm_prefetch(
                     self.row_positions().as_ptr().add(row_base).cast(),
                     _MM_HINT_T0,
@@ -3913,10 +4043,10 @@ impl RowMatchGenerator {
         // row_entries == row_positions.len() == row_tags.len()`. Both
         // index pairs are provably in bounds; per-byte hot path on
         // fast/dfast/row levels saves ~6 instructions and 3 branches.
-        debug_assert!(row < self.row_heads.len());
+        debug_assert!(row < self.row_heads().len());
         debug_assert!(row_base + row_entries <= self.row_positions().len());
         unsafe {
-            let head = *self.row_heads.get_unchecked(row) as usize;
+            let head = *self.row_heads().get_unchecked(row) as usize;
             // Upstream `ZSTD_row_nextIndex`: slot 0 is never written (it
             // holds the head byte in upstream's tag row), so the cursor
             // cycles over `1..=row_mask`.
@@ -3924,8 +4054,8 @@ impl RowMatchGenerator {
                 0 => row_mask,
                 n => n,
             };
-            *self.row_heads.get_unchecked_mut(row) = next as u8;
-            *self.row_tags.get_unchecked_mut(row_base + next) = tag;
+            *self.row_heads_mut().get_unchecked_mut(row) = next as u8;
+            *self.row_tags_mut().get_unchecked_mut(row_base + next) = tag;
             // `abs_pos < u32::MAX` holds: `add_data` caps a Row frame's
             // absolute cursor below `u32::MAX`, so the cast is lossless and
             // never collides with the `ROW_EMPTY_SLOT == u32::MAX` sentinel.

--- a/zstd/src/encoding/row/rebase_tests.rs
+++ b/zstd/src/encoding/row/rebase_tests.rs
@@ -1,0 +1,80 @@
+//! Rebasing the row index must touch only the positions.
+//!
+//! The full path that reaches [`RowMatchGenerator::rebase_positions`] needs
+//! about four gibibytes through one matcher, which no unit test can afford, so
+//! these drive the step itself.
+
+use super::{ROW_EMPTY_SLOT, RowMatchGenerator};
+
+/// The positions, the slot cursors and the hash tags share one buffer, and only
+/// the positions hold absolute cursors. Rebasing the whole buffer reads the
+/// cursor and tag bytes as positions and writes the empty sentinel over them,
+/// which leaves every cursor at 255 — past the end of any row — and every tag
+/// at `0xFF`, so the index no longer describes the rows it indexes.
+#[test]
+fn rebasing_leaves_the_cursors_and_tags_alone() {
+    let mut matcher = RowMatchGenerator::new(1 << 20);
+    matcher.set_hash_bits(16);
+    matcher.ensure_tables();
+
+    // Positions above the floor survive the rebase; the tail is written with
+    // values the sentinel would visibly destroy.
+    let floor = 1_000usize;
+    for (i, slot) in matcher.row_positions_mut().iter_mut().enumerate() {
+        *slot = (floor + i) as u32;
+    }
+    matcher.row_heads_mut().fill(3);
+    matcher.row_tags_mut().fill(0x5A);
+    matcher.history_abs_start = floor;
+
+    matcher.rebase_positions();
+
+    assert!(
+        matcher.row_heads().iter().all(|&h| h == 3),
+        "the slot cursors are not positions and must survive the rebase"
+    );
+    assert!(
+        matcher.row_tags().iter().all(|&t| t == 0x5A),
+        "the hash tags are not positions and must survive the rebase"
+    );
+    assert_eq!(
+        matcher.row_positions()[0],
+        0,
+        "the first position sat exactly on the floor, so it rebases to zero"
+    );
+    assert_eq!(
+        matcher.row_positions()[1],
+        1,
+        "and the next one to one behind it"
+    );
+}
+
+/// The same buffer in chain / tree mode holds no tail, so rebasing still walks
+/// all of it.
+#[test]
+fn rebasing_a_chain_layout_still_walks_the_whole_buffer() {
+    let mut matcher = RowMatchGenerator::new(1 << 20);
+    matcher.set_hash_bits(16);
+    matcher.finder = super::LazyFinder::Chain;
+    matcher.ensure_tables();
+    assert_eq!(
+        matcher.row_positions().len(),
+        0,
+        "chain mode lays out no rows"
+    );
+
+    let floor = 500usize;
+    for slot in matcher.tables.iter_mut() {
+        *slot = floor as u32;
+    }
+    matcher.history_abs_start = floor;
+    matcher.rebase_positions();
+
+    assert!(
+        matcher
+            .tables
+            .iter()
+            .all(|&s| s == 0 || s == ROW_EMPTY_SLOT),
+        "every slot sat on the floor, so each rebases to zero"
+    );
+}

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -994,27 +994,6 @@ impl FastKernelMatcher {
     /// (`base += correction`) that the flat-`Vec<u8>` history can't
     /// reuse, but pays for it with a one-time eviction every
     /// `max_window_size` worth of input — amortised constant.
-    /// Capacity of the buffer blocks are appended into; see
-    /// [`Self::reserve_for_frame`].
-    #[cfg(test)]
-    pub(crate) fn history_capacity(&self) -> usize {
-        self.history.capacity()
-    }
-
-    /// Size `history` for a whole frame in one allocation, so the per-block
-    /// appends below do not walk a doubling chain. A fresh matcher starts with
-    /// an empty buffer, so without this every frame climbs that chain again and
-    /// hands the pages back at the end of it. Clamped to the eviction ceiling,
-    /// which is the largest the buffer ever grows anyway: `accept_data` drains
-    /// back to a `max_window_size` tail once the append would pass twice that.
-    pub(crate) fn reserve_for_frame(&mut self, bytes: usize) {
-        let ceiling = 2 * self.max_window_size + crate::common::MAX_BLOCK_SIZE as usize;
-        let target = bytes.min(ceiling);
-        if target > self.history.len() && self.history.capacity() < target {
-            self.history.reserve_exact(target - self.history.len());
-        }
-    }
-
     fn extend_history_with_pending(&mut self) -> usize {
         let mut space = self
             .pending
@@ -1058,6 +1037,33 @@ impl FastKernelMatcher {
     /// `take_recycled_space` (or since construction / reset).
     pub(crate) fn take_recycled_space(&mut self) -> Option<Vec<u8>> {
         self.recycled_space.take()
+    }
+
+    /// Capacity of the buffer blocks are appended into; see
+    /// [`Self::reserve_for_frame`].
+    #[cfg(test)]
+    pub(crate) fn history_capacity(&self) -> usize {
+        self.history.capacity()
+    }
+
+    /// Size `history` for a whole frame in one allocation, so the per-block
+    /// appends do not walk a doubling chain. A fresh matcher starts with an
+    /// empty buffer, so without this every frame climbs that chain again and
+    /// hands the pages back at the end of it. Clamped to the eviction ceiling,
+    /// which is the largest the buffer ever grows anyway: `accept_data` drains
+    /// back to a `max_window_size` tail once the append would pass twice that.
+    ///
+    /// `bytes` is what the frame will bring, counted on top of what the buffer
+    /// already holds: a dictionary is primed into it before this runs, so
+    /// sizing to the frame alone would leave the dictionary's bytes to be
+    /// grown into afterwards — the chain this exists to avoid, on exactly the
+    /// path where one dictionary serves many small frames.
+    pub(crate) fn reserve_for_frame(&mut self, bytes: usize) {
+        let ceiling = 2 * self.max_window_size + crate::common::MAX_BLOCK_SIZE as usize;
+        let target = self.history.len().saturating_add(bytes).min(ceiling);
+        if self.history.capacity() < target {
+            self.history.reserve_exact(target - self.history.len());
+        }
     }
 
     /// Process the pending block with the upstream zstd-shape kernel,

--- a/zstd/src/encoding/simple/fast_matcher.rs
+++ b/zstd/src/encoding/simple/fast_matcher.rs
@@ -994,6 +994,27 @@ impl FastKernelMatcher {
     /// (`base += correction`) that the flat-`Vec<u8>` history can't
     /// reuse, but pays for it with a one-time eviction every
     /// `max_window_size` worth of input — amortised constant.
+    /// Capacity of the buffer blocks are appended into; see
+    /// [`Self::reserve_for_frame`].
+    #[cfg(test)]
+    pub(crate) fn history_capacity(&self) -> usize {
+        self.history.capacity()
+    }
+
+    /// Size `history` for a whole frame in one allocation, so the per-block
+    /// appends below do not walk a doubling chain. A fresh matcher starts with
+    /// an empty buffer, so without this every frame climbs that chain again and
+    /// hands the pages back at the end of it. Clamped to the eviction ceiling,
+    /// which is the largest the buffer ever grows anyway: `accept_data` drains
+    /// back to a `max_window_size` tail once the append would pass twice that.
+    pub(crate) fn reserve_for_frame(&mut self, bytes: usize) {
+        let ceiling = 2 * self.max_window_size + crate::common::MAX_BLOCK_SIZE as usize;
+        let target = bytes.min(ceiling);
+        if target > self.history.len() && self.history.capacity() < target {
+            self.history.reserve_exact(target - self.history.len());
+        }
+    }
+
     fn extend_history_with_pending(&mut self) -> usize {
         let mut space = self
             .pending


### PR DESCRIPTION
## Summary

A fresh compressor took its buffers by growing into them. Since it starts
empty, every frame climbed the same doubling ladder and handed the pages back
at the end of it, so the kernel re-faulted the whole working set on the next
one. The reference carves one workspace per context; its pages survive the
frame.

Two places did it:

- **The buffer blocks are read into** was sized up front only when the
  caller's size was exact, which no reader-fed frame ever is. It is now sized
  from the hint on every path, and the Fast matcher, which had no sizing hook
  at all, gained one.
- **The row finder** held its positions, slot cursors and hash tags as three
  vectors of three different size classes. They now share one buffer, with the
  cursors and tags packed into the byte tail of the positions.

## What the numbers say

Measured on the i9 over a 1 MB frame with a fresh compressor per frame.
Faults are reported as a **slope over frame count** (10 frames vs 100), not a
single total, so start-up cost is not mistaken for per-frame cost — the
distinction that made the original report of this issue point at the wrong
level.

| level | faults/frame before | after |
|-------|--------------------|-------|
| 3 | 601 | **0** |
| 5 | 1,025 | **0** |
| 8 | 0.04 | 0 |
| 13 | 0.37 | 0 |
| 16 | 0.06 | 0 |
| 19 | 0 | 0 |
| 22 | 0 | 0 |

The reference pays 0.02 on the same shape. Level 5 was re-faulting about 4 MB
per frame with no saturation: 103,099 faults over 100 frames against the
reference's 924.

Cycles fall **5.0% at level 3** and **4.6% at level 5** (paired runs, same
session, flat control). The reused-compressor shape is unchanged — paired runs
flip sign, so the difference is noise.

## Bounds the reservation cannot cross

The size a streaming caller gives is advisory — the reader may deliver far
less than promised — so it is trusted only as far as the frame's own
configuration makes plausible: the window this *level* would choose, never an
overridden one. Overriding the window is itself a claim about the data, and
taking it here let a caller who promised gibibytes and delivered ten bytes
reserve two of them, which a test now holds down. Beyond that bound the buffer
grows as it did before, which costs a few reallocations on frames already large
enough for that to be noise.

The reservation also counts from what the buffer already holds rather than from
the frame alone, because a dictionary is primed into it first. All four
backends did this the same wrong way; a dictionary frame at levels 3 and 5 now
lands on exactly what it needs where it previously overshot by growth. The Fast
backend still ends past its reservation with a dictionary — priming widens its
eviction band by the dictionary's length and those bytes arrive after the frame
is sized — and the test excludes it from the tight bound rather than assert
something this PR has not established.

Raw frames reserve nothing at all. They emit straight from the staged buffer
and never consult the match finder, so sizing its history for them held a
window's worth of memory the frame has no use for: 131,082 bytes for a
ten-byte frame, taken and returned again by every fresh compressor.

## A wrong turn worth recording

The first form of the row carve reached its regions through bounds-checked
accessors that recomputed each width from the logs. That cost **9-13% at
level 5** — more than the churn it removed, and it would have shipped as a
regression had the cycle check been skipped after the fault check passed.
Carrying the widths as fields turned it into the 4.6% gain above. A shared
buffer is only cheaper if reaching into it is as cheap as reaching into a
vector.

## What this does not fix

Levels 1 and 2 still re-fault on the **streaming** path. The dominant
per-frame allocation there is the buffer blocks accumulate into before the
frame header can be written, taken fresh in `compress()` and grown three times
per frame. Its growth is a deliberate trade — the initial capacity is capped
at one block so a frame does not reserve its whole `compress_bound`, which is
what keeps peak memory under the reference's — so it belongs to output sizing,
not to the match finder. Tracked in #481 with the measurements.

The **one-shot** path those levels take when a caller compresses a slice is
already flat, and below the reference in absolute terms (590 faults over 100
frames).

## Issue body

#478 was opened against figures taken before #479 landed, and they no longer
described the code: the level spread it was written about (L13 43,363 faults)
had already collapsed. The body now carries the re-measurement, the corrected
target, and the slope-based acceptance criterion.

## Testing

- Output **byte-identical across levels 1-22**, compared as md5 of the frames
  themselves rather than their lengths (the ultra band re-checked with
  `--ultra`, since a first pass had compared two error paths).
- 1,085 workspace tests, including `cross_every_level_roundtrips_through_the_c_codec_both_ways`;
  1,052 with `lsm` + `ldm`; 23 doctests.
- Rebasing the row index touches only the positions — the cursors and tags
  share the buffer, and walking all of it wrote the empty sentinel over them.
  The full path needs about four gibibytes through one matcher, so the test
  drives the step directly.
- Regression test that fails without the fix: a 700,000-byte frame leaves the
  ingest buffer at exactly 1,048,576 when it grew into it, a power of two no
  reservation lands on. Checked on one level per backend.
- clippy (workspace, all targets), fmt, `x86_64-unknown-linux-gnu` and
  `i686-unknown-linux-gnu` lints, `thumbv7em-none-eabihf` no-std check.

Closes #478


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved compression memory allocation for known and estimated source sizes.
  * Reduced incremental buffer growth during frame processing, improving efficiency for large frames and dictionary-based compression.
  * Added safeguards to prevent overly large allocations when source-size estimates are inaccurate.
  * Improved memory usage across compression strategies without changing compressed output behavior.

* **Reliability**
  * Added regression coverage for large frames, dictionaries, inaccurate size estimates, and internal index updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
