### PR TITLE
chore: name the maintainer in the licence appendix and npm metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2026 Structured World Foundation
+   Copyright 2026 Dmitry Prudnikov
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/zstd-wasm/npm/package.json
+++ b/zstd-wasm/npm/package.json
@@ -47,7 +47,7 @@
     "pure-rust"
   ],
   "license": "Apache-2.0",
-  "author": "Structured World Foundation <foundation@sw.foundation>",
+  "author": "Dmitry Prudnikov <mail@polaz.com>",
   "homepage": "https://github.com/structured-world/structured-zstd#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

The licence appendix and the npm package `author` name the current maintainer, Dmitry Prudnikov. No code change; the registry metadata follows with the next release.

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated copyright and package author attribution from Structured World Foundation to Dmitry Prudnikov.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->