### PR TITLE
chore: name the maintainer in package metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ rather than maintain divergent copies. -->
 
 ## Project relationship
 
-Maintained fork of [KillingSpark/zstd-rs](https://github.com/KillingSpark/zstd-rs) (ruzstd) by the [Structured World Foundation](https://sw.foundation). We sync periodically with upstream but maintain an independent development trajectory focused on the [CoordiNode](https://github.com/structured-world/coordinode) database engine's per-label dictionary needs.
+Maintained fork of [KillingSpark/zstd-rs](https://github.com/KillingSpark/zstd-rs) (ruzstd) by [Dmitry Prudnikov](https://github.com/polaz). We sync periodically with upstream but maintain an independent development trajectory focused on the [CoordiNode](https://github.com/structured-world/coordinode) database engine's per-label dictionary needs.
 
 ## Support the project
 

--- a/c-api/Cargo.toml
+++ b/c-api/Cargo.toml
@@ -2,7 +2,7 @@
 name = "structured-zstd-c"
 version = "0.0.33"
 rust-version = "1.92"
-authors = ["Structured World Foundation <foundation@sw.foundation>"]
+authors = ["Dmitry Prudnikov <mail@polaz.com>"]
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://github.com/structured-world/structured-zstd"

--- a/zstd-wasm/Cargo.toml
+++ b/zstd-wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "structured-zstd-wasm"
 version = "0.0.30"
 rust-version = "1.92"
-authors = ["Structured World Foundation <foundation@sw.foundation>"]
+authors = ["Dmitry Prudnikov <mail@polaz.com>"]
 edition = "2024"
 license = "Apache-2.0"
 homepage = "https://github.com/structured-world/structured-zstd"

--- a/zstd-wasm/npm/README.md
+++ b/zstd-wasm/npm/README.md
@@ -111,5 +111,5 @@ the browser/Deno they are fetched relative to the module.
 
 ## License
 
-[Apache-2.0](./LICENSE) © Structured World Foundation. Built from
+[Apache-2.0](./LICENSE) © Dmitry Prudnikov. Built from
 [`structured-zstd`](https://github.com/structured-world/structured-zstd).

--- a/zstd/Cargo.toml
+++ b/zstd/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.49"
 rust-version = "1.92"
 authors = [
     "Moritz Borcherding <moritz.borcherding@web.de>",
-    "Structured World Foundation <foundation@sw.foundation>",
+    "Dmitry Prudnikov <mail@polaz.com>",
 ]
 edition = "2024"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

The maintainer entry in the crate manifests (`zstd`, `zstd-wasm`, `c-api`), the README and the npm package README now names the current maintainer, Dmitry Prudnikov. The original author entry stays. No code change.

## Testing

`cargo metadata --no-deps` succeeds for the workspace.

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project, package, and license attribution to credit Dmitry Prudnikov instead of the Structured World Foundation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->